### PR TITLE
Randomize data button randomizes colors in pie chart demo

### DIFF
--- a/samples/pie.html
+++ b/samples/pie.html
@@ -96,7 +96,7 @@
         $.each(config.data.datasets, function(i, piece) {
             $.each(piece.data, function(j, value) {
                 config.data.datasets[i].data[j] = randomScalingFactor();
-                //config.data.datasets.backgroundColor[i] = 'rgba(' + randomColorFactor() + ',' + randomColorFactor() + ',' + randomColorFactor() + ',.7)';
+                config.data.datasets[i].backgroundColor[j] = randomColor(0.7);
             });
         });
         window.myPie.update();


### PR DESCRIPTION
Pie chart wasn't randomizing colors when Randomize Data button was clicked. The code to do this was commented out but incorrect. Fixed it and added it back it in. 

Figure someone learning the API would like to see the color change effect. Also, this makes it consistent with other chart samples like bar that do the color change on randomize.