### PR TITLE
Add datasetLabel to elements for tooltip templates

### DIFF
--- a/src/Chart.Bar.js
+++ b/src/Chart.Bar.js
@@ -109,6 +109,7 @@
 						datasetObject.bars.push(new this.BarClass({
 							value : dataPoint,
 							label : data.labels[index],
+							datasetLabel: dataset.label,
 							strokeColor : dataset.strokeColor,
 							fillColor : dataset.fillColor,
 							highlightFill : dataset.highlightFill || dataset.fillColor,

--- a/src/Chart.Line.js
+++ b/src/Chart.Line.js
@@ -104,8 +104,7 @@
 						datasetObject.points.push(new this.PointClass({
 							value : dataPoint,
 							label : data.labels[index],
-							// x: this.scale.calculateX(index),
-							// y: this.scale.endPoint,
+							datasetLabel: dataset.label,
 							strokeColor : dataset.pointStrokeColor,
 							fillColor : dataset.pointColor,
 							highlightFill : dataset.pointHighlightFill || dataset.pointColor,

--- a/src/Chart.Radar.js
+++ b/src/Chart.Radar.js
@@ -121,6 +121,7 @@
 						datasetObject.points.push(new this.PointClass({
 							value : dataPoint,
 							label : data.labels[index],
+							datasetLabel: dataset.label,
 							x: (this.options.animation) ? this.scale.xCenter : pointPosition.x,
 							y: (this.options.animation) ? this.scale.yCenter : pointPosition.y,
 							strokeColor : dataset.pointStrokeColor,


### PR DESCRIPTION
Example usage - for multitooltips in chart options:

```
{
  multiTooltipTemplate: "<%= datasetLabel %>: <%= value %>"
}
```

Resolves #408 
