### PR TITLE
Set maxWidth during title draw to avoid overflow

### DIFF
--- a/src/core/core.title.js
+++ b/src/core/core.title.js
@@ -158,7 +158,8 @@ module.exports = function(Chart) {
 					top = me.top,
 					left = me.left,
 					bottom = me.bottom,
-					right = me.right;
+					right = me.right,
+					maxWidth;
 
 				ctx.fillStyle = valueOrDefault(opts.fontColor, globalDefaults.defaultFontColor); // render in correct colour
 				ctx.font = titleFont;
@@ -167,9 +168,11 @@ module.exports = function(Chart) {
 				if (me.isHorizontal()) {
 					titleX = left + ((right - left) / 2); // midpoint of the width
 					titleY = top + ((bottom - top) / 2); // midpoint of the height
+					maxWidth = right - left;
 				} else {
 					titleX = opts.position === 'left' ? left + (fontSize / 2) : right - (fontSize / 2);
 					titleY = top + ((bottom - top) / 2);
+					maxWidth = bottom - top;
 					rotation = Math.PI * (opts.position === 'left' ? -0.5 : 0.5);
 				}
 
@@ -178,7 +181,7 @@ module.exports = function(Chart) {
 				ctx.rotate(rotation);
 				ctx.textAlign = 'center';
 				ctx.textBaseline = 'middle';
-				ctx.fillText(opts.text, 0, 0);
+				ctx.fillText(opts.text, 0, 0, maxWidth);
 				ctx.restore();
 			}
 		}

--- a/test/core.title.tests.js
+++ b/test/core.title.tests.js
@@ -118,7 +118,7 @@ describe('Title block tests', function() {
 			args: [0]
 		}, {
 			name: 'fillText',
-			args: ['My title', 0, 0]
+			args: ['My title', 0, 0, 400]
 		}, {
 			name: 'restore',
 			args: []
@@ -168,7 +168,7 @@ describe('Title block tests', function() {
 			args: [-0.5 * Math.PI]
 		}, {
 			name: 'fillText',
-			args: ['My title', 0, 0]
+			args: ['My title', 0, 0, 400]
 		}, {
 			name: 'restore',
 			args: []
@@ -201,7 +201,7 @@ describe('Title block tests', function() {
 			args: [0.5 * Math.PI]
 		}, {
 			name: 'fillText',
-			args: ['My title', 0, 0]
+			args: ['My title', 0, 0, 400]
 		}, {
 			name: 'restore',
 			args: []


### PR DESCRIPTION
CanvasRenderingContext2D.fillText() accepts a fourth parameter called maxWidth that sets the maximum width of the drawn text, enforced by scaling the entire line.

This commit uses the title element's layout dimensions to set maxWidth and avoid overflow outside of the canvas.

Example before and after screenshots:
![image](https://cloud.githubusercontent.com/assets/8778207/18801592/933d77ea-81db-11e6-8471-cd4947bf1f62.png)
![image](https://cloud.githubusercontent.com/assets/8778207/18801633/de782c32-81db-11e6-8bfd-9a3f8c269cca.png)

I expect the same logic could be applied to axis labels, but it's not a problem I've run into.