### PR TITLE
Removed scale option from pie/doughnut docs (not used)

### DIFF
--- a/docs/00-Getting-Started.md
+++ b/docs/00-Getting-Started.md
@@ -215,7 +215,7 @@ arc | Object | - | -
 *arc*.borderColor | Color | "#fff" | Default stroke color for arcs
 *arc*.borderWidth | Number | 2 | Default stroke width for arcs
 line | Object | - | -
-*line*.tension | Number | 0.4 | Default bezier curve tension. Set to `0` for no bezier curves.
+*line*.lineTension | Number | 0.4 | Default bezier curve tension. Set to `0` for no bezier curves.
 *line*.backgroundColor | Color | `Chart.defaults.global.defaultColor` | Default line fill color
 *line*.borderWidth | Number | 3 | Default line stroke width
 *line*.borderColor | Color | `Chart.defaults.global.defaultColor` | Default line stroke color

--- a/docs/04-Radar-Chart.md
+++ b/docs/04-Radar-Chart.md
@@ -97,7 +97,7 @@ Name | Type | Default | Description
 scale | Object | [See Scales](#scales) and [Defaults for Radial Linear Scale](#scales-radial-linear-scale) | Options for the one scale used on the chart. Use this to style the ticks, labels, and grid lines.
 *scale*.type | String |"radialLinear" | As defined in ["Radial Linear"](#scales-radial-linear-scale).
 *elements*.line | Object | | Options for all line elements used on the chart, as defined in the global elements, duplicated here to show Radar chart specific defaults.
-*elements.line*.tension | Number | 0 | Tension exhibited by lines when calculating splineCurve. Setting to 0 creates straight lines.
+*elements.line*.lineTension | Number | 0 | Tension exhibited by lines when calculating splineCurve. Setting to 0 creates straight lines.
 
 You can override these for your `Chart` instance by passing a second argument into the `Radar` method as an object with the keys you want to override.
 

--- a/docs/06-Pie-Doughnut-Chart.md
+++ b/docs/06-Pie-Doughnut-Chart.md
@@ -90,9 +90,6 @@ Name | Type | Default | Description
 cutoutPercentage | Number | 50 - for doughnut, 0 - for pie | The percentage of the chart that is cut out of the middle.
 rotation | Number | -0.5 * Math.PI | Starting angle to draw arcs from
 circumference | Number | 2 * Math.PI | Sweep to allow arcs to cover
-scale | Object | [See Scales](#scales) and [Defaults for Radial Linear Scale](#scales-radial-linear-scale) | Options for the one scale used on the chart. Use this to style the ticks, labels, and grid.
-*scale*.type | String |"radialLinear" | As defined in ["Radial Linear"](#scales-radial-linear-scale).
-*scale*.lineArc | Boolean | true | When true, lines are arced compared to straight when false.
 *animation*.animateRotate | Boolean |true | If true, will animate the rotation of the chart.
 *animation*.animateScale | Boolean | false | If true, will animate scaling the Doughnut from the centre.
 *legend*.*labels*.generateLabels | Function | `function(data) {} ` | Returns labels for each the legend


### PR DESCRIPTION
Also changed usages of tension in global element options and radar chart options to lineTension.