### PR TITLE
Fixes anchor link in docs

### DIFF
--- a/docs/05-Polar-Area-Chart.md
+++ b/docs/05-Polar-Area-Chart.md
@@ -76,7 +76,7 @@ These are the customisation options specific to Polar Area charts. These options
 
 Name | Type | Default | Description
 --- | --- | --- | ---
-scale | Array | [See Scales](#scales) and [Defaults for Radial Linear Scale](#getting-started-radial-linear-scale) | Options for the one scale used on the chart. Use this to style the ticks, labels, and grid.
+scale | Array | [See Scales](#scales) and [Defaults for Radial Linear Scale](#scales-radial-linear-scale) | Options for the one scale used on the chart. Use this to style the ticks, labels, and grid.
 *scale*.type | String |"radialLinear" | As defined in ["Radial Linear"](#scales-radial-linear-scale).
 *scale*.lineArc | Boolean | true | When true, lines are circular.
 animateRotate | Boolean |true | If true, will animate the rotation of the chart.

--- a/docs/06-Pie-Doughnut-Chart.md
+++ b/docs/06-Pie-Doughnut-Chart.md
@@ -90,7 +90,7 @@ Name | Type | Default | Description
 cutoutPercentage | Number | 50 - for doughnut, 0 - for pie | The percentage of the chart that is cut out of the middle.
 rotation | Number | -0.5 * Math.PI | Starting angle to draw arcs from
 circumference | Number | 2 * Math.PI | Sweep to allow arcs to cover
-scale | Array | [See Scales](#scales) and [Defaults for Radial Linear Scale](#getting-started-radial-linear-scale) | Options for the one scale used on the chart. Use this to style the ticks, labels, and grid.
+scale | Array | [See Scales](#scales) and [Defaults for Radial Linear Scale](#scales-radial-linear-scale) | Options for the one scale used on the chart. Use this to style the ticks, labels, and grid.
 *scale*.type | String |"radialLinear" | As defined in ["Radial Linear"](#scales-radial-linear-scale).
 *scale*.lineArc | Boolean | true | When true, lines are arced compared to straight when false.
 *animation*.animateRotate | Boolean |true | If true, will animate the rotation of the chart.


### PR DESCRIPTION
This fixes two anchor links in the docs for "Defaults for Radial Linear" which led to nowhere.