### PR TITLE
Update 03-Bar-Chart.md

### DIFF
--- a/docs/03-Bar-Chart.md
+++ b/docs/03-Bar-Chart.md
@@ -79,7 +79,6 @@ The default options for bar chart are defined in `Chart.defaults.bar`.
 
 Name | Type | Default | Description
 --- |:---:| --- | ---
-stacked | Boolean | false |
 *hover*.mode | String | "label" | Label's hover mode. "label" is used since the x axis displays data by the index in the dataset.
 scales | Object | - | -
 *scales*.xAxes | Array |  | The bar chart officially supports only 1 x-axis but uses an array to keep the API consistent. Use a scatter chart if you need multiple x axes.
@@ -87,6 +86,7 @@ scales | Object | - | -
 type | String | "Category" | As defined in [Scales](#scales-category-scale).
 display | Boolean | true | If true, show the scale.
 id | String | "x-axis-1" | Id of the axis so that data can bind to it
+stacked | Boolean | false | If true, bars are stacked on the x-axis
 categoryPercentage | Number | 0.8 | Percent (0-1) of the available width (the space between the gridlines for small datasets) for each data-point to use for the bars. [Read More](#bar-chart-barpercentage-vs-categorypercentage)
 barPercentage | Number | 0.9 | Percent (0-1) of the available width each bar should be within the category percentage. 1.0 will take the whole category width and put the bars right next to each other. [Read More](#bar-chart-barpercentage-vs-categorypercentage)
 gridLines | Object |  [See Scales](#scales) |
@@ -97,6 +97,7 @@ gridLines | Object |  [See Scales](#scales) |
 type | String | "linear" | As defined in [Scales](#scales-linear-scale).
 display | Boolean | true | If true, show the scale.
 id | String | "y-axis-1" | Id of the axis so that data can bind to it.
+stacked | Boolean | false | If true, bars are stacked on the y-axis
 
 You can override these for your `Chart` instance by passing a second argument into the `Bar` method as an object with the keys you want to override.
 


### PR DESCRIPTION
Fix documentation of stacked option to be a subset of the axes rather than a global attribute on a bar chart. The attribute chart was inconsistent with the example below it. It seems the example is correct and the chart was incorrect.