### PR TITLE
This fixes #2584

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -506,7 +506,7 @@ module.exports = function(Chart) {
 				var yTickEnd = options.position === "bottom" ? this.top + tl : this.bottom;
 				skipRatio = false;
 
-                // Only calculate the skip ratio with the half width of longestRotateLabel if we got an ü
+                // Only calculate the skip ratio with the half width of longestRotateLabel if we got an actual rotation
                 // See #2584
                 if (isRotated) {
                     longestRotatedLabel /= 2;

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -506,8 +506,14 @@ module.exports = function(Chart) {
 				var yTickEnd = options.position === "bottom" ? this.top + tl : this.bottom;
 				skipRatio = false;
 
-				if (((longestRotatedLabel / 2) + optionTicks.autoSkipPadding) * this.ticks.length > (this.width - (this.paddingLeft + this.paddingRight))) {
-					skipRatio = 1 + Math.floor((((longestRotatedLabel / 2) + optionTicks.autoSkipPadding) * this.ticks.length) / (this.width - (this.paddingLeft + this.paddingRight)));
+                // Only calculate the skip ratio with the half width of longestRotateLabel if we got an ü
+                // See #2584
+                if (isRotated) {
+                    longestRotatedLabel /= 2;
+                }
+
+				if ((longestRotatedLabel + optionTicks.autoSkipPadding) * this.ticks.length > (this.width - (this.paddingLeft + this.paddingRight))) {
+					skipRatio = 1 + Math.floor(((longestRotatedLabel + optionTicks.autoSkipPadding) * this.ticks.length) / (this.width - (this.paddingLeft + this.paddingRight)));
 				}
 
 				// if they defined a max number of optionTicks,


### PR DESCRIPTION
This fixes the issue when using `maxRotation: 0`.

The problem occurred, because the `skipRatio` is calculate with `longestRotatedLabel / 2`, which doesn't work if we don't have any rotated labels. So I just check if we got a rotation.

Anyways, this doesn't works if `maxRotation` is set at least to `1`. A real collision detection would of course be better.

