### PR TITLE
Improve Tooltip and Hover Interaction

### DIFF
--- a/docs/01-Chart-Configuration.md
+++ b/docs/01-Chart-Configuration.md
@@ -200,7 +200,7 @@ var chartInstance = new Chart(ctx, {
                 fontColor: 'rgb(255, 99, 132)'
             }
         }
-    }
+}
 });
 ```
 
@@ -212,7 +212,8 @@ Name | Type | Default | Description
 --- | --- | --- | ---
 enabled | Boolean | true | Are tooltips enabled
 custom | Function | null | See [section](#advanced-usage-external-tooltips) below
-mode | String | 'single' | Sets which elements appear in the tooltip. Acceptable options are `'single'`, `'label'` or `'x-axis'`. <br>&nbsp;<br>`single` highlights the closest element. <br>&nbsp;<br>`label` highlights elements in all datasets at the same `X` value. <br>&nbsp;<br>`'x-axis'` also highlights elements in all datasets at the same `X` value, but activates when hovering anywhere within the vertical slice of the x-axis representing that `X` value.
+mode | String | 'single' | Sets which elements appear in the tooltip. See [Interaction Modes](#interaction-modes) for details
+intersect | Boolean | true | if true, the tooltip mode applies only when the mouse position intersects with an element. If false, the mode will be applied at all times.
 itemSort | Function | undefined | Allows sorting of [tooltip items](#chart-configuration-tooltip-item-interface). Must implement at minimum a function that can be passed to [Array.prototype.sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort).  This function can also accept a third parameter that is the data object passed to the chart.
 backgroundColor | Color | 'rgba(0,0,0,0.8)' | Background color of the tooltip
 titleFontFamily | String | "'Helvetica Neue', 'Helvetica', 'Arial', sans-serif" | Font family for tooltip title inherited from global font family
@@ -288,7 +289,27 @@ Name | Type | Default | Description
 --- | --- | --- | ---
 mode | String | 'single' | Sets which elements hover. Acceptable options are `'single'`, `'label'`, `'x-axis'`, or `'dataset'`. <br>&nbsp;<br>`single` highlights the closest element. <br>&nbsp;<br>`label` highlights elements in all datasets at the same `X` value. <br>&nbsp;<br>`'x-axis'` also highlights elements in all datasets at the same `X` value, but activates when hovering anywhere within the vertical slice of the x-axis representing that `X` value.  <br>&nbsp;<br>`dataset` highlights the closest dataset.
 animationDuration | Number | 400 | Duration in milliseconds it takes to animate hover style changes
+intersect | Boolean | true | if true, the hover mode only applies when the mouse position intersects an item on the chart
 onHover | Function | null | Called when any of the events fire. Called in the context of the chart and passed an array of active elements (bars, points, etc)
+
+### Interaction Modes
+When configuring interaction with the graph via hover or tooltips, a number of different modes are available.
+
+The following table details the modes and how they behave in conjunction with the `intersect` setting
+
+Mode | Behaviour 
+--- | --- 
+point | Finds all of the items that intersect the point
+nearest | Gets the item that is nearest to the point. The nearest item is determined based on the distance to the center of the chart item (point, bar). If 2 or more items are at the same size, the one with the smallest area is used. If `intersect` is true, this is only triggered when the mouse is above an item the graph. This is very useful for combo charts where points are hidden behind bars.
+single (deprecated) | Finds the first item that intersects the point and returns it.
+label | Finds item at the same index. If the `intersect` setting is true, the first intersecting item is used to determine the index in the data. If `intersect` false the nearest item is used to determine the index. 
+index | Same as `'label'` mode but with a more descriptive name
+x-axis (deprecated) | Behaves like `'index'` mode with `intersect = true`
+dataset | Finds items in the same dataset. If the `intersect` setting is true, the first intersecting item is used to determine the index in the data. If `intersect` false the nearest item is used to determine the index.
+x | Returns all items that would intersect based on the `X` coordinate of the position only. Would be useful for a vertical cursor implementation. Note that this only applies to cartesian charts
+y | Returns all items that would intersect based on the `Y` coordinate of the position. This would be useful for a horizontal cursor implementation. Note that this only applies to cartesian charts.
+
+Acceptable options are `'single'`, `'label'`, `'x-axis'`, . <br>&nbsp;<br>`single` highlights the closest element. <br>&nbsp;<br>`label` highlights elements in all datasets at the same `X` value. <br>&nbsp;<br>`'x-axis'` also highlights elements in all datasets at the same `X` value, but activates when hovering anywhere within the vertical slice of the x-axis representing that `X` value.
 
 ### Animation Configuration
 

--- a/docs/01-Chart-Configuration.md
+++ b/docs/01-Chart-Configuration.md
@@ -36,13 +36,13 @@ This concept was introduced in Chart.js 1.0 to keep configuration [DRY](https://
 
 Chart.js merges the options object passed to the chart with the global configuration using chart type defaults and scales defaults appropriately. This way you can be as specific as you would like in your individual chart configuration, while still changing the defaults for all chart types where applicable. The global general options are defined in `Chart.defaults.global`. The defaults for each chart type are discussed in the documentation for that chart type.
 
-The following example would set the hover mode to 'single' for all charts where this was not overridden by the chart type defaults or the options passed to the constructor on creation.
+The following example would set the hover mode to 'nearest' for all charts where this was not overridden by the chart type defaults or the options passed to the constructor on creation.
 
 ```javascript
-Chart.defaults.global.hover.mode = 'single';
+Chart.defaults.global.hover.mode = 'nearest';
 
