### PR TITLE
Remove new tag from some features

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 		<link rel="stylesheet" type="text/css" href="assets/styles.css">
 		<meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, minimal-ui">
 		<script type="text/javascript" src="//use.typekit.net/dqv7hih.js"></script>
-<script type="text/javascript">try{Typekit.load();}catch(e){}</script>
+		<script type="text/javascript">try{Typekit.load();}catch(e){}</script>
 
 	</head>
 	<body>
@@ -49,14 +49,14 @@
 					<p>Chart.js is dependency free and super lightweight. All six core chart types are only <strong>11.01kb</strong> when minified, concatenated and served gzipped.</p>
 				</article>
 				<article>
-					<h3>Responsive <span class="badge new">new</span></h3>
+					<h3>Responsive</h3>
 					<div class="canvas-holder">
 						<img width="400" height="250" src="assets/responsive.svg"/>
 					</div>
 					<p>Chart.js will resize your chart if the browser changes size, along with providing the perfect scale granularity for that size</p>
 				</article>
 				<article>
-					<h3>Modular <span class="badge new">new</span></h3>
+					<h3>Modular</h3>
 					<div class="labeled-chart-container">
 						<div class="canvas-holder">
 							<canvas id="modular-doughnut" width="250" height="250">
@@ -66,7 +66,7 @@
 					<p>Chart.js is modular, and each of the chart types have been split up, so you can load only which chart types you need for your project</p>
 				</article>
 				<article>
-					<h3>Interactive <span class="badge new">new</span></h3>
+					<h3>Interactive</h3>
 					<div class="canvas-holder half">
 						<canvas id="interactive-bar" width="400" height="250">
 						</canvas>


### PR DESCRIPTION
These features have been around for quite some time now, so the indication that they are "new" no longer has to be used.