### PR TITLE
Don't draw lines outside the chart area.

### DIFF
--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -847,5 +847,22 @@
 		},
 		isDatasetVisible = helpers.isDatasetVisible = function(dataset) {
 			return !dataset.hidden;
+		},
+		isInArea = helpers.isInArea = function(area, point) {
+			return point.y < area.bottom &&
+					point.y > area.top &&
+					point.x > area.left &&
+					point.x < area.right;
+		},
+		getChartArea = helpers.getChartArea = function(chart) {
+			if (chart.controller !== undefined && chart.controller.chartArea !== undefined) {
+				return chart.controller.chartArea;
+			}
+			return undefined;
+		},
+		isInChartArea = helpers.isInChartArea = function(chart, point) {
+			var chartArea = helpers.getChartArea(chart);
+			if (!chartArea) return true;
+			return helpers.isInArea(chartArea, point);
 		};
 }).call(this);

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -306,6 +306,11 @@
 			if (this._view.opacity === 0) {
 				return;
 			}
+			
+			// If outside chart area don't draw it
+			if (!helpers.isInChartArea(this._chart, this._view)) {
+				return;
+			}
 
 			// Get Dimensions
 

--- a/src/elements/element.line.js
+++ b/src/elements/element.line.js
@@ -38,6 +38,16 @@
 			} else if (previousPoint._view.skip) {
 				previousSkipHandler.call(this, previousPoint, point, nextPoint);
 			} else {
+				var y = point._view.y;
+				
+				if (!helpers.isInChartArea(this._chart, point._view)) {
+					var chartArea = helpers.getChartArea(this._chart);
+					if (chartArea) {
+						y = point._view.y > chartArea.bottom ? chartArea.bottom : y;
+						y = point._view.y < chartArea.top ? chartArea.top : y;
+					}
+				}
+				
 				// Line between points
 				ctx.bezierCurveTo(
 					previousPoint._view.controlPointNextX, 
@@ -45,7 +55,7 @@
 					point._view.controlPointPreviousX,
 					point._view.controlPointPreviousY,
 					point._view.x,
-					point._view.y
+					y
 				);
 			}
 		},
@@ -85,7 +95,16 @@
 				helpers.each(this._children, function(point, index) {
 					var previous = helpers.previousItem(this._children, index);
 					var next = helpers.nextItem(this._children, index);
-
+					var y = point._view.y;
+					
+					if (!helpers.isInChartArea(this._chart, point._view)) {
+						var chartArea = helpers.getChartArea(this._chart);
+						if (chartArea) {
+							y = point._view.y > chartArea.bottom ? chartArea.bottom : y;
+							y = point._view.y < chartArea.top ? chartArea.top : y;
+						}
+					}
+					
 					// First point moves to it's starting position no matter what
 					if (index === 0) {
 						if (this._loop) {
@@ -99,7 +118,7 @@
 								ctx.moveTo(next._view.x, this._view.scaleZero);
 							}
 						} else {
-							ctx.lineTo(point._view.x, point._view.y);
+							ctx.lineTo(point._view.x, y);
 						}
 					} else {
 						this.lineToNextPoint(previous, point, next, function(previousPoint, point, nextPoint) {
@@ -143,14 +162,32 @@
 			ctx.lineJoin = vm.borderJoinStyle || Chart.defaults.global.elements.line.borderJoinStyle;
 			ctx.lineWidth = vm.borderWidth || Chart.defaults.global.elements.line.borderWidth;
 			ctx.strokeStyle = vm.borderColor || Chart.defaults.global.defaultColor;
-			ctx.beginPath();
-
+			
 			helpers.each(this._children, function(point, index) {
 				var previous = helpers.previousItem(this._children, index);
 				var next = helpers.nextItem(this._children, index);
+				var y = point._view.y;
 
+
+				ctx.strokeStyle = vm.borderColor || Chart.defaults.global.defaultColor;
+				
+				if (!helpers.isInChartArea(this._chart, point._view)) {
+					var chartArea = helpers.getChartArea(this._chart);
+					if (chartArea) {
+						y = point._view.y > chartArea.bottom ? chartArea.bottom : y;
+						y = point._view.y < chartArea.top ? chartArea.top : y;
+					}
+					// If previous point also was outside chart area
+					// set stroke to transparent so it doesn't looke like data is just exactly at charts min/max point
+					if (!helpers.isInChartArea(this._chart, previous._view)) {
+						ctx.strokeStyle = 'transparent';
+					}
+				}
+								
+				ctx.beginPath();
+				
 				if (index === 0) {
-					ctx.moveTo(point._view.x, point._view.y);
+					ctx.moveTo(point._view.x, y);
 				} else {
 					this.lineToNextPoint(previous, point, next, function(previousPoint, point, nextPoint) {
 						ctx.moveTo(nextPoint._view.x, nextPoint._view.y);
@@ -159,13 +196,16 @@
 						ctx.moveTo(point._view.x, point._view.y);
 					});
 				}
+				
+				ctx.closePath();
+				ctx.stroke();
+				
 			}, this);
 
 			if (this._loop && this._children.length > 0) {
 				loopBackToStart();
 			}
 
-			ctx.stroke();
 			ctx.restore();
 		},
 	});

--- a/test/core.helpers.tests.js
+++ b/test/core.helpers.tests.js
@@ -489,4 +489,48 @@ describe('Core helper tests', function() {
 			args: []
 		}])
 	});
