### PR TITLE
Fixed tooltip not showing in NULL datapoint in multi line chart

### DIFF
--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -197,7 +197,7 @@ module.exports = function(Chart) {
 			var yPositions = [];
 
 			helpers.each(elements, function(el) {
-				if (el) {
+				if (el && el.hasValue()){
 					var pos = el.tooltipPosition();
 					xPositions.push(pos.x);
 					yPositions.push(pos.y);


### PR DESCRIPTION
Example:
http://codepen.io/adileo/pen/oxRxGw

The 3rd datapoint is NULL in one chart and that affects the calculation of the tooltip position. The position is calculated here: `core.tooltip.js` `getAveragePosition`

Checking if the point `hasValue()` before pushing it into the list avoids the error.