### PR TITLE
This PR allows for multi-line labels, as per Slack discussion..

### DIFF
--- a/docs/02-Scales.md
+++ b/docs/02-Scales.md
@@ -74,7 +74,7 @@ The grid line configuration is nested under the scale configuration in the `tick
 Name | Type | Default | Description
 --- | --- | --- | ---
 autoSkip | Boolean | true | If true, automatically calculates how many labels that can be shown and hides labels accordingly. Turn it off to show all labels no matter what
-callback | Function | `function(value) { return '' + value; } ` | Returns the string representation of the tick value as it should be displayed on the chart. See [callback](#scales-creating-custom-tick-formats) section below.
+callback | Function | `function(value) { return helpers.isArray(value) ? value : '' + value; }` | Returns the string representation of the tick value as it should be displayed on the chart. See [callback](#scales-creating-custom-tick-formats) section below.
 display | Boolean | true | If true, show the ticks.
 fontColor | Color | "#666" | Font color for the tick labels.
 fontFamily | String | "'Helvetica Neue', 'Helvetica', 'Arial', sans-serif" | Font family for the tick labels, follows CSS font-family options.
@@ -359,8 +359,8 @@ The default configuration for a scale can be easily changed using the scale serv
 For example, to set the minimum value of 0 for all linear scales, you would do the following. Any linear scales created after this time would now have a minimum of 0.
 ```
 Chart.scaleService.updateScaleDefaults('linear', {
-	ticks: {
-		min: 0
-	}
+    ticks: {
+        min: 0
+    }
 })
 ```

--- a/docs/03-Line-Chart.md
+++ b/docs/03-Line-Chart.md
@@ -96,7 +96,7 @@ The label key on each dataset is optional, and can be used when generating a sca
 
 ### Data Points
 
-The data passed to the chart can be passed in two formats. The most common method is to pass the data array as an array of numbers. In this case, the `data.labels` array must be specified and must contain a label for each point.
+The data passed to the chart can be passed in two formats. The most common method is to pass the data array as an array of numbers. In this case, the `data.labels` array must be specified and must contain a label for each point or, in the case of labels to be displayed over multiple lines an array of labels (one for each line) i.e `[["June","2015"], "July"]`.
 
 The alternate is used for sparse datasets. Data is specified using an object containing `x` and `y` properties. This is used for scatter charts as documented below.
 

--- a/samples/line-multiline-labels.html
+++ b/samples/line-multiline-labels.html
@@ -1,0 +1,218 @@
+<!doctype html>
+<html>
+
+<head>
+    <title>Line Chart</title>
+    <script src="../dist/Chart.bundle.js"></script>
+    <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+    <style>
+    canvas{
+        -moz-user-select: none;
+        -webkit-user-select: none;
+        -ms-user-select: none;
+    }
+    </style>
+</head>
+
+<body>
+    <div style="width:90%;">
+        <canvas id="canvas"></canvas>
+    </div>
+    <br>
+    <br>
+    <button id="randomizeData">Randomize Data</button>
+    <button id="changeDataObject">Change Data Object</button>
+    <button id="addDataset">Add Dataset</button>
+    <button id="removeDataset">Remove Dataset</button>
+    <button id="addData">Add Data</button>
+    <button id="removeData">Remove Data</button>
+    <script>
+        var MONTHS = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+        
+        var randomScalingFactor = function() {
+            return Math.round(Math.random() * 100);
+            //return 0;
+        };
+        var randomColorFactor = function() {
+            return Math.round(Math.random() * 255);
+        };
+        var randomColor = function(opacity) {
+            return 'rgba(' + randomColorFactor() + ',' + randomColorFactor() + ',' + randomColorFactor() + ',' + (opacity || '.3') + ')';
+        };
+
+        var config = {
+            type: 'line',
+            data: {
+                labels: [["June","2015"], "July", "August", "September", "October", "November", "December", ["January","2016"],"February", "March", "April", "May"],
+                datasets: [{
+                    label: "My First dataset",
+                    data: [randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor()],
+                    fill: false,
+                    borderDash: [5, 5],
+                }, {
+                    hidden: true,
+                    label: 'hidden dataset',
+                    data: [randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor()],
+                }, {
+                    label: "My Second dataset",
+                    data: [randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor()],
+                }]
+            },
+            options: {
+                responsive: true,
+                title:{
+                    display:true,
+                    text:'Chart.js Line Chart'
+                },
+                tooltips: {
+                    mode: 'label',
+                    callbacks: {
+                        // beforeTitle: function() {
+                        //     return '...beforeTitle';
+                        // },
+                        // afterTitle: function() {
+                        //     return '...afterTitle';
+                        // },
+                        // beforeBody: function() {
+                        //     return '...beforeBody';
+                        // },
+                        // afterBody: function() {
+                        //     return '...afterBody';
+                        // },
+                        // beforeFooter: function() {
+                        //     return '...beforeFooter';
+                        // },
+                        // footer: function() {
+                        //     return 'Footer';
+                        // },
+                        // afterFooter: function() {
+                        //     return '...afterFooter';
+                        // },
+                    }
+                },
+                hover: {
+                    mode: 'dataset'
+                },
+                scales: {
+                    xAxes: [{
+                        display: true,
+                        scaleLabel: {
+                            show: true,
+                            labelString: 'Month'
+                        }
+                    }],
+                    yAxes: [{
+                        display: true,
+                        scaleLabel: {
+                            show: true,
+                            labelString: 'Value'
+                        },
+                        ticks: {
+                            suggestedMin: -10,
+                            suggestedMax: 250,
+                        }
+                    }]
+                }
+            }
+        };
+
+        $.each(config.data.datasets, function(i, dataset) {
+            dataset.borderColor = randomColor(0.4);
+            dataset.backgroundColor = randomColor(0.5);
+            dataset.pointBorderColor = randomColor(0.7);
+            dataset.pointBackgroundColor = randomColor(0.5);
+            dataset.pointBorderWidth = 1;
+        });
+
+        window.onload = function() {
+            var ctx = document.getElementById("canvas").getContext("2d");
+            window.myLine = new Chart(ctx, config);
+        };
+
+        $('#randomizeData').click(function() {
+            $.each(config.data.datasets, function(i, dataset) {
+                dataset.data = dataset.data.map(function() {
+                    return randomScalingFactor();
+                });
+
+            });
+
+            window.myLine.update();
+        });
+
+        $('#changeDataObject').click(function() {
+            config.data = {
+                labels: ["July", "August", "September", "October", "November", "December"],
+                datasets: [{
+                    label: "My First dataset",
+                    data: [randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor()],
+                    fill: false,
+                }, {
+                    label: "My Second dataset",
+                    fill: false,
+                    data: [randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor()],
+                }]
+            };
+
+            $.each(config.data.datasets, function(i, dataset) {
+                dataset.borderColor = randomColor(0.4);
+                dataset.backgroundColor = randomColor(0.5);
+                dataset.pointBorderColor = randomColor(0.7);
+                dataset.pointBackgroundColor = randomColor(0.5);
+                dataset.pointBorderWidth = 1;
+            });
+
+            // Update the chart
+            window.myLine.update();
+        });
+
+        $('#addDataset').click(function() {
+            var newDataset = {
+                label: 'Dataset ' + config.data.datasets.length,
+                borderColor: randomColor(0.4),
+                backgroundColor: randomColor(0.5),
+                pointBorderColor: randomColor(0.7),
+                pointBackgroundColor: randomColor(0.5),
+                pointBorderWidth: 1,
+                data: [],
+            };
+
+            for (var index = 0; index < config.data.labels.length; ++index) {
+                newDataset.data.push(randomScalingFactor());
+            }
+
+            config.data.datasets.push(newDataset);
+            window.myLine.update();
+        });
+
+        $('#addData').click(function() {
+            if (config.data.datasets.length > 0) {
+                var month = MONTHS[config.data.labels.length % MONTHS.length];
+                config.data.labels.push(month);
+
+                $.each(config.data.datasets, function(i, dataset) {
+                    dataset.data.push(randomScalingFactor());
+                });
+
+                window.myLine.update();
+            }
+        });
+
+        $('#removeDataset').click(function() {
+            config.data.datasets.splice(0, 1);
+            window.myLine.update();
+        });
+
+        $('#removeData').click(function() {
+            config.data.labels.splice(-1, 1); // remove the label first
+
+            config.data.datasets.forEach(function(dataset, datasetIndex) {
+                dataset.data.pop();
+            });
+
+            window.myLine.update();
+        });
+    </script>
+</body>
+
+</html>

--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -839,7 +839,7 @@ module.exports = function(Chart) {
 				// to do maybe simplify this function a bit so we can do this more recursively?
 				helpers.each(thing, function(nestedThing) {
 					// Undefined strings and arrays should not be measured
-					if (nestedThing !== undefined && nestedThing !== null && helpers.isArray(nestedThing)) {
+					if (nestedThing !== undefined && nestedThing !== null && !helpers.isArray(nestedThing)) {
 						longest = helpers.measureText(ctx, data, gc, longest, nestedThing);
 					}
 				});

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -43,6 +43,7 @@ module.exports = function(Chart) {
 			autoSkip: true,
 			autoSkipPadding: 0,
 			labelOffset: 0,
+			// We pass through arrays to be rendered as multiline labels, we convert Others to strings here.
 			callback: function(value) {
 				return helpers.isArray(value) ? value : '' + value;
 			}
@@ -548,7 +549,6 @@ module.exports = function(Chart) {
 				helpers.each(this.ticks, function (label, index) {
 					// Blank optionTicks
 					var isLastTick = this.ticks.length === index + 1;
-					var lineHeight;
 
 					// Since we always show the last tick,we need may need to hide the last shown one before
 					var shouldSkip = (skipRatio > 1 && index % skipRatio > 0) || (index % skipRatio === 0 && index + skipRatio >= this.ticks.length);
@@ -597,13 +597,13 @@ module.exports = function(Chart) {
 						context.font = tickLabelFont;
 						context.textAlign = (isRotated) ? "right" : "center";
 						context.textBaseline = (isRotated) ? "middle" : options.position === "top" ? "bottom" : "top";
-						
-						lineHeight = context.measureText("M").width * 1.2;
-
+					
 						if (helpers.isArray(label)) {
 							for (var i = 0, y = 0; i < label.length; ++i) {
-								context.fillText(label[i], 0, y);
-								y += lineHeight;
+								// We just make sure the multiline element is a string here..
+								context.fillText('' + label[i], 0, y);
+								// apply same lineSpacing as calculated @ L#320
+								y += (tickFontSize * 1.5);
 							}
 						} else {
 							context.fillText(label, 0, 0);

--- a/test/core.helpers.tests.js
+++ b/test/core.helpers.tests.js
@@ -454,6 +454,68 @@ describe('Core helper tests', function() {
 		}]);
 	});
 
+	it('should return the width of the longest text in an Array and 2D Array', function() {
+		var context = window.createMockContext();
+		var font = "normal 12px 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif";
+		var arrayOfThings_1D = ['FooBar','Bar'];
+		var arrayOfThings_2D = [['FooBar_1','Bar_2'],'Foo_1'];
+		
+
+		// Regardless 'FooBar' is the longest label it should return (charcters * 10)
+		expect(helpers.longestText(context, font, arrayOfThings_1D, {})).toEqual(60);
+		expect(helpers.longestText(context, font, arrayOfThings_2D, {})).toEqual(80);
+		// We check to make sure we made the right calls to the canvas.
+		expect(context.getCalls()).toEqual([{
+			name: 'measureText',
+			args: ['FooBar']
+		}, {
+			name: 'measureText',
+			args: ['Bar']
+		}, {
+			name: 'measureText',
+			args: ['FooBar_1']
+		}, {
+			name: 'measureText',
+			args: ['Bar_2']
+		}, {
+			name: 'measureText',
+			args: ['Foo_1']
+		}]);
+	});
+
+	it('compare text with current longest and update', function() {
+		var context = window.createMockContext();
+		var data = {};
+		var gc = [];
+		var longest = 70;
+
+		expect(helpers.measureText(context, data, gc, longest, 'foobar')).toEqual(70);
+		expect(helpers.measureText(context, data, gc, longest, 'foobar_')).toEqual(70);
+		expect(helpers.measureText(context, data, gc, longest, 'foobar_1')).toEqual(80);
+		// We check to make sure we made the right calls to the canvas.
+		expect(context.getCalls()).toEqual([{
+			name: 'measureText',
+			args: ['foobar']
+		}, {
+			name: 'measureText',
+			args: ['foobar_']
+		}, {
+			name: 'measureText',
+			args: ['foobar_1']
+		}]);
+	});
+
+	it('count look at all the labels and return maximum number of lines', function() {
+		var context = window.createMockContext();
+		var arrayOfThings_1 = ['Foo','Bar'];
+		var arrayOfThings_2 = [['Foo','Bar'],'Foo'];
+		var arrayOfThings_3 = [['Foo','Bar','Boo'],['Foo','Bar'],'Foo'];
+
+		expect(helpers.numberOfLabelLines(arrayOfThings_1)).toEqual(1);
+		expect(helpers.numberOfLabelLines(arrayOfThings_2)).toEqual(2);
+		expect(helpers.numberOfLabelLines(arrayOfThings_3)).toEqual(3);
+	});
+
 	it('should draw a rounded rectangle', function() {
 		var context = window.createMockContext();
 		helpers.drawRoundedRectangle(context, 10, 20, 30, 40, 5);


### PR DESCRIPTION
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/CONTRIBUTING.md

Example of changes on an interactive website such as the following:
- http://jsbin.com/
- http://jsfiddle.net/
- http://codepen.io/pen/
- Premade template: http://codepen.io/pen?template=JXVYzq

Usage: If a label is an `array` as opposed to a `string` i.e. `[["June","2015"], "July"]` then each element is treated as a seperate line. The appropriate calculations are made to determine the correct height and width, and rotation is still supported.

view samples/line-multiline-labels.html to see it working.

On branch multiline_labels
Changes to be committed:
	modified:   docs/03-Line-Chart.md
	new file:   samples/line-multiline-labels.html
	modified:   src/core/core.helpers.js
	modified:   src/core/core.scale.js