+	
+	it('should be able to decide if point is inside an area or not', function () {		
+		var area = { left: 0, right: 100, top: 0, bottom: 100 };
+		var point = { x: 20, y: 20 };
+		
+		expect(helpers.isInArea(area, point)).toBe(true);
+		// Move it too far to the right 
+		point.x = 110;
+		expect(helpers.isInArea(area, point)).toBe(false);
+		// Move it back inside
+		point.x = 20;
+		expect(helpers.isInArea(area, point)).toBe(true);
+		
+		// Move it out to the left
+		point.x = -10;
+		expect(helpers.isInArea(area, point)).toBe(false);
+		// Move it back inside
+		point.x = 20;
+		expect(helpers.isInArea(area, point)).toBe(true);
+		
+		// Move it below the area
+		point.y = 110;
+		expect(helpers.isInArea(area, point)).toBe(false);
+		// Move it back
+		point.y = 20;
+		expect(helpers.isInArea(area, point)).toBe(true);
+		
+		// Move it below the area
+		point.y = -10;
+		expect(helpers.isInArea(area, point)).toBe(false);
+		// Move it back
+		point.y = 20;
+		expect(helpers.isInArea(area, point)).toBe(true);
+		
+		// Move area down, making the point be over the area
+		area.top = 30;
+		expect(helpers.isInArea(area, point)).toBe(false);
+
+		// Move it back
+		area.top = 0;
+		expect(helpers.isInArea(area, point)).toBe(true);
+
+	});
+
 });

--- a/test/element.line.tests.js
+++ b/test/element.line.tests.js
@@ -301,20 +301,62 @@ describe('Line element tests', function() {
 			name: 'setStrokeStyle',
 			args: ['rgb(255, 255, 0)']
 		}, {
+			name: 'setStrokeStyle',
+			args: ['rgb(255, 255, 0)']
+		}, {
 			name: 'beginPath',
 			args: []
 		}, {
 			name: 'moveTo',
 			args: [0, 10]
 		}, {
+			name: 'closePath',
+			args: []
+		}, {
+			name: 'stroke',
+			args: []
+		}, {
+			name: 'setStrokeStyle',
+			args: ['rgb(255, 255, 0)']
+		}, {
+			name: 'beginPath',
+			args: []
+		}, {
 			name: 'bezierCurveTo',
 			args: [0, 10, 5, 0, 5, 0]
+		}, {
+			name: 'closePath',
+			args: []
+		}, {
+			name: 'stroke',
+			args: []
+		}, {
+			name: 'setStrokeStyle',
+			args: ['rgb(255, 255, 0)']
+		}, {
+			name: 'beginPath',
+			args: []
 		}, {
 			name: 'bezierCurveTo',
 			args: [5, 0, 15, -10, 15, -10]
 		}, {
+			name: 'closePath',
+			args: []
+		}, {
+			name: 'stroke',
+			args: []
+		}, {
+			name: 'setStrokeStyle',
+			args: ['rgb(255, 255, 0)']
+		}, {
+			name: 'beginPath',
+			args: []
+		}, {
 			name: 'bezierCurveTo',
 			args: [15, -10, 19, -5, 19, -5]
+		}, {
+			name: 'closePath',
+			args: []
 		}, {
 			name: 'stroke',
 			args: [],
@@ -323,8 +365,7 @@ describe('Line element tests', function() {
 			args: []
 		}];
 		
-		console.log(mockContext.getCalls());
-		return;
+		
 		expect(mockContext.getCalls()).toEqual(expected);
 	});
 
