### PR TITLE
Allow passing a value to the time scale getPixelForValue method

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -327,6 +327,7 @@ module.exports = function(Chart) {
 		},
 		getPixelForValue: function(value, index, datasetIndex) {
 			var me = this;
+			value = moment(value);
 			var labelMoment = value && value.isValid && value.isValid() ? value : me.getLabelMoment(datasetIndex, index);
 
 			if (labelMoment) {

--- a/test/scale.time.tests.js
+++ b/test/scale.time.tests.js
@@ -391,6 +391,7 @@ describe('Time scale tests', function() {
 
 		expect(xScale.getPixelForValue('', 0, 0)).toBeCloseToPixel(78);
 		expect(xScale.getPixelForValue('', 6, 0)).toBeCloseToPixel(452);
+		expect(xScale.getPixelForValue('2015-01-01T20:00:00')).toBeCloseToPixel(78);
 
 		expect(xScale.getValueForPixel(78)).toBeCloseToTime({
 			value: moment(chartInstance.data.labels[0]),


### PR DESCRIPTION
Fixes #2604 