### PR TITLE
Fix link to extension react-chartjs

### DIFF
--- a/docs/10-Notes.md
+++ b/docs/10-Notes.md
@@ -98,6 +98,7 @@ There are many extensions which are available for use with popular frameworks. S
 
 #### React
  - <a href="https://github.com/reactjs/react-chartjs" target="_blank">react-chartjs</a>
+ - <a href="https://github.com/gor181/react-chartjs-2" target="_blank">react-chartjs-2</a>
 
 #### Django
  - <a href="https://github.com/novafloss/django-chartjs" target="_blank">Django Chartjs</a>

--- a/docs/10-Notes.md
+++ b/docs/10-Notes.md
@@ -97,7 +97,7 @@ There are many extensions which are available for use with popular frameworks. S
  - <a href="https://github.com/earlonrails/angular-chartjs-directive" target="_blank">Angular Chart-js Directive</a>
 
 #### React
- - <a href="https://github.com/earlonrails/angular-chartjs-directive" target="_blank">react-chartjs</a>
+ - <a href="https://github.com/reactjs/react-chartjs" target="_blank">react-chartjs</a>
 
 #### Django
  - <a href="https://github.com/novafloss/django-chartjs" target="_blank">Django Chartjs</a>

--- a/docs/10-Notes.md
+++ b/docs/10-Notes.md
@@ -97,7 +97,7 @@ There are many extensions which are available for use with popular frameworks. S
  - <a href="https://github.com/earlonrails/angular-chartjs-directive" target="_blank">Angular Chart-js Directive</a>
 
 #### React
- - <a href="https://github.com/reactjs/react-chartjs" target="_blank">react-chartjs</a>
+ - <a href="https://github.com/topdmc/react-chartjs2" target="_blank">react-chartjs2</a>
  - <a href="https://github.com/gor181/react-chartjs-2" target="_blank">react-chartjs-2</a>
 
 #### Django


### PR DESCRIPTION
Fixed a link to a related project in the docs. I searched for the project (because the link pointed to the wrong repository) and hope that I found the correct one (please check).