### PR TITLE
Pie chart borders truncated #2844

### DIFF
--- a/src/controllers/controller.doughnut.js
+++ b/src/controllers/controller.doughnut.js
@@ -166,8 +166,9 @@ module.exports = function(Chart) {
 				minSize = Math.min(availableWidth / size.width, availableHeight / size.height);
 				offset = {x: (max.x + min.x) * -0.5, y: (max.y + min.y) * -0.5};
 			}
+            chart.borderWidth = me.getMaxBorderWidth(meta.data);
 
-			chart.outerRadius = Math.max(minSize / 2, 0);
+			chart.outerRadius = Math.max((minSize - chart.borderWidth) / 2, 0);
 			chart.innerRadius = Math.max(cutoutPercentage ? (chart.outerRadius / 100) * (cutoutPercentage) : 1, 0);
 			chart.radiusLength = (chart.outerRadius - chart.innerRadius) / chart.getVisibleDatasetCount();
 			chart.offsetX = offset.x * chart.outerRadius;
@@ -262,6 +263,20 @@ module.exports = function(Chart) {
 			} else {
 				return 0;
 			}
-		}
+		},
+		
+		//gets the max border or hover width to properly scale pie charts
+        getMaxBorderWidth: function (elements) {
+            var max = 0;
+
+            for (var i = 0; i < elements.length; i++) {
+                var borderWidth = elements[i]._model ? elements[i]._model.borderWidth : 0,
+                    hoverWidth = elements[i]._chart ? elements[i]._chart.config.data.datasets[this.index].hoverBorderWidth : 0;
+				
+                max = borderWidth > max ? borderWidth : max;
+                max = hoverWidth > max ? hoverWidth : max;
+            }
+            return max;
+        }
 	});
 };

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -157,7 +157,9 @@ module.exports = function(Chart) {
 			model.borderColor = custom.hoverBorderColor ? custom.hoverBorderColor : valueOrDefault(dataset.hoverBorderColor, index, getHoverColor(model.borderColor));
 			model.borderWidth = custom.hoverBorderWidth ? custom.hoverBorderWidth : valueOrDefault(dataset.hoverBorderWidth, index, model.borderWidth);
 		}
-	});
+		
+    });
+	
 
 	Chart.DatasetController.extend = helpers.inherits;
 };


### PR DESCRIPTION
This is pull request fixes the issues with the pie borders being cut off.
It is a replicate of the previous pull request but it fixes the  white spaces issues that caused git-diff to go out of whack. I am new to git and was having trouble rebasing so I just made a new fork and started from scratch. 

> 
the SetHoverStyle function is a bit more complicated so it should probably use the same logic.

This is still not fixed but, am not entirely sure that it is necessary, as I believe the variable is being set to the value that is created through the setHover logic; but please correct me If I am wrong and I will gladly look into fixing it .