### PR TITLE
iframe may not resize after the container.

### DIFF
--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -882,7 +882,6 @@ module.exports = function(Chart) {
 		style.border = 0;
 		style.height = 0;
 		style.margin = 0;
-		style.position = 'absolute';
 		style.left = 0;
 		style.right = 0;
 		style.top = 0;


### PR DESCRIPTION
This fixes the chart may not resize after the container while the hiddenIframe's position is 'absolute'.
This problem happens in Chrome(52.0.2743.116) sometimes.

Problem preview(The box shows the border of the container):
![20160816190235](https://cloud.githubusercontent.com/assets/4678123/17697007/bbb00b26-63e4-11e6-9184-84dbeaa77871.png)

Problem Code: [http://codepen.io/anon/pen/zBbvLq](http://codepen.io/anon/pen/zBbvLq)

