### PR TITLE
Adding data index to point construction

### DIFF
--- a/Chart.js
+++ b/Chart.js
@@ -2617,6 +2617,7 @@
 					datasetObject.points.push(new this.PointClass({
 						value : dataPoint,
 						label : data.labels[index],
+						dataIndex: index,
 						datasetLabel: dataset.label,
 						strokeColor : dataset.pointStrokeColor,
 						fillColor : dataset.pointColor,


### PR DESCRIPTION
Currently on the 1.x branch (not sure about 2.x) there's no way to know the index of the data point that you're currently hovering over.

Sometimes you may wanna have a more complex template for the tooltip/call a function and it's very handy and more efficient to have this available!