### PR TITLE
Fix #2221 by reducing graph range by one step when possible

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -456,6 +456,8 @@
 						//If the user has said integers only, we need to check that making the scale more granular wouldn't make it a float
 						if(stepValue/2 % 1 === 0){
 							stepValue /=2;
+							if ((graphMax - stepValue) >= maxValue)
+								graphRange -= stepValue;
 							numberOfSteps = Math.round(graphRange/stepValue);
 						}
 						//If it would make it a float break out of the loop
@@ -466,6 +468,8 @@
 					//If the scale doesn't have to be an int, make the scale more granular anyway.
 					else{
 						stepValue /=2;
+						if ((graphMax - stepValue) >= maxValue)
+							graphRange -= stepValue;
 						numberOfSteps = Math.round(graphRange/stepValue);
 					}
 


### PR DESCRIPTION
The algorithm used to determine the scale is centered around orders of magnitude, so there's always going to be potential for a large gap here (say, max value is 10,001), but it seems harmless enough to change the procedure where, if half-order-of-magnitude steps have been created, and the higher half of that range isn't being used, reducing the range of the graph by one step value. Just by changing the step value the rest of the values are then calculated correctly.