### PR TITLE
Fix for issue#149

### DIFF
--- a/Chart.js
+++ b/Chart.js
@@ -1100,11 +1100,12 @@ window.Chart = function(context){
 				ctx.beginPath();
 				ctx.moveTo(yAxisPosX + (i+1) * valueHop, xAxisPosY+3);
 				
-				//Check i isnt 0, so we dont go over the Y axis twice.
+				if(config.scaleShowGridLines){
 					ctx.lineWidth = config.scaleGridLineWidth;
 					ctx.strokeStyle = config.scaleGridLineColor;					
 					ctx.lineTo(yAxisPosX + (i+1) * valueHop, 5);
-				ctx.stroke();
+					ctx.stroke();
+				}
 			}
 			
 			//Y axis


### PR DESCRIPTION
**scaleShowGridLines** set to _false_ does not remove vertical grid lines for bar chart.

![image](https://f.cloud.github.com/assets/623670/693112/46f3e34a-dc72-11e2-953e-ee626daa6339.png)

Image taken from bar chart example in repo.
