### PR TITLE
Fix for documentation issue #2628

### DIFF
--- a/docs/02-Line-Chart.md
+++ b/docs/02-Line-Chart.md
@@ -128,9 +128,11 @@ new Chart(ctx, {
 	type: 'line',
 	data: data,
 	options: {
-		xAxes: [{
-			display: false
-		}]
+		scales: {
+			xAxes: [{
+				display: false
+			}]
+		}
 	}
 });
 // This will create a chart with all of the default options, merged from the global config,


### PR DESCRIPTION
Added `scales` to make the example work. Fixes documentation issue #2628 concerning the Line chart options example .