### PR TITLE
Fix infinity on first addData() call in Bar chart

### DIFF
--- a/src/Chart.Bar.js
+++ b/src/Chart.Bar.js
@@ -226,6 +226,9 @@
 			this.scale = new this.ScaleClass(scaleOptions);
 		},
 		addData : function(valuesArray,label){
+			// Add label to X axis
+			this.scale.addXLabel(label);
+
 			//Map the values array for each of the datasets
 			helpers.each(valuesArray,function(value,datasetIndex){
 				//Add a new point for each piece of data, passing any required data to draw.
@@ -241,7 +244,6 @@
 				}));
 			},this);
 
-			this.scale.addXLabel(label);
 			//Then re-render the chart.
 			this.update();
 		},


### PR DESCRIPTION
Fixes Issue https://github.com/nnnick/Chart.js/issues/620

When first addData() was called, variable valuesCount was 0, because addXLabel(), which is responsible to increment valuesCount, happened only after calculateX(). This is the reason to raise a DOMException because of division by zero, on calculateX() function.

This only affects addData().

There is the bug and the fix:
Bug: http://jsbin.com/rozepubikecu/1/edit
Fix: http://jsbin.com/rozepubikecu/7/edit
