### PR TITLE
Change templates for issues/PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,2 +1,9 @@
-- [ ] I have read the [guidelines for contributing](https://github.com/chartjs/Chart.js/blob/master/CONTRIBUTING.md)
-- [ ] I have included an example of my issue on a website such as [JS Bin](http://jsbin.com/), [JS Fiddle](http://jsfiddle.net/), or [Codepen](http://codepen.io/pen/). ([Template](http://codepen.io/pen?template=JXVYzq))
+Please consider the following before submitting an issue:
+
+Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/CONTRIBUTING.md
+
+Example of issue on an interactive website such as the following:
+- http://jsbin.com/
+- http://jsfiddle.net/
+- http://codepen.io/pen/
+- Premade template: http://codepen.io/pen?template=JXVYzq

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,2 +1,9 @@
-- [ ] I have read the [guidelines for contributing](https://github.com/chartjs/Chart.js/blob/master/CONTRIBUTING.md)
-- [ ] I have included an example of my changes on a website such as [JS Bin](http://jsbin.com/), [JS Fiddle](http://jsfiddle.net/), or [Codepen](http://codepen.io/pen/). ([Template](http://codepen.io/pen?template=JXVYzq))
+Please consider the following before submitting a pull request:
+
+Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/CONTRIBUTING.md
+
+Example of changes on an interactive website such as the following:
+- http://jsbin.com/
+- http://jsfiddle.net/
+- http://codepen.io/pen/
+- Premade template: http://codepen.io/pen?template=JXVYzq


### PR DESCRIPTION
Since the templates do not show in markdown by default, these changes make it easier to understand what is requested when submitting an issue. Most people delete it before submitting anyway so it is not useful to have it in checklist form. Also addresses #2663 