### PR TITLE
Reflow the Radar before updating to update scale

### DIFF
--- a/src/Chart.Radar.js
+++ b/src/Chart.Radar.js
@@ -275,6 +275,7 @@
 			this.eachPoints(function(point){
 				point.save();
 			});
+			this.reflow();
 			this.render();
 		},
 		reflow: function(){


### PR DESCRIPTION
Fixes #412 by updating the scale when `.update` is called on the Radar chart.
