### PR TITLE
Amend build task with flag for AMD compatible builds (#2298)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -69,7 +69,7 @@ gulp.task('default', ['build', 'watch']);
 
 function buildTask() {
 
-  var bundled = browserify('./src/chart.js')
+  var bundled = browserify('./src/chart.js', { standalone: 'Chart' })
     .bundle()
     .pipe(source('Chart.bundle.js'))
     .pipe(insert.prepend(header))
@@ -81,7 +81,7 @@ function buildTask() {
     .pipe(streamify(concat('Chart.bundle.min.js')))
     .pipe(gulp.dest(outDir));
 
-  var nonBundled = browserify('./src/chart.js')
+  var nonBundled = browserify('./src/chart.js', { standalone: 'Chart' })
     .ignore('moment')
     .bundle()
     .pipe(source('Chart.js'))


### PR DESCRIPTION
Adds flag to build task to make outputs AMD compatible. This functionality seems to have been lost when the build setup was changed after 2.0.0beta. See issue https://github.com/chartjs/Chart.js/issues/2298