### PR TITLE
Deploy dist files in release tags (bower support)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 
 .DS_Store
 .idea
+bower.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,7 @@ deploy:
   on:
     branch: release
 - provider: releases
-  api_key:
-    secure: E6JiZzA/Qy+UD1so/rVfqYnMhgU4m0cUsljxyrKIiYKlt/ZXo1XJabNkpEIYLvckrNx+g/4cmidNcuLfrnAZJtUg53qHLxyqMTXa9zAqmxxJ6aIpQpNK25FIEk9Xwm2XZdbI5rrm0ZciP5rcgg0X8/j5+RtnU3ZpTOCVkp0P73A=
+  api_key: $GITHUB_AUTH_TOKEN
   file:
   - "./dist/Chart.bundle.js"
   - "./dist/Chart.bundle.min.js"
@@ -55,10 +54,8 @@ deploy:
   on:
     tags: true
 - provider: npm
-  email:
-    secure: f6jQXdqhoKtEZ3WBvnNM9PB2l9yg8SGmnUwQzeuLpW731opmv1ngPcMA+CotDAavIRs2BvAgVoLJOVGxMRXRSi5pgahfR0O2LetFoT/Px+q4MMqtn3zMgV/OuYL/fIyKXjyoYwSRfjuaIIGX7VTCOpqOEe29UQJAb7XcG9jhgIo=
-  api_key:
-    secure: O5lgPeX5ofkMSiUeijs+0hrK9Dejmpki/UABd+rgx3Cmjlxvi5DVugHpcn/6C0if0CoHv5/TqwQHVgL43kwR5ZKcspl7bzK2vD2YBpingF42Oz91YVNZwQIJyWNVSSWzzFYzG9xOXO26ZD1gTZ26Z3X+xfZVtugWkzbBa/c8NmQ=
+  email: $NPM_AUTH_EMAIL
+  api_key: $NPM_AUTH_TOKEN
   skip_cleanup: true
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
   - gulp test
   - gulp coverage
   - gulp package
+  - gulp bower
   - cat ./coverage/lcov.info | ./node_modules/.bin/coveralls
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,15 @@ addons:
       - google-chrome-stable
 
 deploy:
