### PR TITLE
Consider left and top when determining value from pixel in category s…

### DIFF
--- a/src/scales/scale.category.js
+++ b/src/scales/scale.category.js
@@ -81,6 +81,8 @@ module.exports = function(Chart) {
 			var innerDimension = horz ? me.width - (me.paddingLeft + me.paddingRight) : me.height - (me.paddingTop + me.paddingBottom);
 			var valueDimension = innerDimension / offsetAmt;
 
+			pixel -= horz ? me.left : me.top;
+
 			if (me.options.gridLines.offsetGridLines) {
 				pixel -= (valueDimension / 2);
 			}

--- a/test/scale.category.tests.js
+++ b/test/scale.category.tests.js
@@ -154,7 +154,7 @@ describe('Category scale tests', function() {
 
 		expect(scale.getPixelForValue(0, 4, 0, false)).toBe(452);
 		expect(scale.getPixelForValue(0, 4, 0, true)).toBe(505);
-		expect(scale.getValueForPixel(452)).toBe(4);
+		expect(scale.getValueForPixel(453)).toBe(4);
 		expect(scale.getValueForPixel(505)).toBe(4);
 
 		config.gridLines.offsetGridLines = false;
@@ -282,7 +282,7 @@ describe('Category scale tests', function() {
 
 		expect(scale.getPixelForValue(0, 4, 0, false)).toBe(161);
 		expect(scale.getPixelForValue(0, 4, 0, true)).toBe(180);
-		expect(scale.getValueForPixel(161)).toBe(4);
+		expect(scale.getValueForPixel(162)).toBe(4);
 
 		config.gridLines.offsetGridLines = false;
 


### PR DESCRIPTION
Fixes #2802 and accounts for the left and top edges of the category scale when determining the value from a pixel