### PR TITLE
Add main in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "homepage": "http://www.chartjs.org",
   "description": "Simple HTML5 charts using the canvas element.",
   "version": "1.0.1-beta.2",
+  "main": "Chart.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/nnnick/Chart.js.git"


### PR DESCRIPTION
When using browserify, importing the package isn't trivial.

``` js
var Chart = require('chart.js');       // fails
var Chart = require('chart.js/Chart'); // ok
```

Adding a `main` in `package.json` solves the issue.

``` js
var Chart = require('chart.js'); // ok
```
