### PR TITLE
Added new plugin Callback `afterScaleUpdate`

### DIFF
--- a/docs/07-Advanced.md
+++ b/docs/07-Advanced.md
@@ -377,6 +377,7 @@ Plugins will be called at the following times
 * Start of initialization
 * End of initialization
 * Start of update
+* After the chart scales have calculated
 * End of update (before render occurs)
 * Start of draw
 * End of draw
@@ -389,6 +390,7 @@ Plugins should derive from Chart.PluginBase and implement the following interfac
 	afterInit: function(chartInstance) { },
 
 	beforeUpdate: function(chartInstance) { },
+	afterScaleUpdate: function(chartInstance) { }
 	afterUpdate: function(chartInstance) { },
 
 	// This is called at the start of a render. It is only called once, even if the animation will run for a number of frames. Use beforeDraw or afterDraw 

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -257,6 +257,9 @@ module.exports = function(Chart) {
 
 			Chart.layoutService.update(this, this.chart.width, this.chart.height);
 
+			// Apply changes to the dataets that require the scales to have been calculated i.e BorderColor chages
+			Chart.pluginService.notifyPlugins('afterScaleUpdate', [this]);
+
 			// Can only reset the new controllers after the scales have been updated
 			helpers.each(newControllers, function(controller) {
 				controller.reset();


### PR DESCRIPTION
Following a Slack conversation add new Callback to allow updates to datasets config (ie borderColor) based on results of the calculated scale, A typical use case would be apply a Gradient fill.

On branch feature_New_plugin_interface_afterScaleUpdate
Changes to be committed:
	modified:   docs/07-Advanced.md
	modified:   src/core/core.controller.js
