### PR TITLE
Respect the hover mode false - bugfix (#3181)

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -673,7 +673,9 @@ module.exports = function(Chart) {
 
 					// We only need to render at this point. Updating will cause scales to be
 					// recomputed generating flicker & using more memory than necessary.
-					me.render(hoverOptions.animationDuration, true);
+					if (hoverOptions.mode !== false) {
+						me.render(hoverOptions.animationDuration, true);
+					}
 				}
 			}
 


### PR DESCRIPTION
Fix for preventing the onProgress callback to be executed when hover mode is set to false in global options.
