### PR TITLE
Add reset method to chart prototype

### DIFF
--- a/docs/09-Advanced.md
+++ b/docs/09-Advanced.md
@@ -34,6 +34,14 @@ myLineChart.data.datasets[0].data[2] = 50; // Would update the first dataset's v
 myLineChart.update(); // Calling update now animates the position of March from 90 to 50.
 ```
 
+#### .reset()
+
+Reset the chart to it's state before the initial animation. A new animation can then be triggered using `update`.
+
+```javascript
+myLineChart.reset();
+```
+
 #### .render(duration, lazy)
 
 Triggers a redraw of all chart elements. Note, this does not update elements for new data. Use `.update()` in that case.

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -367,11 +367,25 @@ module.exports = function(Chart) {
 			return newControllers;
 		},
 
+		/**
+		 * Reset the elements of all datasets
+		 * @method resetElements
+		 * @private
+		 */
 		resetElements: function() {
 			var me = this;
 			helpers.each(me.data.datasets, function(dataset, datasetIndex) {
 				me.getDatasetMeta(datasetIndex).controller.reset();
 			}, me);
+		},
+
+		/**
+		* Resets the chart back to it's state before the initial animation
+		* @method reset
+		*/
+		reset: function() {
+			this.resetElements();
+			this.tooltip.initialize();
 		},
 
 		update: function(animationDuration, lazy) {

--- a/test/core.controller.tests.js
+++ b/test/core.controller.tests.js
@@ -598,4 +598,38 @@ describe('Chart.Controller', function() {
 			expect(wrapper.firstChild.tagName).toBe('CANVAS');
 		});
 	});
+
+	describe('controller.reset', function() {
+		it('should reset the chart elements', function() {
+			var chart = acquireChart({
+				type: 'line',
+				data: {
+					labels: ['A', 'B', 'C', 'D'],
+					datasets: [{
+						data: [10, 20, 30, 0]
+					}]
+				},
+				options: {
+					responsive: true
+				}
+			});
+
+			var meta = chart.getDatasetMeta(0);
+
+			// Verify that points are at their initial correct location,
+			// then we will reset and see that they moved
+			expect(meta.data[0]._model.y).toBe(333);
+			expect(meta.data[1]._model.y).toBe(183);
+			expect(meta.data[2]._model.y).toBe(32);
+			expect(meta.data[3]._model.y).toBe(484);
+
+			chart.reset();
+
+			// For a line chart, the animation state is the bottom
+			expect(meta.data[0]._model.y).toBe(484);
+			expect(meta.data[1]._model.y).toBe(484);
+			expect(meta.data[2]._model.y).toBe(484);
+			expect(meta.data[3]._model.y).toBe(484);
+		});
+	});
 });


### PR DESCRIPTION
With this PR, you can now reset the chart to it's state before the initial animation takes place. Fixes #235 

```javascript
chart.reset();
```