### PR TITLE
feat(core.tooltip): add border and shadow options

### DIFF
--- a/docs/01-Chart-Configuration.md
+++ b/docs/01-Chart-Configuration.md
@@ -238,6 +238,8 @@ caretSize | Number | 5 | Size, in px, of the tooltip arrow
 cornerRadius | Number | 6 | Radius of tooltip corner curves
 multiKeyBackground | Color | "#fff" | Color to draw behind the colored boxes when multiple items are in the tooltip
 callbacks | Object | | See the [callbacks section](#chart-configuration-tooltip-callbacks) below
+strokeColor | Color | 'rgba(0,0,0,0)' | Stroke color for tooltip border
+strokeWidth | Number | 0 | Stroke width for tooltip border
 
 #### Tooltip Callbacks
 

--- a/docs/01-Chart-Configuration.md
+++ b/docs/01-Chart-Configuration.md
@@ -233,6 +233,7 @@ footerSpacing | Number | 2 | Spacing to add to top and bottom of each footer lin
 footerMarginTop | Number | 6 | Margin to add before drawing the footer
 xPadding | Number | 6 | Padding to add on left and right of tooltip
 yPadding | Number | 6 | Padding to add on top and bottom of tooltip
+showCaret | Boolean | true | Draws the caret
 caretSize | Number | 5 | Size, in px, of the tooltip arrow
 cornerRadius | Number | 6 | Radius of tooltip corner curves
 multiKeyBackground | Color | "#fff" | Color to draw behind the colored boxes when multiple items are in the tooltip

--- a/samples/tooltip-stroke.html
+++ b/samples/tooltip-stroke.html
@@ -1,0 +1,163 @@
+<!doctype html>
+<html>
+
+<head>
+    <title>Line Chart</title>
+    <script src="../dist/Chart.bundle.js"></script>
+    <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+    <style>
+    canvas {
+        -moz-user-select: none;
+        -webkit-user-select: none;
+        -ms-user-select: none;
+    }
+    </style>
+</head>
+
+<body>
+    <div style="width:75%;">
+        <canvas id="canvas"></canvas>
+    </div>
+    <br>
+    <br>
+    <button id="randomizeData">Randomize Data</button>
+    <button id="addDataset">Add Dataset</button>
+    <button id="removeDataset">Remove Dataset</button>
+    <button id="addData">Add Data</button>
+    <button id="removeData">Remove Data</button>
+    <script>
+        var MONTHS = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+
+        var randomScalingFactor = function() {
+            return Math.round(Math.random() * 100 * (Math.random() > 0.5 ? -1 : 1));
+        };
+        var randomColorFactor = function() {
+            return Math.round(Math.random() * 255);
+        };
+        var randomColor = function(opacity) {
+            return 'rgba(' + randomColorFactor() + ',' + randomColorFactor() + ',' + randomColorFactor() + ',' + (opacity || '.3') + ')';
+        };
+
+        var config = {
+            type: 'line',
+            data: {
+                labels: ["January", "February", "March", "April", "May", "June", "July"],
+                datasets: [{
+                    label: "My First dataset",
+                    data: [randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor()],
+                    fill: false,
+                    borderDash: [5, 5],
+                }, {
+                    label: "My Second dataset",
+                    data: [randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor()],
+                }]
+            },
+            options: {
+                responsive: true,
+                title:{
+                    display: true,
+                    text: "Chart.js Line Chart - Tooltip Hooks"
+                },
+                tooltips: {
+                    showCaret: true,
+                    titleFontColor: '#333',
+                    bodyFontColor: '#333',
+                    footerFontColor: '#333',
+                    strokeColor: '#bbb',
+                    strokeWidth: 1,
+                    backgroundColor: 'rgba(245,245,245,1)'
+                },
+                scales: {
+                    xAxes: [{
+                        display: true,
+                        scaleLabel: {
+                            show: true,
+                            labelString: 'Month'
+                        }
+                    }],
+                    yAxes: [{
+                        display: true,
+                        scaleLabel: {
+                            show: true,
+                            labelString: 'Value'
+                        }
+                    }]
+                }
+            }
+        };
+
+        $.each(config.data.datasets, function(i, dataset) {
+            dataset.borderColor = randomColor(0.4);
+            dataset.backgroundColor = randomColor(0.5);
+            dataset.pointBorderColor = randomColor(0.7);
+            dataset.pointBackgroundColor = randomColor(0.5);
+            dataset.pointBorderWidth = 1;
+        });
+
+        window.onload = function() {
+            var ctx = document.getElementById("canvas").getContext("2d");
+            window.myLine = new Chart(ctx, config);
+
+        };
+
+        $('#randomizeData').click(function() {
+            $.each(config.data.datasets, function(i, dataset) {
+                dataset.data = dataset.data.map(function() {
+                    return randomScalingFactor();
+                });
+
+            });
+
+            window.myLine.update();
+        });
+
+        $('#addDataset').click(function() {
+            var newDataset = {
+                label: 'Dataset ' + config.data.datasets.length,
+                borderColor: randomColor(0.4),
+                backgroundColor: randomColor(0.5),
+                pointBorderColor: randomColor(0.7),
+                pointBackgroundColor: randomColor(0.5),
+                pointBorderWidth: 1,
+                data: [],
+            };
+
+            for (var index = 0; index < config.data.labels.length; ++index) {
+                newDataset.data.push(randomScalingFactor());
+            }
+
+            config.data.datasets.push(newDataset);
+            window.myLine.update();
+        });
+
+        $('#addData').click(function() {
+            if (config.data.datasets.length > 0) {
+                var month = MONTHS[config.data.labels.length % MONTHS.length];
+                config.data.labels.push(month);
+
+                $.each(config.data.datasets, function(i, dataset) {
+                    dataset.data.push(randomScalingFactor());
+                });
+
+                window.myLine.update();
+            }
+        });
+
+        $('#removeDataset').click(function() {
+            config.data.datasets.splice(0, 1);
+            window.myLine.update();
+        });
+
+        $('#removeData').click(function() {
+            config.data.labels.splice(-1, 1); // remove the label first
+
+            config.data.datasets.forEach(function(dataset, datasetIndex) {
+                dataset.data.pop();
+            });
+
+            window.myLine.update();
+        });
+    </script>
+</body>
+
+</html>

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -26,6 +26,8 @@ module.exports = function(Chart) {
 		xPadding: 6,
 		yAlign : 'center',
 		xAlign : 'center',
+		strokeColor: 'rgba(0,0,0,0)',
+		strokeWidth: 0,
 		showCaret: true,
 		caretSize: 5,
 		cornerRadius: 6,
@@ -194,7 +196,9 @@ module.exports = function(Chart) {
 					cornerRadius: tooltipOpts.cornerRadius,
 					backgroundColor: tooltipOpts.backgroundColor,
 					opacity: 0,
-					legendColorBackground: tooltipOpts.multiKeyBackground
+					legendColorBackground: tooltipOpts.multiKeyBackground,
+					strokeColor: tooltipOpts.strokeColor,
+					strokeWidth: tooltipOpts.strokeWidth
 				}
 			});
 		},
