### PR TITLE
Enhance context acquisition on chart creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 
 .DS_Store
 .idea
+.vscode
 bower.json

--- a/docs/00-Getting-Started.md
+++ b/docs/00-Getting-Started.md
@@ -71,6 +71,7 @@ To create a chart, we need to instantiate the `Chart` class. To do this, we need
 var ctx = document.getElementById("myChart");
 var ctx = document.getElementById("myChart").getContext("2d");
 var ctx = $("#myChart");
+var ctx = "myChart";
 ```
 
 Once you have the element or context, you're ready to instantiate a pre-defined chart-type or create your own!

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -3,22 +3,9 @@
 module.exports = function() {
 
 	// Occupy the global variable of Chart, and create a simple base class
-	var Chart = function(context, config) {
-		var me = this;
-
-		// Support a jQuery'd canvas element
-		if (context.length && context[0].getContext) {
-			context = context[0];
-		}
-
-		// Support a canvas domnode
-		if (context.getContext) {
-			context = context.getContext('2d');
-		}
-
-		me.controller = new Chart.Controller(context, config, me);
-
-		return me.controller;
+	var Chart = function(item, config) {
+		this.controller = new Chart.Controller(item, config, this);
+		return this.controller;
 	};
 
 	// Globally expose the defaults to allow for user updating/changing

--- a/test/core.controller.tests.js
+++ b/test/core.controller.tests.js
@@ -4,7 +4,75 @@ describe('Chart.Controller', function() {
 		setTimeout(callback, 100);
 	}
 
-	describe('config', function() {
+	describe('context acquisition', function() {
+		var canvasId = 'chartjs-canvas';
+
+		beforeEach(function() {
+			var canvas = document.createElement('canvas');
+			canvas.setAttribute('id', canvasId);
+			window.document.body.appendChild(canvas);
+		});
+
+		afterEach(function() {
+			document.getElementById(canvasId).remove();
+		});
+
+		// see https://github.com/chartjs/Chart.js/issues/2807
+		it('should gracefully handle invalid item', function() {
+			var chart = new Chart('foobar');
+
+			expect(chart).not.toBeValidChart();
+
+			chart.destroy();
+		});
+
+		it('should accept a DOM element id', function() {
+			var canvas = document.getElementById(canvasId);
+			var chart = new Chart(canvasId);
+
+			expect(chart).toBeValidChart();
+			expect(chart.chart.canvas).toBe(canvas);
+			expect(chart.chart.ctx).toBe(canvas.getContext('2d'));
+
+			chart.destroy();
+		});
+
+		it('should accept a canvas element', function() {
+			var canvas = document.getElementById(canvasId);
+			var chart = new Chart(canvas);
+
+			expect(chart).toBeValidChart();
+			expect(chart.chart.canvas).toBe(canvas);
+			expect(chart.chart.ctx).toBe(canvas.getContext('2d'));
+
+			chart.destroy();
+		});
+
+		it('should accept a canvas context2D', function() {
+			var canvas = document.getElementById(canvasId);
+			var context = canvas.getContext('2d');
+			var chart = new Chart(context);
+
+			expect(chart).toBeValidChart();
+			expect(chart.chart.canvas).toBe(canvas);
+			expect(chart.chart.ctx).toBe(context);
+
+			chart.destroy();
+		});
+
+		it('should accept an array containing canvas', function() {
+			var canvas = document.getElementById(canvasId);
+			var chart = new Chart([canvas]);
+
+			expect(chart).toBeValidChart();
+			expect(chart.chart.canvas).toBe(canvas);
+			expect(chart.chart.ctx).toBe(canvas.getContext('2d'));
+
+			chart.destroy();
+		});
+	});
+
+	describe('config initialization', function() {
 		it('should create missing config.data properties', function() {
 			var chart = acquireChart({});
 			var data = chart.data;

--- a/test/mockContext.js
+++ b/test/mockContext.js
@@ -158,54 +158,82 @@
 		};
 	}
 
+	function toBeValidChart() {
+		return {
+			compare: function(actual) {
+				var chart = actual && actual.chart;
+				var message = null;
+
+				if (!(actual instanceof Chart.Controller)) {
+					message = 'Expected ' + actual + ' to be an instance of Chart.Controller';
+				} else if (!(chart instanceof Chart)) {
+					message = 'Expected chart to be an instance of Chart';
+				} else if (!(chart.canvas instanceof HTMLCanvasElement)) {
+					message = 'Expected canvas to be an instance of HTMLCanvasElement';
+				} else if (!(chart.ctx instanceof CanvasRenderingContext2D)) {
+					message = 'Expected context to be an instance of CanvasRenderingContext2D';
+				} else if (typeof chart.height !== 'number' || !isFinite(chart.height)) {
+					message = 'Expected height to be a strict finite number';
+				} else if (typeof chart.width !== 'number' || !isFinite(chart.width)) {
+					message = 'Expected width to be a strict finite number';
+				}
+
+				return {
+					message: message? message : 'Expected ' + actual + ' to be valid chart',
+					pass: !message
+				};
+			}
+		};
+	}
+
 	function toBeChartOfSize() {
 		return {
 			compare: function(actual, expected) {
+				var res = toBeValidChart().compare(actual);
+				if (!res.pass) {
+					return res;
+				}
+
 				var message = null;
-				var chart, canvas, style, dh, dw, rh, rw;
+				var chart = actual.chart;
+				var canvas = chart.ctx.canvas;
+				var style = getComputedStyle(canvas);
+				var dh = parseInt(style.height, 10);
+				var dw = parseInt(style.width, 10);
+				var rh = canvas.height;
+				var rw = canvas.width;
 
-				if (!actual || !(actual instanceof Chart.Controller)) {
-					message = 'Expected ' + actual + ' to be an instance of Chart.Controller.';
-				} else {
-					chart = actual.chart;
-					canvas = chart.ctx.canvas;
-					style = getComputedStyle(canvas);
-					dh = parseInt(style.height);
-					dw = parseInt(style.width);
-					rh = canvas.height;
-					rw = canvas.width;
+				// sanity checks
+				if (chart.height !== rh) {
+					message = 'Expected chart height ' + chart.height + ' to be equal to render height ' + rh;
+				} else if (chart.width !== rw) {
+					message = 'Expected chart width ' + chart.width + ' to be equal to render width ' + rw;
+				}
 
-					// sanity checks
-					if (chart.height !== rh) {
-						message = 'Expected chart height ' + chart.height + ' to be equal to render height ' + rh;
-					} else if (chart.width !== rw) {
-						message = 'Expected chart width ' + chart.width + ' to be equal to render width ' + rw;
-					}
-
-					// validity checks
-					if (dh !== expected.dh) {
-						message = 'Expected display height ' + dh + ' to be equal to ' + expected.dh;
-					} else if (dw !== expected.dw) {
-						message = 'Expected display width ' + dw + ' to be equal to ' + expected.dw;
-					} else if (rh !== expected.rh) {
-						message = 'Expected render height ' + rh + ' to be equal to ' + expected.rh;
-					} else if (rw !== expected.rw) {
-						message = 'Expected render width ' + rw + ' to be equal to ' + expected.rw;
-					}
+				// validity checks
+				if (dh !== expected.dh) {
+					message = 'Expected display height ' + dh + ' to be equal to ' + expected.dh;
+				} else if (dw !== expected.dw) {
+					message = 'Expected display width ' + dw + ' to be equal to ' + expected.dw;
+				} else if (rh !== expected.rh) {
+					message = 'Expected render height ' + rh + ' to be equal to ' + expected.rh;
+				} else if (rw !== expected.rw) {
+					message = 'Expected render width ' + rw + ' to be equal to ' + expected.rw;
 				}
 
 				return {
 					message: message? message : 'Expected ' + actual + ' to be a chart of size ' + expected,
 					pass: !message
-				}
+				};
 			}
-		}
+		};
 	}
 
 	beforeEach(function() {
 		jasmine.addMatchers({
 			toBeCloseToPixel: toBeCloseToPixel,
 			toEqualOneOf: toEqualOneOf,
+			toBeValidChart: toBeValidChart,
 			toBeChartOfSize: toBeChartOfSize
 		});
 	});


### PR DESCRIPTION
Add support for creating a chart from the canvas id and prevent exceptions, at construction time, when the given item doesn't provide a valid CanvasRenderingContext2D or when the getContext API is not accessible (e.g. undefined by add-ons to prevent fingerprinting). New jasmine matcher to verify chart validity.

Enhances #2807
Replaces #3303
