### PR TITLE
Added a reference to Chart within Chart for Issue #2483

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -100,6 +100,8 @@ module.exports = function() {
 		}
 	};
 
+	Chart.Chart = Chart;
+
 	return Chart;
 
 };


### PR DESCRIPTION
Issue being fixed: https://github.com/chartjs/Chart.js/issues/2483

Single line changed, just added a reference to the Chart object on itself before returning it from `core.js`. All unit tests passed locally, and I imported it in a current project to make sure it's accessible.

```javascript
// These are now equivalent
import { Chart } from "chart.js";
require("chart.js");
```