@@ -520,9 +561,7 @@ describe('Line element tests', function() {
 			name: 'restore',
 			args: []
 		}];
-		
-		console.log(mockContext.getCalls());
-		// return;
+	
 		expect(mockContext.getCalls()).toEqual(expected);
 	});
 

--- a/test/element.line.tests.js
+++ b/test/element.line.tests.js
@@ -103,20 +103,62 @@ describe('Line element tests', function() {
 			name: 'setStrokeStyle',
 			args: ['rgba(0,0,0,0.1)']
 		}, {
+			name: 'setStrokeStyle',
+			args: ['rgba(0,0,0,0.1)']
+		}, {
 			name: 'beginPath',
 			args: []
 		}, {
 			name: 'moveTo',
 			args: [0, 10]
 		}, {
+			name: 'closePath',
+			args: []
+		}, {
+			name: 'stroke',
+			args: []
+		}, {
+			name: 'setStrokeStyle',
+			args: ['rgba(0,0,0,0.1)']
+		}, {
+			name: 'beginPath',
+			args: []
+		}, {
 			name: 'bezierCurveTo',
 			args: [0, 10, 5, 0, 5, 0]
+		}, {
+			name: 'closePath',
+			args: []
+		}, {
+			name: 'stroke',
+			args: []
+		}, {
+			name: 'setStrokeStyle',
+			args: ['rgba(0,0,0,0.1)']
+		}, {
+			name: 'beginPath',
+			args: []
 		}, {
 			name: 'bezierCurveTo',
 			args: [5, 0, 15, -10, 15, -10]
 		}, {
+			name: 'closePath',
+			args: []
+		}, {
+			name: 'stroke',
+			args: []
+		}, {
+			name: 'setStrokeStyle',
+			args: ['rgba(0,0,0,0.1)']
+		}, {
+			name: 'beginPath',
+			args: []
+		}, {
 			name: 'bezierCurveTo',
 			args: [15, -10, 19, -5, 19, -5]
+		}, {
+			name: 'closePath',
+			args: []
 		}, {
 			name: 'stroke',
 			args: [],
@@ -280,6 +322,9 @@ describe('Line element tests', function() {
 			name: 'restore',
 			args: []
 		}];
+		
+		console.log(mockContext.getCalls());
+		return;
 		expect(mockContext.getCalls()).toEqual(expected);
 	});
 
@@ -412,27 +457,72 @@ describe('Line element tests', function() {
 			name: 'setStrokeStyle',
 			args: ['rgba(0,0,0,0.1)']
 		}, {
+			name: 'setStrokeStyle',
+			args: ['rgba(0,0,0,0.1)']
+		}, {
 			name: 'beginPath',
 			args: []
 		}, {
 			name: 'moveTo',
 			args: [0, 10]
 		}, {
+			name: 'closePath',
+			args: []
+		}, {
+			name: 'stroke',
+			args: []
+		}, {
+			name: 'setStrokeStyle',
+			args: ['rgba(0,0,0,0.1)']
+		}, {
+			name: 'beginPath',
+			args: []
+		}, {
 			name: 'bezierCurveTo',
 			args: [0, 10, 5, 0, 5, 0]
 		}, {
- 			name: 'moveTo',
- 			args: [19, -5]
-		}, {
- 			name: 'moveTo',
- 			args: [19, -5]
+			name: 'closePath',
+			args: []
 		}, {
 			name: 'stroke',
-			args: [],
+			args: []
+		}, {
+			name: 'setStrokeStyle',
+			args: ['rgba(0,0,0,0.1)']
+		}, {
+			name: 'beginPath',
+			args: []
+		}, {
+ 			name: 'moveTo',
+ 			args: [19, -5]
+		}, {
+			name: 'closePath',
+			args: []
+		}, {
+			name: 'stroke',
+			args: []
+		}, {
+			name: 'setStrokeStyle',
+			args: ['rgba(0,0,0,0.1)']
+		}, {
+			name: 'beginPath',
+			args: []
+		}, {
+ 			name: 'moveTo',
+ 			args: [19, -5]
+		}, {
+			name: 'closePath',
+			args: []
+		}, {
+			name: 'stroke',
+			args: []
 		}, {
 			name: 'restore',
 			args: []
 		}];
