### PR TITLE
changed 'chart there are' to 'charts there are'

### DIFF
--- a/docs/07-Pie-Doughnut-Chart.md
+++ b/docs/07-Pie-Doughnut-Chart.md
@@ -3,7 +3,7 @@ title: Pie & Doughnut Charts
 anchor: doughnut-pie-chart
 ---
 ### Introduction
-Pie and doughnut charts are probably the most commonly used chart there are. They are divided into segments, the arc of each segment shows the proportional value of each piece of data.
+Pie and doughnut charts are probably the most commonly used charts there are. They are divided into segments, the arc of each segment shows the proportional value of each piece of data.
 
 They are excellent at showing the relational proportions between data.
 


### PR DESCRIPTION
In the docs for "Pie and Doughnut Charts" there is a line that reads "Pie and doughnut charts are probably the most commonly used chart there are". I believe this should either be "chart there is" at the end, or "charts there are". Since Pie and Doughnut charts are two different (although very similar) charts I went with the plural "charts".

## Description
Added an "s" to the end of the word "chart" in the first line of Introduction in the documentation for pie and doughnut charts.