### PR TITLE
Radar new feature: fillColor depending on the area size

### DIFF
--- a/Chart.js
+++ b/Chart.js
@@ -537,6 +537,38 @@ window.Chart = function(context){
 					ctx.lineTo(0,animationDecimal*(-1*calculateOffset(data.datasets[i].data[j],calculatedScale,scaleHop)));
 			
 				}
+
+				// Update the color depending on the size of the area covered by the data
+				// data.colorProgressive: boolean defining if you want to enable this feature
+				// data.colorMin, data.colorMax: RGBA values to range from. They replace the existing data.fillColor, data.pointColor, data.strokeColor
+				if (data.datasets[i].colorProgressive) {
+					var polygonArea = 0;
+					var sideMax = data.datasets[i].data[0];
+
+					for (var j=1; j<data.datasets[i].data.length; j++){
+						var sideA = data.datasets[i].data[j-1];
+						var sideB = data.datasets[i].data[j];
+						var triangleArea = 0.5 * sideA * sideB * Math.sin(2*Math.PI/data.datasets[i].data.length);
+						polygonArea += triangleArea;
+
+						// get max side length
+						sideMax = Math.max(sideMax, data.datasets[i].data[j]);
+					}
+					var polygonMax =  0.5 * sideMax * sideMax * Math.sin(2*Math.PI/data.datasets[i].data.length) * data.datasets[i].data.length;
+					var coeff = polygonArea / polygonMax;
+
+					var rgbMin = data.datasets[i].colorMin.replace('rgba(', '').replace(')', '').replace(' ', '').split(',');
+					var rgbMax = data.datasets[i].colorMax.replace('rgba(', '').replace(')', '').replace(' ', '').split(',');
+
+					var red = Math.floor(parseInt(rgbMin[0], 10) + coeff * (parseInt(rgbMax[0], 10) - parseInt(rgbMin[0], 10)));
+					var green = Math.floor(parseInt(rgbMin[1], 10) + coeff * (parseInt(rgbMax[1], 10) - parseInt(rgbMin[1], 10)));
+					var blue = Math.floor(parseInt(rgbMin[2], 10) + coeff * (parseInt(rgbMax[2], 10) - parseInt(rgbMin[2], 10)));
+
+					data.datasets[i].fillColor = 'rgba(' + red + ',' + green + ',' + blue + ',' + rgbMin[3] + ')';
+					data.datasets[i].pointColor = 'rgba(' + red + ',' + green + ',' + blue + ', 1)';
+					data.datasets[i].strokeColor = 'rgba(' + red + ',' + green + ',' + blue + ', 1)';
+				}
+
 				ctx.closePath();
 				
 				


### PR DESCRIPTION
In picture: 

![chart1](https://f.cloud.github.com/assets/841776/749333/bc48c49c-e4a8-11e2-9a1e-0ec38a4e6840.png)
![chart2](https://f.cloud.github.com/assets/841776/749335/bebe3324-e4a8-11e2-8499-1ba8ad53b6c3.png)
![chart3](https://f.cloud.github.com/assets/841776/749337/c07e5626-e4a8-11e2-998d-b32f1a73bc76.png)

Sample data (first dataset is used to force the bounds, second one is using the feature):

```
    var data = {
      labels: ['FWs', '3s', 'GIR', 'Ptts', 'PA'],
      datasets: [{
          fillColor: 'rgba(220,220,220,0)',
          strokeColor: 'rgba(220,220,220,0)',
          pointColor: 'rgba(220,220,220,0)',
          pointStrokeColor: '#fff',
          data: [0, 0, 0, 0, 100]
        }, {
          colorProgressive: true,
          colorMin: 'rgba(255, 0, 0, 0.5)',
          colorMax: 'rgba(0, 255, 0, 0.5)',
          pointStrokeColor: '#fff',
          data: []
        }
      ]
    };
```
