### PR TITLE
Fix to work stacked scatter line chart (fixes #2878)

### DIFF
--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -221,18 +221,20 @@ module.exports = function(Chart) {
 					ds = chart.data.datasets[i];
 					dsMeta = chart.getDatasetMeta(i);
 					if (dsMeta.type === 'line' && chart.isDatasetVisible(i)) {
-						if (ds.data[index] < 0) {
-							sumNeg += ds.data[index] || 0;
+						var stackedRightValue = yScale.getRightValue(ds.data[index]);
+						if (stackedRightValue < 0) {
+							sumNeg += stackedRightValue || 0;
 						} else {
-							sumPos += ds.data[index] || 0;
+							sumPos += stackedRightValue || 0;
 						}
 					}
 				}
 
-				if (value < 0) {
-					return yScale.getPixelForValue(sumNeg + value);
+				var rightValue = yScale.getRightValue(value);
+				if (rightValue < 0) {
+					return yScale.getPixelForValue(sumNeg + rightValue);
 				} else {
-					return yScale.getPixelForValue(sumPos + value);
+					return yScale.getPixelForValue(sumPos + rightValue);
 				}
 			}
 

--- a/test/controller.line.tests.js
+++ b/test/controller.line.tests.js
@@ -278,6 +278,76 @@ describe('Line controller tests', function() {
 		
 	});
 
+	it('should update elements when the y scale is stacked and datasets is scatter data', function() {
+		var chart = window.acquireChart({
+			type: 'line',
+			data: {
+				datasets: [{
+					data: [{
+						x: 0,
+						y: 10
+					}, {
+						x: 1,
+						y: -10
+					}, {
+						x: 2,
+						y: 10
+					}, {
+						x: 3,
+						y: -10
+					}],
+					label: 'dataset1'
+				}, {
+					data: [{
+						x: 0,
+						y: 10
+					}, {
+						x: 1,
+						y: 15
+					}, {
+						x: 2,
+						y: 0
+					}, {
+						x: 3,
+						y: -4
+					}],
+					label: 'dataset2'
+				}],
+				labels: ['label1', 'label2', 'label3', 'label4']
+			},
+			options: {
+				scales: {
+					yAxes: [{
+						stacked: true
+					}]
+				}
+			}
+		});
+		
+		var meta0 = chart.getDatasetMeta(0);
+
+		[	{ x:  38, y: 161 },
+			{ x: 189, y: 419 },
+			{ x: 341, y: 161 },
+			{ x: 492, y: 419 }
+		].forEach(function(values, i) {
+				expect(meta0.data[i]._model.x).toBeCloseToPixel(values.x);
+				expect(meta0.data[i]._model.y).toBeCloseToPixel(values.y);
+		});
+
+		var meta1 = chart.getDatasetMeta(1);
+
+		[	{ x:  38, y:  32 },
+			{ x: 189, y:  97 },
+			{ x: 341, y: 161 },
+			{ x: 492, y: 471 }
+		].forEach(function(values, i) {
+				expect(meta1.data[i]._model.x).toBeCloseToPixel(values.x);
+				expect(meta1.data[i]._model.y).toBeCloseToPixel(values.y);
+		});
+		
+	});
+
 	it('should find the correct scale zero when the data is all positive', function() {
 		var chart = window.acquireChart({
 			type: 'line',


### PR DESCRIPTION
I try to add Chart.js renderer to Grafana. (Grafana is a time series data visualization tool.)
https://github.com/grafana/grafana/pull/5417

While integrate Chart.js to Grafana, I notice that "stacked" option doesn't work with Scatter Line Chart.
This PR might resolve the issue. Please review this :-)

Thanks,