### PR TITLE
Use bundle-collapser to reduce build size

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,7 +18,8 @@ var gulp = require('gulp'),
   browserify = require('browserify'),
   streamify = require('gulp-streamify'),
   source = require('vinyl-source-stream'),
-  merge = require('merge-stream');
+  merge = require('merge-stream'),
+  collapse = require('bundle-collapser/plugin');
 
 var srcDir = './src/';
 var outDir = './dist/';
@@ -70,6 +71,7 @@ gulp.task('default', ['build', 'watch']);
 function buildTask() {
 
   var bundled = browserify('./src/chart.js', { standalone: 'Chart' })
+    .plugin(collapse)
     .bundle()
     .pipe(source('Chart.bundle.js'))
     .pipe(insert.prepend(header))
@@ -83,6 +85,7 @@ function buildTask() {
 
   var nonBundled = browserify('./src/chart.js', { standalone: 'Chart' })
     .ignore('moment')
+    .plugin(collapse)
     .bundle()
     .pipe(source('Chart.js'))
     .pipe(insert.prepend(header))
@@ -125,10 +128,10 @@ function bumpTask(complete) {
     // Write these to their own files, then build the output
     fs.writeFileSync('package.json', JSON.stringify(package, null, 2));
     fs.writeFileSync('bower.json', JSON.stringify(bower, null, 2));
-    
+
     var oldCDN = 'https://cdnjs.cloudflare.com/ajax/libs/Chart.js/'+oldVersion+'/Chart.min.js',
       newCDN = 'https://cdnjs.cloudflare.com/ajax/libs/Chart.js/'+newVersion+'/Chart.min.js';
-    
+
     gulp.src(['./README.md'])
       .pipe(replace(oldCDN, newCDN))
       .pipe(gulp.dest('./'));

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "browserify": "^13.0.0",
     "browserify-istanbul": "^0.2.1",
+    "bundle-collapser": "^1.2.1",
     "coveralls": "^2.11.6",
     "gulp": "3.9.x",
     "gulp-concat": "~2.1.x",


### PR DESCRIPTION
An easy change to save some bits: this [browserify plugin](https://github.com/substack/bundle-collapser) converts required string paths to int, lowering our *.min.js by ~1.8KB.

Partial diff of this change:

![image](https://cloud.githubusercontent.com/assets/3874900/15804316/4722b36c-2b04-11e6-8f35-390a5cd91eaf.png)