-// Hover mode is set to single because it was not overridden here
-var chartInstanceHoverModeSingle = new Chart(ctx, {
+// Hover mode is set to nearest because it was not overridden here
+var chartInstanceHoverModeNearest = new Chart(ctx, {
     type: 'line',
     data: data,
 });
@@ -54,7 +54,7 @@ var chartInstanceDifferentHoverMode = new Chart(ctx, {
     options: {
         hover: {
             // Overrides the global setting
-            mode: 'label'
+            mode: 'index'
         }
     }
 })
@@ -212,7 +212,7 @@ Name | Type | Default | Description
 --- | --- | --- | ---
 enabled | Boolean | true | Are tooltips enabled
 custom | Function | null | See [section](#advanced-usage-external-tooltips) below
-mode | String | 'single' | Sets which elements appear in the tooltip. See [Interaction Modes](#interaction-modes) for details
+mode | String | 'nearest' | Sets which elements appear in the tooltip. See [Interaction Modes](#interaction-modes) for details
 intersect | Boolean | true | if true, the tooltip mode applies only when the mouse position intersects with an element. If false, the mode will be applied at all times.
 itemSort | Function | undefined | Allows sorting of [tooltip items](#chart-configuration-tooltip-item-interface). Must implement at minimum a function that can be passed to [Array.prototype.sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort).  This function can also accept a third parameter that is the data object passed to the chart.
 backgroundColor | Color | 'rgba(0,0,0,0.8)' | Background color of the tooltip
@@ -287,9 +287,9 @@ The hover configuration is passed into the `options.hover` namespace. The global
 
 Name | Type | Default | Description
 --- | --- | --- | ---
-mode | String | 'single' | Sets which elements hover. Acceptable options are `'single'`, `'label'`, `'x-axis'`, or `'dataset'`. <br>&nbsp;<br>`single` highlights the closest element. <br>&nbsp;<br>`label` highlights elements in all datasets at the same `X` value. <br>&nbsp;<br>`'x-axis'` also highlights elements in all datasets at the same `X` value, but activates when hovering anywhere within the vertical slice of the x-axis representing that `X` value.  <br>&nbsp;<br>`dataset` highlights the closest dataset.
-animationDuration | Number | 400 | Duration in milliseconds it takes to animate hover style changes
+mode | String | 'naerest' | Sets which elements appear in the tooltip. See [Interaction Modes](#interaction-modes) for details
 intersect | Boolean | true | if true, the hover mode only applies when the mouse position intersects an item on the chart
+animationDuration | Number | 400 | Duration in milliseconds it takes to animate hover style changes
 onHover | Function | null | Called when any of the events fire. Called in the context of the chart and passed an array of active elements (bars, points, etc)
 
 ### Interaction Modes
@@ -300,16 +300,14 @@ The following table details the modes and how they behave in conjunction with th
 Mode | Behaviour 
 --- | --- 
 point | Finds all of the items that intersect the point
-nearest | Gets the item that is nearest to the point. The nearest item is determined based on the distance to the center of the chart item (point, bar). If 2 or more items are at the same size, the one with the smallest area is used. If `intersect` is true, this is only triggered when the mouse is above an item the graph. This is very useful for combo charts where points are hidden behind bars.
-single (deprecated) | Finds the first item that intersects the point and returns it.
-label | Finds item at the same index. If the `intersect` setting is true, the first intersecting item is used to determine the index in the data. If `intersect` false the nearest item is used to determine the index. 
-index | Same as `'label'` mode but with a more descriptive name
+nearest | Gets the item that is nearest to the point. The nearest item is determined based on the distance to the center of the chart item (point, bar). If 2 or more items are at the same distance, the one with the smallest area is used. If `intersect` is true, this is only triggered when the mouse position intersects an item in the graph. This is very useful for combo charts where points are hidden behind bars.
+single (deprecated) | Finds the first item that intersects the point and returns it. Behaves like 'nearest' mode with intersect = true.
+label (deprecated) | See `'index'` mode
+index | Finds item at the same index. If the `intersect` setting is true, the first intersecting item is used to determine the index in the data. If `intersect` false the nearest item is used to determine the index. 
 x-axis (deprecated) | Behaves like `'index'` mode with `intersect = true`
 dataset | Finds items in the same dataset. If the `intersect` setting is true, the first intersecting item is used to determine the index in the data. If `intersect` false the nearest item is used to determine the index.
 x | Returns all items that would intersect based on the `X` coordinate of the position only. Would be useful for a vertical cursor implementation. Note that this only applies to cartesian charts
 y | Returns all items that would intersect based on the `Y` coordinate of the position. This would be useful for a horizontal cursor implementation. Note that this only applies to cartesian charts.
-
-Acceptable options are `'single'`, `'label'`, `'x-axis'`, . <br>&nbsp;<br>`single` highlights the closest element. <br>&nbsp;<br>`label` highlights elements in all datasets at the same `X` value. <br>&nbsp;<br>`'x-axis'` also highlights elements in all datasets at the same `X` value, but activates when hovering anywhere within the vertical slice of the x-axis representing that `X` value.
 
 ### Animation Configuration
 

--- a/samples/AnimationCallbacks/progress-bar.html
+++ b/samples/AnimationCallbacks/progress-bar.html
@@ -75,7 +75,7 @@
                     }
                 },
                 tooltips: {
-                    mode: 'label',
+                    mode: 'index',
                 },
                 scales: {
                     xAxes: [{

--- a/samples/bar-multi-axis.html
+++ b/samples/bar-multi-axis.html
@@ -56,7 +56,7 @@
             data: barChartData, 
             options: {
                 responsive: true,
-                hoverMode: 'label',
+                hoverMode: 'index',
                 hoverAnimationDuration: 400,
                 stacked: false,
                 title:{

--- a/samples/bar-stacked.html
+++ b/samples/bar-stacked.html
@@ -55,7 +55,7 @@
                         text:"Chart.js Bar Chart - Stacked"
                     },
                     tooltips: {
-                        mode: 'label'
+                        mode: 'index'
                     },
                     responsive: true,
                     scales: {

--- a/samples/different-point-sizes.html
+++ b/samples/different-point-sizes.html
@@ -70,7 +70,7 @@
                     position: 'bottom',
                 },
                 hover: {
-                    mode: 'label'
+                    mode: 'index'
                 },
                 scales: {
                     xAxes: [{

--- a/samples/line-cubicInterpolationMode.html
+++ b/samples/line-cubicInterpolationMode.html
@@ -68,7 +68,7 @@
                     text:'Chart.js Line Chart - Cubic interpolation mode'
                 },
                 tooltips: {
-                    mode: 'label'
+                    mode: 'index'
                 },
                 hover: {
                     mode: 'dataset'

--- a/samples/line-legend.html
+++ b/samples/line-legend.html
@@ -68,7 +68,7 @@
                     position: 'bottom',
                 },
                 hover: {
-                    mode: 'label'
+                    mode: 'index'
                 },
                 scales: {
                     xAxes: [{

--- a/samples/line-multi-axis.html
+++ b/samples/line-multi-axis.html
@@ -54,7 +54,7 @@
             data: lineChartData,
             options: {
                 responsive: true,
-                hoverMode: 'label',
+                hoverMode: 'index',
                 stacked: false,
                 title:{
                     display:true,

--- a/samples/line-multiline-labels.html
+++ b/samples/line-multiline-labels.html
@@ -65,7 +65,7 @@
                     text:'Chart.js Line Chart'
                 },
                 tooltips: {
-                    mode: 'label',
+                    mode: 'index',
                     callbacks: {
                         // beforeTitle: function() {
                         //     return '...beforeTitle';

--- a/samples/line-skip-points.html
+++ b/samples/line-skip-points.html
@@ -64,10 +64,10 @@
                     text:'Chart.js Line Chart - Skip Points'
                 },
                 tooltips: {
-                    mode: 'label',
+                    mode: 'index',
                 },
                 hover: {
-                    mode: 'label'
+                    mode: 'index'
                 },
                 scales: {
                     xAxes: [{

--- a/samples/line-stacked-area.html
+++ b/samples/line-stacked-area.html
@@ -63,10 +63,10 @@
           text:"Chart.js Line Chart - Stacked Area"
         },
         tooltips: {
-          mode: 'label',
+          mode: 'index',
         },
         hover: {
-          mode: 'label'
+          mode: 'index'
         },
         scales: {
           xAxes: [{

--- a/samples/line-stepped.html
+++ b/samples/line-stepped.html
@@ -68,7 +68,7 @@
                     text:'Chart.js Line Chart'
                 },
                 tooltips: {
-                    mode: 'label',
+                    mode: 'index',
                     callbacks: {
                         // beforeTitle: function() {
                         //     return '...beforeTitle';

--- a/samples/line.html
+++ b/samples/line.html
@@ -65,7 +65,7 @@
                     text:'Chart.js Line Chart'
                 },
                 tooltips: {
-                    mode: 'label',
+                    mode: 'index',
                     intersect: false,
                     callbacks: {
                         // beforeTitle: function() {

--- a/samples/line.html
+++ b/samples/line.html
@@ -66,6 +66,7 @@
                 },
                 tooltips: {
                     mode: 'label',
+                    intersect: false,
                     callbacks: {
                         // beforeTitle: function() {
                         //     return '...beforeTitle';
@@ -91,7 +92,8 @@
                     }
                 },
                 hover: {
-                    mode: 'dataset'
+                    mode: 'nearest',
+                    intersect: true
                 },
                 scales: {
                     xAxes: [{

--- a/samples/scatter-multi-axis.html
+++ b/samples/scatter-multi-axis.html
@@ -99,7 +99,8 @@
         	data: scatterChartData,
         	options: {
 	            responsive: true,
-	            hoverMode: 'single',
+	            hoverMode: 'nearest',
+	            intersect: true,
             	title: {
 	                display: true,
 	                text: 'Chart.js Scatter Chart - Multi Axis'

--- a/samples/tooltip-hooks.html
+++ b/samples/tooltip-hooks.html
@@ -59,7 +59,7 @@
                     text:"Chart.js Line Chart - Tooltip Hooks"
                 },
                 tooltips: {
-                    mode: 'label',
+                    mode: 'index',
                     callbacks: {
                         beforeTitle: function() {
                             return '...beforeTitle';
@@ -91,7 +91,7 @@
                     }
                 },
                 hover: {
-                    mode: 'label'
+                    mode: 'index'
                 },
                 scales: {
                     xAxes: [{

--- a/src/chart.js
+++ b/src/chart.js
@@ -16,6 +16,7 @@ require('./core/core.ticks.js')(Chart);
 require('./core/core.scale')(Chart);
 require('./core/core.title')(Chart);
 require('./core/core.legend')(Chart);
+require('./core/core.interaction')(Chart);
 require('./core/core.tooltip')(Chart);
 
 require('./elements/element.arc')(Chart);

--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -422,21 +422,6 @@ module.exports = function(Chart) {
 					if (vm.borderWidth) {
 						ctx.stroke();
 					}
-				},
-
-				inRange: function(mouseX, mouseY) {
-					var vm = this._view;
-					var inRange = false;
-
-					if (vm) {
-						if (vm.x < vm.base) {
-							inRange = (mouseY >= vm.y - vm.height / 2 && mouseY <= vm.y + vm.height / 2) && (mouseX >= vm.x && mouseX <= vm.base);
-						} else {
-							inRange = (mouseY >= vm.y - vm.height / 2 && mouseY <= vm.y + vm.height / 2) && (mouseX >= vm.base && mouseX <= vm.x);
-						}
-					}
-
-					return inRange;
 				}
 			});
 

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -607,19 +607,12 @@ module.exports = function(Chart) {
 		},
 
 		getElementsAtEventForMode: function(e, mode) {
-			var me = this;
-			switch (mode) {
-			case 'single':
-				return me.getElementAtEvent(e);
-			case 'label':
-				return me.getElementsAtEvent(e);
-			case 'dataset':
-				return me.getDatasetAtEvent(e);
-			case 'x-axis':
-				return me.getElementsAtXAxis(e);
-			default:
-				return e;
+			var modeLookups = Chart.Interaction.modes;
+			if (typeof modeLookups[mode] === 'function') {
+				return modeLookups[mode](this, e);
 			}
+
+			return e;
 		},
 
 		getDatasetAtEvent: function(e) {

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -523,12 +523,12 @@ module.exports = function(Chart) {
 		},
 
 		getElementsAtEventForMode: function(e, mode, options) {
-			var modeLookups = Chart.Interaction.modes;
-			if (typeof modeLookups[mode] === 'function') {
-				return modeLookups[mode](this, e, options);
+			var method = Chart.Interaction.modes[mode];
+			if (typeof method === 'function') {
+				return method(this, e, options);
 			}
 
-			return e;
+			return [];
 		},
 
 		getDatasetAtEvent: function(e) {

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -511,99 +511,15 @@ module.exports = function(Chart) {
 		// Get the single element that was clicked on
 		// @return : An object containing the dataset index and element index of the matching element. Also contains the rectangle that was draw
 		getElementAtEvent: function(e) {
-			var me = this;
-			var eventPosition = helpers.getRelativePosition(e, me.chart);
-			var elementsArray = [];
-
-			helpers.each(me.data.datasets, function(dataset, datasetIndex) {
-				if (me.isDatasetVisible(datasetIndex)) {
-					var meta = me.getDatasetMeta(datasetIndex);
-					helpers.each(meta.data, function(element) {
-						if (element.inRange(eventPosition.x, eventPosition.y)) {
-							elementsArray.push(element);
-							return elementsArray;
-						}
-					});
-				}
-			});
-
-			return elementsArray.slice(0, 1);
+			return Chart.Interaction.modes.single(this, e);
 		},
 
 		getElementsAtEvent: function(e) {
-			var me = this;
-			var eventPosition = helpers.getRelativePosition(e, me.chart);
-			var elementsArray = [];
-
-			var found = function() {
-				if (me.data.datasets) {
-					for (var i = 0; i < me.data.datasets.length; i++) {
-						var meta = me.getDatasetMeta(i);
-						if (me.isDatasetVisible(i)) {
-							for (var j = 0; j < meta.data.length; j++) {
-								if (meta.data[j].inRange(eventPosition.x, eventPosition.y)) {
-									return meta.data[j];
-								}
-							}
-						}
-					}
-				}
-			}.call(me);
-
-			if (!found) {
-				return elementsArray;
-			}
-
-			helpers.each(me.data.datasets, function(dataset, datasetIndex) {
-				if (me.isDatasetVisible(datasetIndex)) {
-					var meta = me.getDatasetMeta(datasetIndex),
-						element = meta.data[found._index];
-					if (element && !element._view.skip) {
-						elementsArray.push(element);
-					}
-				}
-			}, me);
-
-			return elementsArray;
+			return Chart.Interaction.modes.label(this, e);
 		},
 
 		getElementsAtXAxis: function(e) {
-			var me = this;
-			var eventPosition = helpers.getRelativePosition(e, me.chart);
-			var elementsArray = [];
-
-			var found = function() {
-				if (me.data.datasets) {
-					for (var i = 0; i < me.data.datasets.length; i++) {
-						var meta = me.getDatasetMeta(i);
-						if (me.isDatasetVisible(i)) {
-							for (var j = 0; j < meta.data.length; j++) {
-								if (meta.data[j].inLabelRange(eventPosition.x, eventPosition.y)) {
-									return meta.data[j];
-								}
-							}
-						}
-					}
-				}
-			}.call(me);
-
-			if (!found) {
-				return elementsArray;
-			}
-
-			helpers.each(me.data.datasets, function(dataset, datasetIndex) {
-				if (me.isDatasetVisible(datasetIndex)) {
-					var meta = me.getDatasetMeta(datasetIndex);
-					var index = helpers.findIndex(meta.data, function(it) {
-						return found._model.x === it._model.x;
-					});
-					if (index !== -1 && !meta.data[index]._view.skip) {
-						elementsArray.push(meta.data[index]);
-					}
-				}
-			}, me);
-
-			return elementsArray;
+			return Chart.Interaction.modes['x-axis'](this, e);
 		},
 
 		getElementsAtEventForMode: function(e, mode) {
@@ -616,13 +532,7 @@ module.exports = function(Chart) {
 		},
 
 		getDatasetAtEvent: function(e) {
-			var elementsArray = this.getElementAtEvent(e);
-
-			if (elementsArray.length > 0) {
-				elementsArray = this.getDatasetMeta(elementsArray[0]._datasetIndex).data;
-			}
-
-			return elementsArray;
+			return Chart.Interaction.modes.dataset(this, e);
 		},
 
 		getDatasetMeta: function(datasetIndex) {

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -522,10 +522,10 @@ module.exports = function(Chart) {
 			return Chart.Interaction.modes['x-axis'](this, e);
 		},
 
-		getElementsAtEventForMode: function(e, mode) {
+		getElementsAtEventForMode: function(e, mode, intersect) {
 			var modeLookups = Chart.Interaction.modes;
 			if (typeof modeLookups[mode] === 'function') {
-				return modeLookups[mode](this, e);
+				return modeLookups[mode](this, e, intersect);
 			}
 
 			return e;
@@ -666,8 +666,8 @@ module.exports = function(Chart) {
 				me.active = [];
 				me.tooltipActive = [];
 			} else {
-				me.active = me.getElementsAtEventForMode(e, hoverOptions.mode);
-				me.tooltipActive = me.getElementsAtEventForMode(e, tooltipsOptions.mode);
+				me.active = me.getElementsAtEventForMode(e, hoverOptions.mode, hoverOptions.intersect);
+				me.tooltipActive = me.getElementsAtEventForMode(e, tooltipsOptions.mode, tooltipsOptions.intersect);
 			}
 
 			// On Hover hook

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -515,17 +515,17 @@ module.exports = function(Chart) {
 		},
 
 		getElementsAtEvent: function(e) {
-			return Chart.Interaction.modes.label(this, e);
+			return Chart.Interaction.modes.label(this, e, {intersect: true});
 		},
 
 		getElementsAtXAxis: function(e) {
-			return Chart.Interaction.modes['x-axis'](this, e);
+			return Chart.Interaction.modes['x-axis'](this, e, {intersect: true});
 		},
 
-		getElementsAtEventForMode: function(e, mode, intersect) {
+		getElementsAtEventForMode: function(e, mode, options) {
 			var modeLookups = Chart.Interaction.modes;
 			if (typeof modeLookups[mode] === 'function') {
-				return modeLookups[mode](this, e, intersect);
+				return modeLookups[mode](this, e, options);
 			}
 
 			return e;
@@ -666,8 +666,8 @@ module.exports = function(Chart) {
 				me.active = [];
 				me.tooltipActive = [];
 			} else {
-				me.active = me.getElementsAtEventForMode(e, hoverOptions.mode, hoverOptions.intersect);
-				me.tooltipActive = me.getElementsAtEventForMode(e, tooltipsOptions.mode, tooltipsOptions.intersect);
+				me.active = me.getElementsAtEventForMode(e, hoverOptions.mode, hoverOptions);
+				me.tooltipActive = me.getElementsAtEventForMode(e, tooltipsOptions.mode, tooltipsOptions);
 			}
 
 			// On Hover hook

--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -308,6 +308,9 @@ module.exports = function(Chart) {
 			distance: radialDistanceFromCenter
 		};
 	};
+	helpers.distanceBetweenPoints = function(pt1, pt2) {
+		return Math.sqrt(Math.pow(pt2.x - pt1.x, 2) + Math.pow(pt2.y - pt1.y, 2));
+	};
 	helpers.aliasPixel = function(pixelWidth) {
 		return (pixelWidth % 2 === 0) ? 0 : 0.5;
 	};

--- a/src/core/core.interaction.js
+++ b/src/core/core.interaction.js
@@ -1,0 +1,26 @@
+'use strict';
+
+module.exports = function(Chart) {
+
+	/*
+	 * @namespace Chart.Interaction
+	 * Contains interaction related functions
+	 */
+	Chart.Interaction = {
+		// Helper function for different modes
+		modes: {
+			single: function(chartInstance, e) {
+				return chartInstance.getElementAtEvent(e);
+			},
+			label: function(chartInstance, e) {
+				return chartInstance.getElementsAtEvent(e);
+			},
+			dataset: function(chartInstance, e) {
+				return chartInstance.getDatasetAtEvent(e);
+			},
+			'x-axis': function(chartInstance, e) {
+				return chartInstance.getElementsAtXAxis(e);
+			}
+		}
+	};
+};

--- a/src/core/core.interaction.js
+++ b/src/core/core.interaction.js
@@ -110,6 +110,32 @@ module.exports = function(Chart) {
 			},
 
 			// Modes introduced in v2.4
+
+			/**
+			 * Intersection mode returns all elements that hit test based on the position
+			 * of the event
+			 * @function Chart.Interaction.modes.intersect
+			 * @param chartInstance {ChartInstance} the chart we are returning items from
+			 * @param e {Event} the event we are find things at
+			 * @return {Chart.Element[]} Array of elements that are under the point. If none are found, an empty array is returned
+			 */
+			intersect: function(chartInstance, e) {
+				var eventPosition = helpers.getRelativePosition(e, chartInstance.chart);
+				var elementsArray = [];
+
+				helpers.each(chartInstance.data.datasets, function(dataset, datasetIndex) {
+					if (chartInstance.isDatasetVisible(datasetIndex)) {
+						var meta = chartInstance.getDatasetMeta(datasetIndex);
+						helpers.each(meta.data, function(element) {
+							if (element.inRange(eventPosition.x, eventPosition.y)) {
+								elementsArray.push(element);
+							}
+						});
+					}
+				});
+
+				return elementsArray;
+			}
 		}
 	};
 };

--- a/src/core/core.interaction.js
+++ b/src/core/core.interaction.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = function(Chart) {
-
+	var helpers = Chart.helpers;
 	/*
 	 * @namespace Chart.Interaction
 	 * Contains interaction related functions
@@ -10,17 +10,106 @@ module.exports = function(Chart) {
 		// Helper function for different modes
 		modes: {
 			single: function(chartInstance, e) {
-				return chartInstance.getElementAtEvent(e);
+				var eventPosition = helpers.getRelativePosition(e, chartInstance.chart);
+				var elementsArray = [];
+
+				helpers.each(chartInstance.data.datasets, function(dataset, datasetIndex) {
+					if (chartInstance.isDatasetVisible(datasetIndex)) {
+						var meta = chartInstance.getDatasetMeta(datasetIndex);
+						helpers.each(meta.data, function(element) {
+							if (element.inRange(eventPosition.x, eventPosition.y)) {
+								elementsArray.push(element);
+								return elementsArray;
+							}
+						});
+					}
+				});
+
+				return elementsArray.slice(0, 1);
 			},
 			label: function(chartInstance, e) {
-				return chartInstance.getElementsAtEvent(e);
+				var eventPosition = helpers.getRelativePosition(e, chartInstance.chart);
+				var elementsArray = [];
+
+				var found = function() {
+					if (chartInstance.data.datasets) {
+						for (var i = 0; i < chartInstance.data.datasets.length; i++) {
+							var meta = chartInstance.getDatasetMeta(i);
+							if (chartInstance.isDatasetVisible(i)) {
+								for (var j = 0; j < meta.data.length; j++) {
+									if (meta.data[j].inRange(eventPosition.x, eventPosition.y)) {
+										return meta.data[j];
+									}
+								}
+							}
+						}
+					}
+				}.call(chartInstance);
+
+				if (!found) {
+					return elementsArray;
+				}
+
+				helpers.each(chartInstance.data.datasets, function(dataset, datasetIndex) {
+					if (chartInstance.isDatasetVisible(datasetIndex)) {
+						var meta = chartInstance.getDatasetMeta(datasetIndex),
+							element = meta.data[found._index];
+						if (element && !element._view.skip) {
+							elementsArray.push(element);
+						}
+					}
+				}, chartInstance);
+
+				return elementsArray;
 			},
 			dataset: function(chartInstance, e) {
-				return chartInstance.getDatasetAtEvent(e);
+				var elementsArray = chartInstance.getElementAtEvent(e);
+
+				if (elementsArray.length > 0) {
+					elementsArray = chartInstance.getDatasetMeta(elementsArray[0]._datasetIndex).data;
+				}
+
+				return elementsArray;
 			},
 			'x-axis': function(chartInstance, e) {
-				return chartInstance.getElementsAtXAxis(e);
-			}
+				var eventPosition = helpers.getRelativePosition(e, chartInstance.chart);
+				var elementsArray = [];
+
+				var found = function() {
+					if (chartInstance.data.datasets) {
+						for (var i = 0; i < chartInstance.data.datasets.length; i++) {
+							var meta = chartInstance.getDatasetMeta(i);
+							if (chartInstance.isDatasetVisible(i)) {
+								for (var j = 0; j < meta.data.length; j++) {
+									if (meta.data[j].inLabelRange(eventPosition.x, eventPosition.y)) {
+										return meta.data[j];
+									}
+								}
+							}
+						}
+					}
+				}.call(chartInstance);
+
+				if (!found) {
+					return elementsArray;
+				}
+
+				helpers.each(chartInstance.data.datasets, function(dataset, datasetIndex) {
+					if (chartInstance.isDatasetVisible(datasetIndex)) {
+						var meta = chartInstance.getDatasetMeta(datasetIndex);
+						var index = helpers.findIndex(meta.data, function(it) {
+							return found._model.x === it._model.x;
+						});
+						if (index !== -1 && !meta.data[index]._view.skip) {
+							elementsArray.push(meta.data[index]);
+						}
+					}
+				}, chartInstance);
+
+				return elementsArray;
+			},
+
+			// Modes introduced in v2.4
 		}
 	};
 };

--- a/src/core/core.interaction.js
+++ b/src/core/core.interaction.js
@@ -222,6 +222,38 @@ module.exports = function(Chart) {
 
 				// Return only 1 item
 				return nearestItems.slice(0, 1);
+			},
+
+			/**
+			 * x mode returns the elements that hit-test at the current x coordinate
+			 * @function Chart.Interaction.modes.x
+			 * @param chartInstance {ChartInstance} the chart we are returning items from
+			 * @param e {Event} the event we are find things at
+			 * @param options {IInteractionOptions} options to use
+			 * @return {Chart.Element[]} Array of elements that are under the point. If none are found, an empty array is returned
+			 */
+			x: function(chartInstance, e, options) {
+				var eventPosition = helpers.getRelativePosition(e, chartInstance.chart);
+				var items = getAllItems(chartInstance).filter(function(item) {
+					return item.inXRange(eventPosition.x);
+				});
+				return items;
+			},
+
+			/**
+			 * y mode returns the elements that hit-test at the current y coordinate
+			 * @function Chart.Interaction.modes.y
+			 * @param chartInstance {ChartInstance} the chart we are returning items from
+			 * @param e {Event} the event we are find things at
+			 * @param options {IInteractionOptions} options to use
+			 * @return {Chart.Element[]} Array of elements that are under the point. If none are found, an empty array is returned
+			 */
+			y: function(chartInstance, e, options) {
+				var eventPosition = helpers.getRelativePosition(e, chartInstance.chart);
+				var items = getAllItems(chartInstance).filter(function(item) {
+					return item.inYRange(eventPosition.x);
+				});
+				return items;
 			}
 		}
 	};

--- a/src/core/core.interaction.js
+++ b/src/core/core.interaction.js
@@ -70,9 +70,9 @@ module.exports = function(Chart) {
 		return nearestItems;
 	}
 
-	function indexMode(chartInstance, e, intersect) {
+	function indexMode(chartInstance, e, options) {
 		var eventPosition = helpers.getRelativePosition(e, chartInstance.chart);
-		var items = intersect ? getIntersectItems(chartInstance, eventPosition) : getNearestItems(getAllItems(chartInstance), eventPosition);
+		var items = options.intersect ? getIntersectItems(chartInstance, eventPosition) : getNearestItems(getAllItems(chartInstance), eventPosition);
 
 		var elementsArray = [];
 
@@ -92,6 +92,15 @@ module.exports = function(Chart) {
 
 		return elementsArray;
 	}
+
+	/**
+	 * @interface IInteractionOptions
+	 */
+	/**
+	 * If true, only consider items that intersect the point
+	 * @name IInterfaceOptions#boolean
+	 * @type Boolean
+	 */
 
 	/**
 	 * @namespace Chart.Interaction
@@ -127,29 +136,29 @@ module.exports = function(Chart) {
 			label: indexMode,
 
 			/**
-			 * Returns items at the same index. If the intersect parameter is true, we only return items if we intersect something
-			 * If the intersect mode is false, we find the nearest item and return the items at the same index as that item
+			 * Returns items at the same index. If the options.intersect parameter is true, we only return items if we intersect something
+			 * If the options.intersect mode is false, we find the nearest item and return the items at the same index as that item
 			 * @function Chart.Interaction.modes.index
 			 * @since v2.4.0
 			 * @param chartInstance {ChartInstance} the chart we are returning items from
 			 * @param e {Event} the event we are find things at
-			 * @param intersect {Boolean} if true, only consider items that intersect the event position
+			 * @param options {IInteractionOptions} options to use during interaction
 			 * @return {Chart.Element[]} Array of elements that are under the point. If none are found, an empty array is returned
 			 */
 			index: indexMode,
 
 			/**
-			 * Returns items in the same dataset. If the intersect parameter is true, we only return items if we intersect something
-			 * If the intersect mode is false, we find the nearest item and return the items in that dataset
+			 * Returns items in the same dataset. If the options.intersect parameter is true, we only return items if we intersect something
+			 * If the options.intersect is false, we find the nearest item and return the items in that dataset
 			 * @function Chart.Interaction.modes.dataset
 			 * @param chartInstance {ChartInstance} the chart we are returning items from
 			 * @param e {Event} the event we are find things at
-			 * @param intersect {Boolean} if true, only consider items that intersect the event position
+			 * @param options {IInteractionOptions} options to use during interaction
 			 * @return {Chart.Element[]} Array of elements that are under the point. If none are found, an empty array is returned
 			 */
-			dataset: function(chartInstance, e, intersect) {
+			dataset: function(chartInstance, e, options) {
 				var eventPosition = helpers.getRelativePosition(e, chartInstance.chart);
-				var items = intersect ? getIntersectItems(chartInstance, eventPosition) : getNearestItems(getAllItems(chartInstance), eventPosition);
+				var items = options.intersect ? getIntersectItems(chartInstance, eventPosition) : getNearestItems(getAllItems(chartInstance), eventPosition);
 
 				if (items.length > 0) {
 					items = chartInstance.getDatasetMeta(items[0]._datasetIndex).data;
@@ -185,12 +194,12 @@ module.exports = function(Chart) {
 			 * @function Chart.Interaction.modes.intersect
 			 * @param chartInstance {ChartInstance} the chart we are returning items from
 			 * @param e {Event} the event we are find things at
-			 * @param intersect {Boolean} if true, only consider items that intersect the event position
+			 * @param options {IInteractionOptions} options to use
 			 * @return {Chart.Element[]} Array of elements that are under the point. If none are found, an empty array is returned
 			 */
-			nearest: function(chartInstance, e, intersect) {
+			nearest: function(chartInstance, e, options) {
 				var eventPosition = helpers.getRelativePosition(e, chartInstance.chart);
-				var items = intersect ? getIntersectItems(chartInstance, eventPosition) : getAllItems(chartInstance);
+				var items = options.intersect ? getIntersectItems(chartInstance, eventPosition) : getAllItems(chartInstance);
 
 				// Filter to nearest items
 				var nearestItems = getNearestItems(items, eventPosition);

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -30,7 +30,7 @@ module.exports = function() {
 			events: ['mousemove', 'mouseout', 'click', 'touchstart', 'touchmove'],
 			hover: {
 				onHover: null,
-				mode: 'single',
+				mode: 'nearest',
 				intersect: true,
 				animationDuration: 400
 			},

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -31,6 +31,7 @@ module.exports = function() {
 			hover: {
 				onHover: null,
 				mode: 'single',
+				intersect: true,
 				animationDuration: 400
 			},
 			onClick: null,

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -8,6 +8,7 @@ module.exports = function(Chart) {
 		enabled: true,
 		custom: null,
 		mode: 'single',
+		intersect: true,
 		backgroundColor: 'rgba(0,0,0,0.8)',
 		titleFontStyle: 'bold',
 		titleSpacing: 2,

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -7,7 +7,7 @@ module.exports = function(Chart) {
 	Chart.defaults.global.tooltips = {
 		enabled: true,
 		custom: null,
-		mode: 'single',
+		mode: 'nearest',
 		intersect: true,
 		backgroundColor: 'rgba(0,0,0,0.8)',
 		titleFontStyle: 'bold',

--- a/src/elements/element.arc.js
+++ b/src/elements/element.arc.js
@@ -52,15 +52,14 @@ module.exports = function(Chart) {
 			}
 			return false;
 		},
-		distanceToCenter: function(point) {
+		getCenterPoint: function() {
 			var vm = this._view;
 			var halfAngle = (vm.startAngle + vm.endAngle) / 2;
 			var halfRadius = (vm.innerRadius + vm.outerRadius) / 2;
-			var centerPoint = {
+			return {
 				x: vm.x + Math.cos(halfAngle) * halfRadius,
 				y: vm.y + Math.sin(halfAngle) * halfRadius
 			};
-			return helpers.distanceBetweenPoints(point, centerPoint);
 		},
 		getArea: function() {
 			var vm = this._view;

--- a/src/elements/element.arc.js
+++ b/src/elements/element.arc.js
@@ -52,6 +52,20 @@ module.exports = function(Chart) {
 			}
 			return false;
 		},
+		distanceToCenter: function(point) {
+			var vm = this._view;
+			var halfAngle = (vm.startAngle + vm.endAngle) / 2;
+			var halfRadius = (vm.innerRadius + vm.outerRadius) / 2;
+			var centerPoint = {
+				x: vm.x + Math.cos(halfAngle) * halfRadius,
+				y: vm.y + Math.sin(halfAngle) * halfRadius
+			};
+			return helpers.distanceBetweenPoints(point, centerPoint);
+		},
+		getArea: function() {
+			var vm = this._view;
+			return Math.PI * ((vm.endAngle - vm.startAngle) / (2 * Math.PI)) * (Math.pow(vm.outerRadius, 2) - Math.pow(vm.innerRadius, 2));
+		},
 		tooltipPosition: function() {
 			var vm = this._view;
 

--- a/src/elements/element.point.js
+++ b/src/elements/element.point.js
@@ -38,12 +38,12 @@ module.exports = function(Chart) {
 		inXRange: xRange,
 		inYRange: yRange,
 
-		distanceToCenter: function(point) {
+		getCenterPoint: function() {
 			var vm = this._view;
-			return helpers.distanceBetweenPoints(point, {
+			return {
 				x: vm.x,
 				y: vm.y
-			});
+			};
 		},
 		getArea: function() {
 			return Math.PI * Math.pow(this._view.radius, 2);

--- a/src/elements/element.point.js
+++ b/src/elements/element.point.js
@@ -18,15 +18,26 @@ module.exports = function(Chart) {
 		hoverBorderWidth: 1
 	};
 
+	function xRange(mouseX) {
+		var vm = this._view;
+		return vm ? (Math.pow(mouseX - vm.x, 2) < Math.pow(vm.radius + vm.hitRadius, 2)) : false;
+	}
+
+	function yRange(mouseY) {
+		var vm = this._view;
+		return vm ? (Math.pow(mouseY - vm.y, 2) < Math.pow(vm.radius + vm.hitRadius, 2)) : false;
+	}
+
 	Chart.elements.Point = Chart.Element.extend({
 		inRange: function(mouseX, mouseY) {
 			var vm = this._view;
 			return vm ? ((Math.pow(mouseX - vm.x, 2) + Math.pow(mouseY - vm.y, 2)) < Math.pow(vm.hitRadius + vm.radius, 2)) : false;
 		},
-		inLabelRange: function(mouseX) {
-			var vm = this._view;
-			return vm ? (Math.pow(mouseX - vm.x, 2) < Math.pow(vm.radius + vm.hitRadius, 2)) : false;
-		},
+
+		inLabelRange: xRange,
+		inXRange: xRange,
+		inYRange: yRange,
+
 		distanceToCenter: function(point) {
 			var vm = this._view;
 			return helpers.distanceBetweenPoints(point, {

--- a/src/elements/element.point.js
+++ b/src/elements/element.point.js
@@ -27,6 +27,16 @@ module.exports = function(Chart) {
 			var vm = this._view;
 			return vm ? (Math.pow(mouseX - vm.x, 2) < Math.pow(vm.radius + vm.hitRadius, 2)) : false;
 		},
+		distanceToCenter: function(point) {
+			var vm = this._view;
+			return helpers.distanceBetweenPoints(point, {
+				x: vm.x,
+				y: vm.y
+			});
+		},
+		getArea: function() {
+			return Math.PI * Math.pow(this._view.radius, 2);
+		},
 		tooltipPosition: function() {
 			var vm = this._view;
 			return {

--- a/src/elements/element.rectangle.js
+++ b/src/elements/element.rectangle.js
@@ -11,6 +11,44 @@ module.exports = function(Chart) {
 		borderSkipped: 'bottom'
 	};
 
+	function isVertical(bar) {
+		return bar._view.width !== undefined;
+	}
+
+	/**
+	 * Helper function to get the bounds of the bar regardless of the orientation
+	 * @private
+	 * @param bar {Chart.Element.Rectangle} the bar
+	 * @return {Bounds} bounds of the bar
+	 */
+	function getBarBounds(bar) {
+		var vm = bar._view;
+		var x1, x2, y1, y2;
+
+		if (isVertical(bar)) {
+			// vertical
+			var halfWidth = vm.width / 2;
+			x1 = vm.x - halfWidth;
+			x2 = vm.x + halfWidth;
+			y1 = Math.min(vm.y, vm.base);
+			y2 = Math.max(vm.y, vm.base);
+		} else {
+			// horizontal bar
+			var halfHeight = vm.height / 2;
+			x1 = Math.min(vm.x, vm.base);
+			x2 = Math.max(vm.x, vm.base);
+			y1 = vm.y - halfHeight;
+			y2 = vm.y + halfHeight;
+		}
+
+		return {
+			left: x1,
+			top: y1,
+			right: x2,
+			bottom: y2
+		};
+	}
+
 	Chart.elements.Rectangle = Chart.Element.extend({
 		draw: function() {
 			var ctx = this._chart.ctx;
@@ -72,16 +110,37 @@ module.exports = function(Chart) {
 			return vm.base - vm.y;
 		},
 		inRange: function(mouseX, mouseY) {
-			var vm = this._view;
-			return vm ?
-					(vm.y < vm.base ?
-						(mouseX >= vm.x - vm.width / 2 && mouseX <= vm.x + vm.width / 2) && (mouseY >= vm.y && mouseY <= vm.base) :
-						(mouseX >= vm.x - vm.width / 2 && mouseX <= vm.x + vm.width / 2) && (mouseY >= vm.base && mouseY <= vm.y)) :
-					false;
+			var inRange = false;
+
+			if (this._view) {
+				var bounds = getBarBounds(this);
+				inRange = mouseX >= bounds.left && mouseX <= bounds.right && mouseY >= bounds.top && mouseY <= bounds.bottom;
+			}
+			
+			return inRange;
 		},
-		inLabelRange: function(mouseX) {
-			var vm = this._view;
-			return vm ? (mouseX >= vm.x - vm.width / 2 && mouseX <= vm.x + vm.width / 2) : false;
+		inLabelRange: function(mouseX, mouseY) {
+			var me = this;
+			var inRange = false;
+			if (me._view) {
+				var bounds = getBarBounds(me);
+
+				if (isVertical(me)) {
+					inRange = mouseX >= bounds.left && mouseX <= bounds.right;
+				} else {
+					inRange = mouseY >= bounds.top && mouseY <= bounds.bottom;
+				}
+			}
+
+			return inRange;
+		},
+		inXRange: function(mouseX) {
+			var bounds = getBarBounds(this);
+			return mouseX >= bounds.left && mouseX <= bounds.right;
+		},
+		inYRange: function(mouseY) {
+			var bounds = getBarBounds(this);
+			return mouseY >= bounds.top && mouseY <= bounds.bottom;
 		},
 		distanceToCenter: function(point) {
 			var vm = this._view;

--- a/src/elements/element.rectangle.js
+++ b/src/elements/element.rectangle.js
@@ -83,6 +83,17 @@ module.exports = function(Chart) {
 			var vm = this._view;
 			return vm ? (mouseX >= vm.x - vm.width / 2 && mouseX <= vm.x + vm.width / 2) : false;
 		},
+		distanceToCenter: function(point) {
+			var vm = this._view;
+			return Chart.helpers.distanceBetweenPoints(point, {
+				x: vm.x,
+				y: (vm.y + vm.base) / 2
+			});
+		},
+		getArea: function() {
+			var vm = this._view;
+			return vm.width * Math.abs(vm.y - vm.base);
+		},
 		tooltipPosition: function() {
 			var vm = this._view;
 			return {

--- a/src/elements/element.rectangle.js
+++ b/src/elements/element.rectangle.js
@@ -116,20 +116,22 @@ module.exports = function(Chart) {
 				var bounds = getBarBounds(this);
 				inRange = mouseX >= bounds.left && mouseX <= bounds.right && mouseY >= bounds.top && mouseY <= bounds.bottom;
 			}
-			
+
 			return inRange;
 		},
 		inLabelRange: function(mouseX, mouseY) {
 			var me = this;
-			var inRange = false;
-			if (me._view) {
-				var bounds = getBarBounds(me);
+			if (!me._view) {
+				return false;
+			}
 
-				if (isVertical(me)) {
-					inRange = mouseX >= bounds.left && mouseX <= bounds.right;
-				} else {
-					inRange = mouseY >= bounds.top && mouseY <= bounds.bottom;
-				}
+			var inRange = false;
+			var bounds = getBarBounds(me);
+
+			if (isVertical(me)) {
+				inRange = mouseX >= bounds.left && mouseX <= bounds.right;
+			} else {
+				inRange = mouseY >= bounds.top && mouseY <= bounds.bottom;
 			}
 
 			return inRange;
@@ -142,12 +144,18 @@ module.exports = function(Chart) {
 			var bounds = getBarBounds(this);
 			return mouseY >= bounds.top && mouseY <= bounds.bottom;
 		},
-		distanceToCenter: function(point) {
+		getCenterPoint: function() {
 			var vm = this._view;
-			return Chart.helpers.distanceBetweenPoints(point, {
-				x: vm.x,
-				y: (vm.y + vm.base) / 2
-			});
+			var x, y;
+			if (isVertical(this)) {
+				x = vm.x;
+				y = (vm.y + vm.base) / 2;
+			} else {
+				x = (vm.x + vm.base) / 2;
+				y = vm.y;
+			}
+
+			return {x: x, y: y};
 		},
 		getArea: function() {
 			var vm = this._view;

--- a/test/core.interaction.tests.js
+++ b/test/core.interaction.tests.js
@@ -115,7 +115,7 @@ describe('Core.Interaction', function() {
 				currentTarget: node
 			};
 
-			var elements = Chart.Interaction.modes.index(chartInstance, evt, true);
+			var elements = Chart.Interaction.modes.index(chartInstance, evt, { intersect: true });
 			expect(elements).toEqual([point, meta1.data[1]]);
 		});
 
@@ -154,7 +154,7 @@ describe('Core.Interaction', function() {
 				currentTarget: node
 			};
 
-			var elements = Chart.Interaction.modes.index(chartInstance, evt, false);
+			var elements = Chart.Interaction.modes.index(chartInstance, evt, { intersect: false });
 			expect(elements).toEqual([meta0.data[0], meta1.data[0]]);
 		});
 	});
@@ -195,7 +195,7 @@ describe('Core.Interaction', function() {
 				currentTarget: node
 			};
 
-			var elements = Chart.Interaction.modes.dataset(chartInstance, evt, true);
+			var elements = Chart.Interaction.modes.dataset(chartInstance, evt, { intersect: true });
 			expect(elements).toEqual(meta.data);
 		});
 
@@ -230,7 +230,7 @@ describe('Core.Interaction', function() {
 				currentTarget: node
 			};
 
-			var elements = Chart.Interaction.modes.dataset(chartInstance, evt, false);
+			var elements = Chart.Interaction.modes.dataset(chartInstance, evt, { intersect: false });
 
 			var meta = chartInstance.getDatasetMeta(1);
 			expect(elements).toEqual(meta.data);
@@ -271,7 +271,7 @@ describe('Core.Interaction', function() {
 			};
 
 			// Nearest to 0,0 (top left) will be first point of dataset 2
-			var elements = Chart.Interaction.modes.nearest(chartInstance, evt, false);
+			var elements = Chart.Interaction.modes.nearest(chartInstance, evt, { intersect: false });
 			expect(elements).toEqual([meta.data[0]]);
 		});
 
@@ -318,7 +318,7 @@ describe('Core.Interaction', function() {
 			};
 
 			// Nearest to 0,0 (top left) will be first point of dataset 2
-			var elements = Chart.Interaction.modes.nearest(chartInstance, evt, false);
+			var elements = Chart.Interaction.modes.nearest(chartInstance, evt, { intersect: false });
 			expect(elements).toEqual([meta0.data[1]]);
 		});
 
@@ -365,7 +365,7 @@ describe('Core.Interaction', function() {
 			};
 
 			// Nearest to 0,0 (top left) will be first point of dataset 2
-			var elements = Chart.Interaction.modes.nearest(chartInstance, evt, false);
+			var elements = Chart.Interaction.modes.nearest(chartInstance, evt, { intersect: false });
 			expect(elements).toEqual([meta0.data[1]]);
 		});
 	});
@@ -406,7 +406,7 @@ describe('Core.Interaction', function() {
 			};
 
 			// Nothing intersects so find nothing
-			var elements = Chart.Interaction.modes.nearest(chartInstance, evt, true);
+			var elements = Chart.Interaction.modes.nearest(chartInstance, evt, { intersect: true });
 			expect(elements).toEqual([]);
 
 			evt = {
@@ -417,7 +417,7 @@ describe('Core.Interaction', function() {
 				clientY: rect.top + point._view.y,
 				currentTarget: node
 			};
-			elements = Chart.Interaction.modes.nearest(chartInstance, evt, true);
+			elements = Chart.Interaction.modes.nearest(chartInstance, evt, { intersect: true });
 			expect(elements).toEqual([point]);
 		});
 
@@ -463,7 +463,7 @@ describe('Core.Interaction', function() {
 			};
 
 			// Nearest to 0,0 (top left) will be first point of dataset 2
-			var elements = Chart.Interaction.modes.nearest(chartInstance, evt, true);
+			var elements = Chart.Interaction.modes.nearest(chartInstance, evt, { intersect: true });
 			expect(elements).toEqual([meta0.data[1]]);
 		});
 
@@ -509,7 +509,7 @@ describe('Core.Interaction', function() {
 			};
 
 			// Nearest to 0,0 (top left) will be first point of dataset 2
-			var elements = Chart.Interaction.modes.nearest(chartInstance, evt, true);
+			var elements = Chart.Interaction.modes.nearest(chartInstance, evt, { intersect: true });
 			expect(elements).toEqual([meta0.data[1]]);
 		});
 
@@ -555,7 +555,7 @@ describe('Core.Interaction', function() {
 			};
 
 			// Nearest to 0,0 (top left) will be first point of dataset 2
-			var elements = Chart.Interaction.modes.nearest(chartInstance, evt, true);
+			var elements = Chart.Interaction.modes.nearest(chartInstance, evt, { intersect: true });
 			expect(elements).toEqual([meta0.data[1]]);
 		});
 	});

--- a/test/core.interaction.tests.js
+++ b/test/core.interaction.tests.js
@@ -1,0 +1,90 @@
+// Tests of the interaction handlers in Core.Interaction
+
+// Test the rectangle element
+describe('Core.Interaction', function() {
+	describe('intersect mode', function() {
+		it ('should return all items under the point', function() {
+			var chartInstance = window.acquireChart({
+				type: 'line',
+				data: {
+					datasets: [{
+						label: 'Dataset 1',
+						data: [10, 20, 30],
+						pointHoverBorderColor: 'rgb(255, 0, 0)',
+						pointHoverBackgroundColor: 'rgb(0, 255, 0)'
+					}, {
+						label: 'Dataset 2',
+						data: [40, 20, 40],
+						pointHoverBorderColor: 'rgb(0, 0, 255)',
+						pointHoverBackgroundColor: 'rgb(0, 255, 255)'
+					}],
+					labels: ['Point 1', 'Point 2', 'Point 3']
+				},
+				options: {
+					tooltips: {
+						mode: 'single'
+					}
+				}
+			});
+
+			// Trigger an event over top of the
+			var meta0 = chartInstance.getDatasetMeta(0);
+			var meta1 = chartInstance.getDatasetMeta(1);
+			var point = meta0.data[1];
+
+			var node = chartInstance.chart.canvas;
+			var rect = node.getBoundingClientRect();
+
+			var evt = {
+				view: window,
+				bubbles: true,
+				cancelable: true,
+				clientX: rect.left + point._model.x,
+				clientY: rect.top + point._model.y,
+				currentTarget: node
+			};
+
+			var elements = Chart.Interaction.modes.intersect(chartInstance, evt);
+			expect(elements).toEqual([point, meta1.data[1]]);
+		});
+
+		it ('should return an empty array when no items are found', function() {
+			var chartInstance = window.acquireChart({
+				type: 'line',
+				data: {
+					datasets: [{
+						label: 'Dataset 1',
+						data: [10, 20, 30],
+						pointHoverBorderColor: 'rgb(255, 0, 0)',
+						pointHoverBackgroundColor: 'rgb(0, 255, 0)'
+					}, {
+						label: 'Dataset 2',
+						data: [40, 20, 40],
+						pointHoverBorderColor: 'rgb(0, 0, 255)',
+						pointHoverBackgroundColor: 'rgb(0, 255, 255)'
+					}],
+					labels: ['Point 1', 'Point 2', 'Point 3']
+				},
+				options: {
+					tooltips: {
+						mode: 'single'
+					}
+				}
+			});
+
+			// Trigger an event at (0, 0)
+			var node = chartInstance.chart.canvas;
+			var evt = {
+				view: window,
+				bubbles: true,
+				cancelable: true,
+				clientX: 0,
+				clientY: 0,
+				currentTarget: node
+			};
+
+			var elements = Chart.Interaction.modes.intersect(chartInstance, evt);
+			expect(elements).toEqual([]);
+		});
+	});
+});

--- a/test/core.interaction.tests.js
+++ b/test/core.interaction.tests.js
@@ -2,7 +2,7 @@
 
 // Test the rectangle element
 describe('Core.Interaction', function() {
-	describe('intersect mode', function() {
+	describe('point mode', function() {
 		it ('should return all items under the point', function() {
 			var chartInstance = window.acquireChart({
 				type: 'line',
@@ -39,7 +39,7 @@ describe('Core.Interaction', function() {
 				currentTarget: node
 			};
 
-			var elements = Chart.Interaction.modes.intersect(chartInstance, evt);
+			var elements = Chart.Interaction.modes.point(chartInstance, evt);
 			expect(elements).toEqual([point, meta1.data[1]]);
 		});
 
@@ -73,7 +73,7 @@ describe('Core.Interaction', function() {
 				currentTarget: node
 			};
 
-			var elements = Chart.Interaction.modes.intersect(chartInstance, evt);
+			var elements = Chart.Interaction.modes.point(chartInstance, evt);
 			expect(elements).toEqual([]);
 		});
 	});
@@ -115,8 +115,47 @@ describe('Core.Interaction', function() {
 				currentTarget: node
 			};
 
-			var elements = Chart.Interaction.modes.index(chartInstance, evt);
+			var elements = Chart.Interaction.modes.index(chartInstance, evt, true);
 			expect(elements).toEqual([point, meta1.data[1]]);
+		});
+
+		it ('should return all items at the same index when intersect is false', function() {
+			var chartInstance = window.acquireChart({
+				type: 'line',
+				data: {
+					datasets: [{
+						label: 'Dataset 1',
+						data: [10, 20, 30],
+						pointHoverBorderColor: 'rgb(255, 0, 0)',
+						pointHoverBackgroundColor: 'rgb(0, 255, 0)'
+					}, {
+						label: 'Dataset 2',
+						data: [40, 40, 40],
+						pointHoverBorderColor: 'rgb(0, 0, 255)',
+						pointHoverBackgroundColor: 'rgb(0, 255, 255)'
+					}],
+					labels: ['Point 1', 'Point 2', 'Point 3']
+				}
+			});
+
+			// Trigger an event over top of the
+			var meta0 = chartInstance.getDatasetMeta(0);
+			var meta1 = chartInstance.getDatasetMeta(1);
+
+			var node = chartInstance.chart.canvas;
+			var rect = node.getBoundingClientRect();
+
+			var evt = {
+				view: window,
+				bubbles: true,
+				cancelable: true,
+				clientX: rect.left,
+				clientY: rect.top,
+				currentTarget: node
+			};
+
+			var elements = Chart.Interaction.modes.index(chartInstance, evt, false);
+			expect(elements).toEqual([meta0.data[0], meta1.data[0]]);
 		});
 	});
 
@@ -156,7 +195,44 @@ describe('Core.Interaction', function() {
 				currentTarget: node
 			};
 
-			var elements = Chart.Interaction.modes.dataset(chartInstance, evt);
+			var elements = Chart.Interaction.modes.dataset(chartInstance, evt, true);
+			expect(elements).toEqual(meta.data);
+		});
+
+		it ('should return all items in the dataset of the first item found when intersect is false', function() {
+			var chartInstance = window.acquireChart({
+				type: 'line',
+				data: {
+					datasets: [{
+						label: 'Dataset 1',
+						data: [10, 20, 30],
+						pointHoverBorderColor: 'rgb(255, 0, 0)',
+						pointHoverBackgroundColor: 'rgb(0, 255, 0)'
+					}, {
+						label: 'Dataset 2',
+						data: [40, 40, 40],
+						pointHoverBorderColor: 'rgb(0, 0, 255)',
+						pointHoverBackgroundColor: 'rgb(0, 255, 255)'
+					}],
+					labels: ['Point 1', 'Point 2', 'Point 3']
+				}
+			});
+
+			var node = chartInstance.chart.canvas;
+			var rect = node.getBoundingClientRect();
+
+			var evt = {
+				view: window,
+				bubbles: true,
+				cancelable: true,
+				clientX: rect.left,
+				clientY: rect.top,
+				currentTarget: node
+			};
+
+			var elements = Chart.Interaction.modes.dataset(chartInstance, evt, false);
+
+			var meta = chartInstance.getDatasetMeta(1);
 			expect(elements).toEqual(meta.data);
 		});
 	});
@@ -195,7 +271,7 @@ describe('Core.Interaction', function() {
 			};
 
 			// Nearest to 0,0 (top left) will be first point of dataset 2
-			var elements = Chart.Interaction.modes.nearest(chartInstance, evt);
+			var elements = Chart.Interaction.modes.nearest(chartInstance, evt, false);
 			expect(elements).toEqual([meta.data[0]]);
 		});
 
@@ -242,7 +318,7 @@ describe('Core.Interaction', function() {
 			};
 
 			// Nearest to 0,0 (top left) will be first point of dataset 2
-			var elements = Chart.Interaction.modes.nearest(chartInstance, evt);
+			var elements = Chart.Interaction.modes.nearest(chartInstance, evt, false);
 			expect(elements).toEqual([meta0.data[1]]);
 		});
 
@@ -289,12 +365,12 @@ describe('Core.Interaction', function() {
 			};
 
 			// Nearest to 0,0 (top left) will be first point of dataset 2
-			var elements = Chart.Interaction.modes.nearest(chartInstance, evt);
+			var elements = Chart.Interaction.modes.nearest(chartInstance, evt, false);
 			expect(elements).toEqual([meta0.data[1]]);
 		});
 	});
 
-	describe('nearestIntersect mode', function() {
+	describe('nearest intersect mode', function() {
 		it ('should return the nearest item', function() {
 			var chartInstance = window.acquireChart({
 				type: 'line',
@@ -330,7 +406,7 @@ describe('Core.Interaction', function() {
 			};
 
 			// Nothing intersects so find nothing
-			var elements = Chart.Interaction.modes.nearestIntersect(chartInstance, evt);
+			var elements = Chart.Interaction.modes.nearest(chartInstance, evt, true);
 			expect(elements).toEqual([]);
 
 			evt = {
@@ -341,7 +417,7 @@ describe('Core.Interaction', function() {
 				clientY: rect.top + point._view.y,
 				currentTarget: node
 			};
-			elements = Chart.Interaction.modes.nearestIntersect(chartInstance, evt);
+			elements = Chart.Interaction.modes.nearest(chartInstance, evt, true);
 			expect(elements).toEqual([point]);
 		});
 
@@ -387,7 +463,7 @@ describe('Core.Interaction', function() {
 			};
 
 			// Nearest to 0,0 (top left) will be first point of dataset 2
-			var elements = Chart.Interaction.modes.nearestIntersect(chartInstance, evt);
+			var elements = Chart.Interaction.modes.nearest(chartInstance, evt, true);
 			expect(elements).toEqual([meta0.data[1]]);
 		});
 
@@ -433,7 +509,7 @@ describe('Core.Interaction', function() {
 			};
 
 			// Nearest to 0,0 (top left) will be first point of dataset 2
-			var elements = Chart.Interaction.modes.nearestIntersect(chartInstance, evt);
+			var elements = Chart.Interaction.modes.nearest(chartInstance, evt, true);
 			expect(elements).toEqual([meta0.data[1]]);
 		});
 
@@ -479,7 +555,7 @@ describe('Core.Interaction', function() {
 			};
 
 			// Nearest to 0,0 (top left) will be first point of dataset 2
-			var elements = Chart.Interaction.modes.nearestIntersect(chartInstance, evt);
+			var elements = Chart.Interaction.modes.nearest(chartInstance, evt, true);
 			expect(elements).toEqual([meta0.data[1]]);
 		});
 	});

--- a/test/core.interaction.tests.js
+++ b/test/core.interaction.tests.js
@@ -19,11 +19,6 @@ describe('Core.Interaction', function() {
 						pointHoverBackgroundColor: 'rgb(0, 255, 255)'
 					}],
 					labels: ['Point 1', 'Point 2', 'Point 3']
-				},
-				options: {
-					tooltips: {
-						mode: 'single'
-					}
 				}
 			});
 
@@ -64,11 +59,6 @@ describe('Core.Interaction', function() {
 						pointHoverBackgroundColor: 'rgb(0, 255, 255)'
 					}],
 					labels: ['Point 1', 'Point 2', 'Point 3']
-				},
-				options: {
-					tooltips: {
-						mode: 'single'
-					}
 				}
 			});
 
@@ -85,6 +75,412 @@ describe('Core.Interaction', function() {
 
 			var elements = Chart.Interaction.modes.intersect(chartInstance, evt);
 			expect(elements).toEqual([]);
+		});
+	});
+
+	describe('index mode', function() {
+		it ('should return all items at the same index', function() {
+			var chartInstance = window.acquireChart({
+				type: 'line',
+				data: {
+					datasets: [{
+						label: 'Dataset 1',
+						data: [10, 20, 30],
+						pointHoverBorderColor: 'rgb(255, 0, 0)',
+						pointHoverBackgroundColor: 'rgb(0, 255, 0)'
+					}, {
+						label: 'Dataset 2',
+						data: [40, 40, 40],
+						pointHoverBorderColor: 'rgb(0, 0, 255)',
+						pointHoverBackgroundColor: 'rgb(0, 255, 255)'
+					}],
+					labels: ['Point 1', 'Point 2', 'Point 3']
+				}
+			});
+
+			// Trigger an event over top of the
+			var meta0 = chartInstance.getDatasetMeta(0);
+			var meta1 = chartInstance.getDatasetMeta(1);
+			var point = meta0.data[1];
+
+			var node = chartInstance.chart.canvas;
+			var rect = node.getBoundingClientRect();
+
+			var evt = {
+				view: window,
+				bubbles: true,
+				cancelable: true,
+				clientX: rect.left + point._model.x,
+				clientY: rect.top + point._model.y,
+				currentTarget: node
+			};
+
+			var elements = Chart.Interaction.modes.index(chartInstance, evt);
+			expect(elements).toEqual([point, meta1.data[1]]);
+		});
+	});
+
+	describe('dataset mode', function() {
+		it ('should return all items in the dataset of the first item found', function() {
+			var chartInstance = window.acquireChart({
+				type: 'line',
+				data: {
+					datasets: [{
+						label: 'Dataset 1',
+						data: [10, 20, 30],
+						pointHoverBorderColor: 'rgb(255, 0, 0)',
+						pointHoverBackgroundColor: 'rgb(0, 255, 0)'
+					}, {
+						label: 'Dataset 2',
+						data: [40, 40, 40],
+						pointHoverBorderColor: 'rgb(0, 0, 255)',
+						pointHoverBackgroundColor: 'rgb(0, 255, 255)'
+					}],
+					labels: ['Point 1', 'Point 2', 'Point 3']
+				}
+			});
+
+			// Trigger an event over top of the
+			var meta = chartInstance.getDatasetMeta(0);
+			var point = meta.data[1];
+
+			var node = chartInstance.chart.canvas;
+			var rect = node.getBoundingClientRect();
+
+			var evt = {
+				view: window,
+				bubbles: true,
+				cancelable: true,
+				clientX: rect.left + point._model.x,
+				clientY: rect.top + point._model.y,
+				currentTarget: node
+			};
+
+			var elements = Chart.Interaction.modes.dataset(chartInstance, evt);
+			expect(elements).toEqual(meta.data);
+		});
+	});
+
+	describe('nearest mode', function() {
+		it ('should return the nearest item', function() {
+			var chartInstance = window.acquireChart({
+				type: 'line',
+				data: {
+					datasets: [{
+						label: 'Dataset 1',
+						data: [10, 20, 30],
+						pointHoverBorderColor: 'rgb(255, 0, 0)',
+						pointHoverBackgroundColor: 'rgb(0, 255, 0)'
+					}, {
+						label: 'Dataset 2',
+						data: [40, 40, 40],
+						pointHoverBorderColor: 'rgb(0, 0, 255)',
+						pointHoverBackgroundColor: 'rgb(0, 255, 255)'
+					}],
+					labels: ['Point 1', 'Point 2', 'Point 3']
+				}
+			});
+
+			// Trigger an event over top of the
+			var meta = chartInstance.getDatasetMeta(1);
+			var node = chartInstance.chart.canvas;
+			var rect = node.getBoundingClientRect();
+			var evt = {
+				view: window,
+				bubbles: true,
+				cancelable: true,
+				clientX: 0,
+				clientY: 0,
+				currentTarget: node
+			};
+
+			// Nearest to 0,0 (top left) will be first point of dataset 2
+			var elements = Chart.Interaction.modes.nearest(chartInstance, evt);
+			expect(elements).toEqual([meta.data[0]]);
+		});
+
+		it ('should return the smallest item if more than 1 are at the same distance', function() {
+			var chartInstance = window.acquireChart({
+				type: 'line',
+				data: {
+					datasets: [{
+						label: 'Dataset 1',
+						data: [10, 40, 30],
+						pointRadius: [5, 5, 5],
+						pointHoverBorderColor: 'rgb(255, 0, 0)',
+						pointHoverBackgroundColor: 'rgb(0, 255, 0)'
+					}, {
+						label: 'Dataset 2',
+						data: [40, 40, 40],
+						pointRadius: [10, 10, 10],
+						pointHoverBorderColor: 'rgb(0, 0, 255)',
+						pointHoverBackgroundColor: 'rgb(0, 255, 255)'
+					}],
+					labels: ['Point 1', 'Point 2', 'Point 3']
+				}
+			});
+
+			// Trigger an event over top of the
+			var meta0 = chartInstance.getDatasetMeta(0);
+			var meta1 = chartInstance.getDatasetMeta(1);
+
+			// Halfway between 2 mid points
+			var pt = {
+				x: meta0.data[1]._view.x,
+				y: (meta0.data[1]._view.y + meta1.data[1]._view.y) / 2
+			};
+
+			var node = chartInstance.chart.canvas;
+			var rect = node.getBoundingClientRect();
+			var evt = {
+				view: window,
+				bubbles: true,
+				cancelable: true,
+				clientX: rect.left + pt.x,
+				clientY: rect.top + pt.y,
+				currentTarget: node
+			};
+
+			// Nearest to 0,0 (top left) will be first point of dataset 2
+			var elements = Chart.Interaction.modes.nearest(chartInstance, evt);
+			expect(elements).toEqual([meta0.data[1]]);
+		});
+
+		it ('should return the lowest dataset index if size and area are the same', function() {
+			var chartInstance = window.acquireChart({
+				type: 'line',
+				data: {
+					datasets: [{
+						label: 'Dataset 1',
+						data: [10, 40, 30],
+						pointRadius: [5, 10, 5],
+						pointHoverBorderColor: 'rgb(255, 0, 0)',
+						pointHoverBackgroundColor: 'rgb(0, 255, 0)'
+					}, {
+						label: 'Dataset 2',
+						data: [40, 40, 40],
+						pointRadius: [10, 10, 10],
+						pointHoverBorderColor: 'rgb(0, 0, 255)',
+						pointHoverBackgroundColor: 'rgb(0, 255, 255)'
+					}],
+					labels: ['Point 1', 'Point 2', 'Point 3']
+				}
+			});
+
+			// Trigger an event over top of the
+			var meta0 = chartInstance.getDatasetMeta(0);
+			var meta1 = chartInstance.getDatasetMeta(1);
+
+			// Halfway between 2 mid points
+			var pt = {
+				x: meta0.data[1]._view.x,
+				y: (meta0.data[1]._view.y + meta1.data[1]._view.y) / 2
+			};
+
+			var node = chartInstance.chart.canvas;
+			var rect = node.getBoundingClientRect();
+			var evt = {
+				view: window,
+				bubbles: true,
+				cancelable: true,
+				clientX: rect.left + pt.x,
+				clientY: rect.top + pt.y,
+				currentTarget: node
+			};
+
+			// Nearest to 0,0 (top left) will be first point of dataset 2
+			var elements = Chart.Interaction.modes.nearest(chartInstance, evt);
+			expect(elements).toEqual([meta0.data[1]]);
+		});
+	});
+
+	describe('nearestIntersect mode', function() {
+		it ('should return the nearest item', function() {
+			var chartInstance = window.acquireChart({
+				type: 'line',
+				data: {
+					datasets: [{
+						label: 'Dataset 1',
+						data: [10, 20, 30],
+						pointHoverBorderColor: 'rgb(255, 0, 0)',
+						pointHoverBackgroundColor: 'rgb(0, 255, 0)'
+					}, {
+						label: 'Dataset 2',
+						data: [40, 40, 40],
+						pointHoverBorderColor: 'rgb(0, 0, 255)',
+						pointHoverBackgroundColor: 'rgb(0, 255, 255)'
+					}],
+					labels: ['Point 1', 'Point 2', 'Point 3']
+				}
+			});
+
+			// Trigger an event over top of the
+			var meta = chartInstance.getDatasetMeta(1);
+			var point = meta.data[1];
+
+			var node = chartInstance.chart.canvas;
+			var rect = node.getBoundingClientRect();
+			var evt = {
+				view: window,
+				bubbles: true,
+				cancelable: true,
+				clientX: rect.left + point._view.x + 15,
+				clientY: rect.top + point._view.y,
+				currentTarget: node
+			};
+
+			// Nothing intersects so find nothing
+			var elements = Chart.Interaction.modes.nearestIntersect(chartInstance, evt);
+			expect(elements).toEqual([]);
+
+			evt = {
+				view: window,
+				bubbles: true,
+				cancelable: true,
+				clientX: rect.left + point._view.x,
+				clientY: rect.top + point._view.y,
+				currentTarget: node
+			};
+			elements = Chart.Interaction.modes.nearestIntersect(chartInstance, evt);
+			expect(elements).toEqual([point]);
+		});
+
+		it ('should return the nearest item even if 2 intersect', function() {
+			var chartInstance = window.acquireChart({
+				type: 'line',
+				data: {
+					datasets: [{
+						label: 'Dataset 1',
+						data: [10, 39, 30],
+						pointRadius: [5, 30, 5],
+						pointHoverBorderColor: 'rgb(255, 0, 0)',
+						pointHoverBackgroundColor: 'rgb(0, 255, 0)'
+					}, {
+						label: 'Dataset 2',
+						data: [40, 40, 40],
+						pointRadius: [10, 10, 10],
+						pointHoverBorderColor: 'rgb(0, 0, 255)',
+						pointHoverBackgroundColor: 'rgb(0, 255, 255)'
+					}],
+					labels: ['Point 1', 'Point 2', 'Point 3']
+				}
+			});
+
+			// Trigger an event over top of the
+			var meta0 = chartInstance.getDatasetMeta(0);
+
+			// Halfway between 2 mid points
+			var pt = {
+				x: meta0.data[1]._view.x,
+				y: meta0.data[1]._view.y
+			};
+
+			var node = chartInstance.chart.canvas;
+			var rect = node.getBoundingClientRect();
+			var evt = {
+				view: window,
+				bubbles: true,
+				cancelable: true,
+				clientX: rect.left + pt.x,
+				clientY: rect.top + pt.y,
+				currentTarget: node
+			};
+
+			// Nearest to 0,0 (top left) will be first point of dataset 2
+			var elements = Chart.Interaction.modes.nearestIntersect(chartInstance, evt);
+			expect(elements).toEqual([meta0.data[1]]);
+		});
+
+		it ('should return the smallest item if more than 1 are at the same distance', function() {
+			var chartInstance = window.acquireChart({
+				type: 'line',
+				data: {
+					datasets: [{
+						label: 'Dataset 1',
+						data: [10, 40, 30],
+						pointRadius: [5, 5, 5],
+						pointHoverBorderColor: 'rgb(255, 0, 0)',
+						pointHoverBackgroundColor: 'rgb(0, 255, 0)'
+					}, {
+						label: 'Dataset 2',
+						data: [40, 40, 40],
+						pointRadius: [10, 10, 10],
+						pointHoverBorderColor: 'rgb(0, 0, 255)',
+						pointHoverBackgroundColor: 'rgb(0, 255, 255)'
+					}],
+					labels: ['Point 1', 'Point 2', 'Point 3']
+				}
+			});
+
+			// Trigger an event over top of the
+			var meta0 = chartInstance.getDatasetMeta(0);
+
+			// Halfway between 2 mid points
+			var pt = {
+				x: meta0.data[1]._view.x,
+				y: meta0.data[1]._view.y
+			};
+
+			var node = chartInstance.chart.canvas;
+			var rect = node.getBoundingClientRect();
+			var evt = {
+				view: window,
+				bubbles: true,
+				cancelable: true,
+				clientX: rect.left + pt.x,
+				clientY: rect.top + pt.y,
+				currentTarget: node
+			};
+
+			// Nearest to 0,0 (top left) will be first point of dataset 2
+			var elements = Chart.Interaction.modes.nearestIntersect(chartInstance, evt);
+			expect(elements).toEqual([meta0.data[1]]);
+		});
+
+		it ('should return the item at the lowest dataset index if distance and area are the same', function() {
+			var chartInstance = window.acquireChart({
+				type: 'line',
+				data: {
+					datasets: [{
+						label: 'Dataset 1',
+						data: [10, 40, 30],
+						pointRadius: [5, 10, 5],
+						pointHoverBorderColor: 'rgb(255, 0, 0)',
+						pointHoverBackgroundColor: 'rgb(0, 255, 0)'
+					}, {
+						label: 'Dataset 2',
+						data: [40, 40, 40],
+						pointRadius: [10, 10, 10],
+						pointHoverBorderColor: 'rgb(0, 0, 255)',
+						pointHoverBackgroundColor: 'rgb(0, 255, 255)'
+					}],
+					labels: ['Point 1', 'Point 2', 'Point 3']
+				}
+			});
+
+			// Trigger an event over top of the
+			var meta0 = chartInstance.getDatasetMeta(0);
+
+			// Halfway between 2 mid points
+			var pt = {
+				x: meta0.data[1]._view.x,
+				y: meta0.data[1]._view.y
+			};
+
+			var node = chartInstance.chart.canvas;
+			var rect = node.getBoundingClientRect();
+			var evt = {
+				view: window,
+				bubbles: true,
+				cancelable: true,
+				clientX: rect.left + pt.x,
+				clientY: rect.top + pt.y,
+				currentTarget: node
+			};
+
+			// Nearest to 0,0 (top left) will be first point of dataset 2
+			var elements = Chart.Interaction.modes.nearestIntersect(chartInstance, evt);
+			expect(elements).toEqual([meta0.data[1]]);
 		});
 	});
 });

--- a/test/element.arc.tests.js
+++ b/test/element.arc.tests.js
@@ -79,7 +79,7 @@ describe('Arc element tests', function() {
 		expect(arc.getArea()).toBeCloseTo(0.5 * Math.PI, 6);
 	});
 
-	it ('should get the distance to the center', function() {
+	it ('should get the center', function() {
 		var arc = new Chart.elements.Arc({
 			_datasetIndex: 2,
 			_index: 1
@@ -95,7 +95,9 @@ describe('Arc element tests', function() {
 			outerRadius: Math.sqrt(2),
 		};
 
-		expect(arc.distanceToCenter({ x: 0, y: 0 })).toEqual(Math.sqrt(0.5));
+		var center = arc.getCenterPoint();
+		expect(center.x).toBeCloseTo(0.5, 6);
+		expect(center.y).toBeCloseTo(0.5, 6);
 	});
 
 	it ('should draw correctly with no border', function() {

--- a/test/element.arc.tests.js
+++ b/test/element.arc.tests.js
@@ -60,6 +60,44 @@ describe('Arc element tests', function() {
 		expect(pos.y).toBeCloseTo(0.5);
 	});
 
+	it ('should get the area', function() {
+		var arc = new Chart.elements.Arc({
+			_datasetIndex: 2,
+			_index: 1
+		});
+
+		// Mock out the view as if the controller put it there
+		arc._view = {
+			startAngle: 0,
+			endAngle: Math.PI / 2,
+			x: 0,
+			y: 0,
+			innerRadius: 0,
+			outerRadius: Math.sqrt(2),
+		};
+
+		expect(arc.getArea()).toBeCloseTo(0.5 * Math.PI, 6);
+	});
+
+	it ('should get the distance to the center', function() {
+		var arc = new Chart.elements.Arc({
+			_datasetIndex: 2,
+			_index: 1
+		});
+
+		// Mock out the view as if the controller put it there
+		arc._view = {
+			startAngle: 0,
+			endAngle: Math.PI / 2,
+			x: 0,
+			y: 0,
+			innerRadius: 0,
+			outerRadius: Math.sqrt(2),
+		};
+
+		expect(arc.distanceToCenter({ x: 0, y: 0 })).toEqual(Math.sqrt(0.5));
+	});
+
 	it ('should draw correctly with no border', function() {
 		var mockContext = window.createMockContext();
 		var arc = new Chart.elements.Arc({

--- a/test/element.point.tests.js
+++ b/test/element.point.tests.js
@@ -78,7 +78,7 @@ describe('Point element tests', function() {
 		expect(point.getArea()).toEqual(Math.PI * 4);
 	});
 
-	it('should get the correct distance to the center', function() {
+	it('should get the correct center point', function() {
 		var point = new Chart.elements.Point({
 			_datasetIndex: 2,
 			_index: 1
@@ -91,7 +91,7 @@ describe('Point element tests', function() {
 			y: 10
 		};
 
-		expect(point.distanceToCenter({ x: 0, y: 0 })).toEqual(Math.sqrt(200));
+		expect(point.getCenterPoint()).toEqual({ x: 10, y: 10 });
 	});
 
 	it ('should draw correctly', function() {

--- a/test/element.point.tests.js
+++ b/test/element.point.tests.js
@@ -64,6 +64,36 @@ describe('Point element tests', function() {
 		});
 	});
 
+	it('should get the correct area', function() {
+		var point = new Chart.elements.Point({
+			_datasetIndex: 2,
+			_index: 1
+		});
+
+		// Attach a view object as if we were the controller
+		point._view = {
+			radius: 2,
+		};
+
+		expect(point.getArea()).toEqual(Math.PI * 4);
+	});
+
+	it('should get the correct distance to the center', function() {
+		var point = new Chart.elements.Point({
+			_datasetIndex: 2,
+			_index: 1
+		});
+
+		// Attach a view object as if we were the controller
+		point._view = {
+			radius: 2,
+			x: 10,
+			y: 10
+		};
+
+		expect(point.distanceToCenter({ x: 0, y: 0 })).toEqual(Math.sqrt(200));
+	});
+
 	it ('should draw correctly', function() {
 		var mockContext = window.createMockContext();
 		var point = new Chart.elements.Point({

--- a/test/element.rectangle.tests.js
+++ b/test/element.rectangle.tests.js
@@ -149,7 +149,7 @@ describe('Rectangle element tests', function() {
 		expect(rectangle.getArea()).toEqual(60);
 	});
 
-	it ('should get the distance to the center', function() {
+	it ('should get the center', function() {
 		var rectangle = new Chart.elements.Rectangle({
 			_datasetIndex: 2,
 			_index: 1
@@ -163,7 +163,7 @@ describe('Rectangle element tests', function() {
 			y: 15
 		};
 
-		expect(rectangle.distanceToCenter({ x: 0, y: 0 })).toEqual(Math.sqrt(100 + Math.pow(7.5, 2)));
+		expect(rectangle.getCenterPoint()).toEqual({ x: 10, y: 7.5 });
 	});
 
 	it ('should draw correctly', function() {

--- a/test/element.rectangle.tests.js
+++ b/test/element.rectangle.tests.js
@@ -132,6 +132,40 @@ describe('Rectangle element tests', function() {
 		});
 	});
 
+	it ('should get the correct area', function() {
+		var rectangle = new Chart.elements.Rectangle({
+			_datasetIndex: 2,
+			_index: 1
+		});
+
+		// Attach a view object as if we were the controller
+		rectangle._view = {
+			base: 0,
+			width: 4,
+			x: 10,
+			y: 15
+		};
+
+		expect(rectangle.getArea()).toEqual(60);
+	});
+
+	it ('should get the distance to the center', function() {
+		var rectangle = new Chart.elements.Rectangle({
+			_datasetIndex: 2,
+			_index: 1
+		});
+
+		// Attach a view object as if we were the controller
+		rectangle._view = {
+			base: 0,
+			width: 4,
+			x: 10,
+			y: 15
+		};
+
+		expect(rectangle.distanceToCenter({ x: 0, y: 0 })).toEqual(Math.sqrt(100 + Math.pow(7.5, 2)));
+	});
+
 	it ('should draw correctly', function() {
 		var mockContext = window.createMockContext();
 		var rectangle = new Chart.elements.Rectangle({


### PR DESCRIPTION
Significant improvements to the tooltip and hover modes

## New Configuration
In addition to the `hover.mode` and `tooltips.mode` settings, `hover.intersect` and `tooltips.intersect` have been added. The intersect settings are used to configure certain modes so that when items are shown can be controlled

## New Modes
Mode | Description
--- | ---
point | Returns all items under the point
index | renamed `'label'` mode
nearest | Returns the nearest item. Using in conjunction with `intersect` set to true works well for points that are hidden behind 
x | returns items that intersect the x coordinate
y | returns items that intersect the y coordinate

### Point Mode
![point mode](https://cloud.githubusercontent.com/assets/6757853/19017242/24180eee-8801-11e6-974e-e919db19d076.gif)

### Nearest Mode, Intersect On
![nearest with intersect](https://cloud.githubusercontent.com/assets/6757853/19017253/61a04588-8801-11e6-91c0-89f2ce9bbb1d.gif)

### Nearest Mode, No Intersect
![nearest no intersect](https://cloud.githubusercontent.com/assets/6757853/19017261/a2915668-8801-11e6-8b3b-40c019588729.gif)

## Deprecated Modes
The `'single'` and `'x-axis'` modes are deprecated.
Single mode has been replaced by `'point'` which returns all of the items that intersect with the cursor
The X axis mode has been replaced by the `index` mode coupled with setting `intersect` to true.
