### PR TITLE
When drawTicks is false, we should not include their size in the size…

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -277,6 +277,7 @@ module.exports = function(Chart) {
 			var globalDefaults = Chart.defaults.global;
 			var tickOpts = opts.ticks;
 			var scaleLabelOpts = opts.scaleLabel;
+			var gridLineOpts = opts.gridLines;
 			var display = opts.display;
 			var isHorizontal = me.isHorizontal();
 
@@ -294,12 +295,12 @@ module.exports = function(Chart) {
 				// subtract the margins to line up with the chartArea if we are a full width scale
 				minSize.width = me.isFullWidth() ? me.maxWidth - me.margins.left - me.margins.right : me.maxWidth;
 			} else {
-				minSize.width = display ? tickMarkLength : 0;
+				minSize.width = display && gridLineOpts.drawTicks ? tickMarkLength : 0;
 			}
 
 			// height
 			if (isHorizontal) {
-				minSize.height = display ? tickMarkLength : 0;
+				minSize.height = display && gridLineOpts.drawTicks ? tickMarkLength : 0;
 			} else {
 				minSize.height = me.maxHeight; // fill all the height
 			}

--- a/test/scale.linear.tests.js
+++ b/test/scale.linear.tests.js
@@ -730,4 +730,56 @@ describe('Linear Scale', function() {
 		expect(yScale.width).toBeCloseToPixel(59);
 		expect(yScale.height).toBeCloseToPixel(434);
 	});
+
+	it('should fit correctly when display is turned off', function() {
+		chartInstance = window.acquireChart({
+			type: 'line',
+			data: {
+				datasets: [{
+					xAxisID: 'xScale0',
+					yAxisID: 'yScale0',
+					data: [{
+						x: 10,
+						y: 100
+					}, {
+						x: -10,
+						y: 0
+					}, {
+						x: 0,
+						y: 0
+					}, {
+						x: 99,
+						y: 7
+					}]
+				}],
+			},
+			options: {
+				scales: {
+					xAxes: [{
+						id: 'xScale0',
+						type: 'linear',
+						position: 'bottom'
+					}],
+					yAxes: [{
+						id: 'yScale0',
+						type: 'linear',
+						gridLines: {
+							drawTicks: false,
+							drawBorder: false
+						},
+						scaleLabel: {
+							display: false
+						},
+						ticks: {
+							display: false,
+							padding: 0
+						}
+					}]
+				}
+			}
+		});
+
+		var yScale = chartInstance.scales.yScale0;
+		expect(yScale.width).toBeCloseToPixel(0);
+	});
 });


### PR DESCRIPTION
When `gridLines.drawTicks == false` the size of the tick marks should not be considered when the size of the axis is determined.

Fixes #2872 