### PR TITLE
Fix handling of moments by scale.getRightValue

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -396,7 +396,7 @@ module.exports = function(Chart) {
 			}
 			// If it is in fact an object, dive in one more level
 			if (typeof(rawValue) === "object") {
-				if (rawValue instanceof Date) {
+				if ((rawValue instanceof Date) || (rawValue.isValid)) {
 					return rawValue;
 				} else {
 					return getRightValue(this.isHorizontal() ? rawValue.x : rawValue.y);


### PR DESCRIPTION
When using {x: moment, y: value} datapoints