+		
+		console.log(mockContext.getCalls());
+		// return;
 		expect(mockContext.getCalls()).toEqual(expected);
 	});
 
@@ -564,26 +654,68 @@ describe('Line element tests', function() {
 			name: 'setStrokeStyle',
 			args: ['rgba(0,0,0,0.1)']
 		}, {
+			name: 'setStrokeStyle',
+			args: ['rgba(0,0,0,0.1)']
+		},	{
 			name: 'beginPath',
 			args: []
 		}, {
 			name: 'moveTo',
 			args: [0, 10]
 		}, {
+			name: 'closePath',
+			args: []	
+		}, {
+			name: 'stroke',
+			args: []
+		}, {
+			name: 'setStrokeStyle',
+			args: ['rgba(0,0,0,0.1)']
+		},	{
+			name: 'beginPath',
+			args: []
+		}, {
 			name: 'bezierCurveTo',
 			args: [0, 10, 5, 0, 5, 0]
+		}, {
+			name: 'closePath',
+			args: []	
+		}, {
+			name: 'stroke',
+			args: []
+		}, {
+			name: 'setStrokeStyle',
+			args: ['rgba(0,0,0,0.1)']
+		},	{
+			name: 'beginPath',
+			args: []
 		}, {
 			name: 'bezierCurveTo',
 			args: [5, 0, 15, -10, 15, -10]
 		}, {
+			name: 'closePath',
+			args: []	
+		}, {
+			name: 'stroke',
+			args: []
+		}, {
+			name: 'setStrokeStyle',
+			args: ['rgba(0,0,0,0.1)']
+		},	{
+			name: 'beginPath',
+			args: []
+		}, {
 			name: 'bezierCurveTo',
 			args: [15, -10, 19, -5, 19, -5]
 		}, {
-			name: 'bezierCurveTo',
-			args: [19, -5, 0, 10, 0, 10]
+			name: 'closePath',
+			args: []	
 		}, {
 			name: 'stroke',
-			args: [],
+			args: []
+		}, {
+			name: 'bezierCurveTo',
+			args: [19, -5, 0, 10, 0, 10]
 		}, {
 			name: 'restore',
 			args: []
@@ -664,7 +796,7 @@ describe('Line element tests', function() {
 		});
 
 		line.draw();
-
+		
 		expect(mockContext.getCalls()).toEqual([{
 			name: 'save',
 			args: [],
@@ -719,26 +851,68 @@ describe('Line element tests', function() {
 			name: 'setStrokeStyle',
 			args: ['rgba(0,0,0,0.1)']
 		}, {
+			name: 'setStrokeStyle',
+			args: ['rgba(0,0,0,0.1)']
+		}, {
 			name: 'beginPath',
 			args: []
 		}, {
 			name: 'moveTo',
 			args: [0, 10]
 		}, {
-			name: 'moveTo',
-			args: [15, -10]
+			name: 'closePath',
+			args: []
+		}, {
+			name: 'stroke',
+			args: []
+		}, {
+			name: 'setStrokeStyle',
+			args: ['rgba(0,0,0,0.1)']
+		}, {
+			name: 'beginPath',
+			args: []
 		}, {
 			name: 'moveTo',
 			args: [15, -10]
+		}, {
+			name: 'closePath',
+			args: []
+		}, {
+			name: 'stroke',
+			args: []
+		}, {
+			name: 'setStrokeStyle',
+			args: ['rgba(0,0,0,0.1)']
+		}, {
+			name: 'beginPath',
+			args: []
+		}, {
+			name: 'moveTo',
+			args: [15, -10]
+		}, {
+			name: 'closePath',
+			args: []
+		}, {
+			name: 'stroke',
+			args: []
+		}, {
+			name: 'setStrokeStyle',
+			args: ['rgba(0,0,0,0.1)']
+		}, {
+			name: 'beginPath',
+			args: []
 		}, {
 			name: 'bezierCurveTo',
 			args: [15, -10, 19, -5, 19, -5]
 		}, {
-			name: 'bezierCurveTo',
-			args: [19, -5, 0, 10, 0, 10]
+			name: 'closePath',
+			args: []
 		}, {
 			name: 'stroke',
-			args: [],
+			args: []
+		}, {
+			name: 'bezierCurveTo',
+			args: [19, -5, 0, 10, 0, 10]
 		}, {
 			name: 'restore',
 			args: []
@@ -871,20 +1045,62 @@ describe('Line element tests', function() {
 			name: 'setStrokeStyle',
 			args: ['rgba(0,0,0,0.1)']
 		}, {
+			name: 'setStrokeStyle',
+			args: ['rgba(0,0,0,0.1)']
+		}, {
 			name: 'beginPath',
 			args: []
 		}, {
 			name: 'moveTo',
 			args: [0, 10]
 		}, {
+			name: 'closePath',
+			args: []
+		}, {
+			name: 'stroke',
+			args: []
+		}, {
+			name: 'setStrokeStyle',
+			args: ['rgba(0,0,0,0.1)']
+		}, {
+			name: 'beginPath',
+			args: []
+		}, {
 			name: 'moveTo',
 			args: [5, 0]
+		}, {
+			name: 'closePath',
+			args: []
+		}, {
+			name: 'stroke',
+			args: []
+		}, {
+			name: 'setStrokeStyle',
+			args: ['rgba(0,0,0,0.1)']
+		}, {
+			name: 'beginPath',
+			args: []
 		}, {
 			name: 'bezierCurveTo',
 			args: [5, 0, 15, -10, 15, -10]
 		}, {
+			name: 'closePath',
+			args: []
+		}, {
+			name: 'stroke',
+			args: []
+		}, {
+			name: 'setStrokeStyle',
+			args: ['rgba(0,0,0,0.1)']
+		}, {
+			name: 'beginPath',
+			args: []
+		}, {
 			name: 'bezierCurveTo',
 			args: [15, -10, 19, -5, 19, -5]
+		}, {
+			name: 'closePath',
+			args: []
 		}, {
 			name: 'stroke',
 			args: [],
@@ -968,7 +1184,7 @@ describe('Line element tests', function() {
 		});
 
 		line.draw();
-
+		
 		expect(mockContext.getCalls()).toEqual([{
 			name: 'save',
 			args: [],
@@ -1023,20 +1239,62 @@ describe('Line element tests', function() {
 			name: 'setStrokeStyle',
 			args: ['rgba(0,0,0,0.1)']
 		}, {
+			name: 'setStrokeStyle',
+			args: ['rgba(0,0,0,0.1)']
+		}, {
 			name: 'beginPath',
 			args: []
 		}, {
 			name: 'moveTo',
 			args: [0, 10]
 		}, {
+			name: "closePath",
+			args: []
+		}, {
+			name: "stroke",
+			args: []
+		}, {
+			name: 'setStrokeStyle',
+			args: ['rgba(0,0,0,0.1)']
+		}, {
+			name: 'beginPath',
+			args: []
+		}, {
 			name: 'bezierCurveTo',
 			args: [0, 10, 5, 0, 5, 0]
+		}, {
+			name: "closePath",
+			args: []
+		}, {
+			name: "stroke",
+			args: []
+		}, {
+			name: 'setStrokeStyle',
+			args: ['rgba(0,0,0,0.1)']
+		}, {
+			name: 'beginPath',
+			args: []
 		}, {
 			name: 'bezierCurveTo',
 			args: [5, 0, 15, -10, 15, -10]
 		}, {
+			name: "closePath",
+			args: []
+		}, {
+			name: "stroke",
+			args: []
+		}, {
+			name: 'setStrokeStyle',
+			args: ['rgba(0,0,0,0.1)']
+		}, {
+			name: 'beginPath',
+			args: []
+		}, {
 			name: 'moveTo',
 			args: [19, -5]
+		}, {
+			name: 'closePath',
+			args: []
 		}, {
 			name: 'stroke',
 			args: [],


### PR DESCRIPTION
As discussed in #1779 the ability to set min and max options for the axes might cause some problems when we have data outside of those settings causing it flow outside of the chart area.

As being shown by @Raf2k:
![example](https://cloud.githubusercontent.com/assets/5588190/11810144/f3e9cd42-a33c-11e5-9721-29c72d06c1ae.png)


This fixes it.

![skarmavbild 2015-12-16 kl 15 11 59](https://cloud.githubusercontent.com/assets/1079027/11843001/61d4ae2e-a407-11e5-8478-f325c50f6074.png)

I'm not really sure about all possible edge cases though or if this even is the best approach to the problem.
There's also probably some tests that could be written along with the fixes. Not sure how though