### PR TITLE
Make canvas element display: block by default, with config option to …

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -21,6 +21,8 @@ module.exports = function() {
 		me.ctx = context;
 		me.canvas = context.canvas;
 
+		context.canvas.style.display = context.canvas.style.display || 'block';
+
 		// Figure out what the size of the chart will be.
 		// If the canvas has a specified width and height, we use those else
 		// we look to see if the canvas node has a CSS width and height.


### PR DESCRIPTION
Quick change change to `display: block` for the canvas element per [discussion in Slack](https://chartjs.slack.com/archives/general/p1464960758001565). Related https://github.com/chartjs/Chart.js/issues/2538 and https://github.com/chartjs/Chart.js/issues/2582