### PR TITLE
Suport minUnit for time scale

### DIFF
--- a/docs/02-Scales.md
+++ b/docs/02-Scales.md
@@ -224,6 +224,7 @@ round | String | - | If defined, dates will be rounded to the start of this unit
 tooltipFormat | String | '' | The moment js format string to use for the tooltip.
 unit | String | - | If defined, will force the unit to be a certain type. See [Time Units](#scales-time-units) section below for details.
 unitStepSize | Number | 1 | The number of units between grid lines.
+minUnit | String | 'millisecond' | The minimum display format to be used for a time unit
 
 #### Date Formats
 

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -48,6 +48,7 @@ module.exports = function(Chart) {
 			round: false, // none, or override with week, month, year, etc.
 			displayFormat: false, // DEPRECATED
 			isoWeekday: false, // override week start day - see http://momentjs.com/docs/#/get-set/iso-weekday/
+			minUnit: 'millisecond',
 
 			// defaults to unit's corresponding unitFormat below or override using pattern string from http://momentjs.com/docs/#/displaying/format/
 			displayFormats: {
@@ -195,7 +196,7 @@ module.exports = function(Chart) {
 				var labelCapacity = innerWidth / (tickLabelWidth);
 
 				// Start as small as possible
-				me.tickUnit = 'millisecond';
+				me.tickUnit = me.options.time.minUnit;
 				me.scaleSizeInUnits = me.lastTick.diff(me.firstTick, me.tickUnit, true);
 				me.displayFormat = me.options.time.displayFormats[me.tickUnit];
 

--- a/test/scale.time.tests.js
+++ b/test/scale.time.tests.js
@@ -84,6 +84,7 @@ describe('Time scale tests', function() {
 				round: false,
 				isoWeekday: false,
 				displayFormat: false,
+				minUnit: 'millisecond',
 				displayFormats: {
 					'millisecond': 'h:mm:ss.SSS a', // 11:20:01.123 AM
 					'second': 'h:mm:ss a', // 11:20:01 AM
@@ -277,6 +278,31 @@ describe('Time scale tests', function() {
 		//scale.buildTicks();
 		scale.update(400, 50);
 		expect(scale.ticks).toEqual(['Jan 1, 8PM', 'Jan 1, 9PM', 'Jan 1, 10PM', 'Jan 1, 11PM', 'Jan 2, 12AM', 'Jan 2, 1AM', 'Jan 2, 2AM', 'Jan 2, 3AM', 'Jan 2, 4AM', 'Jan 2, 5AM', 'Jan 2, 6AM', 'Jan 2, 7AM', 'Jan 2, 8AM', 'Jan 2, 9AM', 'Jan 2, 10AM', 'Jan 2, 11AM', 'Jan 2, 12PM', 'Jan 2, 1PM', 'Jan 2, 2PM', 'Jan 2, 3PM', 'Jan 2, 4PM', 'Jan 2, 5PM', 'Jan 2, 6PM', 'Jan 2, 7PM', 'Jan 2, 8PM', 'Jan 2, 9PM']);
+	});
+
+	it('build ticks honoring the minUnit', function() {
+		var scaleID = 'myScale';
+
+		var mockData = {
+			labels: ["2015-01-01T20:00:00", "2015-01-02T21:00:00"], // days
+		};
+
+		var mockContext = window.createMockContext();
+		var config = Chart.helpers.clone(Chart.scaleService.getScaleDefaults('time'));
+		config.time.minUnit = 'day';
+		var Constructor = Chart.scaleService.getScaleConstructor('time');
+		var scale = new Constructor({
+			ctx: mockContext,
+			options: config, // use default config for scale
+			chart: {
+				data: mockData
+			},
+			id: scaleID
+		});
+
+		//scale.buildTicks();
+		scale.update(400, 50);
+		expect(scale.ticks).toEqual(['Jan 1, 2015', 'Jan 2, 2015', 'Jan 3, 2015']);
 	});
 
 	it('should build ticks using the config diff', function() {


### PR DESCRIPTION
When dealing with time-delineated datasets, often we have data for known
intervals of time. For example, we may have a dataset which represents number
of purchases per day:

```js
{
	labels: ['2016-01-01', '2016-01-02', '2016-01-03']
	datasets: [
		{
			data: [12, 87, 42]
		}
	],
	'...': '...'
}
```

In this case, Chart.js will attempt to figure out the best interval to display
the data, and could pick `hours` as the unit. However, in this case, we would
prefer to just use the `days` interval since our data's granularity can not be
represented well with `hours`.

To remedy this, this commit adds the `minDisplayFormat` option which allows
users to (optionally) specify what the minimum display format they would like
to use.