### PR TITLE
save and restore context for Tooltip drawing

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -1185,6 +1185,7 @@
 		draw : function(){
 
 			var ctx = this.chart.ctx;
+			ctx.save();
 
 			ctx.font = fontString(this.fontSize,this.fontStyle,this.fontFamily);
 
@@ -1255,6 +1256,8 @@
 			ctx.textAlign = "center";
 			ctx.textBaseline = "middle";
 			ctx.fillText(this.text, tooltipX + tooltipWidth/2, tooltipY + tooltipRectHeight/2);
+
+			ctx.restore();
 		}
 	});
 


### PR DESCRIPTION
When I calls fillText at the end of Chart.Doughnut draw function, the text always moved after the tooltip disappeared. Then I found out the drawing context in showTooltip was not cleaned after disappear.

So I add save and restore to keep their context independent
