### PR TITLE
Remove smallestLabelSeparation from TimeScale

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -255,14 +255,6 @@ module.exports = function(Chart) {
 				me.scaleSizeInUnits = me.lastTick.diff(me.firstTick, me.tickUnit, true);
 			}
 
-			me.smallestLabelSeparation = me.width;
-
-			helpers.each(me.chart.data.datasets, function(dataset, datasetIndex) {
-				for (var i = 1; i < me.labelMoments[datasetIndex].length; i++) {
-					me.smallestLabelSeparation = Math.min(me.smallestLabelSeparation, me.labelMoments[datasetIndex][i].diff(me.labelMoments[datasetIndex][i - 1], me.tickUnit, true));
-				}
-			}, me);
-
 			// Tick displayFormat override
 			if (me.options.time.displayFormat) {
 				me.displayFormat = me.options.time.displayFormat;


### PR DESCRIPTION
In case of charts with over 4000 points, smallestLabelSeparation calculation contributes significantly to total cpu usage (about 25% according to built-in Chrome profiler). Important thing to note is that result
of this calculation is not used at all.

Related commits:
  * 677c249b613bf1a4ebccb1bebda9f04f7346b866
    introduced smallestLabelSeparation. It was used in calculateBaseWidth function.
  * d198157fb8ea479ec9286bcf0ffb72e2e62e9661
    removed last use of smallestLabelSeparation. Since then the calculated value was never used.