### PR TITLE
Option to skip specific x-labels.

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -1779,6 +1779,10 @@
 				},this);
 
 				each(this.xLabels,function(label,index){
+					if (label === false) {
+						return;
+					}
+					
 					var xPos = this.calculateX(index) + aliasPixel(this.lineWidth),
 						// Check to see if line/bar here and decide where to place the line
 						linePos = this.calculateX(index - (this.offsetGridLines ? 0.5 : 0)) + aliasPixel(this.lineWidth),


### PR DESCRIPTION
In cases where you have a large data set, you probably wouldn't want to show every x-label. For example, if your x is the a list of dates and you have daily values for a year or more, you don't need a label for every day. Maybe you would only want specific intervals or maybe only the first day of each month or something. Rather than providing some option(s) that can be set to control this, I'm proposing that any value of `false` in the `xLabels` array simply be skipped. In this way, library users can control precisely which labels are shown using whatever logic they see fit.