### PR TITLE
When destroying the chart, any animations should be stopped.

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -434,6 +434,7 @@ module.exports = function(Chart) {
 		},
 
 		destroy: function destroy() {
+			this.stop();
 			this.clear();
 			helpers.unbindEvents(this, this.events);
 			helpers.removeResizeListener(this.chart.canvas.parentNode);


### PR DESCRIPTION
Fixes #2613 

## Testing Done

Created fiddle from issue locally and verified that it was fixed.