### PR TITLE
Alternative radar chart scale style

### DIFF
--- a/Chart.js
+++ b/Chart.js
@@ -209,6 +209,7 @@ window.Chart = function(context){
 			scaleShowLine : true,
 			scaleLineColor : "rgba(0,0,0,.1)",
 			scaleLineWidth : 1,
+			scaleStyle : "web",
 			scaleShowLabels : false,
 			scaleLabel : "<%=value%>",
 			scaleFontFamily : "'Arial'",
@@ -591,14 +592,21 @@ window.Chart = function(context){
 				if(config.scaleShowLine){
 					ctx.strokeStyle = config.scaleLineColor;
 					ctx.lineWidth = config.scaleLineWidth;
-					ctx.moveTo(0,-scaleHop * (i+1));					
-					for (var j=0; j<data.datasets[0].data.length; j++){
-					    ctx.rotate(rotationDegree);
-						ctx.lineTo(0,-scaleHop * (i+1));
+
+					if (config.scaleStyle == "web"){
+						ctx.moveTo(0,-scaleHop * (i+1));
+						for (var j=0; j<data.datasets[0].data.length; j++){
+							ctx.rotate(rotationDegree);
+							ctx.lineTo(0,-scaleHop * (i+1));
+						}
 					}
+
+					if (config.scaleStyle == "scope"){
+						ctx.arc(0,0,scaleHop * (i+1),0,-360,true);
+					}
+
 					ctx.closePath();
-					ctx.stroke();			
-							
+					ctx.stroke();
 				}
 				
 				if (config.scaleShowLabels){				


### PR DESCRIPTION
Aesthetic: Added an option to toggle between the native "web" style and an alternative "scope" style for the underlying radar chart scale.
![alternative-radar-scale-style](https://f.cloud.github.com/assets/373596/2476358/54d6b20c-b062-11e3-80f7-00832702fd32.jpg)
