### PR TITLE
No longer merge arrays during the config merge

### DIFF
--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -58,37 +58,23 @@ module.exports = function(Chart) {
 		var base = helpers.clone(_base);
 		helpers.each(Array.prototype.slice.call(arguments, 1), function(extension) {
 			helpers.each(extension, function(value, key) {
-				if (key === 'scales') {
-					// Scale config merging is complex. Add out own function here for that
-					base[key] = helpers.scaleMerge(base.hasOwnProperty(key) ? base[key] : {}, value);
+				var baseHasProperty = base.hasOwnProperty(key);
+				var baseVal = baseHasProperty ? base[key] : {};
 
+				if (key === 'scales') {
+					// Scale config merging is complex. Add our own function here for that
+					base[key] = helpers.scaleMerge(baseVal, value);
 				} else if (key === 'scale') {
 					// Used in polar area & radar charts since there is only one scale
-					base[key] = helpers.configMerge(base.hasOwnProperty(key) ? base[key] : {}, Chart.scaleService.getScaleDefaults(value.type), value);
-				} else if (base.hasOwnProperty(key) && helpers.isArray(base[key]) && helpers.isArray(value)) {
-					// In this case we have an array of objects replacing another array. Rather than doing a strict replace,
-					// merge. This allows easy scale option merging
-					var baseArray = base[key];
-
-					helpers.each(value, function(valueObj, index) {
-
-						if (index < baseArray.length) {
-							if (typeof baseArray[index] === 'object' && baseArray[index] !== null && typeof valueObj === 'object' && valueObj !== null) {
-								// Two objects are coming together. Do a merge of them.
-								baseArray[index] = helpers.configMerge(baseArray[index], valueObj);
-							} else {
-								// Just overwrite in this case since there is nothing to merge
-								baseArray[index] = valueObj;
-							}
-						} else {
-							baseArray.push(valueObj); // nothing to merge
-						}
-					});
-
-				} else if (base.hasOwnProperty(key) && typeof base[key] === 'object' && base[key] !== null && typeof value === 'object') {
+					base[key] = helpers.configMerge(baseVal, Chart.scaleService.getScaleDefaults(value.type), value);
+				} else if (baseHasProperty
+						&& typeof baseVal === 'object'
+						&& !helpers.isArray(baseVal)
+						&& baseVal !== null
+						&& typeof value === 'object'
+						&& !helpers.isArray(value)) {
 					// If we are overwriting an object with an object, do a merge of the properties.
-					base[key] = helpers.configMerge(base[key], value);
-
+					base[key] = helpers.configMerge(baseVal, value);
 				} else {
 					// can just overwrite the value in this case
 					base[key] = value;

--- a/test/core.helpers.tests.js
+++ b/test/core.helpers.tests.js
@@ -121,43 +121,12 @@ describe('Core helper tests', function() {
 		expect(merged).toEqual({
 			valueProp: 5,
 			valueProp2: null,
-			arrayProp: ['a', 'c', 3, 4, 5, 6],
+			arrayProp: ['a', 'c'],
 			objectProp: {
 				prop1: 'c',
 				prop2: 56,
 				prop3: 'prop3'
 			}
-		});
-	});
-
-	it('should merge arrays containing objects', function() {
-		var baseConfig = {
-			arrayProp: [{
-				prop1: 'abc',
-				prop2: 56
-			}],
-		};
-
-		var toMerge = {
-			arrayProp: [{
-				prop1: 'myProp1',
-				prop3: 'prop3'
-			}, 2, {
-				prop1: 'myProp1'
-			}],
-		};
-
-		var merged = helpers.configMerge(baseConfig, toMerge);
-		expect(merged).toEqual({
-			arrayProp: [{
-					prop1: 'myProp1',
-					prop2: 56,
-					prop3: 'prop3'
-				},
-				2, {
-					prop1: 'myProp1'
-				}
-			],
 		});
 	});
 


### PR DESCRIPTION
Now we simply replace the property even if they are arrays since the array merges are weird.

Fixes #3075 