+# Creates a tag containing dist files and bower.json
+# Requires GITHUB_AUTH_TOKEN and GITHUB_AUTH_EMAIL environment variables
+# IMPORTANT: the script has to be set executable in the Git repository (error 127)
+# https://github.com/travis-ci/travis-ci/issues/5538#issuecomment-225025939
+- provider: script
+  script: ./scripts/release.sh
+  skip_cleanup: true
+  on:
+    branch: release
 - provider: releases
   api_key:
     secure: E6JiZzA/Qy+UD1so/rVfqYnMhgU4m0cUsljxyrKIiYKlt/ZXo1XJabNkpEIYLvckrNx+g/4cmidNcuLfrnAZJtUg53qHLxyqMTXa9zAqmxxJ6aIpQpNK25FIEk9Xwm2XZdbI5rrm0ZciP5rcgg0X8/j5+RtnU3ZpTOCVkp0P73A=

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -1,0 +1,36 @@
+# Maintaining
+## Release Process
+Chart.js relies on [Travis CI](https://travis-ci.org/) to automate the library [releases](https://github.com/chartjs/Chart.js/releases).
+
+### Releasing a New Version
+
+1. draft release notes on [GitHub](https://github.com/chartjs/Chart.js/releases/new) for the upcoming tag
+1. update `master` `package.json` version using [semver](http://semver.org/) semantic
+1. merge `master` into the `release` branch
+1. follow the build process on [Travis CI](https://travis-ci.org/chartjs/Chart.js)
+
+> **Note:** if `master` is merged in `release` with a `package.json` version that already exists, the tag
+creation fails and the release process is aborted.
+
+### Automated Tasks
+Merging into the `release` branch kicks off the automated release process:
+
+* build of the `dist/*.js` files
+* `bower.json` is generated from `package.json`
+* `dist/*.js` and `bower.json` are added to a detached branch
+* a tag is created from the `package.json` version
+* tag (with dist files) is pushed to GitHub
+
+Creation of this tag triggers a new build:
+
+* `Chart.js.zip` package is generated, containing dist files and examples
+* `dist/*.js` and `Chart.js.zip` are attached to the GitHub release (downloads)
+* a new npm package is published on [npmjs](https://www.npmjs.com/package/chart.js)
+
+Finally, [cdnjs](https://cdnjs.com/libraries/Chart.js) is automatically updated from the npm release.
+
+### Further Reading
+
+* [Travis GitHub releases](/chartjs/Chart.js/pull/2555)
+* [Bower support and dist/* files](/chartjs/Chart.js/issues/3033)
+* [cdnjs npm auto update](/cdnjs/cdnjs/pull/8401)

--- a/docs/00-Getting-Started.md
+++ b/docs/00-Getting-Started.md
@@ -5,7 +5,7 @@ anchor: getting-started
 
 ### Download Chart.js
 
-You can download the latest version of [Chart.js on GitHub](https://github.com/chartjs/Chart.js/releases/latest) or just use these [Chart.js CDN](https://cdnjs.com/libraries/Chart.js) links. 
+You can download the latest version of [Chart.js on GitHub](https://github.com/chartjs/Chart.js/releases/latest) or just use these [Chart.js CDN](https://cdnjs.com/libraries/Chart.js) links.
 If you download or clone the repository, you must run `gulp build` to generate the dist files. Chart.js no longer comes with prebuilt release versions, so an alternative option to downloading the repo is **strongly** advised.
 
 ### Installation
@@ -18,23 +18,11 @@ npm install chart.js --save
 
 #### bower
 
-Bower support has been dropped since version 2.2.0 but you can still use Chart.js with Bower thanks to [bower-npm-resolver](https://www.npmjs.com/package/bower-npm-resolver).
-
-First, add the resolver in your .bowerrc file:
-```json
-{
-  "resolvers": [
-    "bower-npm-resolver"
-  ]
-}
-```
-
-Then:
-
 ```bash
-npm install -g bower-npm-resolver
-bower install npm:chart.js --save
+bower install Chart.js --save
 ```
+
+> Note: Bower native support has been reintroduced at version 2.2.3 (previously dropped at version 2.2.0).
 
 ### Selecting the Correct Build
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,10 +10,7 @@ var gulp = require('gulp'),
   htmlv = require('gulp-html-validator'),
   insert = require('gulp-insert'),
   zip = require('gulp-zip'),
-  inquirer = require('inquirer'),
-  semver = require('semver'),
   exec = require('child_process').exec,
-  fs = require('fs'),
   package = require('./package.json'),
   karma = require('gulp-karma'),
   browserify = require('browserify'),
@@ -54,8 +51,6 @@ gulp.task('build', buildTask);
 gulp.task('package', packageTask);
 gulp.task('coverage', coverageTask);
 gulp.task('watch', watchTask);
-gulp.task('bump', bumpTask);
-gulp.task('release', ['build'], releaseTask);
 gulp.task('jshint', jshintTask);
 gulp.task('test', ['jshint', 'validHTML', 'unittest']);
 gulp.task('size', ['library-size', 'module-sizes']);
@@ -135,56 +130,12 @@ function packageTask() {
   .pipe(gulp.dest(outDir));
 }
 
-/*
- *  Usage : gulp bump
- *  Prompts: Version increment to bump
- *  Output: - New version number written into package.json
- */
-function bumpTask(complete) {
-  util.log('Current version:', util.colors.cyan(package.version));
-  var choices = ['major', 'premajor', 'minor', 'preminor', 'patch', 'prepatch', 'prerelease'].map(function(versionType) {
-    return versionType + ' (v' + semver.inc(package.version, versionType) + ')';
-  });
-  inquirer.prompt({
-    type: 'list',
-    name: 'version',
-    message: 'What version update would you like?',
-    choices: choices
-  }, function(res) {
-    var increment = res.version.split(' ')[0],
-      newVersion = semver.inc(package.version, increment),
-      oldVersion = package.version;
-
-    // Set the new versions into the package object
-    package.version = newVersion;
-
-    // Write these to their own files, then build the output
-    fs.writeFileSync('package.json', JSON.stringify(package, null, 2));
-
-    var oldCDN = 'https://cdnjs.cloudflare.com/ajax/libs/Chart.js/'+oldVersion+'/Chart.min.js',
-      newCDN = 'https://cdnjs.cloudflare.com/ajax/libs/Chart.js/'+newVersion+'/Chart.min.js';
-
-    gulp.src(['./README.md'])
-      .pipe(replace(oldCDN, newCDN))
-      .pipe(gulp.dest('./'));
-
-    complete();
-  });
-}
-
-
-function releaseTask() {
-  exec('git tag -a v' + package.version);
-}
-
-
 function jshintTask() {
   return gulp.src(srcDir + '**/*.js')
     .pipe(jshint('config.jshintrc'))
     .pipe(jshint.reporter('jshint-stylish'))
     .pipe(jshint.reporter('fail'));
 }
-
 
 function validHTMLTask() {
   return gulp.src('samples/*.html')

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,6 @@
 var gulp = require('gulp'),
   concat = require('gulp-concat'),
+  file = require('gulp-file'),
   uglify = require('gulp-uglify'),
   util = require('gulp-util'),
   jshint = require('gulp-jshint'),
@@ -48,6 +49,7 @@ var testFiles = [
   '!./test/defaultConfig.tests.js',
 ];
 
+gulp.task('bower', bowerTask);
 gulp.task('build', buildTask);
 gulp.task('package', packageTask);
 gulp.task('coverage', coverageTask);
@@ -65,9 +67,25 @@ gulp.task('library-size', librarySizeTask);
 gulp.task('module-sizes', moduleSizesTask);
 gulp.task('_open', _openTask);
 gulp.task('dev', ['server', 'default']);
-
 gulp.task('default', ['build', 'watch']);
 
+/**
+ * Generates the bower.json manifest file which will be pushed along release tags.
+ * Specs: https://github.com/bower/spec/blob/master/json.md
+ */
+function bowerTask() {
+  var json = JSON.stringify({
+      name: package.name,
+      description: package.description,
+      homepage: package.homepage,
+      license: package.license,
+      version: package.version,
+      main: outDir + "Chart.js"
+    }, null, 2);
+
+  return file('bower.json', json, { src: true })
+    .pipe(gulp.dest('./'));
+}
 
 function buildTask() {
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "gulp-umd": "~0.2.0",
     "gulp-util": "~2.2.x",
     "gulp-zip": "~3.2.0",
-    "inquirer": "^0.5.1",
     "jasmine": "^2.3.2",
     "jasmine-core": "^2.3.4",
     "jquery": "^2.1.4",
@@ -42,7 +41,6 @@
     "karma-jasmine": "^0.3.6",
     "karma-jasmine-html-reporter": "^0.1.8",
     "merge-stream": "^1.0.0",
-    "semver": "^3.0.1",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "gulp": "3.9.x",
     "gulp-concat": "~2.1.x",
     "gulp-connect": "~2.0.5",
+    "gulp-file": "^0.3.0",
     "gulp-html-validator": "^0.0.2",
     "gulp-insert": "~0.5.0",
     "gulp-jshint": "~1.5.1",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+if [ "$TRAVIS_BRANCH" != "release" ]; then
+    echo "Skipping release because this is not the 'release' branch"
+    exit 0
+fi
+
+# Travis executes this script from the repository root, so at the same level than package.json
+VERSION=$(node -p -e "require('./package.json').version")
+
+# Make sure that the associated tag doesn't already exist
+GITTAG=$(git ls-remote origin refs/tags/v$VERSION)
+if [ "$GITTAG" != "" ]; then
+    echo "Tag for package.json version already exists, aborting release"
+    exit 1
+fi
+
+git remote add auth-origin https://$GITHUB_AUTH_TOKEN@github.com/$TRAVIS_REPO_SLUG.git
+git config --global user.email "$GITHUB_AUTH_EMAIL"
+git config --global user.name "Chart.js"
+git checkout --detach --quiet
+git add -f dist/*.js bower.json
+git commit -m "Release $VERSION"
+git tag -a "v$VERSION" -m "Version $VERSION"
+git push -q auth-origin refs/tags/v$VERSION 2>/dev/null
+git remote rm auth-origin
+git checkout -f @{-1}


### PR DESCRIPTION
Bring back to life `bower.json` and dist files in the repository:  the only (big) difference with before is that `dist/*.js` files are not in any branches but only in tags. They are automatically generated from the new [release branch](/chartjs/Chart.js/tree/release) and pushed along the created tag. @chartjs/contributors: can you please read the Release-Process.md file for details and, if needed, propose a better wording and report typos.

Related issues: #3033, #3081, #3182, #3145, #3216