### PR TITLE
Fix line example not showing Scale Titles

### DIFF
--- a/samples/line.html
+++ b/samples/line.html
@@ -97,14 +97,14 @@
                     xAxes: [{
                         display: true,
                         scaleLabel: {
-                            show: true,
+                            display: true,
                             labelString: 'Month'
                         }
                     }],
                     yAxes: [{
                         display: true,
                         scaleLabel: {
-                            show: true,
+                            display: true,
                             labelString: 'Value'
                         },
                         ticks: {


### PR DESCRIPTION
http://codepen.io/anon/pen/pbRQrG

scaleLabel should have display: true instead of show: true