### PR TITLE
Added "onHover" functionality for legend

### DIFF
--- a/docs/01-Chart-Configuration.md
+++ b/docs/01-Chart-Configuration.md
@@ -127,7 +127,8 @@ Name | Type | Default | Description
 display | Boolean | true | Is the legend displayed
 position | String | 'top' | Position of the legend. Possible values are 'top', 'left', 'bottom' and 'right'.
 fullWidth | Boolean | true | Marks that this box should take the full width of the canvas (pushing down other boxes)
-onClick | Function | `function(event, legendItem) {}` | A callback that is called when a click is registered on top of a label item
+onClick | Function | `function(event, legendItem) {}` | A callback that is called when a 'click' event is registered on top of a label item
+onHover | Function | `function(event, legendItem) {}` | A callback that is called when a 'mousemove' event is registered on top of a label item
 labels |Object|-| See the [Legend Label Configuration](#chart-configuration-legend-label-configuration) section below.
 
 #### Legend Label Configuration

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -630,13 +630,14 @@ module.exports = function(Chart) {
 			if (hoverOptions.onHover) {
 				hoverOptions.onHover.call(me, me.active);
 			}
+			
+			if (me.legend && me.legend.handleEvent) {
+				me.legend.handleEvent(e);
+			}
 
 			if (e.type === 'mouseup' || e.type === 'click') {
 				if (options.onClick) {
 					options.onClick.call(me, e, me.active);
-				}
-				if (me.legend && me.legend.handleEvent) {
-					me.legend.handleEvent(e);
 				}
 			}
 

--- a/src/core/core.legend.js
+++ b/src/core/core.legend.js
@@ -427,8 +427,7 @@ module.exports = function(Chart) {
 		handleEvent: function(e) {
 			var me = this;
 			var opts = me.options;
-			var type = e.type;
-			type = type === 'mouseup' ? 'click' : type;
+			var type = e.type === 'mouseup' ? 'click' : e.type;
 
 			if (type === 'mousemove') {
 				if (!opts.onHover) {

--- a/src/core/core.legend.js
+++ b/src/core/core.legend.js
@@ -25,6 +25,8 @@ module.exports = function(Chart) {
 			ci.update();
 		},
 
+		onHover: null,
+
 		labels: {
 			boxWidth: 40,
 			padding: 10,
@@ -424,10 +426,25 @@ module.exports = function(Chart) {
 		// Handle an event
 		handleEvent: function(e) {
 			var me = this;
+			var opts = me.options;
+			var type = e.type;
+			type = type === 'mouseup' ? 'click' : type;
+
+			if (type === 'mousemove') {
+				if (!opts.onHover) {
+					return;
+				}
+			} else if (type === 'click') {
+				if (!opts.onClick) {
+					return;
+				}
+			} else {
+				return;
+			}
+
 			var position = helpers.getRelativePosition(e, me.chart.chart),
 				x = position.x,
-				y = position.y,
-				opts = me.options;
+				y = position.y;
 
 			if (x >= me.left && x <= me.right && y >= me.top && y <= me.bottom) {
 				// See if we are touching one of the dataset boxes
@@ -437,10 +454,13 @@ module.exports = function(Chart) {
 
 					if (x >= hitBox.left && x <= hitBox.left + hitBox.width && y >= hitBox.top && y <= hitBox.top + hitBox.height) {
 						// Touching an element
-						if (opts.onClick) {
+						if (type === 'click') {
 							opts.onClick.call(me, e, me.legendItems[i]);
+							break;
+						} else if (type === 'mousemove') {
+							opts.onHover.call(me, e, me.legendItems[i]);
+							break;
 						}
-						break;
 					}
 				}
 			}

--- a/test/core.legend.tests.js
+++ b/test/core.legend.tests.js
@@ -23,7 +23,7 @@ describe('Legend block tests', function() {
 
 			// a callback that will handle
 			onClick: jasmine.any(Function),
-			onHover: undefined,
+			onHover: null,
 
 			labels: {
 				boxWidth: 40,

--- a/test/core.legend.tests.js
+++ b/test/core.legend.tests.js
@@ -23,6 +23,7 @@ describe('Legend block tests', function() {
 
 			// a callback that will handle
 			onClick: jasmine.any(Function),
+			onHover: undefined,
 
 			labels: {
 				boxWidth: 40,


### PR DESCRIPTION
* core.legend.js
   - Created an "onHover" property in the legend object that will hold a user defined function (default is null)
   - Modified the "handleEvent" function of the legend to check if the event passed to it is a "click/mouseup" or a "mousemove" to determine whether to call the "onClick" or the "onHover" event (this is for the sake of reusing the legend hitbox calculations)
   - The "onHover" event will receive the same parameters as the "onClick" (the "event" itself and the "legendItem" the user is hovering over)

* core.controller.js
   - Added a "mousemove" event to the "eventHandler" of the controller and put the new legend "onHover" logic in it
   - Also moved the original chart "onHover" functionality under the "mousemove" clause too in order to put the hover events in one place for consistency.