### PR TITLE
feat(completedDraw): adds "completedDraw" plugin events. Fixes #3289

### DIFF
--- a/docs/09-Advanced.md
+++ b/docs/09-Advanced.md
@@ -426,13 +426,16 @@ Plugins should derive from Chart.PluginBase and implement the following interfac
 	beforeDatasetsDraw: function(chartInstance, easing) { },
 	afterDatasetsDraw: function(chartInstance, easing) { },
 
+    // After rendering fully finished
+    completedDraw: function(chartInstance) { },
+
 	destroy: function(chartInstance) { }
 }
 ```
 
 ### Building Chart.js
 
-Chart.js uses <a href="http://gulpjs.com/" target="_blank">gulp</a> to build the library into a single JavaScript file. 
+Chart.js uses <a href="http://gulpjs.com/" target="_blank">gulp</a> to build the library into a single JavaScript file.
 
 Firstly, we need to ensure development dependencies are installed. With node and npm installed, after cloning the Chart.js repo to a local directory, and navigating to that directory in the command line, we can run the following:
 

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -332,6 +332,8 @@ module.exports = function(Chart) {
 				if (animationOptions && animationOptions.onComplete && animationOptions.onComplete.call) {
 					animationOptions.onComplete.call(me);
 				}
+
+				Chart.plugins.notify('completedDraw', [me]);
 			}
 			return me;
 		},


### PR DESCRIPTION
Copy/pasting [our discussion](https://github.com/chartjs/Chart.js/issues/3289#issuecomment-247062315) with @etimberg 👍 

> there is no plugin call for after rendering fully finished (ie only after the last frame of animation). afterDraw will do after each frame
> I would accept a PR adding it (could call it at the same place the onComplete animation callback is called)

So here it is @etimberg !