### PR TITLE
Added watchify dev dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "karma-jasmine-html-reporter": "^0.1.8",
     "merge-stream": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
+    "watchify": "^3.7.0",
     "yargs": "^5.0.0"
   },
   "spm": {


### PR DESCRIPTION
When trying to run `gulp unittestWatch` I got an error for a missing watchify dep. This PR fixes it 👍 
