### PR TITLE
Fix tooltip not shown for missing dataset-value

### DIFF
--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -117,8 +117,10 @@ module.exports = function(Chart) {
 		var x = 0,
 			y = 0;
 		for (i = 0; i < xPositions.length; ++i) {
-			x += xPositions[i];
-			y += yPositions[i];
+			if (xPositions[ i ]) {
+				x += xPositions[i];
+				y += yPositions[i];
+			}
 		}
 
 		return {


### PR DESCRIPTION
When two datasets are shown and one does not have all y-values, because they represent some gaps for example, then the position of the tooltip is not calculated correctly, when using mode 'label' or 'dataset'. For those gaps the y-value is set to 'null', which leads to a problem when calculating the tooltip position. This fix checks if the position of every dataset exists, before it is used.

The problem can be seen in this jsbin:
http://jsbin.com/nefasokosi/edit?html,output