### PR TITLE
legendCallback improvement

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -90,8 +90,8 @@ module.exports = function() {
 				var text = [];
 				text.push('<ul class="' + chart.id + '-legend">');
 				for (var i = 0; i < chart.data.datasets.length; i++) {
-					text.push('<li><span style="background-color:' + chart.data.datasets[i].backgroundColor + '"></span>');
-					if (chart.data.datasets[i].label) {
+					text.push('<li style="font-family:' + chart.options.legend.fontFamily + ';"><span style="background-color:' + chart.data.datasets[i].backgroundColor + '; border: 3px solid ' + chart.data.datasets[i].borderColor + '; width: 42px; height: 14px;"></span>');
+            		if (chart.data.datasets[i].label) {
 						text.push(chart.data.datasets[i].label);
 					}
 					text.push('</li>');

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -94,7 +94,7 @@ module.exports = function() {
 						text.push('<li style="font-family:'+chart.options.legend.fontFamily+';">');
 					} else {
 						text.push('<li style="font-family:'+Chart.defaults.global.legend.labels.fontFamily+';">');
-					}        
+					}
 					text.push('<span style="background-color:'+chart.data.datasets[i].backgroundColor+'; border: 3px solid '+chart.data.datasets[i].borderColor+'; width: 42px; height: 14px;"></span>');
 					if (chart.data.datasets[i].label) {
 						text.push(chart.data.datasets[i].label);

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -91,12 +91,11 @@ module.exports = function() {
 				text.push('<ul class="' + chart.id + '-legend">');
 				for (var i = 0; i < chart.data.datasets.length; i++) {
 					if (chart.options.legend.fontFamily) {
-						text.push('<li style="font-family:' + chart.options.legend.fontFamily + ';">');
-					}
-					else {
-						text.push('<li style="font-family:' + Chart.defaults.global.legend.labels.fontFamily + ';">');
+						text.push('<li style="font-family:'+chart.options.legend.fontFamily+';">');
+					} else {
+						text.push('<li style="font-family:'+Chart.defaults.global.legend.labels.fontFamily+';">');
 					}        
-					text.push('<span style="background-color:' + chart.data.datasets[i].backgroundColor + '; border: 3px solid ' + chart.data.datasets[i].borderColor + '; width: 42px; height: 14px;"></span>');
+					text.push('<span style="background-color:'+chart.data.datasets[i].backgroundColor+'; border: 3px solid '+chart.data.datasets[i].borderColor+'; width: 42px; height: 14px;"></span>');
 					if (chart.data.datasets[i].label) {
 						text.push(chart.data.datasets[i].label);
 					}

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -90,7 +90,13 @@ module.exports = function() {
 				var text = [];
 				text.push('<ul class="' + chart.id + '-legend">');
 				for (var i = 0; i < chart.data.datasets.length; i++) {
-					text.push('<li style="font-family:' + chart.options.legend.fontFamily + ';"><span style="background-color:' + chart.data.datasets[i].backgroundColor + '; border: 3px solid ' + chart.data.datasets[i].borderColor + '; width: 42px; height: 14px;"></span>');
+					if (chart.options.legend.fontFamily) {
+                		text.push('<li style="font-family:' + chart.options.legend.fontFamily + ';">');
+            		}
+            		else {
+                		text.push('<li style="font-family:' + Chart.defaults.global.legend.labels.fontFamily + ';">');
+            		}        
+            		text.push('<span style="background-color:' + chart.data.datasets[i].backgroundColor + '; border: 3px solid ' + chart.data.datasets[i].borderColor + '; width: 42px; height: 14px;"></span>');
             		if (chart.data.datasets[i].label) {
 						text.push(chart.data.datasets[i].label);
 					}

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -91,13 +91,13 @@ module.exports = function() {
 				text.push('<ul class="' + chart.id + '-legend">');
 				for (var i = 0; i < chart.data.datasets.length; i++) {
 					if (chart.options.legend.fontFamily) {
-                		text.push('<li style="font-family:' + chart.options.legend.fontFamily + ';">');
-            		}
-            		else {
-                		text.push('<li style="font-family:' + Chart.defaults.global.legend.labels.fontFamily + ';">');
-            		}        
-            		text.push('<span style="background-color:' + chart.data.datasets[i].backgroundColor + '; border: 3px solid ' + chart.data.datasets[i].borderColor + '; width: 42px; height: 14px;"></span>');
-            		if (chart.data.datasets[i].label) {
+						text.push('<li style="font-family:' + chart.options.legend.fontFamily + ';">');
+					}
+					else {
+						text.push('<li style="font-family:' + Chart.defaults.global.legend.labels.fontFamily + ';">');
+					}        
+					text.push('<span style="background-color:' + chart.data.datasets[i].backgroundColor + '; border: 3px solid ' + chart.data.datasets[i].borderColor + '; width: 42px; height: 14px;"></span>');
+					if (chart.data.datasets[i].label) {
 						text.push(chart.data.datasets[i].label);
 					}
 					text.push('</li>');


### PR DESCRIPTION
Since fixing the legendCallback before, i've noticed that the legend produced by it looks nothing like the one produced on the canvas. So i've improved the styling to make it look as close to the canvas one as possible. The font of the generated Legend can now also be set in the chart's options i.e. Options: { display: false, legend: { fontFamily: "insert font family here" } }, this will stop the Canvas legend from displaying but still set the font for the generated legend. then the user must call generateLegend() and apply the generated html to the inner html of an element as per usual.
