### PR TITLE
getElementAtEvent: enforce one element limit

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -384,7 +384,7 @@ module.exports = function(Chart) {
 				}
 			});
 
-			return elementsArray;
+			return elementsArray.slice(0, 1);
 		},
 
 		getElementsAtEvent: function(e) {


### PR DESCRIPTION
Fixes an issue where if two (or more) points are very close together, all of them will be returned by `getElementAtEvent`. This makes the tooltip `mode: 'single'` not to work as expected in some cases.
Citing from the function's description: 
```
// Get the single element that was clicked on
```
This fixes #2981, #2884.