### PR TITLE
Fix for null value label/x-axis multi-tooltip bug

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -414,7 +414,9 @@ module.exports = function(Chart) {
 			helpers.each(me.data.datasets, function(dataset, datasetIndex) {
 				if (me.isDatasetVisible(datasetIndex)) {
 					var meta = me.getDatasetMeta(datasetIndex);
-					elementsArray.push(meta.data[found._index]);
+					if(!meta.data[found._index]._view.skip){
+						elementsArray.push(meta.data[found._index]);
+					}
 				}
 			}, me);
 
@@ -448,7 +450,9 @@ module.exports = function(Chart) {
             helpers.each(me.data.datasets, function(dataset, datasetIndex) {
                 if (me.isDatasetVisible(datasetIndex)) {
                     var meta = me.getDatasetMeta(datasetIndex);
-                    elementsArray.push(meta.data[found._index]);
+                    if(!meta.data[found._index]._view.skip){
+                    	elementsArray.push(meta.data[found._index]);
+                    }
                 }
             }, me);
 


### PR DESCRIPTION
Prevents a data point with a null value from being selected by `label` and `x-axis` hover/tooltip modes, which would previously cause a multi-tooltip to vanish entirely (even if it contained one or more other valid numeric data-points)

Closes #2875 

**NOTE**: This bug also manifests in the `dataset` mode as well, but I'm not yet familiar with the code base to address that separate instance.