### PR TITLE
Multiline support for axes using \n

### DIFF
--- a/samples/timeScale/line-time-scale.html
+++ b/samples/timeScale/line-time-scale.html
@@ -27,7 +27,7 @@
 	<button id="addData">Add Data</button>
 	<button id="removeData">Remove Data</button>
 	<script>
-		var timeFormat = 'MM/DD/YYYY HH:mm';
+		var timeFormat = 'MM/DD[\n]YYYY';
 
 		function randomScalingFactor() {
 			return Math.round(Math.random() * 100 * (Math.random() > 0.5 ? -1 : 1));
@@ -93,7 +93,10 @@
 					xAxes: [{
 						type: "time",
 						time: {
-							format: timeFormat,
+							unit: 'day',
+							displayFormats:{
+								day:timeFormat
+							},
 							// round: 'day'
 							tooltipFormat: 'll HH:mm'
 						},

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -320,6 +320,9 @@ module.exports = function(Chart) {
 		// Function to format an individual tick mark
 		tickFormatFunction: function(tick, index, ticks) {
 			var formattedTick = tick.format(this.displayFormat);
+			if(formattedTick.indexOf("\n")>0){
+				formattedTick = formattedTick.split("\n");
+			}
 			var tickOpts = this.options.ticks;
 			var callback = helpers.getValueOrDefault(tickOpts.callback, tickOpts.userCallback);
 


### PR DESCRIPTION
You can format momentjs times in axes using [\n]. See: https://github.com/moment/moment/pull/1158/

Updated line-time-scale.html example using [\n]. Removed deprecated property "format"
