### PR TITLE
cached index and length

### DIFF
--- a/src/controllers/controller.doughnut.js
+++ b/src/controllers/controller.doughnut.js
@@ -267,11 +267,15 @@ module.exports = function(Chart) {
 		
 		//gets the max border or hover width to properly scale pie charts
         getMaxBorderWidth: function (elements) {
-            var max = 0;
+            var max = 0,
+				index = this.index,
+				length = elements.length,
+				borderWidth,
+				hoverWidth;
 
-            for (var i = 0; i < elements.length; i++) {
-                var borderWidth = elements[i]._model ? elements[i]._model.borderWidth : 0,
-                    hoverWidth = elements[i]._chart ? elements[i]._chart.config.data.datasets[this.index].hoverBorderWidth : 0;
+            for (var i = 0; i < length; i++) {
+               	borderWidth = elements[i]._model ? elements[i]._model.borderWidth : 0;
+                hoverWidth = elements[i]._chart ? elements[i]._chart.config.data.datasets[index].hoverBorderWidth : 0;
 				
                 max = borderWidth > max ? borderWidth : max;
                 max = hoverWidth > max ? hoverWidth : max;


### PR DESCRIPTION
Fixed the minor performance issue, by caching the index and length outside for loop.