### PR TITLE
Fix error where pie/doughnut charts did not render correctly with multiple datasets

### DIFF
--- a/src/controllers/controller.doughnut.js
+++ b/src/controllers/controller.doughnut.js
@@ -76,7 +76,10 @@ module.exports = function(Chart) {
 
 				for (i = 0, ilen = (chart.data.datasets || []).length; i < ilen; ++i) {
 					meta = chart.getDatasetMeta(i);
-					meta.data[index].hidden = !meta.data[index].hidden;
+					// toggle visibility of index if exists
+					if (meta.data[index]) {
+						meta.data[index].hidden = !meta.data[index].hidden;
+					}
 				}
 
 				chart.update();


### PR DESCRIPTION
Addresses the issue presented in #3309. Pie and Doughnut charts will now render correctly when the corresponding component is clicked on the legend.

Here is an example **before** the changes: http://codepen.io/zachpanz88/pen/yaOzJV
Here is an example **with** the changes: http://codepen.io/zachpanz88/pen/mAEbdz