### PR TITLE
Correct default scaleShowLabels value in document

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -99,7 +99,7 @@ var myNewChart = new Chart(ctx);</code></pre>
 	scaleLineWidth : 1,
 
 	//Boolean - Whether to show labels on the scale	
-	scaleShowLabels : false,
+	scaleShowLabels : true,
 	
 	//Interpolated JS string - can access value
 	scaleLabel : "<%=value%>",
@@ -212,7 +212,7 @@ var myNewChart = new Chart(ctx);</code></pre>
 	scaleLineWidth : 1,
 
 	//Boolean - Whether to show labels on the scale	
-	scaleShowLabels : false,
+	scaleShowLabels : true,
 	
 	//Interpolated JS string - can access value
 	scaleLabel : "<%=value%>",


### PR DESCRIPTION
default scaleShowLabels value for Line and Bar is true in js file, but
it is false in document page.
Correct document page to match the value to reduce the confuse
