### PR TITLE
Fix incorrect default setting in documentation

### DIFF
--- a/docs/00-Getting-Started.md
+++ b/docs/00-Getting-Started.md
@@ -126,7 +126,7 @@ The global options for the chart title is defined in `Chart.defaults.global.titl
 
 Name | Type | Default | Description
 --- | --- | --- | ---
-display | Boolean | true | Show the title block
+display | Boolean | false | Show the title block
 position | String | 'top' | Position of the title. 'top' or 'bottom' are allowed
 fullWidth | Boolean | true | Marks that this box should take the full width of the canvas (pushing down other boxes)
 fontColor | Color  | '#666' | Text color


### PR DESCRIPTION
The current documentation indicates that the default setting for `Chart.defaults.global.title.display` is `true`, but it is actually `false`. (See [here](https://github.com/chartjs/Chart.js/blob/master/src/core/core.title.js#L8)).