### PR TITLE
Add onAnimationProgress callback function

### DIFF
--- a/Chart.js
+++ b/Chart.js
@@ -1240,6 +1240,9 @@ window.Chart = function(context){
 
         function animateFrame(){
             var easeAdjustedAnimationPercent =(config.animation)? CapValue(easingFunction(percentAnimComplete),null,0) : 1;
+
+            if (typeof config.onAnimationProgress === "function") config.onAnimationProgress(easeAdjustedAnimationPercent);
+
             clear(ctx);
             if(config.scaleOverlay){
                 drawData(easeAdjustedAnimationPercent);


### PR DESCRIPTION
In my case, I am doing a simple doughnut pie chart with only 2 data values. I wanted to display the percent complete of one of them as the animation was in progress.

I realize the library isn't made for interactiveness, per se -- but in addition to the already existing onAnimationComplete callback, this simple addition just provides insight to the percent of the animation completed. I think it serves as a good fit with the current config options.

it would just be another option used like:

```
onAnimationProgress: function(progress) {
    console.log(progress); // 0 to 1
}
```
