### PR TITLE
fix typo in tooltip conf doc.

### DIFF
--- a/docs/01-Chart-Configuration.md
+++ b/docs/01-Chart-Configuration.md
@@ -189,7 +189,7 @@ var chartInstance = new Chart(ctx, {
 
 ### Tooltip Configuration
 
-The title configuration is passed into the `options.tooltips` namespace. The global options for the chart tooltips is defined in `Chart.defaults.global.title`.
+The title configuration is passed into the `options.tooltips` namespace. The global options for the chart tooltips is defined in `Chart.defaults.global.tooltips`.
 
 Name | Type | Default | Description
 --- | --- | --- | ---


### PR DESCRIPTION
The documentation mentioned `title` where `tooltips` was meant. 