@@ -559,6 +563,7 @@ module.exports = function(Chart) {
 				}
 			}
 
+			this.applyStroke(tooltipPoint, vm, ctx, opacity);
 
 			var bgColor = helpers.color(vm.backgroundColor);
 
@@ -569,6 +574,23 @@ module.exports = function(Chart) {
 			ctx.lineTo(x3, y3);
 			ctx.closePath();
 			ctx.fill();
+
+			// Draw a line to cover the third line of the caret
+			if(Number.isFinite(vm.strokeWidth) && vm.strokeWidth > 0) {
+				ctx.strokeStyle = bgColor.alpha(opacity * bgColor.alpha()).rgbString();
+				ctx.lineWidth = vm.strokeWidth;
+				ctx.beginPath();
+				ctx.moveTo(x1, y1);
+				ctx.lineTo(x3, y3);
+				ctx.stroke();
+			}
+		},
+		applyStroke: function(pt, vm, ctx, opacity) {
+			var strokeColor = helpers.color(vm.strokeColor);
+
+			ctx.strokeStyle = strokeColor.alpha(opacity * strokeColor.alpha()).rgbString();
+			ctx.lineWidth = vm.strokeWidth;
+			ctx.stroke();
 		},
 		drawTitle: function(pt, vm, ctx, opacity) {
 			var title = vm.title;
@@ -698,6 +720,8 @@ module.exports = function(Chart) {
 				ctx.fillStyle = bgColor.alpha(opacity * bgColor.alpha()).rgbString();
 				helpers.drawRoundedRectangle(ctx, pt.x, pt.y, tooltipSize.width, tooltipSize.height, vm.cornerRadius);
 				ctx.fill();
+
+				this.applyStroke(pt, vm, ctx, opacity);
 
 				// Draw Caret
 				if(vm.showCaret) {

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -26,6 +26,7 @@ module.exports = function(Chart) {
 		xPadding: 6,
 		yAlign : 'center',
 		xAlign : 'center',
+		showCaret: true,
 		caretSize: 5,
 		cornerRadius: 6,
 		multiKeyBackground: '#fff',
@@ -188,6 +189,7 @@ module.exports = function(Chart) {
 					footerMarginTop: tooltipOpts.footerMarginTop,
 
 					// Appearance
+					showCaret: tooltipOpts.showCaret,
 					caretSize: tooltipOpts.caretSize,
 					cornerRadius: tooltipOpts.cornerRadius,
 					backgroundColor: tooltipOpts.backgroundColor,
@@ -557,7 +559,9 @@ module.exports = function(Chart) {
 				}
 			}
 
+
 			var bgColor = helpers.color(vm.backgroundColor);
+
 			ctx.fillStyle = bgColor.alpha(opacity * bgColor.alpha()).rgbString();
 			ctx.beginPath();
 			ctx.moveTo(x1, y1);
@@ -696,7 +700,9 @@ module.exports = function(Chart) {
 				ctx.fill();
 
 				// Draw Caret
-				this.drawCaret(pt, tooltipSize, opacity);
+				if(vm.showCaret) {
+					this.drawCaret(pt, tooltipSize, opacity);
+				}
 
 				// Draw Title, Body, and Footer
 				pt.x += vm.xPadding;

--- a/test/core.tooltip.tests.js
+++ b/test/core.tooltip.tests.js
@@ -94,6 +94,9 @@ describe('tooltip tests', function() {
 			backgroundColor: 'rgba(0,0,0,0.8)',
 			opacity: 1,
 			legendColorBackground: '#fff',
+			strokeColor: 'rgba(0,0,0,0)',
+			strokeWidth: 0,
+			showCaret: true,
 
 			// Text
 			title: ['Point 2'],
@@ -208,6 +211,9 @@ describe('tooltip tests', function() {
 			backgroundColor: 'rgba(0,0,0,0.8)',
 			opacity: 1,
 			legendColorBackground: '#fff',
+			strokeColor: 'rgba(0,0,0,0)',
+			strokeWidth: 0,
+			showCaret: true,
 
 			// Text
 			title: ['Point 2'],
@@ -347,6 +353,9 @@ describe('tooltip tests', function() {
 			backgroundColor: 'rgba(0,0,0,0.8)',
 			opacity: 1,
 			legendColorBackground: '#fff',
+			strokeColor: 'rgba(0,0,0,0)',
+			strokeWidth: 0,
+			showCaret: true,
 
 			// Text
 			title: ['beforeTitle', 'title', 'afterTitle'],


### PR DESCRIPTION
is this useful to anyone? my organization was interested to see if we could customize tooltip stroke to match an internal style guide. i **kinda** got it working but it feels strange and i'm leaning towards just submitting a custom tooltip instead.

if this is thought to be useful, though, i can add the documentation and clean up / add more tests.

cheers. happy friday and thanks for the awesome lib.

update: removed shadow option. worked well with main rectangle of tooltip but had lots of issues with the overlapping caret + shadow + background opacity. perhaps someone else can tackle that later.
