### PR TITLE
Link to previous version docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ CDN: https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.0.0/Chart.js
 
 ## Documentation
 
-You can find documentation at [www.chartjs.org/docs](http://www.chartjs.org/docs). The markdown files that build the site are available under `/docs`. Please note - in some of the json examples of configuration you might notice some liquid tags - this is just for the generating the site html, please disregard.
+You can find documentation at [www.chartjs.org/docs](http://www.chartjs.org/docs). The markdown files that build the site are available under `/docs`. Previous version documentation is available at [www.chartjs.org/docs/#notes-previous-versions](http://www.chartjs.org/docs/#notes-previous-versions).
 
 ## Contributing
 

--- a/docs/08-Notes.md
+++ b/docs/08-Notes.md
@@ -2,6 +2,11 @@
 title: Notes
 anchor: notes
 ---
+### Previous versions
+
+Please note - documentation for previous versions are available on the GitHub repo.
+
+- [1.x Documentation](https://github.com/chartjs/Chart.js/tree/v1.1.1/docs)
 
 ### Browser support
 


### PR DESCRIPTION
This change points users in the direction of 1.x docs in the repo.