### PR TITLE
This fixes #2599

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -274,23 +274,20 @@ module.exports = function(Chart) {
 			}
 
 			// Always show the right tick
-			var diff = this.ticks[this.ticks.length - 1].diff(this.lastTick, this.tickUnit);
-			if (diff !== 0 || this.scaleSizeInUnits === 0) {
-                this.ticks.push(this.lastTick.clone());
-
-                // Remove the next to the last tick, so it won't be overlapping with the last one. See #2599
-                if (this.ticks.length >= 2) {
-                    this.ticks.splice(this.ticks.length - 2, 1);
+            if (!this.options.ticks.allowSkipLastTick) {
+                var diff = this.ticks[this.ticks.length - 1].diff(this.lastTick, this.tickUnit);
+                if (diff !== 0 || this.scaleSizeInUnits === 0) {
+                    // this is a weird case. If the <max> option is the same as the end option, we can't just diff the times because the tick was created from the roundedStart
+                    // but the last tick was not rounded.
+                    if (this.options.time.max) {
+                        this.ticks.push(this.lastTick.clone());
+                        this.scaleSizeInUnits = this.lastTick.diff(this.ticks[0], this.tickUnit, true);
+                    } else {
+                        this.ticks.push(this.lastTick.clone());
+                        this.scaleSizeInUnits = this.lastTick.diff(this.firstTick, this.tickUnit, true);
+                    }
                 }
-
-                // this is a weird case. If the <max> option is the same as the end option, we can't just diff the times because the tick was created from the roundedStart
-                // but the last tick was not rounded.
-                if (this.options.time.max) {
-                    this.scaleSizeInUnits = this.lastTick.diff(this.ticks[0], this.tickUnit, true);
-                } else {
-                    this.scaleSizeInUnits = this.lastTick.diff(this.firstTick, this.tickUnit, true);
-                }
-			}
+            }
 
 			this.ctx.restore();
 		},

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -276,15 +276,20 @@ module.exports = function(Chart) {
 			// Always show the right tick
 			var diff = this.ticks[this.ticks.length - 1].diff(this.lastTick, this.tickUnit);
 			if (diff !== 0 || this.scaleSizeInUnits === 0) {
-				// this is a weird case. If the <max> option is the same as the end option, we can't just diff the times because the tick was created from the roundedStart
-				// but the last tick was not rounded.
-				if (this.options.time.max) {
-					this.ticks.push(this.lastTick.clone());
-					this.scaleSizeInUnits = this.lastTick.diff(this.ticks[0], this.tickUnit, true);
-				} else {
-					this.ticks.push(this.lastTick.clone());
-					this.scaleSizeInUnits = this.lastTick.diff(this.firstTick, this.tickUnit, true);
-				}
+                this.ticks.push(this.lastTick.clone());
+
+                // Remove the next to the last tick, so it won't be overlapping with the last one. See #2599
+                if (this.ticks.length >= 2) {
+                    this.ticks.splice(this.ticks.length - 2, 1);
+                }
+
+                // this is a weird case. If the <max> option is the same as the end option, we can't just diff the times because the tick was created from the roundedStart
+                // but the last tick was not rounded.
+                if (this.options.time.max) {
+                    this.scaleSizeInUnits = this.lastTick.diff(this.ticks[0], this.tickUnit, true);
+                } else {
+                    this.scaleSizeInUnits = this.lastTick.diff(this.firstTick, this.tickUnit, true);
+                }
 			}
 
 			this.ctx.restore();


### PR DESCRIPTION
This hides the next to the last tick, since the last tick is always shown.

Before:
![bildschirmfoto 2016-05-19 um 14 00 42](https://cloud.githubusercontent.com/assets/13450260/15393127/e1b624cc-1dcb-11e6-8756-98fd95068443.png)

After:
![bildschirmfoto 2016-05-19 um 14 01 03](https://cloud.githubusercontent.com/assets/13450260/15393130/eb595eea-1dcb-11e6-80c6-a18b45ee379d.png)
