### PR TITLE
Fix tests

### DIFF
--- a/docs/03-Line-Chart.md
+++ b/docs/03-Line-Chart.md
@@ -58,6 +58,7 @@ pointHoverBorderColor | `Color or Array<Color>` | Point border color when hovere
 pointHoverBorderWidth | `Number or Array<Number>` | Border width of point when hovered
 pointStyle | `String, Array<String>, Image, Array<Image>` | The style of point. Options are 'circle', 'triangle', 'rect', 'rectRot', 'cross', 'crossRot', 'star', 'line', and 'dash'. If the option is an image, that image is drawn on the canvas using `drawImage`. 
 showLine | `Boolean` | If false, the line is not drawn for this dataset
+spanGaps | `Boolean` | If true, lines will be drawn between points with no or null data
 
 An example data object using these attributes is shown below.
 ```javascript
@@ -84,6 +85,7 @@ var data = {
 			pointRadius: 1,
 			pointHitRadius: 10,
 			data: [65, 59, 80, 81, 56, 55, 40],
+			spanGaps: false,
 		}
 	]
 };
@@ -93,6 +95,8 @@ The line chart usually requires an array of labels. This labels are shown on the
 The data for line charts is broken up into an array of datasets. Each dataset has a colour for the fill, a colour for the line and colours for the points and strokes of the points. These colours are strings just like CSS. You can use RGBA, RGB, HEX or HSL notation.
 
 The label key on each dataset is optional, and can be used when generating a scale for the chart.
+
+When `spanGaps` is set to true, the gaps between points in sparse datasets are filled in. By default, it is off.
 
 ### Data Points
 

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -75,6 +75,10 @@ module.exports = function(Chart) {
 				// Model
 				line._model = {
 					// Appearance
+					// The default behavior of lines is to break at null values, according
+					// to https://github.com/chartjs/Chart.js/issues/2435#issuecomment-216718158
+					// This option gives linse the ability to span gaps
+					spanGaps: dataset.spanGaps ? dataset.spanGaps : false,
 					tension: custom.tension ? custom.tension : helpers.getValueOrDefault(dataset.lineTension, lineElementOptions.tension),
 					backgroundColor: custom.backgroundColor ? custom.backgroundColor : (dataset.backgroundColor || lineElementOptions.backgroundColor),
 					borderWidth: custom.borderWidth ? custom.borderWidth : (dataset.borderWidth || lineElementOptions.borderWidth),

--- a/src/elements/element.line.js
+++ b/src/elements/element.line.js
@@ -22,9 +22,9 @@ module.exports = function(Chart) {
 			var me = this;
 			var ctx = me._chart.ctx;
 
-			if (point._view.skip) {
+			if (point._view.skip && !me._model.spanGaps) {
 				skipHandler.call(me, previousPoint, point, nextPoint);
-			} else if (previousPoint._view.skip) {
+			} else if (previousPoint._view.skip && !me._model.spanGaps) {
 				previousSkipHandler.call(me, previousPoint, point, nextPoint);
 			} else if (point._view.tension === 0) {
 				ctx.lineTo(point._view.x, point._view.y);

--- a/src/elements/element.line.js
+++ b/src/elements/element.line.js
@@ -21,10 +21,11 @@ module.exports = function(Chart) {
 		lineToNextPoint: function(previousPoint, point, nextPoint, skipHandler, previousSkipHandler) {
 			var me = this;
 			var ctx = me._chart.ctx;
+			var spanGaps = me._model ? me._model.spanGaps : false;
 
-			if (point._view.skip && !me._model.spanGaps) {
+			if (point._view.skip && !spanGaps) {
 				skipHandler.call(me, previousPoint, point, nextPoint);
-			} else if (previousPoint._view.skip && !me._model.spanGaps) {
+			} else if (previousPoint._view.skip && !spanGaps) {
 				previousSkipHandler.call(me, previousPoint, point, nextPoint);
 			} else if (point._view.tension === 0) {
 				ctx.lineTo(point._view.x, point._view.y);


### PR DESCRIPTION
I fixed the tests by adding a very swift check in lineToNextPoint() in element.line. This was necessary because the tests--presumably adding points in a way that one might see in the wild--adds points manually, bypassing the line._model setup.

My options were to either alter the tests, thereby breaking potential functionality, or to add the quick check to lineToNextPoint(). I settled on the latter for backward compatibility's sake.