### PR TITLE
Bar chart y-axis labels were off by 1 position

### DIFF
--- a/Chart.js
+++ b/Chart.js
@@ -1147,7 +1147,7 @@ var Chart = function(context){
 				
 				ctx.stroke();
 				if (config.scaleShowLabels){
-					ctx.fillText(calculatedScale.labels[j],yAxisPosX-8,xAxisPosY - ((j+1) * scaleHop));
+					ctx.fillText(calculatedScale.labels[j],yAxisPosX-8,xAxisPosY - ((j) * scaleHop));
 				}
 			}
 			


### PR DESCRIPTION
This caused the labels to begin one position higher than the baseline. It was especially noticeable if you tried to force the scale to start at 0, where the 0 label would show where 1 should have. This pull request fixes that.
