### PR TITLE
Only fill dataset if there are points in it

### DIFF
--- a/Chart.js
+++ b/Chart.js
@@ -2688,7 +2688,7 @@
 				ctx.stroke();
 
 
-				if (this.options.datasetFill){
+				if (this.options.datasetFill && dataset.points.length > 0){
 					//Round off the line by going to the base of the chart, back to the start, then fill.
 					ctx.lineTo(dataset.points[dataset.points.length-1].x, this.scale.endPoint);
 					ctx.lineTo(this.scale.calculateX(0), this.scale.endPoint);


### PR DESCRIPTION
otherwise it will fail since dataset.points[dataset.points.length - 1].x will be dataset.points[-1] .x
