### PR TITLE
Use parser options in getPixelForValue for time scale

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -338,7 +338,7 @@ module.exports = function(Chart) {
 			var me = this;
 			if (!value || !value.isValid) {
 				// not already a moment object
-				value = moment(me.getRightValue(value));
+				value = me.parseTime(me.getRightValue(value));
 			}
 			var labelMoment = value && value.isValid && value.isValid() ? value : me.getLabelMoment(datasetIndex, index);
 


### PR DESCRIPTION
This ensures that data points can be correctly located even if the time scale uses a custom parser.