### PR TITLE
Enhancement for Issue #2927

### DIFF
--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -276,6 +276,8 @@ module.exports = function(Chart) {
 
 			var data = me._data;
 			var chartInstance = me._chartInstance;
+			
+			var tooltipItems = [];
 
 			var i, len;
 
@@ -285,7 +287,6 @@ module.exports = function(Chart) {
 				var labelColors = [],
 					tooltipPosition = getAveragePosition(active);
 
-				var tooltipItems = [];
 				for (i = 0, len = active.length; i < len; ++i) {
 					tooltipItems.push(createTooltipItem(active[i]));
 				}


### PR DESCRIPTION
I added two new arguments to the custom tooltip callback. Adding tooltipItems and the graph data as arguments gives developers the data they need to fully describe in a custom tooltip the point clicked.