### PR TITLE
Bar controller: use the right dataset in calculateBarY

### DIFF
--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -216,7 +216,7 @@ module.exports = function(Chart) {
 			var me = this;
 			var meta = me.getMeta();
 			var yScale = me.getScaleForId(meta.yAxisID);
-			var value = me.getDataset().data[index];
+			var value = me.chart.data.datasets[datasetIndex].data[index];
 
 			if (yScale.options.stacked) {
 


### PR DESCRIPTION
I was trying to extend the bar controller draw function to display a label above the bars. 

I noticed it doesn't work because the `calculateBarY` function doesn't take the dataset using the index passed as argument. The final result is that I have multiple labels on each bar.

Here is an example with the fix: http://codepen.io/mariolamacchia/pen/JKbOpW