### PR TITLE
Explicit global definition

### DIFF
--- a/Chart.js
+++ b/Chart.js
@@ -8,7 +8,7 @@
  */
 
 //Define the global Chart Variable as a class.
-var Chart = function(context){
+window.Chart = function(context){
 
 	var chart = this;
 	


### PR DESCRIPTION
Some script bundlers such as Browserify compile a wrapper function over the modules. If var-statement is used to define the global it will be hidden inside it. Use window-global to define Chart global explicitly.

You could also just drop the var statement, but using `window` explicitly makes the intention clear.
