### PR TITLE
Tests cleanup

### DIFF
--- a/test/controller.bar.tests.js
+++ b/test/controller.bar.tests.js
@@ -5,10 +5,6 @@ describe('Bar controller tests', function() {
 		window.addDefaultMatchers(jasmine);
 	});
 
-	afterEach(function() {
-		window.releaseAllCharts();
-	});
-
 	it('should be constructed', function() {
 		var chart = window.acquireChart({
 			type: 'bar',

--- a/test/controller.bar.tests.js
+++ b/test/controller.bar.tests.js
@@ -1,10 +1,5 @@
 // Test the bar controller
 describe('Bar controller tests', function() {
-
-	beforeEach(function() {
-		window.addDefaultMatchers(jasmine);
-	});
-
 	it('should be constructed', function() {
 		var chart = window.acquireChart({
 			type: 'bar',

--- a/test/controller.bubble.tests.js
+++ b/test/controller.bubble.tests.js
@@ -5,10 +5,6 @@ describe('Bubble controller tests', function() {
 		window.addDefaultMatchers(jasmine);
 	});
 
-	afterEach(function() {
-		window.releaseAllCharts();
-	});
-
 	it('should be constructed', function() {
 		var chart = window.acquireChart({
 			type: 'bubble',

--- a/test/controller.bubble.tests.js
+++ b/test/controller.bubble.tests.js
@@ -1,10 +1,5 @@
 // Test the bubble controller
 describe('Bubble controller tests', function() {
-
-	beforeEach(function() {
-		window.addDefaultMatchers(jasmine);
-	});
-
 	it('should be constructed', function() {
 		var chart = window.acquireChart({
 			type: 'bubble',

--- a/test/controller.doughnut.tests.js
+++ b/test/controller.doughnut.tests.js
@@ -5,10 +5,6 @@ describe('Doughnut controller tests', function() {
 		window.addDefaultMatchers(jasmine);
 	});
 
-	afterEach(function() {
-		window.releaseAllCharts();
-	});
-
 	it('should be constructed', function() {
 		var chart = window.acquireChart({
 			type: 'doughnut',

--- a/test/controller.doughnut.tests.js
+++ b/test/controller.doughnut.tests.js
@@ -1,10 +1,5 @@
 // Test the bar controller
 describe('Doughnut controller tests', function() {
-
-	beforeEach(function() {
-		window.addDefaultMatchers(jasmine);
-	});
-
 	it('should be constructed', function() {
 		var chart = window.acquireChart({
 			type: 'doughnut',

--- a/test/controller.line.tests.js
+++ b/test/controller.line.tests.js
@@ -5,10 +5,6 @@ describe('Line controller tests', function() {
 		window.addDefaultMatchers(jasmine);
 	});
 
-	afterEach(function() {
-		window.releaseAllCharts();
-	});
-
 	it('should be constructed', function() {
 		var chart = window.acquireChart({
 			type: 'line',

--- a/test/controller.line.tests.js
+++ b/test/controller.line.tests.js
@@ -1,10 +1,5 @@
 // Test the line controller
 describe('Line controller tests', function() {
-
-	beforeEach(function() {
-		window.addDefaultMatchers(jasmine);
-	});
-
 	it('should be constructed', function() {
 		var chart = window.acquireChart({
 			type: 'line',

--- a/test/controller.polarArea.tests.js
+++ b/test/controller.polarArea.tests.js
@@ -1,10 +1,5 @@
 // Test the polar area controller
 describe('Polar area controller tests', function() {
-
-	beforeEach(function() {
-		window.addDefaultMatchers(jasmine);
-	});
-
 	it('should be constructed', function() {
 		var chart = window.acquireChart({
 		type: 'polarArea',

--- a/test/controller.polarArea.tests.js
+++ b/test/controller.polarArea.tests.js
@@ -5,10 +5,6 @@ describe('Polar area controller tests', function() {
 		window.addDefaultMatchers(jasmine);
 	});
 
-	afterEach(function() {
-		window.releaseAllCharts();
-	});
-
 	it('should be constructed', function() {
 		var chart = window.acquireChart({
 		type: 'polarArea',

--- a/test/controller.radar.tests.js
+++ b/test/controller.radar.tests.js
@@ -1,9 +1,5 @@
 // Test the polar area controller
 describe('Radar controller tests', function() {
-	beforeEach(function() {
-		window.addDefaultMatchers(jasmine);
-	});
-
 	it('Should be constructed', function() {
 		var chart = window.acquireChart({
 			type: 'radar',

--- a/test/controller.radar.tests.js
+++ b/test/controller.radar.tests.js
@@ -4,10 +4,6 @@ describe('Radar controller tests', function() {
 		window.addDefaultMatchers(jasmine);
 	});
 
-	afterEach(function() {
-		window.releaseAllCharts();
-	});
-
 	it('Should be constructed', function() {
 		var chart = window.acquireChart({
 			type: 'radar',
@@ -137,7 +133,7 @@ describe('Radar controller tests', function() {
 			tension: 0.1,
 		}));
 
-		[ 
+		[
 			{ x: 256, y: 272, cppx: 256, cppy: 272, cpnx: 256, cpny: 272},
 			{ x: 256, y: 272, cppx: 256, cppy: 272, cpnx: 256, cpny: 272},
 			{ x: 256, y: 272, cppx: 256, cppy: 272, cpnx: 256, cpny: 272},
@@ -163,8 +159,8 @@ describe('Radar controller tests', function() {
 
 		// Now update controller and ensure proper updates
 		meta.controller.update();
-		
-		[ 
+
+		[
 			{ x: 256, y: 133, cppx: 246, cppy: 133, cpnx: 272, cpny: 133 },
 			{ x: 464, y: 272, cppx: 464, cppy: 264, cpnx: 464, cpny: 278 },
 			{ x: 256, y: 272, cppx: 276.9, cppy: 272, cpnx: 250.4, cpny: 272 },
@@ -225,7 +221,7 @@ describe('Radar controller tests', function() {
 		}));
 
 		// Since tension is now 0, we don't care about the control points
-		[ 
+		[
 			{ x: 256, y: 133 },
 			{ x: 464, y: 272 },
 			{ x: 256, y: 272 },
@@ -245,7 +241,7 @@ describe('Radar controller tests', function() {
 			}));
 		});
 
-		
+
 		// Use custom styles for lines & first point
 		meta.dataset.custom = {
 			tension: 0.25,

--- a/test/core.layoutService.tests.js
+++ b/test/core.layoutService.tests.js
@@ -1,9 +1,5 @@
 // Tests of the scale service
 describe('Test the layout service', function() {
-	beforeEach(function() {
-		window.addDefaultMatchers(jasmine);
-	});
-
 	it('should fit a simple chart with 2 scales', function() {
 		var chart = window.acquireChart({
 			type: 'bar',

--- a/test/core.layoutService.tests.js
+++ b/test/core.layoutService.tests.js
@@ -4,10 +4,6 @@ describe('Test the layout service', function() {
 		window.addDefaultMatchers(jasmine);
 	});
 
-	afterEach(function() {
-		window.releaseAllCharts();
-	});
-
 	it('should fit a simple chart with 2 scales', function() {
 		var chart = window.acquireChart({
 			type: 'bar',
@@ -30,8 +26,10 @@ describe('Test the layout service', function() {
 				}
 			}
 		}, {
-			height: '150px',
-			width: '250px'
+			canvas: {
+				height: 150,
+				width: 250
+			}
 		});
 
 		expect(chart.chartArea.bottom).toBeCloseToPixel(112);
@@ -78,8 +76,10 @@ describe('Test the layout service', function() {
 				}
 			}
 		}, {
-			height: '150px',
-			width: '250px'
+			canvas: {
+				height: 150,
+				width: 250
+			}
 		});
 
 		expect(chart.chartArea.bottom).toBeCloseToPixel(150);
@@ -157,8 +157,10 @@ describe('Test the layout service', function() {
 				}
 			}
 		}, {
-			height: '150px',
-			width: '250px'
+			canvas: {
+				height: 150,
+				width: 250
+			}
 		});
 
 		expect(chart.chartArea.bottom).toBeCloseToPixel(102);

--- a/test/core.legend.tests.js
+++ b/test/core.legend.tests.js
@@ -5,10 +5,6 @@ describe('Legend block tests', function() {
 		window.addDefaultMatchers(jasmine);
 	});
 
-	afterEach(function() {
-		window.releaseAllCharts();
-	});
-
 	it('Should be constructed', function() {
 		var legend = new Chart.Legend({});
 		expect(legend).not.toBe(undefined);

--- a/test/core.legend.tests.js
+++ b/test/core.legend.tests.js
@@ -1,10 +1,5 @@
 // Test the rectangle element
 describe('Legend block tests', function() {
-
-	beforeEach(function() {
-		window.addDefaultMatchers(jasmine);
-	});
-
 	it('Should be constructed', function() {
 		var legend = new Chart.Legend({});
 		expect(legend).not.toBe(undefined);

--- a/test/core.tooltip.tests.js
+++ b/test/core.tooltip.tests.js
@@ -5,10 +5,6 @@ describe('tooltip tests', function() {
 		window.addDefaultMatchers(jasmine);
 	});
 
-	afterEach(function() {
-		window.releaseAllCharts();
-	});
-
 	it('Should display in label mode', function() {
 		var chartInstance = window.acquireChart({
 			type: 'line',

--- a/test/core.tooltip.tests.js
+++ b/test/core.tooltip.tests.js
@@ -1,10 +1,5 @@
 // Test the rectangle element
 describe('tooltip tests', function() {
-
-	beforeEach(function() {
-		window.addDefaultMatchers(jasmine);
-	});
-
 	it('Should display in label mode', function() {
 		var chartInstance = window.acquireChart({
 			type: 'line',

--- a/test/mockContext.js
+++ b/test/mockContext.js
@@ -168,29 +168,47 @@
 	// Canvas injection helpers
 	var charts = {};
 
-	function acquireChart(config, style) {
+	/**
+	 * Injects a new canvas (and div wrapper) and creates teh associated Chart instance
+	 * using the given config. Additional options allow tweaking elements generation.
+	 * @param {object} config - Chart config.
+	 * @param {object} options - Chart acquisition options.
+	 * @param {object} options.canvas - Canvas attributes.
+	 * @param {object} options.wrapper - Canvas wrapper attributes.
+	 * @param {boolean} options.persistent - If true, the chart will not be released after the spec.
+	 */
+	function acquireChart(config, options) {
 		var wrapper = document.createElement("div");
 		var canvas = document.createElement("canvas");
-		wrapper.className = 'chartjs-wrapper';
+		var chart, key;
 
-		style = style || { height: '512px', width: '512px' };
-		for (var k in style) {
-			wrapper.style[k] = style[k];
-			canvas.style[k] = style[k];
+		options = options || {};
+		options.canvas = options.canvas || { height: 512, width: 512 };
+		options.wrapper = options.wrapper || { class: 'chartjs-wrapper' };
+
+		for (key in options.canvas) {
+			if (options.canvas.hasOwnProperty(key)) {
+				canvas.setAttribute(key, options.canvas[key]);
+			}
 		}
 
-		canvas.height = canvas.style.height && parseInt(canvas.style.height);
-		canvas.width = canvas.style.width && parseInt(canvas.style.width);
+		for (key in options.wrapper) {
+			if (options.wrapper.hasOwnProperty(key)) {
+				wrapper.setAttribute(key, options.wrapper[key]);
+			}
+		}
 
 		// by default, remove chart animation and auto resize
-		var options = config.options = config.options || {};
-		options.animation = options.animation === undefined? false : options.animation;
-		options.responsive = options.responsive === undefined? false : options.responsive;
-		options.defaultFontFamily = options.defaultFontFamily || 'Arial';
+		config.options = config.options || {};
+		config.options.animation = config.options.animation === undefined? false : config.options.animation;
+		config.options.responsive = config.options.responsive === undefined? false : config.options.responsive;
+		config.options.defaultFontFamily = config.options.defaultFontFamily || 'Arial';
 
 		wrapper.appendChild(canvas);
 		window.document.body.appendChild(wrapper);
-		var chart = new Chart(canvas.getContext("2d"), config);
+
+		chart = new Chart(canvas.getContext("2d"), config);
+		chart.__test_persistent = options.persistent;
 		charts[chart.id] = chart;
 		return chart;
 	}
@@ -201,12 +219,15 @@
 		delete chart;
 	}
 
-	function releaseAllCharts(scope) {
+	afterEach(function() {
+		// Auto releasing acquired charts
 		for (var id in charts) {
 			var chart = charts[id];
-			releaseChart(chart);
+			if (!chart.__test_persistent) {
+				releaseChart(chart);
+			}
 		}
-	}
+	});
 
 	function injectCSS(css) {
 		// http://stackoverflow.com/q/3922139
@@ -223,7 +244,6 @@
 
 	window.acquireChart = acquireChart;
 	window.releaseChart = releaseChart;
-	window.releaseAllCharts = releaseAllCharts;
 
 	// some style initialization to limit differences between browsers across different plateforms.
 	injectCSS(

--- a/test/mockContext.js
+++ b/test/mockContext.js
@@ -158,12 +158,12 @@
 		};
 	}
 
-	window.addDefaultMatchers = function(jasmine) {
+	beforeEach(function() {
 		jasmine.addMatchers({
 			toBeCloseToPixel: toBeCloseToPixel,
 			toEqualOneOf: toEqualOneOf
 		});
-	}
+	});
 
 	// Canvas injection helpers
 	var charts = {};

--- a/test/scale.linear.tests.js
+++ b/test/scale.linear.tests.js
@@ -1,8 +1,4 @@
 describe('Linear Scale', function() {
-	beforeEach(function() {
-		window.addDefaultMatchers(jasmine);
-	});
-
 	it('Should register the constructor with the scale service', function() {
 		var Constructor = Chart.scaleService.getScaleConstructor('linear');
 		expect(Constructor).not.toBe(undefined);

--- a/test/scale.linear.tests.js
+++ b/test/scale.linear.tests.js
@@ -1,15 +1,6 @@
 describe('Linear Scale', function() {
-	var chartInstance;
-
 	beforeEach(function() {
 		window.addDefaultMatchers(jasmine);
-	});
-
-	afterEach(function() {
-		if (chartInstance)
-		{
-			releaseChart(chartInstance);
-		}
 	});
 
 	it('Should register the constructor with the scale service', function() {
@@ -61,7 +52,7 @@ describe('Linear Scale', function() {
 	});
 
 	it('Should correctly determine the max & min data values', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'bar',
 			data: {
 				datasets: [{
@@ -89,13 +80,13 @@ describe('Linear Scale', function() {
 			}
 		});
 
-		expect(chartInstance.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chartInstance.scales.yScale0.min).toBe(-100);
-		expect(chartInstance.scales.yScale0.max).toBe(150);
+		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
+		expect(chart.scales.yScale0.min).toBe(-100);
+		expect(chart.scales.yScale0.max).toBe(150);
 	});
 
 	it('Should correctly determine the max & min of string data values', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'bar',
 			data: {
 				datasets: [{
@@ -123,13 +114,13 @@ describe('Linear Scale', function() {
 			}
 		});
 
-		expect(chartInstance.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chartInstance.scales.yScale0.min).toBe(-100);
-		expect(chartInstance.scales.yScale0.max).toBe(150);
+		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
+		expect(chart.scales.yScale0.min).toBe(-100);
+		expect(chart.scales.yScale0.max).toBe(150);
 	});
 
 	it('Should correctly determine the max & min data values ignoring hidden datasets', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'bar',
 			data: {
 				datasets: [{
@@ -158,13 +149,13 @@ describe('Linear Scale', function() {
 			}
 		});
 
-		expect(chartInstance.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chartInstance.scales.yScale0.min).toBe(-100);
-		expect(chartInstance.scales.yScale0.max).toBe(80);
+		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
+		expect(chart.scales.yScale0.min).toBe(-100);
+		expect(chart.scales.yScale0.max).toBe(80);
 	});
 
 	it('Should correctly determine the max & min data values ignoring data that is NaN', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'bar',
 			data: {
 				datasets: [{
@@ -183,19 +174,19 @@ describe('Linear Scale', function() {
 			}
 		});
 
-		expect(chartInstance.scales.yScale0.min).toBe(30);
-		expect(chartInstance.scales.yScale0.max).toBe(90);
+		expect(chart.scales.yScale0.min).toBe(30);
+		expect(chart.scales.yScale0.max).toBe(90);
 
 		// Scale is now stacked
-		chartInstance.scales.yScale0.options.stacked = true;
-		chartInstance.update();
+		chart.scales.yScale0.options.stacked = true;
+		chart.update();
 
-		expect(chartInstance.scales.yScale0.min).toBe(0);
-		expect(chartInstance.scales.yScale0.max).toBe(90);
+		expect(chart.scales.yScale0.min).toBe(0);
+		expect(chart.scales.yScale0.max).toBe(90);
 	});
 
 	it('Should correctly determine the max & min for scatter data', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'line',
 			data: {
 				datasets: [{
@@ -230,16 +221,16 @@ describe('Linear Scale', function() {
 				}
 			}
 		});
-		chartInstance.update();
+		chart.update();
 
-		expect(chartInstance.scales.xScale0.min).toBe(-20);
-		expect(chartInstance.scales.xScale0.max).toBe(100);
-		expect(chartInstance.scales.yScale0.min).toBe(0);
-		expect(chartInstance.scales.yScale0.max).toBe(100);
+		expect(chart.scales.xScale0.min).toBe(-20);
+		expect(chart.scales.xScale0.max).toBe(100);
+		expect(chart.scales.yScale0.min).toBe(0);
+		expect(chart.scales.yScale0.max).toBe(100);
 	});
 
 	it('Should correctly get the label for the given index', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'line',
 			data: {
 				datasets: [{
@@ -274,13 +265,13 @@ describe('Linear Scale', function() {
 				}
 			}
 		});
-		chartInstance.update();
+		chart.update();
 
-		expect(chartInstance.scales.yScale0.getLabelForIndex(3, 0)).toBe(7);
+		expect(chart.scales.yScale0.getLabelForIndex(3, 0)).toBe(7);
 	});
 
 	it('Should correctly determine the min and max data values when stacked mode is turned on', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'line',
 			data: {
 				datasets: [{
@@ -314,14 +305,14 @@ describe('Linear Scale', function() {
 				}
 			}
 		});
-		chartInstance.update();
+		chart.update();
 
-		expect(chartInstance.scales.yScale0.min).toBe(-150);
-		expect(chartInstance.scales.yScale0.max).toBe(200);
+		expect(chart.scales.yScale0.min).toBe(-150);
+		expect(chart.scales.yScale0.max).toBe(200);
 	});
 
 	it('Should correctly determine the min and max data values when stacked mode is turned on and there are hidden datasets', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'bar',
 			data: {
 				datasets: [{
@@ -353,14 +344,14 @@ describe('Linear Scale', function() {
 				}
 			}
 		});
-		chartInstance.update();
+		chart.update();
 
-		expect(chartInstance.scales.yScale0.min).toBe(-150);
-		expect(chartInstance.scales.yScale0.max).toBe(200);
+		expect(chart.scales.yScale0.min).toBe(-150);
+		expect(chart.scales.yScale0.max).toBe(200);
 	});
 
 	it('Should correctly determine the min and max data values when stacked mode is turned on there are multiple types of datasets', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'bar',
 			data: {
 				datasets: [{
@@ -387,13 +378,13 @@ describe('Linear Scale', function() {
 			}
 		});
 
-		chartInstance.scales.yScale0.determineDataLimits();
-		expect(chartInstance.scales.yScale0.min).toBe(-105);
-		expect(chartInstance.scales.yScale0.max).toBe(160);
+		chart.scales.yScale0.determineDataLimits();
+		expect(chart.scales.yScale0.min).toBe(-105);
+		expect(chart.scales.yScale0.max).toBe(160);
 	});
 
 	it('Should ensure that the scale has a max and min that are not equal', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'bar',
 			data: {
 				datasets: [],
@@ -409,13 +400,13 @@ describe('Linear Scale', function() {
 			}
 		});
 
-		expect(chartInstance.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chartInstance.scales.yScale0.min).toBe(-1);
-		expect(chartInstance.scales.yScale0.max).toBe(1);
+		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
+		expect(chart.scales.yScale0.min).toBe(-1);
+		expect(chart.scales.yScale0.max).toBe(1);
 	});
 
 	it('Should ensure that the scale has a max and min that are not equal when beginAtZero is set', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'bar',
 			data: {
 				datasets: [],
@@ -434,13 +425,13 @@ describe('Linear Scale', function() {
 			}
 		});
 
-		expect(chartInstance.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chartInstance.scales.yScale0.min).toBe(0);
-		expect(chartInstance.scales.yScale0.max).toBe(1);
+		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
+		expect(chart.scales.yScale0.min).toBe(0);
+		expect(chart.scales.yScale0.max).toBe(1);
 	});
 
 	it('Should use the suggestedMin and suggestedMax options', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'bar',
 			data: {
 				datasets: [{
@@ -463,13 +454,13 @@ describe('Linear Scale', function() {
 			}
 		});
 
-		expect(chartInstance.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chartInstance.scales.yScale0.min).toBe(-10);
-		expect(chartInstance.scales.yScale0.max).toBe(10);
+		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
+		expect(chart.scales.yScale0.min).toBe(-10);
+		expect(chart.scales.yScale0.max).toBe(10);
 	});
 
 	it('Should use the min and max options', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'bar',
 			data: {
 				datasets: [{
@@ -492,15 +483,15 @@ describe('Linear Scale', function() {
 			}
 		});
 
-		expect(chartInstance.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chartInstance.scales.yScale0.min).toBe(-1010);
-		expect(chartInstance.scales.yScale0.max).toBe(1010);
-		expect(chartInstance.scales.yScale0.ticks[0]).toBe('1010');
-		expect(chartInstance.scales.yScale0.ticks[chartInstance.scales.yScale0.ticks.length - 1]).toBe('-1010');
+		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
+		expect(chart.scales.yScale0.min).toBe(-1010);
+		expect(chart.scales.yScale0.max).toBe(1010);
+		expect(chart.scales.yScale0.ticks[0]).toBe('1010');
+		expect(chart.scales.yScale0.ticks[chart.scales.yScale0.ticks.length - 1]).toBe('-1010');
 	});
 
 	it('should forcibly include 0 in the range if the beginAtZero option is used', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'bar',
 			data: {
 				datasets: [{
@@ -519,24 +510,24 @@ describe('Linear Scale', function() {
 			}
 		});
 
-		expect(chartInstance.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chartInstance.scales.yScale0.ticks).toEqual(['50', '45', '40', '35', '30', '25', '20']);
+		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
+		expect(chart.scales.yScale0.ticks).toEqual(['50', '45', '40', '35', '30', '25', '20']);
 
-		chartInstance.scales.yScale0.options.ticks.beginAtZero = true;
-		chartInstance.update();
-		expect(chartInstance.scales.yScale0.ticks).toEqual(['50', '45', '40', '35', '30', '25', '20', '15', '10', '5', '0']);
+		chart.scales.yScale0.options.ticks.beginAtZero = true;
+		chart.update();
+		expect(chart.scales.yScale0.ticks).toEqual(['50', '45', '40', '35', '30', '25', '20', '15', '10', '5', '0']);
 
-		chartInstance.data.datasets[0].data = [-20, -30, -40, -50];
-		chartInstance.update();
-		expect(chartInstance.scales.yScale0.ticks).toEqual(['0', '-5', '-10', '-15', '-20', '-25', '-30', '-35', '-40', '-45', '-50']);
+		chart.data.datasets[0].data = [-20, -30, -40, -50];
+		chart.update();
+		expect(chart.scales.yScale0.ticks).toEqual(['0', '-5', '-10', '-15', '-20', '-25', '-30', '-35', '-40', '-45', '-50']);
 
-		chartInstance.scales.yScale0.options.ticks.beginAtZero = false;
-		chartInstance.update();
-		expect(chartInstance.scales.yScale0.ticks).toEqual(['-20', '-25', '-30', '-35', '-40', '-45', '-50']);
+		chart.scales.yScale0.options.ticks.beginAtZero = false;
+		chart.update();
+		expect(chart.scales.yScale0.ticks).toEqual(['-20', '-25', '-30', '-35', '-40', '-45', '-50']);
 	});
 
 	it('Should generate tick marks in the correct order in reversed mode', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'bar',
 			data: {
 				datasets: [{
@@ -558,13 +549,13 @@ describe('Linear Scale', function() {
 			}
 		});
 
-		expect(chartInstance.scales.yScale0.ticks).toEqual(['0', '10', '20', '30', '40', '50', '60', '70', '80']);
-		expect(chartInstance.scales.yScale0.start).toBe(80);
-		expect(chartInstance.scales.yScale0.end).toBe(0);
+		expect(chart.scales.yScale0.ticks).toEqual(['0', '10', '20', '30', '40', '50', '60', '70', '80']);
+		expect(chart.scales.yScale0.start).toBe(80);
+		expect(chart.scales.yScale0.end).toBe(0);
 	});
 
 	it('should use the correct number of decimal places in the default format function', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'bar',
 			data: {
 				datasets: [{
@@ -582,11 +573,11 @@ describe('Linear Scale', function() {
 				}
 			}
 		});
-		expect(chartInstance.scales.yScale0.ticks).toEqual(['0.06', '0.05', '0.04', '0.03', '0.02', '0.01', '0']);
+		expect(chart.scales.yScale0.ticks).toEqual(['0.06', '0.05', '0.04', '0.03', '0.02', '0.01', '0']);
 	});
 
 	it('Should build labels using the user supplied callback', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'bar',
 			data: {
 				datasets: [{
@@ -611,11 +602,11 @@ describe('Linear Scale', function() {
 		});
 
 		// Just the index
-		expect(chartInstance.scales.yScale0.ticks).toEqual(['0', '1', '2', '3', '4', '5', '6', '7', '8']);
+		expect(chart.scales.yScale0.ticks).toEqual(['0', '1', '2', '3', '4', '5', '6', '7', '8']);
 	});
 
 	it('Should get the correct pixel value for a point', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'line',
 			data: {
 				datasets: [{
@@ -639,7 +630,7 @@ describe('Linear Scale', function() {
 			}
 		});
 
-		var xScale = chartInstance.scales.xScale0;
+		var xScale = chart.scales.xScale0;
 		expect(xScale.getPixelForValue(1, 0, 0)).toBeCloseToPixel(501); // right - paddingRight
 		expect(xScale.getPixelForValue(-1, 0, 0)).toBeCloseToPixel(41); // left + paddingLeft
 		expect(xScale.getPixelForValue(0, 0, 0)).toBeCloseToPixel(271); // halfway*/
@@ -648,7 +639,7 @@ describe('Linear Scale', function() {
 		expect(xScale.getValueForPixel(41)).toBeCloseTo(-1, 1e-2);
 		expect(xScale.getValueForPixel(271)).toBeCloseTo(0, 1e-2);
 
-		var yScale = chartInstance.scales.yScale0;
+		var yScale = chart.scales.yScale0;
 		expect(yScale.getPixelForValue(1, 0, 0)).toBeCloseToPixel(32); // right - paddingRight
 		expect(yScale.getPixelForValue(-1, 0, 0)).toBeCloseToPixel(484); // left + paddingLeft
 		expect(yScale.getPixelForValue(0, 0, 0)).toBeCloseToPixel(258); // halfway*/
@@ -659,7 +650,7 @@ describe('Linear Scale', function() {
 	});
 
 	it('should fit correctly', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'line',
 			data: {
 				datasets: [{
@@ -695,7 +686,7 @@ describe('Linear Scale', function() {
 			}
 		});
 
-		var xScale = chartInstance.scales.xScale0;
+		var xScale = chart.scales.xScale0;
 		expect(xScale.paddingTop).toBeCloseToPixel(0);
 		expect(xScale.paddingBottom).toBeCloseToPixel(0);
 		expect(xScale.paddingLeft).toBeCloseToPixel(0);
@@ -703,7 +694,7 @@ describe('Linear Scale', function() {
 		expect(xScale.width).toBeCloseToPixel(471);
 		expect(xScale.height).toBeCloseToPixel(28);
 
-		var yScale = chartInstance.scales.yScale0;
+		var yScale = chart.scales.yScale0;
 		expect(yScale.paddingTop).toBeCloseToPixel(0);
 		expect(yScale.paddingBottom).toBeCloseToPixel(0);
 		expect(yScale.paddingLeft).toBeCloseToPixel(0);
@@ -714,7 +705,7 @@ describe('Linear Scale', function() {
 		// Extra size when scale label showing
 		xScale.options.scaleLabel.display = true;
 		yScale.options.scaleLabel.display = true;
-		chartInstance.update();
+		chart.update();
 
 		expect(xScale.paddingTop).toBeCloseToPixel(0);
 		expect(xScale.paddingBottom).toBeCloseToPixel(0);
@@ -732,7 +723,7 @@ describe('Linear Scale', function() {
 	});
 
 	it('should fit correctly when display is turned off', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'line',
 			data: {
 				datasets: [{
@@ -779,7 +770,7 @@ describe('Linear Scale', function() {
 			}
 		});
 
-		var yScale = chartInstance.scales.yScale0;
+		var yScale = chart.scales.yScale0;
 		expect(yScale.width).toBeCloseToPixel(0);
 	});
 });

--- a/test/scale.logarithmic.tests.js
+++ b/test/scale.logarithmic.tests.js
@@ -1,9 +1,4 @@
 describe('Logarithmic Scale tests', function() {
-
-	beforeEach(function() {
-		window.addDefaultMatchers(jasmine);
-	});
-
 	it('should register the constructor with the scale service', function() {
 		var Constructor = Chart.scaleService.getScaleConstructor('logarithmic');
 		expect(Constructor).not.toBe(undefined);

--- a/test/scale.logarithmic.tests.js
+++ b/test/scale.logarithmic.tests.js
@@ -4,10 +4,6 @@ describe('Logarithmic Scale tests', function() {
 		window.addDefaultMatchers(jasmine);
 	});
 
-	afterEach(function() {
-		window.releaseAllCharts();
-	});
-
 	it('should register the constructor with the scale service', function() {
 		var Constructor = Chart.scaleService.getScaleConstructor('logarithmic');
 		expect(Constructor).not.toBe(undefined);

--- a/test/scale.radialLinear.tests.js
+++ b/test/scale.radialLinear.tests.js
@@ -1,9 +1,5 @@
 // Tests for the radial linear scale used by the polar area and radar charts
 describe('Test the radial linear scale', function() {
-	beforeEach(function() {
-		window.addDefaultMatchers(jasmine);
-	});
-
 	it('Should register the constructor with the scale service', function() {
 		var Constructor = Chart.scaleService.getScaleConstructor('radialLinear');
 		expect(Constructor).not.toBe(undefined);

--- a/test/scale.radialLinear.tests.js
+++ b/test/scale.radialLinear.tests.js
@@ -1,15 +1,7 @@
 // Tests for the radial linear scale used by the polar area and radar charts
 describe('Test the radial linear scale', function() {
-	var chartInstance;
-
 	beforeEach(function() {
 		window.addDefaultMatchers(jasmine);
-	});
-
-	afterEach(function() {
-		if (chartInstance) {
-			releaseChart(chartInstance);
-		}
 	});
 
 	it('Should register the constructor with the scale service', function() {
@@ -77,7 +69,7 @@ describe('Test the radial linear scale', function() {
 	});
 
 	it('Should correctly determine the max & min data values', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'radar',
 			data: {
 				datasets: [{
@@ -88,18 +80,16 @@ describe('Test the radial linear scale', function() {
 				labels: ['lablel1', 'label2', 'label3', 'label4', 'label5', 'label6']
 			},
 			options: {
-				scales: {
-
-				}
+				scales: {}
 			}
 		});
 
-		expect(chartInstance.scale.min).toBe(-100);
-		expect(chartInstance.scale.max).toBe(150);
+		expect(chart.scale.min).toBe(-100);
+		expect(chart.scale.max).toBe(150);
 	});
 
 	it('Should correctly determine the max & min of string data values', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'radar',
 			data: {
 				datasets: [{
@@ -110,18 +100,16 @@ describe('Test the radial linear scale', function() {
 				labels: ['lablel1', 'label2', 'label3', 'label4', 'label5', 'label6']
 			},
 			options: {
-				scales: {
-
-				}
+				scales: {}
 			}
 		});
 
-		expect(chartInstance.scale.min).toBe(-100);
-		expect(chartInstance.scale.max).toBe(150);
+		expect(chart.scale.min).toBe(-100);
+		expect(chart.scale.max).toBe(150);
 	});
 
 	it('Should correctly determine the max & min data values when there are hidden datasets', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'radar',
 			data: {
 				datasets: [{
@@ -135,18 +123,16 @@ describe('Test the radial linear scale', function() {
 				labels: ['lablel1', 'label2', 'label3', 'label4', 'label5', 'label6']
 			},
 			options: {
-				scales: {
-
-				}
+				scales: {}
 			}
 		});
 
-		expect(chartInstance.scale.min).toBe(-100);
-		expect(chartInstance.scale.max).toBe(150);
+		expect(chart.scale.min).toBe(-100);
+		expect(chart.scale.max).toBe(150);
 	});
 
 	it('Should correctly determine the max & min data values when there is NaN data', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'radar',
 			data: {
 				datasets: [{
@@ -155,14 +141,12 @@ describe('Test the radial linear scale', function() {
 				labels: ['lablel1', 'label2', 'label3', 'label4', 'label5', 'label6']
 			},
 			options: {
-				scales: {
-
-				}
+				scales: {}
 			}
 		});
 
-		expect(chartInstance.scale.min).toBe(50);
-		expect(chartInstance.scale.max).toBe(70);
+		expect(chart.scale.min).toBe(50);
+		expect(chart.scale.max).toBe(70);
 	});
 
 	it('Should ensure that the scale has a max and min that are not equal', function() {
@@ -190,7 +174,7 @@ describe('Test the radial linear scale', function() {
 	});
 
 	it('Should use the suggestedMin and suggestedMax options', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'radar',
 			data: {
 				datasets: [{
@@ -208,12 +192,12 @@ describe('Test the radial linear scale', function() {
 			}
 		});
 
-		expect(chartInstance.scale.min).toBe(-10);
-		expect(chartInstance.scale.max).toBe(10);
+		expect(chart.scale.min).toBe(-10);
+		expect(chart.scale.max).toBe(10);
 	});
 
 	it('Should use the min and max options', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'radar',
 			data: {
 				datasets: [{
@@ -231,13 +215,13 @@ describe('Test the radial linear scale', function() {
 			}
 		});
 
-		expect(chartInstance.scale.min).toBe(-1010);
-		expect(chartInstance.scale.max).toBe(1010);
-		expect(chartInstance.scale.ticks).toEqual(['-1010', '-1000', '-500', '0', '500', '1000', '1010']);
+		expect(chart.scale.min).toBe(-1010);
+		expect(chart.scale.max).toBe(1010);
+		expect(chart.scale.ticks).toEqual(['-1010', '-1000', '-500', '0', '500', '1000', '1010']);
 	});
 
 	it('should forcibly include 0 in the range if the beginAtZero option is used', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'radar',
 			data: {
 				datasets: [{
@@ -254,26 +238,26 @@ describe('Test the radial linear scale', function() {
 			}
 		});
 
-		expect(chartInstance.scale.ticks).toEqual(['20', '25', '30', '35', '40', '45', '50']);
+		expect(chart.scale.ticks).toEqual(['20', '25', '30', '35', '40', '45', '50']);
 
-		chartInstance.scale.options.ticks.beginAtZero = true;
-		chartInstance.update();
+		chart.scale.options.ticks.beginAtZero = true;
+		chart.update();
 
-		expect(chartInstance.scale.ticks).toEqual(['0', '5', '10', '15', '20', '25', '30', '35', '40', '45', '50']);
+		expect(chart.scale.ticks).toEqual(['0', '5', '10', '15', '20', '25', '30', '35', '40', '45', '50']);
 
-		chartInstance.data.datasets[0].data = [-20, -30, -40, -50];
-		chartInstance.update();
+		chart.data.datasets[0].data = [-20, -30, -40, -50];
+		chart.update();
 
-		expect(chartInstance.scale.ticks).toEqual(['-50', '-45', '-40', '-35', '-30', '-25', '-20', '-15', '-10', '-5', '0']);
+		expect(chart.scale.ticks).toEqual(['-50', '-45', '-40', '-35', '-30', '-25', '-20', '-15', '-10', '-5', '0']);
 
-		chartInstance.scale.options.ticks.beginAtZero = false;
-		chartInstance.update();
+		chart.scale.options.ticks.beginAtZero = false;
+		chart.update();
 
-		expect(chartInstance.scale.ticks).toEqual(['-50', '-45', '-40', '-35', '-30', '-25', '-20']);
+		expect(chart.scale.ticks).toEqual(['-50', '-45', '-40', '-35', '-30', '-25', '-20']);
 	});
 
 	it('Should generate tick marks in the correct order in reversed mode', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'radar',
 			data: {
 				datasets: [{
@@ -290,13 +274,13 @@ describe('Test the radial linear scale', function() {
 			}
 		});
 
-		expect(chartInstance.scale.ticks).toEqual(['80', '70', '60', '50', '40', '30', '20', '10', '0']);
-		expect(chartInstance.scale.start).toBe(80);
-		expect(chartInstance.scale.end).toBe(0);
+		expect(chart.scale.ticks).toEqual(['80', '70', '60', '50', '40', '30', '20', '10', '0']);
+		expect(chart.scale.start).toBe(80);
+		expect(chart.scale.end).toBe(0);
 	});
 
 	it('Should build labels using the user supplied callback', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'radar',
 			data: {
 				datasets: [{
@@ -315,12 +299,12 @@ describe('Test the radial linear scale', function() {
 			}
 		});
 
-		expect(chartInstance.scale.ticks).toEqual(['0', '1', '2', '3', '4', '5', '6', '7', '8']);
-		expect(chartInstance.scale.pointLabels).toEqual(['label1', 'label2', 'label3', 'label4', 'label5']);
+		expect(chart.scale.ticks).toEqual(['0', '1', '2', '3', '4', '5', '6', '7', '8']);
+		expect(chart.scale.pointLabels).toEqual(['label1', 'label2', 'label3', 'label4', 'label5']);
 	});
 
 	it('Should build point labels using the user supplied callback', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'radar',
 			data: {
 				datasets: [{
@@ -339,11 +323,11 @@ describe('Test the radial linear scale', function() {
 			}
 		});
 
-		expect(chartInstance.scale.pointLabels).toEqual(['0', '1', '2', '3', '4']);
+		expect(chart.scale.pointLabels).toEqual(['0', '1', '2', '3', '4']);
 	});
 
 	it('should correctly set the center point', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'radar',
 			data: {
 				datasets: [{
@@ -362,13 +346,13 @@ describe('Test the radial linear scale', function() {
 			}
 		});
 
-		expect(chartInstance.scale.drawingArea).toBe(225);
-		expect(chartInstance.scale.xCenter).toBe(256);
-		expect(chartInstance.scale.yCenter).toBe(272);
+		expect(chart.scale.drawingArea).toBe(225);
+		expect(chart.scale.xCenter).toBe(256);
+		expect(chart.scale.yCenter).toBe(272);
 	});
 
 	it('should correctly get the label for a given data index', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'radar',
 			data: {
 				datasets: [{
@@ -386,11 +370,11 @@ describe('Test the radial linear scale', function() {
 				}
 			}
 		});
-		expect(chartInstance.scale.getLabelForIndex(1, 0)).toBe(5);
+		expect(chart.scale.getLabelForIndex(1, 0)).toBe(5);
 	});
 
 	it('should get the correct distance from the center point', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'radar',
 			data: {
 				datasets: [{
@@ -409,22 +393,22 @@ describe('Test the radial linear scale', function() {
 			}
 		});
 
-		expect(chartInstance.scale.getDistanceFromCenterForValue(chartInstance.scale.min)).toBe(0);
-		expect(chartInstance.scale.getDistanceFromCenterForValue(chartInstance.scale.max)).toBe(225);
-		expect(chartInstance.scale.getPointPositionForValue(1, 5)).toEqual({
+		expect(chart.scale.getDistanceFromCenterForValue(chart.scale.min)).toBe(0);
+		expect(chart.scale.getDistanceFromCenterForValue(chart.scale.max)).toBe(225);
+		expect(chart.scale.getPointPositionForValue(1, 5)).toEqual({
 			x: 269,
 			y: 268,
 		});
 
-		chartInstance.scale.options.reverse = true;
-		chartInstance.update();
+		chart.scale.options.reverse = true;
+		chart.update();
 
-		expect(chartInstance.scale.getDistanceFromCenterForValue(chartInstance.scale.min)).toBe(225);
-		expect(chartInstance.scale.getDistanceFromCenterForValue(chartInstance.scale.max)).toBe(0);
+		expect(chart.scale.getDistanceFromCenterForValue(chart.scale.min)).toBe(225);
+		expect(chart.scale.getDistanceFromCenterForValue(chart.scale.max)).toBe(0);
 	});
 
 	it('should correctly get angles for all points', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'radar',
 			data: {
 				datasets: [{
@@ -451,14 +435,14 @@ describe('Test the radial linear scale', function() {
 		var slice = 72; // (360 / 5)
 
 		for(var i = 0; i < 5; i++) {
-			expect(radToNearestDegree(chartInstance.scale.getIndexAngle(i))).toBe(15 + (slice * i) - 90);
+			expect(radToNearestDegree(chart.scale.getIndexAngle(i))).toBe(15 + (slice * i) - 90);
 		}
 
-		chartInstance.options.startAngle = 0;
-		chartInstance.update();
+		chart.options.startAngle = 0;
+		chart.update();
 
 		for(var i = 0; i < 5; i++) {
-			expect(radToNearestDegree(chartInstance.scale.getIndexAngle(i))).toBe((slice * i) - 90);
+			expect(radToNearestDegree(chart.scale.getIndexAngle(i))).toBe((slice * i) - 90);
 		}
 	});
 });

--- a/test/scale.time.tests.js
+++ b/test/scale.time.tests.js
@@ -1,8 +1,6 @@
 // Time scale tests
 describe('Time scale tests', function() {
 	beforeEach(function() {
-		window.addDefaultMatchers(jasmine);
-
 		// Need a time matcher for getValueFromPixel
 		jasmine.addMatchers({
 			toBeCloseToTime: function() {

--- a/test/scale.time.tests.js
+++ b/test/scale.time.tests.js
@@ -1,7 +1,5 @@
 // Time scale tests
 describe('Time scale tests', function() {
-	var chartInstance;
-
 	beforeEach(function() {
 		window.addDefaultMatchers(jasmine);
 
@@ -22,13 +20,6 @@ describe('Time scale tests', function() {
 				}
 			}
 		});
-	});
-
-	afterEach(function() {
-		if (chartInstance)
-		{
-			releaseChart(chartInstance);
-		}
 	});
 
 	it('Should load moment.js as a dependency', function() {
@@ -162,7 +153,7 @@ describe('Time scale tests', function() {
 			return moment('01/01/2015 12:00', 'DD/MM/YYYY HH:mm').add(days, 'd').toDate();
 		}
 
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'line',
 			data: {
 				datasets: [{
@@ -208,12 +199,12 @@ describe('Time scale tests', function() {
 		});
 
 		// Counts down because the lines are drawn top to bottom
-		var xScale = chartInstance.scales.xScale0;
+		var xScale = chart.scales.xScale0;
 		expect(xScale.ticks).toEqual([ 'Jan 1, 2015', 'Jan 3, 2015', 'Jan 5, 2015', 'Jan 7, 2015', 'Jan 9, 2015', 'Jan 11, 2015' ]);
 	});
 
 	it('should allow custom time parsers', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'line',
 			data: {
 				datasets: [{
@@ -248,7 +239,7 @@ describe('Time scale tests', function() {
 		});
 
 		// Counts down because the lines are drawn top to bottom
-		var xScale = chartInstance.scales.xScale0;
+		var xScale = chart.scales.xScale0;
 
 		// Counts down because the lines are drawn top to bottom
 		expect(xScale.ticks[0]).toEqualOneOf(['Nov 19, 1981', 'Nov 20, 1981', 'Nov 21, 1981']); // handle time zone changes
@@ -389,7 +380,7 @@ describe('Time scale tests', function() {
 	});
 
 	it('should get the correct pixel for a value', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'line',
 			data: {
 				datasets: [{
@@ -415,25 +406,25 @@ describe('Time scale tests', function() {
 			}
 		});
 
-		var xScale = chartInstance.scales.xScale0;
+		var xScale = chart.scales.xScale0;
 
 		expect(xScale.getPixelForValue('', 0, 0)).toBeCloseToPixel(78);
 		expect(xScale.getPixelForValue('', 6, 0)).toBeCloseToPixel(452);
 		expect(xScale.getPixelForValue('2015-01-01T20:00:00')).toBeCloseToPixel(78);
 
 		expect(xScale.getValueForPixel(78)).toBeCloseToTime({
-			value: moment(chartInstance.data.labels[0]),
+			value: moment(chart.data.labels[0]),
 			unit: 'hour',
 			threshold: 0.75
 		});
 		expect(xScale.getValueForPixel(452)).toBeCloseToTime({
-			value: moment(chartInstance.data.labels[6]),
+			value: moment(chart.data.labels[6]),
 			unit: 'hour'
 		});
 	});
 
 	it('should get the correct label for a data value', function() {
-		chartInstance = window.acquireChart({
+		var chart = window.acquireChart({
 			type: 'line',
 			data: {
 				datasets: [{
@@ -459,7 +450,7 @@ describe('Time scale tests', function() {
 			}
 		});
 
-		var xScale = chartInstance.scales.xScale0;
+		var xScale = chart.scales.xScale0;
 		expect(xScale.getLabelForIndex(0, 0)).toBe('2015-01-01T20:00:00');
 		expect(xScale.getLabelForIndex(6, 0)).toBe('2015-01-10T12:00');
 
@@ -497,12 +488,12 @@ describe('Time scale tests', function() {
 			}
 		});
 
-		var xScale = chartInstance.scales.xScale0;
+		var xScale = chart.scales.xScale0;
 
 		expect(xScale.getPixelForValue('', 0, 0)).toBeCloseToPixel(78);
 
 		expect(xScale.getValueForPixel(78)).toBeCloseToTime({
-			value: moment(chartInstance.data.labels[0]),
+			value: moment(chart.data.labels[0]),
 			unit: 'day',
 			threshold: 0.75
 		});
@@ -528,7 +519,7 @@ describe('Time scale tests', function() {
 			}
 		});
 
-		var xScale = chartInstance.scales.xScale0;
+		var xScale = chart.scales.xScale0;
 
 		var getOutOfBoundLabelMoment = function() {
 			xScale.getLabelMoment(12, 0);
@@ -536,7 +527,7 @@ describe('Time scale tests', function() {
 
 		expect(getOutOfBoundLabelMoment).not.toThrow();
 	});
-	
+
 	it("should not throw an error if the datasetIndex or index are null", function() {
 		var chart = window.acquireChart({
 			type: 'line',
@@ -557,12 +548,12 @@ describe('Time scale tests', function() {
 			}
 		});
 
-		var xScale = chartInstance.scales.xScale0;
+		var xScale = chart.scales.xScale0;
 
 		var getNullDatasetIndexLabelMoment = function() {
 			xScale.getLabelMoment(null, 1);
 		};
-		
+
 		var getNullIndexLabelMoment = function() {
 			xScale.getLabelMoment(1, null);
 		};

--- a/test/scale.time.tests.js
+++ b/test/scale.time.tests.js
@@ -453,36 +453,24 @@ describe('Time scale tests', function() {
 		var xScale = chart.scales.xScale0;
 		expect(xScale.getLabelForIndex(0, 0)).toBe('2015-01-01T20:00:00');
 		expect(xScale.getLabelForIndex(6, 0)).toBe('2015-01-10T12:00');
-
 	});
+
 	it('should get the correct pixel for only one data in the dataset', function() {
 		var chart = window.acquireChart({
 			type: 'line',
 			data: {
 				labels: ["2016-05-27"],
 				datasets: [{
-					type: "line",
+					xAxisID: 'xScale0',
 					data: [5]
 				}]
 			},
 			options: {
 				scales: {
 					xAxes: [{
+						id: 'xScale0',
 						display: true,
-						type: "time",
-						time: {
-							displayFormats: {
-								"day": "YYYY-MM-DD"
-							}
-						}
-					}],
-					yAxes: [{
-						type: "linear",
-						ticks: {
-							reverse: true,
-							min: 0,
-							max: 10
-						}
+						type: "time"
 					}]
 				}
 			}
@@ -490,9 +478,9 @@ describe('Time scale tests', function() {
 
 		var xScale = chart.scales.xScale0;
 
-		expect(xScale.getPixelForValue('', 0, 0)).toBeCloseToPixel(78);
+		expect(xScale.getPixelForValue('', 0, 0)).toBeCloseToPixel(62);
 
-		expect(xScale.getValueForPixel(78)).toBeCloseToTime({
+		expect(xScale.getValueForPixel(62)).toBeCloseToTime({
 			value: moment(chart.data.labels[0]),
 			unit: 'day',
 			threshold: 0.75
@@ -505,13 +493,14 @@ describe('Time scale tests', function() {
 			data: {
 				labels: ["2016-06-26"],
 				datasets: [{
-					type: "line",
+					xAxisID: 'xScale0',
 					data: [5]
 				}]
 			},
 			options: {
 				scales: {
 					xAxes: [{
+						id: 'xScale0',
 						display: true,
 						type: "time",
 					}]
@@ -520,7 +509,6 @@ describe('Time scale tests', function() {
 		});
 
 		var xScale = chart.scales.xScale0;
-
 		var getOutOfBoundLabelMoment = function() {
 			xScale.getLabelMoment(12, 0);
 		};
@@ -534,13 +522,14 @@ describe('Time scale tests', function() {
 			data: {
 				labels: ["2016-06-26"],
 				datasets: [{
-					type: "line",
+					xAxisID: 'xScale0',
 					data: [5]
 				}]
 			},
 			options: {
 				scales: {
 					xAxes: [{
+						id: 'xScale0',
 						display: true,
 						type: "time",
 					}]


### PR DESCRIPTION
- new `options` parameter to acquire a chart, allowing to configure canvas and wrapper attributes
- charts are now automatically deleted after each tests (ignored if `persistent` option is true)
- fix unit tests that was using a global instance but was supposed to test a local chart
- make sure that all charts are locally acquired and released (no more global instance)
- Jasmine custom matchers are automatically exposed to all tests