### PR TITLE
Bump chartjs-color to version 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "main": "Chart.js"
   },
   "dependencies": {
-    "chartjs-color": "^1.0.2",
+    "chartjs-color": "^2.0.0",
     "moment": "^2.10.6"
   }
 }

--- a/src/core/core.element.js
+++ b/src/core/core.element.js
@@ -60,7 +60,7 @@ module.exports = function(Chart) {
         // Color transitions if possible
         else if (typeof value === 'string') {
           try {
-            var color = helpers.color(this._start[key]).mix(helpers.color(this._model[key]), ease);
+            var color = helpers.color(this._model[key]).mix(helpers.color(this._start[key]), ease);
             this._view[key] = color.rgbString();
           } catch (err) {
             this._view[key] = value;


### PR DESCRIPTION
Let's use the new chartjs-color repository!

Also [fix mix](https://github.com/chartjs/chartjs-color/commit/1a82d1efc122ee8cc47008298504f1b57845ee81) ;) Fix color animation because the color lib changed the `mix` implementation to match SASS behavior, so the weight specifies the amount of the first color that should be included in the returned color.