### PR TITLE
Correct default scaleShowLabels value to match js file setting

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -99,7 +99,7 @@ var myNewChart = new Chart(ctx);</code></pre>
 	scaleLineWidth : 1,
 
 	//Boolean - Whether to show labels on the scale	
-	scaleShowLabels : false,
+	scaleShowLabels : true,
 	
 	//Interpolated JS string - can access value
 	scaleLabel : "<%=value%>",
@@ -212,7 +212,7 @@ var myNewChart = new Chart(ctx);</code></pre>
 	scaleLineWidth : 1,
 
 	//Boolean - Whether to show labels on the scale	
-	scaleShowLabels : false,
+	scaleShowLabels : true,
 	
 	//Interpolated JS string - can access value
 	scaleLabel : "<%=value%>",


### PR DESCRIPTION
default scaleShowLabels value for Line and Bar is true in js file, but it is false in document. Match the value to reduce confuse
