### PR TITLE
Fix for line chart with one data point

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -259,6 +259,12 @@ module.exports = function(Chart) {
 				me.displayFormat = me.options.time.displayFormat;
 			}
 
+			if (me.firstTick.diff(me.lastTick, me.tickUnit, true) === 0) {
+				me.lastTick = me.firstTick.clone().add(1, me.tickUnit);
+				me.firstTick = me.firstTick.clone().subtract(1, me.tickUnit);
+				me.scaleSizeInUnits = me.lastTick.diff(me.firstTick, me.tickUnit, true);
+			}
+
 			// first tick. will have been rounded correctly if options.time.min is not specified
 			me.ticks.push(me.firstTick.clone());
 


### PR DESCRIPTION
For #2354 - shows the single point in the middle, with one tick unit on each side.
