### PR TITLE
Compute correct tooltip size when there is no title present

### DIFF
--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -354,7 +354,7 @@ module.exports = function(Chart) {
 				footerFontSize = vm.footerFontSize;
 
 			size.height += titleLineCount * titleFontSize; // Title Lines
-			size.height += (titleLineCount - 1) * vm.titleSpacing; // Title Line Spacing
+			size.height += titleLineCount ? (titleLineCount - 1) * vm.titleSpacing : 0; // Title Line Spacing
 			size.height += titleLineCount ? vm.titleMarginBottom : 0; // Title's bottom Margin
 			size.height += combinedBodyLength * bodyFontSize; // Body Lines
 			size.height += combinedBodyLength ? (combinedBodyLength - 1) * vm.bodySpacing : 0; // Body Line Spacing


### PR DESCRIPTION
When there was no tooltip, the size was too small because we accidentally subtracted the title bottom margin.

## After Fix
![tooltip after fix](https://cloud.githubusercontent.com/assets/6757853/18608836/0a6a41dc-7cc2-11e6-8280-0bd6c8c21235.png)
