### PR TITLE
Enhancement for Issue #2927

### DIFF
--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -325,7 +325,7 @@ module.exports = function(Chart) {
 			}
 
 			if (changed && opts.custom) {
-				opts.custom.call(me, model);
+				opts.custom.call(me, model, tooltipItems, data);
 			}
 
 			return me;


### PR DESCRIPTION
I added the data point items and the graph data to the arguments passed to the custom tooltip callback so a developer can fully describe the point on the graph the user clicked when they are attempting to do so in a custom tooltip.