### PR TITLE
Error possible when using the plugin Chart.Zoom.js used with time scale

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -76,9 +76,10 @@ module.exports = function(Chart) {
 			Chart.Scale.prototype.initialize.call(this);
 		},
 		getLabelMoment: function(datasetIndex, index) {
-			if (datasetIndex === null || index === null)
+			if (datasetIndex === null || index === null) {
 				return null;
-
+            }
+            
 			if (typeof this.labelMoments[datasetIndex] != 'undefined') {
 				return this.labelMoments[datasetIndex][index];
 			}

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -240,19 +240,16 @@ module.exports = function(Chart) {
 			// Only round the last tick if we have no hard maximum
 			if (!me.options.time.max) {
 				var roundedEnd = me.getMomentStartOf(me.lastTick);
-				if (roundedEnd.diff(me.lastTick, me.tickUnit, true) !== 0) {
+				var delta = roundedEnd.diff(me.lastTick, me.tickUnit, true);
+				if (delta < 0) {
 					// Do not use end of because we need me to be in the next time unit
 					me.lastTick = me.getMomentStartOf(me.lastTick.add(1, me.tickUnit));
+				} else if (delta >= 0) {
+					me.lastTick = roundedEnd;
 				}
+
+				me.scaleSizeInUnits = me.lastTick.diff(me.firstTick, me.tickUnit, true);
 			}
-
-			me.smallestLabelSeparation = me.width;
-
-			helpers.each(me.chart.data.datasets, function(dataset, datasetIndex) {
-				for (var i = 1; i < me.labelMoments[datasetIndex].length; i++) {
-					me.smallestLabelSeparation = Math.min(me.smallestLabelSeparation, me.labelMoments[datasetIndex][i].diff(me.labelMoments[datasetIndex][i - 1], me.tickUnit, true));
-				}
-			}, me);
 
 			// Tick displayFormat override
 			if (me.options.time.displayFormat) {
@@ -329,7 +326,7 @@ module.exports = function(Chart) {
 			var me = this;
 			if (!value || !value.isValid) {
 				// not already a moment object
-				value = moment(me.getRightValue(value));
+				value = me.parseTime(me.getRightValue(value));
 			}
 			var labelMoment = value && value.isValid && value.isValid() ? value : me.getLabelMoment(datasetIndex, index);
 

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -76,7 +76,7 @@ module.exports = function(Chart) {
 			Chart.Scale.prototype.initialize.call(this);
 		},
 		getLabelMoment: function(datasetIndex, index) {
-			return this.labelMoments[datasetIndex][index];
+			return datasetIndex == null || index == null ? null : this.labelMoments[datasetIndex][index];
 		},
 		getMomentStartOf: function(tick) {
 			var me = this;

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -76,7 +76,7 @@ module.exports = function(Chart) {
 			Chart.Scale.prototype.initialize.call(this);
 		},
 		getLabelMoment: function(datasetIndex, index) {
-			return datasetIndex == null || index == null ? null : this.labelMoments[datasetIndex][index];
+			return datasetIndex === null || index === null ? null : this.labelMoments[datasetIndex][index];
 		},
 		getMomentStartOf: function(tick) {
 			var me = this;

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -76,7 +76,14 @@ module.exports = function(Chart) {
 			Chart.Scale.prototype.initialize.call(this);
 		},
 		getLabelMoment: function(datasetIndex, index) {
-			return datasetIndex === null || index === null ? null : this.labelMoments[datasetIndex][index];
+			if (datasetIndex === null || index === null)
+				return null;
+
+			if (typeof this.labelMoments[datasetIndex] != 'undefined') {
+				return this.labelMoments[datasetIndex][index];
+			}
+
+			return null;
 		},
 		getMomentStartOf: function(tick) {
 			var me = this;

--- a/test/scale.time.tests.js
+++ b/test/scale.time.tests.js
@@ -504,10 +504,44 @@ describe('Time scale tests', function() {
 
 		var xScale = chartInstance.scales.xScale0;
 
-		var getOutOfBoundPixelForValue = function() {
+		var getOutOfBoundLabelMoment = function() {
 			xScale.getLabelMoment(12, 0);
 		};
 
-		expect(getOutOfBoundPixelForValue).not.toThrow();
+		expect(getOutOfBoundLabelMoment).not.toThrow();
+	});
+	
+	it("should not throw an error if the datasetIndex or index are null", function() {
+		var chart = window.acquireChart({
+			type: 'line',
+			data: {
+				labels: ["2016-06-26"],
+				datasets: [{
+					type: "line",
+					data: [5]
+				}]
+			},
+			options: {
+				scales: {
+					xAxes: [{
+						display: true,
+						type: "time",
+					}]
+				}
+			}
+		});
+
+		var xScale = chartInstance.scales.xScale0;
+
+		var getNullDatasetIndexLabelMoment = function() {
+			xScale.getLabelMoment(null, 1);
+		};
+		
+		var getNullIndexLabelMoment = function() {
+			xScale.getLabelMoment(1, null);
+		};
+
+		expect(getNullDatasetIndexLabelMoment).not.toThrow();
+		expect(getNullIndexLabelMoment).not.toThrow();
 	});
 });


### PR DESCRIPTION
Zooming in can cause the params `datasetIndex` and `index` to be null in
method `getLabelMoment`. This happens when no ticks are visible on
scale. It throws an error and the chart becomes broken. This is the same as #3024, but resolves conflicts