### PR TITLE
Fix the Pie Chart hover issue (#2983)

### DIFF
--- a/docs/07-Pie-Doughnut-Chart.md
+++ b/docs/07-Pie-Doughnut-Chart.md
@@ -15,7 +15,7 @@ They are also registered under two aliases in the `Chart` core. Other than their
 	<canvas width="250" height="125"></canvas>
 </div>
 
-<div class="canvas-holder half">
+<div class="canvas-holder">
 	<canvas width="250" height="125"></canvas>
 </div>
 <br>


### PR DESCRIPTION
Fixes Issue #2983
Adding the class .half to both the chart elements was causing the issue of the h3 shadowing the charts. This was also visible by seeing that the link(#) symbol was appearing near the first chart instead of the h3. Removing the class from the right chart fixes this.