### PR TITLE
Missing draw method in Writing new chart types

### DIFF
--- a/docs/06-Advanced.md
+++ b/docs/06-Advanced.md
@@ -92,6 +92,9 @@ Chart.Type.extend({
 	initialize:  function(data){
 		this.chart.ctx // The drawing context for this chart
 		this.chart.canvas // the canvas node for this chart
+	},
+	// Used to draw something on the canvas
+	draw: function() {
 	}
 });
 


### PR DESCRIPTION
Added the draw method to "Writing new chart types" in the documentation. If you use the template without the draw method, you get an undefined error because Chart.Type.prototype.render calls this.draw() on line 808 in Chart.Core.js.
