### PR TITLE
Add spanGaps option to line chart datasets

### DIFF
--- a/docs/03-Line-Chart.md
+++ b/docs/03-Line-Chart.md
@@ -84,6 +84,7 @@ var data = {
 			pointRadius: 1,
 			pointHitRadius: 10,
 			data: [65, 59, 80, 81, 56, 55, 40],
+			spanGaps: false,
 		}
 	]
 };
@@ -93,6 +94,8 @@ The line chart usually requires an array of labels. This labels are shown on the
 The data for line charts is broken up into an array of datasets. Each dataset has a colour for the fill, a colour for the line and colours for the points and strokes of the points. These colours are strings just like CSS. You can use RGBA, RGB, HEX or HSL notation.
 
 The label key on each dataset is optional, and can be used when generating a scale for the chart.
+
+When `spanGaps` is set to true, the gaps between points in sparse datasets are filled in. By default, it is off.
 
 ### Data Points
 

--- a/src/elements/element.line.js
+++ b/src/elements/element.line.js
@@ -21,14 +21,10 @@ module.exports = function(Chart) {
 		lineToNextPoint: function(previousPoint, point, nextPoint, skipHandler, previousSkipHandler) {
 			var me = this;
 			var ctx = me._chart.ctx;
-			
-			// This adds an option to all data arrays in the dataset options to let
-			// line bars span gaps. This is useful with sparse data.
-			var spanGaps = this._chart.config.data.datasets[point._datasetIndex].spanGaps
 
-			if (point._view.skip && !spanGaps) {
+			if (point._view.skip && !me._model.spanGaps) {
 				skipHandler.call(me, previousPoint, point, nextPoint);
-			} else if (previousPoint._view.skip && !spanGaps) {
+			} else if (previousPoint._view.skip && !me._model.spanGaps) {
 				previousSkipHandler.call(me, previousPoint, point, nextPoint);
 			} else if (point._view.tension === 0) {
 				ctx.lineTo(point._view.x, point._view.y);

--- a/src/elements/element.line.js
+++ b/src/elements/element.line.js
@@ -21,10 +21,14 @@ module.exports = function(Chart) {
 		lineToNextPoint: function(previousPoint, point, nextPoint, skipHandler, previousSkipHandler) {
 			var me = this;
 			var ctx = me._chart.ctx;
+			
+			// This adds an option to all data arrays in the dataset options to let
+			// line bars span gaps. This is useful with sparse data.
+			var spanGaps = this._chart.config.data.datasets[point._datasetIndex].spanGaps
 
-			if (point._view.skip) {
+			if (point._view.skip && !spanGaps) {
 				skipHandler.call(me, previousPoint, point, nextPoint);
-			} else if (previousPoint._view.skip) {
+			} else if (previousPoint._view.skip && !spanGaps) {
 				previousSkipHandler.call(me, previousPoint, point, nextPoint);
 			} else if (point._view.tension === 0) {
 				ctx.lineTo(point._view.x, point._view.y);


### PR DESCRIPTION
In reference to my own needs and to #2435, this very slim patch (including its relevant documentation addition) adds a small option to line chart datasets (`spanGaps`) that allows users trying to graph sparse datasets to have lines between `null` entries drawn, rather than omitted.