### PR TITLE
Fix build to remove all comments other than header

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -76,9 +76,9 @@ function buildTask() {
     .pipe(insert.prepend(header))
     .pipe(streamify(replace('{{ version }}', package.version)))
     .pipe(gulp.dest(outDir))
-    .pipe(streamify(uglify({
-      preserveComments: 'some'
-    })))
+    .pipe(streamify(uglify()))
+    .pipe(insert.prepend(header))
+    .pipe(streamify(replace('{{ version }}', package.version)))
     .pipe(streamify(concat('Chart.bundle.min.js')))
     .pipe(gulp.dest(outDir));
 
@@ -89,9 +89,9 @@ function buildTask() {
     .pipe(insert.prepend(header))
     .pipe(streamify(replace('{{ version }}', package.version)))
     .pipe(gulp.dest(outDir))
-    .pipe(streamify(uglify({
-      preserveComments: 'some'
-    })))
+    .pipe(streamify(uglify()))
+    .pipe(insert.prepend(header))
+    .pipe(streamify(replace('{{ version }}', package.version)))
     .pipe(streamify(concat('Chart.min.js')))
     .pipe(gulp.dest(outDir));
 


### PR DESCRIPTION
This removes all comments that should not be in the final minified version ([example](https://github.com/chartjs/Chart.js/blob/master/dist/Chart.bundle.min.js#L11-L15)). It may seem that adding the comment to the build twice is repetitive, but it first adds it to the normal version and outputs, minifies, stripping all comments in the process, and then adds the header back in and outputs the minified version.