### PR TITLE
Skip Infinity datapoints in getRightValue

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -392,7 +392,7 @@ module.exports = function(Chart) {
 		// Get the correct value. NaN bad inputs, If the value type is object get the x or y based on whether we are horizontal or not
 		getRightValue: function(rawValue) {
 			// Null and undefined values first
-			if (rawValue === null || typeof(rawValue) === 'undefined') {
+			if (rawValue === null || typeof(rawValue) === 'undefined' || rawValue === Infinity) {
 				return NaN;
 			}
 			// isNaN(object) returns true, so make sure NaN is checking for a number

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -392,11 +392,11 @@ module.exports = function(Chart) {
 		// Get the correct value. NaN bad inputs, If the value type is object get the x or y based on whether we are horizontal or not
 		getRightValue: function(rawValue) {
 			// Null and undefined values first
-			if (rawValue === null || typeof(rawValue) === 'undefined' || rawValue === Infinity) {
+			if (rawValue === null || typeof(rawValue) === 'undefined') {
 				return NaN;
 			}
-			// isNaN(object) returns true, so make sure NaN is checking for a number
-			if (typeof(rawValue) === 'number' && isNaN(rawValue)) {
+			// isNaN(object) returns true, so make sure NaN is checking for a number; Discard Infinite values
+			if (typeof(rawValue) === 'number' && (isNaN(rawValue) || !isFinite(rawValue))) {
 				return NaN;
 			}
 			// If it is in fact an object, dive in one more level

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -396,7 +396,7 @@ module.exports = function(Chart) {
 				return NaN;
 			}
 			// isNaN(object) returns true, so make sure NaN is checking for a number; Discard Infinite values
-			if (typeof(rawValue) === 'number' && (isNaN(rawValue) || !isFinite(rawValue))) {
+			if (typeof(rawValue) === 'number' && !isFinite(rawValue)) {
 				return NaN;
 			}
 			// If it is in fact an object, dive in one more level

--- a/test/scale.linear.tests.js
+++ b/test/scale.linear.tests.js
@@ -167,9 +167,9 @@ describe('Linear Scale', function() {
 			data: {
 				datasets: [{
 					yAxisID: 'yScale0',
-					data: [null, 90, NaN, undefined, 45, 30]
+					data: [null, 90, NaN, undefined, 45, 30, Infinity, -Infinity]
 				}],
-				labels: ['a', 'b', 'c', 'd', 'e', 'f']
+				labels: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']
 			},
 			options: {
 				scales: {

--- a/test/scale.logarithmic.tests.js
+++ b/test/scale.logarithmic.tests.js
@@ -170,11 +170,11 @@ describe('Logarithmic Scale tests', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					data: [undefined, 10, null, 5, 5000, NaN, 78, 450]
+					data: [undefined, 10, null, 5, 5000, NaN, 78, 450, Infinity, -Infinity]
 				}, {
-					data: [undefined, 28, null, 1000, 500, NaN, 50, 42]
+					data: [undefined, 28, null, 1000, 500, NaN, 50, 42, Infinity, -Infinity]
 				}],
-				labels: ['a', 'b', 'c', 'd', 'e', 'f' ,'g']
+				labels: ['a', 'b', 'c', 'd', 'e', 'f' ,'g', 'h', 'i']
 			},
 			options: {
 				scales: {

--- a/test/scale.radialLinear.tests.js
+++ b/test/scale.radialLinear.tests.js
@@ -148,9 +148,9 @@ describe('Test the radial linear scale', function() {
 			type: 'radar',
 			data: {
 				datasets: [{
-					data: [50, 60, NaN, 70, null, undefined]
+					data: [50, 60, NaN, 70, null, undefined, Infinity, -Infinity]
 				}],
-				labels: ['lablel1', 'label2', 'label3', 'label4', 'label5', 'label6']
+				labels: ['lablel1', 'label2', 'label3', 'label4', 'label5', 'label6', 'label7', 'label8']
 			},
 			options: {
 				scales: {


### PR DESCRIPTION
Addresses #3125.

Skips `Infinity` datapoints in `getRightValue` to fix graph creation glitches resulting from 'infinite' datapoints.