### PR TITLE
Error possible when using the plugin Chart.Zoom.js used with time scale

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -76,7 +76,7 @@ module.exports = function(Chart) {
 			Chart.Scale.prototype.initialize.call(this);
 		},
 		getLabelMoment: function(datasetIndex, index) {
-			return this.labelMoments[datasetIndex][index];
+			return datasetIndex == null || index == null ? null : this.labelMoments[datasetIndex][index];
 		},
 		getMomentStartOf: function(tick) {
 			var me = this;

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -76,7 +76,7 @@ module.exports = function(Chart) {
 			Chart.Scale.prototype.initialize.call(this);
 		},
 		getLabelMoment: function(datasetIndex, index) {
-			return datasetIndex == null || index == null ? null : this.labelMoments[datasetIndex][index];
+			return datasetIndex === null || index === null ? null : this.labelMoments[datasetIndex][index];
 		},
 		getMomentStartOf: function(tick) {
 			var me = this;


### PR DESCRIPTION
Zooming in can cause the params `datasetIndex` and `index` to be null in
method `getLabelMoment`. This happens when no ticks are visible on
scale. It throws an error and the chart becomes broken.