### PR TITLE
Fixed last tick overlap for time scale

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -246,6 +246,8 @@ module.exports = function(Chart) {
 				}
 			}
 
+			me.scaleSizeInUnits = me.lastTick.diff(me.firstTick, me.tickUnit, true);
+
 			me.smallestLabelSeparation = me.width;
 
 			helpers.each(me.chart.data.datasets, function(dataset, datasetIndex) {
@@ -284,7 +286,7 @@ module.exports = function(Chart) {
 				if (me.options.time.max) {
 					me.ticks.push(me.lastTick.clone());
 					me.scaleSizeInUnits = me.lastTick.diff(me.ticks[0], me.tickUnit, true);
-				} else {
+				} else if (me.scaleSizeInUnits === 0) {
 					me.ticks.push(me.lastTick.clone());
 					me.scaleSizeInUnits = me.lastTick.diff(me.firstTick, me.tickUnit, true);
 				}


### PR DESCRIPTION
First off, thanks for all the great work on this library!

This is a fix for #2599. It hides the last label unless it's equally spaced.