### PR TITLE
beginAtZero and linear scales with no data should play nice

### DIFF
--- a/src/scales/scale.linear.js
+++ b/src/scales/scale.linear.js
@@ -147,8 +147,11 @@ module.exports = function(Chart) {
 			}
 
 			if (this.min === this.max) {
-				this.min--;
 				this.max++;
+
+				if (!this.options.ticks.beginAtZero) {
+					this.min--;
+				}
 			}
 		},
 		buildTicks: function() {

--- a/test/scale.linear.tests.js
+++ b/test/scale.linear.tests.js
@@ -409,6 +409,31 @@ describe('Linear Scale', function() {
 		expect(chartInstance.scales.yScale0.max).toBe(1);
 	});
 
+	it('Should ensure that the scale has a max and min that are not equal when beginAtZero is set', function() {
+		chartInstance = window.acquireChart({
+			type: 'bar',
+			data: {
+				datasets: [],
+				labels: ['a', 'b', 'c', 'd', 'e', 'f']
+			},
+			options: {
+				scales: {
+					yAxes: [{
+						id: 'yScale0',
+						type: 'linear',
+						ticks: {
+							beginAtZero: true
+						}
+					}]
+				}
+			}
+		});
+
+		expect(chartInstance.scales.yScale0).not.toEqual(undefined); // must construct
+		expect(chartInstance.scales.yScale0.min).toBe(0);
+		expect(chartInstance.scales.yScale0.max).toBe(1);
+	});
+
 	it('Should use the suggestedMin and suggestedMax options', function() {
 		chartInstance = window.acquireChart({
 			type: 'bar',


### PR DESCRIPTION
Fixes #2476 

## New Behaviour
If there is no data and `beginAtZero` is true, the min will be 0 and the max will be 1
![new behaviour](https://cloud.githubusercontent.com/assets/6757853/15094533/b92dc45c-1474-11e6-9f6c-4c64bcc380fc.png)
