### PR TITLE
Bump ESLint to v3.x (gulp and Code Climate)

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -6,6 +6,7 @@ engines:
       - javascript
   eslint:
     enabled: true
+    channel: "eslint-3"
   fixme:
     enabled: true
 ratings:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "gulp": "3.9.x",
     "gulp-concat": "~2.1.x",
     "gulp-connect": "~2.0.5",
-    "gulp-eslint": "^2.0.0",
+    "gulp-eslint": "^3.0.0",
     "gulp-file": "^0.3.0",
     "gulp-html-validator": "^0.0.2",
     "gulp-insert": "~0.5.0",


### PR DESCRIPTION
[Code Climate builds](https://codeclimate.com/github/chartjs/Chart.js/builds) are broken since the ESLint rules update (#3308) because CC (with no explicit channel config) is currently based on [ESLint version 1.10.3](https://docs.codeclimate.com/docs/eslint) which doesn't support some of the introduced rules (e.g. extended `no-console`, `func-names`, etc.)