### PR TITLE
Adding padding by config to chart.js

### DIFF
--- a/src/core/core.layoutService.js
+++ b/src/core/core.layoutService.js
@@ -32,8 +32,13 @@ module.exports = function(Chart) {
 				return;
 			}
 
-			var xPadding = 0;
-			var yPadding = 0;
+			//Getting padding from config or setting by default:
+			 var paddingX = chartInstance.config.options.padding ? chartInstance.config.options.padding.x : 0,
+					 paddingY = chartInstance.config.options.padding ? chartInstance.config.options.padding.y : 0,
+					 validYConfigPadding = paddingY < height / 2 && (paddingY > 0),
+					 validXConfigPadding = paddingX < width / 2 && (paddingX > 0),
+					 xPadding = (validXConfigPadding ? paddingX : (width > 30 ? 5 : 2)),
+					 yPadding = (validYConfigPadding ? paddingY : (height > 30 ? 5 : 2));
 
 			var leftBoxes = helpers.where(chartInstance.boxes, function(box) {
 				return box.options.position === 'left';


### PR DESCRIPTION
Hello all.

As I tell on #3257 and #3332 I've been investigated how to make a hotfix to  solve that. I saw three strange behaviors:

1- The data breaks if have heavy changes, for example:
````javascript
[0, 10, 70, 30, 20, 12, 50, 200, 200, 200, 200, 200]
````
2- The 'error' is always the half of the height of our borderWidth.

3- That error may was introduced when we changed the line 36 of core.layoutService.js on the next [COMMIT](https://github.com/chartjs/Chart.js/commit/798f643fab383872486880a6dc47ed181741f417)

In second place I saw two strange padding vars inside the function 'update' of the core.layoutService:

Around the line 29 we have the function and on lines 35 and 36 we have the strange vars.
````javascript
// The most important function
		update: function(chartInstance, width, height) {

			if (!chartInstance) {
				return;
			}

			var xPadding = 0;
			var yPadding = 0;
````
I have been seen what the function does with that vars, specially with yPadding. I couldn't se any useful calc done with yPadding. In my opinion here is the problem. We always maintain the yPadding to 0 and IMHO it was an error applied in another version of that file [HERE](https://github.com/chartjs/Chart.js/commit/798f643fab383872486880a6dc47ed181741f417) .

The solution is that follows and I developed that because is the demand behind the developer of [that commit](https://github.com/chartjs/Chart.js/commit/798f643fab383872486880a6dc47ed181741f417) deleted the line.

THAT'S A HOTFIX, I WILL MAKE A PR AND IF IT IS APPROVED IT WILL BE THE SOLUTION

If you apply that code you will can set your padding on the styles config of the chart, also, if you don't apply any config he will take a default based on the chart height.

Config prop example:
````javascript
padding: {
  x: 5,
  y: 4
},
`````
You have more info on the code.