### PR TITLE
Prevent spare datasets from breaking MultiTooltips

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -873,7 +873,9 @@
 								yMin;
 							helpers.each(this.datasets, function(dataset){
 								dataCollection = dataset.points || dataset.bars || dataset.segments;
-								Elements.push(dataCollection[dataIndex]);
+								if (dataCollection[dataIndex]){
+									Elements.push(dataCollection[dataIndex]);
+								}
 							});
 
 							helpers.each(Elements, function(element) {


### PR DESCRIPTION
Fixes issue where sparse datasets would throw an exception when rendering a MultiTooltip
