### PR TITLE
Span gaps option should be specified at the chart level

### DIFF
--- a/docs/03-Line-Chart.md
+++ b/docs/03-Line-Chart.md
@@ -144,6 +144,7 @@ These are the customisation options specific to Line charts. These options are m
 Name | Type | Default | Description
 --- | --- | --- | ---
 showLines | Boolean | true | If false, the lines between points are not drawn
+spanGaps | Boolean | false | If true, NaN data does not break the line 
 
 You can override these for your `Chart` instance by passing a member `options` into the `Line` method.
 

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -6,6 +6,7 @@ module.exports = function(Chart) {
 
 	Chart.defaults.line = {
 		showLines: true,
+		spanGaps: false,
 
 		hover: {
 			mode: "label"
@@ -78,7 +79,7 @@ module.exports = function(Chart) {
 					// The default behavior of lines is to break at null values, according
 					// to https://github.com/chartjs/Chart.js/issues/2435#issuecomment-216718158
 					// This option gives linse the ability to span gaps
-					spanGaps: dataset.spanGaps ? dataset.spanGaps : false,
+					spanGaps: dataset.spanGaps ? dataset.spanGaps : options.spanGaps,
 					tension: custom.tension ? custom.tension : helpers.getValueOrDefault(dataset.lineTension, lineElementOptions.tension),
 					backgroundColor: custom.backgroundColor ? custom.backgroundColor : (dataset.backgroundColor || lineElementOptions.backgroundColor),
 					borderWidth: custom.borderWidth ? custom.borderWidth : (dataset.borderWidth || lineElementOptions.borderWidth),


### PR DESCRIPTION
Allows the `spanGaps` option to be specified per chart