### PR TITLE
Show dataset label in tooltip when present

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -142,8 +142,8 @@
 			// String - Template string for single tooltips
 			tooltipTemplate: "<%if (label){%><%=label%>: <%}%><%= value %>",
 
-			// String - Template string for single tooltips
-			multiTooltipTemplate: "<%= value %>",
+			// String - Template string for multi tooltips
+			multiTooltipTemplate: "<%if (datasetLabel){%><%=datasetLabel%>: <%}%><%= value %>",
 
 			// String - Colour behind the legend colour block
 			multiTooltipKeyBackground: '#fff',


### PR DESCRIPTION
This shows the dataset label when it exists in the tooltip between the colour span and the value.
