### PR TITLE
Fix aspect ratio and add responsive unit tests

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,6 +17,7 @@ var browserify = require('browserify');
 var source = require('vinyl-source-stream');
 var merge = require('merge-stream');
 var collapse = require('bundle-collapser/plugin');
+var argv  = require('yargs').argv
 var package = require('./package.json');
 
 var srcDir = './src/';
@@ -33,11 +34,10 @@ var header = "/*!\n" +
   " */\n";
 
 var preTestFiles = [
-  './node_modules/moment/min/moment.min.js',
+  './node_modules/moment/min/moment.min.js'
 ];
 
 var testFiles = [
-  './test/mockContext.js',
   './test/*.js',
 
   // Disable tests which need to be rewritten based on changes introduced by
@@ -157,10 +157,13 @@ function validHTMLTask() {
 }
 
 function startTest() {
-  var files = ['./src/**/*.js'];
-  Array.prototype.unshift.apply(files, preTestFiles);
-  Array.prototype.push.apply(files, testFiles);
-  return files;
+  return [].concat(preTestFiles).concat([
+      './src/**/*.js',
+      './test/mockContext.js'
+    ]).concat(
+      argv.inputs?
+        argv.inputs.split(';'):
+        testFiles);
 }
 
 function unittestTask() {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "karma-jasmine": "^0.3.6",
     "karma-jasmine-html-reporter": "^0.1.8",
     "merge-stream": "^1.0.0",
-    "vinyl-source-stream": "^1.1.0"
+    "vinyl-source-stream": "^1.1.0",
+    "yargs": "^5.0.0"
   },
   "spm": {
     "main": "Chart.js"

--- a/samples/doughnut.html
+++ b/samples/doughnut.html
@@ -15,7 +15,7 @@
 </head>
 
 <body>
-    <div id="canvas-holder" style="width:75%">
+    <div id="canvas-holder" style="width:40%">
         <canvas id="chart-area" />
     </div>
     <button id="randomizeData">Randomize Data</button>

--- a/samples/polar-area.html
+++ b/samples/polar-area.html
@@ -15,7 +15,7 @@
 </head>
 
 <body>
-    <div id="canvas-holder" style="width:75%">
+    <div id="canvas-holder" style="width:40%">
         <canvas id="chart-area"></canvas>
     </div>
     <button id="randomizeData">Randomize Data</button>

--- a/samples/radar-skip-points.html
+++ b/samples/radar-skip-points.html
@@ -15,7 +15,7 @@
 </head>
 
 <body>
-    <div style="width:75%">
+    <div style="width:40%">
         <canvas id="canvas"></canvas>
     </div>
     <button id="randomizeData">Randomize Data</button>

--- a/samples/radar.html
+++ b/samples/radar.html
@@ -15,7 +15,7 @@
 </head>
 
 <body>
-    <div style="width:75%">
+    <div style="width:40%">
         <canvas id="canvas"></canvas>
     </div>
     <button id="randomizeData">Randomize Data</button>

--- a/src/charts/Chart.Radar.js
+++ b/src/charts/Chart.Radar.js
@@ -3,7 +3,6 @@
 module.exports = function(Chart) {
 
 	Chart.Radar = function(context, config) {
-		config.options = Chart.helpers.configMerge({aspectRatio: 1}, config.options);
 		config.type = 'radar';
 
 		return new Chart(context, config);

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -5,6 +5,7 @@ module.exports = function(Chart) {
 	var helpers = Chart.helpers;
 
 	Chart.defaults.radar = {
+		aspectRatio: 1,
 		scale: {
 			type: 'radialLinear'
 		},

--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -859,9 +859,6 @@ module.exports = function(Chart) {
 			// when destroy is called
 			chart.originalDevicePixelRatio = chart.originalDevicePixelRatio || pixelRatio;
 		}
-
-		canvas.style.width = width + 'px';
-		canvas.style.height = height + 'px';
 	};
 	// -- Canvas methods
 	helpers.clear = function(chart) {

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -5,12 +5,6 @@ module.exports = function() {
 	// Occupy the global variable of Chart, and create a simple base class
 	var Chart = function(context, config) {
 		var me = this;
-		var helpers = Chart.helpers;
-		me.config = config || {
-			data: {
-				datasets: []
-			}
-		};
 
 		// Support a jQuery'd canvas element
 		if (context.length && context[0].getContext) {
@@ -22,44 +16,9 @@ module.exports = function() {
 			context = context.getContext('2d');
 		}
 
-		me.ctx = context;
-		me.canvas = context.canvas;
+		me.controller = new Chart.Controller(context, config, me);
 
-		context.canvas.style.display = context.canvas.style.display || 'block';
-
-		// Figure out what the size of the chart will be.
-		// If the canvas has a specified width and height, we use those else
-		// we look to see if the canvas node has a CSS width and height.
-		// If there is still no height, fill the parent container
-		me.width = context.canvas.width || parseInt(helpers.getStyle(context.canvas, 'width'), 10) || helpers.getMaximumWidth(context.canvas);
-		me.height = context.canvas.height || parseInt(helpers.getStyle(context.canvas, 'height'), 10) || helpers.getMaximumHeight(context.canvas);
-
-		me.aspectRatio = me.width / me.height;
-
-		if (isNaN(me.aspectRatio) || isFinite(me.aspectRatio) === false) {
-			// If the canvas has no size, try and figure out what the aspect ratio will be.
-			// Some charts prefer square canvases (pie, radar, etc). If that is specified, use that
-			// else use the canvas default ratio of 2
-			me.aspectRatio = config.aspectRatio !== undefined ? config.aspectRatio : 2;
-		}
-
-		// Store the original style of the element so we can set it back
-		me.originalCanvasStyleWidth = context.canvas.style.width;
-		me.originalCanvasStyleHeight = context.canvas.style.height;
-
-		// High pixel density displays - multiply the size of the canvas height/width by the device pixel ratio, then scale.
-		helpers.retinaScale(me);
-		me.controller = new Chart.Controller(me);
-
-		// Always bind this so that if the responsive state changes we still work
-		helpers.addResizeListener(context.canvas.parentNode, function() {
-			if (me.controller && me.controller.config.options.responsive) {
-				me.controller.resize();
-			}
-		});
-
-		return me.controller ? me.controller : me;
-
+		return me.controller;
 	};
 
 	// Globally expose the defaults to allow for user updating/changing
@@ -106,5 +65,4 @@ module.exports = function() {
 	Chart.Chart = Chart;
 
 	return Chart;
-
 };

--- a/test/core.controller.tests.js
+++ b/test/core.controller.tests.js
@@ -1,0 +1,488 @@
+describe('Chart.Controller', function() {
+
+	function processResizeEvent(chart, callback) {
+		setTimeout(callback, 100);
+	}
+
+	describe('config.options.aspectRatio', function() {
+		it('should use default "global" aspect ratio for render and display sizes', function() {
+			var chart = acquireChart({
+				options: {
+					responsive: false
+				}
+			}, {
+				canvas: {
+					style: 'width: 620px'
+				}
+			});
+
+			expect(chart).toBeChartOfSize({
+				dw: 620, dh: 310,
+				rw: 620, rh: 310,
+			});
+		});
+
+		it('should use default "chart" aspect ratio for render and display sizes', function() {
+			var chart = acquireChart({
+				type: 'doughnut',
+				options: {
+					responsive: false
+				}
+			}, {
+				canvas: {
+					style: 'width: 425px'
+				}
+			});
+
+			expect(chart).toBeChartOfSize({
+				dw: 425, dh: 425,
+				rw: 425, rh: 425,
+			});
+		});
+
+		it('should use "user" aspect ratio for render and display sizes', function() {
+			var chart = acquireChart({
+				options: {
+					responsive: false,
+					aspectRatio: 3
+				}
+			}, {
+				canvas: {
+					style: 'width: 405px'
+				}
+			});
+
+			expect(chart).toBeChartOfSize({
+				dw: 405, dh: 135,
+				rw: 405, rh: 135,
+			});
+		});
+
+		it('should NOT apply aspect ratio when height specified', function() {
+			var chart = acquireChart({
+				options: {
+					responsive: false,
+					aspectRatio: 3
+				}
+			}, {
+				canvas: {
+					style: 'width: 400px; height: 410px'
+				}
+			});
+
+			expect(chart).toBeChartOfSize({
+				dw: 400, dh: 410,
+				rw: 400, rh: 410,
+			});
+		});
+	});
+
+	describe('config.options.responsive: false', function() {
+		it('should use default canvas size for render and display sizes', function() {
+			var chart = acquireChart({
+				options: {
+					responsive: false
+				}
+			}, {
+				canvas: {
+					style: ''
+				}
+			});
+
+			expect(chart).toBeChartOfSize({
+				dw: 300, dh: 150,
+				rw: 300, rh: 150,
+			});
+		});
+
+		it('should use canvas attributes for render and display sizes', function() {
+			var chart = acquireChart({
+				options: {
+					responsive: false
+				}
+			}, {
+				canvas: {
+					style: '',
+					width: 305,
+					height: 245,
+				}
+			});
+
+			expect(chart).toBeChartOfSize({
+				dw: 305, dh: 245,
+				rw: 305, rh: 245,
+			});
+		});
+
+		it('should use canvas style for render and display sizes (if no attributes)', function() {
+			var chart = acquireChart({
+				options: {
+					responsive: false
+				}
+			}, {
+				canvas: {
+					style: 'width: 345px; height: 125px'
+				}
+			});
+
+			expect(chart).toBeChartOfSize({
+				dw: 345, dh: 125,
+				rw: 345, rh: 125,
+			});
+		});
+
+		it('should use attributes for the render size and style for the display size', function() {
+			var chart = acquireChart({
+				options: {
+					responsive: false
+				}
+			}, {
+				canvas: {
+					style: 'width: 345px; height: 125px;',
+					width: 165,
+					height: 85,
+				}
+			});
+
+			expect(chart).toBeChartOfSize({
+				dw: 345, dh: 125,
+				rw: 165, rh: 85,
+			});
+		});
+	});
+
+	describe('config.options.responsive: true (maintainAspectRatio: false)', function() {
+		it('should fill parent width and height', function() {
+			var chart = acquireChart({
+				options: {
+					responsive: true,
+					maintainAspectRatio: false
+				}
+			}, {
+				canvas: {
+					style: 'width: 150px; height: 245px'
+				},
+				wrapper: {
+					style: 'width: 300px; height: 350px'
+				}
+			});
+
+			expect(chart).toBeChartOfSize({
+				dw: 300, dh: 350,
+				rw: 300, rh: 350,
+			});
+		});
+
+		it('should resize the canvas when parent width changes', function(done) {
+			var chart = acquireChart({
+				options: {
+					responsive: true,
+					maintainAspectRatio: false
+				}
+			}, {
+				canvas: {
+					style: ''
+				},
+				wrapper: {
+					style: 'width: 300px; height: 350px; position: relative'
+				}
+			});
+
+			expect(chart).toBeChartOfSize({
+				dw: 300, dh: 350,
+				rw: 300, rh: 350,
+			});
+
+			var wrapper = chart.chart.canvas.parentNode;
+			wrapper.style.width = '455px';
+			processResizeEvent(chart, function() {
+				expect(chart).toBeChartOfSize({
+					dw: 455, dh: 350,
+					rw: 455, rh: 350,
+				});
+
+				wrapper.style.width = '150px';
+				processResizeEvent(chart, function() {
+					expect(chart).toBeChartOfSize({
+						dw: 150, dh: 350,
+						rw: 150, rh: 350,
+					});
+
+					done();
+				});
+			});
+		});
+
+		it('should resize the canvas when parent height changes', function(done) {
+			var chart = acquireChart({
+				options: {
+					responsive: true,
+					maintainAspectRatio: false
+				}
+			}, {
+				canvas: {
+					style: ''
+				},
+				wrapper: {
+					style: 'width: 300px; height: 350px; position: relative'
+				}
+			});
+
+			expect(chart).toBeChartOfSize({
+				dw: 300, dh: 350,
+				rw: 300, rh: 350,
+			});
+
+			var wrapper = chart.chart.canvas.parentNode;
+			wrapper.style.height = '455px';
+			processResizeEvent(chart, function() {
+				expect(chart).toBeChartOfSize({
+					dw: 300, dh: 455,
+					rw: 300, rh: 455,
+				});
+
+				wrapper.style.height = '150px';
+				processResizeEvent(chart, function() {
+					expect(chart).toBeChartOfSize({
+						dw: 300, dh: 150,
+						rw: 300, rh: 150,
+					});
+
+					done();
+				});
+			});
+		});
+
+		it('should NOT include parent padding when resizing the canvas', function(done) {
+			var chart = acquireChart({
+				type: 'line',
+				options: {
+					responsive: true,
+					maintainAspectRatio: false
+				}
+			}, {
+				canvas: {
+					style: ''
+				},
+				wrapper: {
+					style: 'padding: 50px; width: 320px; height: 350px; position: relative'
+				}
+			});
+
+			expect(chart).toBeChartOfSize({
+				dw: 320, dh: 350,
+				rw: 320, rh: 350,
+			});
+
+			var wrapper = chart.chart.canvas.parentNode;
+			wrapper.style.height = '355px';
+			wrapper.style.width = '455px';
+			processResizeEvent(chart, function() {
+				expect(chart).toBeChartOfSize({
+					dw: 455, dh: 355,
+					rw: 455, rh: 355,
+				});
+
+				done();
+			});
+		});
+
+		it('should resize the canvas when the canvas display style changes from "none" to "block"', function(done) {
+			var chart = acquireChart({
+				options: {
+					responsive: true,
+					maintainAspectRatio: false
+				}
+			}, {
+				canvas: {
+					style: 'display: none;'
+				},
+				wrapper: {
+					style: 'width: 320px; height: 350px'
+				}
+			});
+
+			var canvas = chart.chart.canvas;
+			canvas.style.display = 'block';
+			processResizeEvent(chart, function() {
+				expect(chart).toBeChartOfSize({
+					dw: 320, dh: 350,
+					rw: 320, rh: 350,
+				});
+
+				done();
+			});
+		});
+
+		it('should resize the canvas when the wrapper display style changes from "none" to "block"', function(done) {
+			var chart = acquireChart({
+				options: {
+					responsive: true,
+					maintainAspectRatio: false
+				}
+			}, {
+				canvas: {
+					style: ''
+				},
+				wrapper: {
+					style: 'display: none; width: 460px; height: 380px'
+				}
+			});
+
+			var wrapper = chart.chart.canvas.parentNode;
+			wrapper.style.display = 'block';
+			processResizeEvent(chart, function() {
+				expect(chart).toBeChartOfSize({
+					dw: 460, dh: 380,
+					rw: 460, rh: 380,
+				});
+
+				done();
+			});
+		});
+	});
+
+	describe('config.options.responsive: true (maintainAspectRatio: true)', function() {
+		it('should fill parent width and use aspect ratio to calculate height', function() {
+			var chart = acquireChart({
+				options: {
+					responsive: true,
+					maintainAspectRatio: true
+				}
+			}, {
+				canvas: {
+					style: 'width: 150px; height: 245px'
+				},
+				wrapper: {
+					style: 'width: 300px; height: 350px'
+				}
+			});
+
+			expect(chart).toBeChartOfSize({
+				dw: 300, dh: 490,
+				rw: 300, rh: 490,
+			});
+		});
+
+		it('should resize the canvas with correct apect ratio when parent width changes', function(done) {
+			var chart = acquireChart({
+				type: 'line', // AR == 2
+				options: {
+					responsive: true,
+					maintainAspectRatio: true
+				}
+			}, {
+				canvas: {
+					style: ''
+				},
+				wrapper: {
+					style: 'width: 300px; height: 350px; position: relative'
+				}
+			});
+
+			expect(chart).toBeChartOfSize({
+				dw: 300, dh: 150,
+				rw: 300, rh: 150,
+			});
+
+			var wrapper = chart.chart.canvas.parentNode;
+			wrapper.style.width = '450px';
+			processResizeEvent(chart, function() {
+				expect(chart).toBeChartOfSize({
+					dw: 450, dh: 225,
+					rw: 450, rh: 225,
+				});
+
+				wrapper.style.width = '150px';
+				processResizeEvent(chart, function() {
+					expect(chart).toBeChartOfSize({
+						dw: 150, dh: 75,
+						rw: 150, rh: 75,
+					});
+
+					done();
+				});
+			});
+		});
+
+		it('should NOT resize the canvas when parent height changes', function(done) {
+			var chart = acquireChart({
+				options: {
+					responsive: true,
+					maintainAspectRatio: true
+				}
+			}, {
+				canvas: {
+					style: ''
+				},
+				wrapper: {
+					style: 'width: 320px; height: 350px; position: relative'
+				}
+			});
+
+			expect(chart).toBeChartOfSize({
+				dw: 320, dh: 160,
+				rw: 320, rh: 160,
+			});
+
+			var wrapper = chart.chart.canvas.parentNode;
+			wrapper.style.height = '455px';
+			processResizeEvent(chart, function() {
+				expect(chart).toBeChartOfSize({
+					dw: 320, dh: 160,
+					rw: 320, rh: 160,
+				});
+
+				wrapper.style.height = '150px';
+				processResizeEvent(chart, function() {
+					expect(chart).toBeChartOfSize({
+						dw: 320, dh: 160,
+						rw: 320, rh: 160,
+					});
+
+					done();
+				});
+			});
+		});
+	});
+
+	describe('controller.destroy', function() {
+		it('should restore canvas (and context) initial values', function(done) {
+			var chart = acquireChart({
+				type: 'line',
+				options: {
+					responsive: true,
+					maintainAspectRatio: false
+				}
+			}, {
+				canvas: {
+					width: 180,
+					style: 'width: 512px; height: 480px'
+				},
+				wrapper: {
+					style: 'width: 450px; height: 450px; position: relative'
+				}
+			});
+
+			var canvas = chart.chart.canvas;
+			var wrapper = canvas.parentNode;
+			wrapper.style.width = '475px';
+			processResizeEvent(chart, function() {
+				expect(chart).toBeChartOfSize({
+					dw: 475, dh: 450,
+					rw: 475, rh: 450,
+				});
+
+				chart.destroy();
+
+				expect(canvas.getAttribute('width')).toBe('180');
+				expect(canvas.getAttribute('height')).toBe(null);
+				expect(canvas.style.width).toBe('512px');
+				expect(canvas.style.height).toBe('480px');
+				expect(canvas.style.display).toBe('');
+
+				done();
+			});
+		});
+	});
+});

--- a/test/mockContext.js
+++ b/test/mockContext.js
@@ -158,10 +158,55 @@
 		};
 	}
 
+	function toBeChartOfSize() {
+		return {
+			compare: function(actual, expected) {
+				var message = null;
+				var chart, canvas, style, dh, dw, rh, rw;
+
+				if (!actual || !(actual instanceof Chart.Controller)) {
+					message = 'Expected ' + actual + ' to be an instance of Chart.Controller.';
+				} else {
+					chart = actual.chart;
+					canvas = chart.ctx.canvas;
+					style = getComputedStyle(canvas);
+					dh = parseInt(style.height);
+					dw = parseInt(style.width);
+					rh = canvas.height;
+					rw = canvas.width;
+
+					// sanity checks
+					if (chart.height !== rh) {
+						message = 'Expected chart height ' + chart.height + ' to be equal to render height ' + rh;
+					} else if (chart.width !== rw) {
+						message = 'Expected chart width ' + chart.width + ' to be equal to render width ' + rw;
+					}
+
+					// validity checks
+					if (dh !== expected.dh) {
+						message = 'Expected display height ' + dh + ' to be equal to ' + expected.dh;
+					} else if (dw !== expected.dw) {
+						message = 'Expected display width ' + dw + ' to be equal to ' + expected.dw;
+					} else if (rh !== expected.rh) {
+						message = 'Expected render height ' + rh + ' to be equal to ' + expected.rh;
+					} else if (rw !== expected.rw) {
+						message = 'Expected render width ' + rw + ' to be equal to ' + expected.rw;
+					}
+				}
+
+				return {
+					message: message? message : 'Expected ' + actual + ' to be a chart of size ' + expected,
+					pass: !message
+				}
+			}
+		}
+	}
+
 	beforeEach(function() {
 		jasmine.addMatchers({
 			toBeCloseToPixel: toBeCloseToPixel,
-			toEqualOneOf: toEqualOneOf
+			toEqualOneOf: toEqualOneOf,
+			toBeChartOfSize: toBeChartOfSize
 		});
 	});
 
@@ -214,6 +259,7 @@
 	}
 
 	function releaseChart(chart) {
+		chart.destroy();
 		chart.chart.canvas.parentNode.remove();
 		delete charts[chart.id];
 		delete chart;


### PR DESCRIPTION
Should have been only unit tests but then I realized that aspect ratio for none responsive chart was totally broken. So I decided to clean up the whole canvas initialization process and I hope to not have broken too many things :)

This PR includes:

- correctly handles aspect ratio on chart creation (see unit tests for the many cases)
- properly restore initial canvas render size and overridden style on destroy
- fix default `aspectRatio` for radar chart and associated samples
- move most of the canvas initialization in the `core.controller.js`
- new `test/core.controller.tests.js` currently testing AR and responsiveness (see screenshot below)
- new command switch to run specific tests (`gulp unittest --inputs=test/core.controller.tests.js`)

More details in commit messages

![image](https://cloud.githubusercontent.com/assets/3874900/18792987/12c9f0d8-81b9-11e6-877a-b9cb298c3828.png)
