### PR TITLE
time type xAxis height crah in line chart #2622

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -332,7 +332,7 @@ module.exports = function(Chart) {
 			if (labelMoment) {
 				var offset = labelMoment.diff(me.firstTick, me.tickUnit, true);
 
-				var decimal = offset / me.scaleSizeInUnits;
+				var decimal = offset !== 0 ? offset / me.scaleSizeInUnits : offset;
 
 				if (me.isHorizontal()) {
 					var innerWidth = me.width - (me.paddingLeft + me.paddingRight);

--- a/test/scale.time.tests.js
+++ b/test/scale.time.tests.js
@@ -435,4 +435,47 @@ describe('Time scale tests', function() {
 		expect(xScale.getLabelForIndex(6, 0)).toBe('2015-01-10T12:00');
 
 	});
+	it('should get the correct pixel for only one data in the dataset', function() {
+		var chart = window.acquireChart({
+			type: 'line',
+			data: {
+				labels: ["2016-05-27"],
+				datasets: [{
+					type: "line",
+					data: [5]
+				}]
+			},
+			options: {
+				scales: {
+					xAxes: [{
+						display: true,
+						type: "time",
+						time: {
+							displayFormats: {
+								"day": "YYYY-MM-DD"
+							}
+						}
+					}],
+					yAxes: [{
+						type: "linear",
+						ticks: {
+							reverse: true,
+							min: 0,
+							max: 10
+						}
+					}]
+				}
+			}
+		});
+
+		var xScale = chartInstance.scales.xScale0;
+
+		expect(xScale.getPixelForValue('', 0, 0)).toBeCloseToPixel(78);
+
+		expect(xScale.getValueForPixel(78)).toBeCloseToTime({
+			value: moment(chartInstance.data.labels[0]),
+			unit: 'day',
+			threshold: 0.75
+		});
+	});
 });


### PR DESCRIPTION
Please consider the following before submitting a pull request:

if input only one data in dataset and xAxis type is date make offset crash.

check offset value and don't devide 0 value.
Add xAxis check test case.