### PR TITLE
Update polar area chart to allow variable arc widths 

### DIFF
--- a/Chart.js
+++ b/Chart.js
@@ -356,7 +356,7 @@ window.Chart = function(context){
 
 	var PolarArea = function(data,config,ctx){
 		var maxSize, scaleHop, calculatedScale, labelHeight, scaleHeight, valueBounds, labelTemplateString;		
-		
+		var angleSteps = new Array();
 		
 		calculateDrawingSizes();
 		
@@ -380,6 +380,20 @@ window.Chart = function(context){
 		}
 		
 		scaleHop = maxSize/(calculatedScale.steps);
+
+		// Compute arc angles
+		var totalFraction = 0.0;
+		for (var i=0; i<data.length; i++) {
+			angleSteps[i] = (Math.PI*2);
+			if ( data[i].fraction ) {
+				totalFraction += data[i].fraction;
+				angleSteps[i] *= data[i].fraction;
+			}
+		}
+		if ( 0.0 == totalFraction )
+			totalFraction = data.length;
+		for (var i=0; i<data.length; i++)
+			angleSteps[i] /= totalFraction;
 
 		//Wrap in an animation loop wrapper
 		animationLoop(config,drawScale,drawAllSegments,ctx);
@@ -437,7 +451,6 @@ window.Chart = function(context){
 		}
 		function drawAllSegments(animationDecimal){
 			var startAngle = -Math.PI/2,
-			angleStep = (Math.PI*2)/data.length,
 			scaleAnimation = 1,
 			rotateAnimation = 1;
 			if (config.animation) {
@@ -452,7 +465,7 @@ window.Chart = function(context){
 			for (var i=0; i<data.length; i++){
 
 				ctx.beginPath();
-				ctx.arc(width/2,height/2,scaleAnimation * calculateOffset(data[i].value,calculatedScale,scaleHop),startAngle, startAngle + rotateAnimation*angleStep, false);
+				ctx.arc(width/2,height/2,scaleAnimation * calculateOffset(data[i].value,calculatedScale,scaleHop),startAngle, startAngle + rotateAnimation*angleSteps[i], false);
 				ctx.lineTo(width/2,height/2);
 				ctx.closePath();
 				ctx.fillStyle = data[i].color;
@@ -463,7 +476,7 @@ window.Chart = function(context){
 					ctx.lineWidth = config.segmentStrokeWidth;
 					ctx.stroke();
 				}
-				startAngle += rotateAnimation*angleStep;
+				startAngle += rotateAnimation*angleSteps[i];
 			}
 		}
 		function getValueBounds() {

--- a/samples/polarAreaVariable.html
+++ b/samples/polarAreaVariable.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html>
+	<head>
+		<title>Variable Arc Polar Area Chart</title>
+		<script src="../Chart.js"></script>
+		<meta name = "viewport" content = "initial-scale = 1, user-scalable = no">
+		<style>
+		</style>
+	</head>
+	<body>
+		<canvas id="canvas" height="400" width="400"></canvas>
+
+
+	<script>
+	var chartData = [
+			{
+				value : Math.random() * 0.8 + 0.2,
+				fraction : Math.random() * 0.95 + 0.05,
+				color: "#D97041"
+			},
+			{
+				value : Math.random() * 0.8 + 0.2,
+				fraction : Math.random() * 0.95 + 0.05,
+				color: "#C7604C"
+			},
+			{
+				value : Math.random() * 0.8 + 0.2,
+				fraction : Math.random() * 0.95 + 0.05,
+				color: "#21323D"
+			},
+			{
+				value : Math.random() * 0.8 + 0.2,
+				fraction : Math.random() * 0.95 + 0.05,
+				color: "#9D9B7F"
+			},
+			{
+				value : Math.random() * 0.8 + 0.2,
+				fraction : Math.random() * 0.95 + 0.05,
+				color: "#7D4F6D"
+			},
+			{
+				value : Math.random() * 0.8 + 0.2,
+				fraction : Math.random() * 0.95 + 0.05,
+				color: "#584A5E"
+			}
+		];
+	var options = {
+		scaleShowLabels : true,
+		scaleOverride: true,
+		scaleSteps: 10,
+		scaleStepWidth: 0.1,
+		scaleStartValue: 0.0,
+	};
+	var myPolarArea = new Chart(document.getElementById("canvas").getContext("2d")).PolarArea(chartData,options);
+	</script>
+	</body>
+</html>


### PR DESCRIPTION
I've extended the polarArea chart to allow variable arc widths via a new "fraction" property on each data entry.   If the property is missing, the chart will fall back to the default equal arc polarArea chart.

![image](https://f.cloud.github.com/assets/1063975/1795173/b3e161e4-69ee-11e3-97cc-ee47cde9943f.png)

![image](https://f.cloud.github.com/assets/1063975/1795181/3384d09c-69f0-11e3-858d-d7698686abb3.png)
