### PR TITLE
Fix for outer tick (gridLIne) not shown in radar chart when scale is reverse #3251

### DIFF
--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -304,8 +304,8 @@ module.exports = function(Chart) {
 						var yCenterOffset = me.getDistanceFromCenterForValue(me.ticksAsNumbers[index]);
 						var yHeight = me.yCenter - yCenterOffset;
 
-						// Draw circular lines around the scale
-						if (gridLineOpts.display && index !== 0) {
+						// Draw circular lines around the scale (if they are not in the center)
+							if ((gridLineOpts.display && index !== 0 && !opts.reverse ) || (gridLineOpts.display && opts.reverse && index!== me.ticks.length-1 )) {
 							ctx.strokeStyle = helpers.getValueAtIndexOrDefault(gridLineOpts.color, index - 1);
 							ctx.lineWidth = helpers.getValueAtIndexOrDefault(gridLineOpts.lineWidth, index - 1);
 

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -305,7 +305,7 @@ module.exports = function(Chart) {
 						var yHeight = me.yCenter - yCenterOffset;
 
 						// Draw circular lines around the scale (if they are not in the center)
-							if ((gridLineOpts.display && index !== 0 && !opts.reverse ) || (gridLineOpts.display && opts.reverse && index!== me.ticks.length-1 )) {
+						if ((gridLineOpts.display && index !== 0 && !opts.reverse ) || (gridLineOpts.display && opts.reverse && index!== me.ticks.length-1 )) {
 							ctx.strokeStyle = helpers.getValueAtIndexOrDefault(gridLineOpts.color, index - 1);
 							ctx.lineWidth = helpers.getValueAtIndexOrDefault(gridLineOpts.lineWidth, index - 1);
 


### PR DESCRIPTION
Build two different conditions, weather normal or reverse scale. 
In original this condition surpressed the drawing at index=0 which is the inner tick.
This leaded to surpressing the drawing of the outest gridLine if the scale is reversed.
In every case the inner gridline shouldnot to be drawn. which in normal scale is at index =0 and in reverse mode the last found index (me.ticks.length-1).
