### PR TITLE
When a buffered update occurs, a normal render must be triggered

### DIFF
--- a/src/core/core.animation.js
+++ b/src/core/core.animation.js
@@ -27,6 +27,14 @@ module.exports = function(Chart) {
 		animations: [],
 		dropFrames: 0,
 		request: null,
+
+		/**
+		 * @function Chart.animationService.addAnimation
+		 * @param chartInstance {ChartController} the chart to animate
+		 * @param animationObject {IAnimation} the animation that we will animate
+		 * @param duration {Number} length of animation in ms
+		 * @param lazy {Boolean} if true, the chart is not marked as animating to enable more responsive interactions
+		 */
 		addAnimation: function(chartInstance, animationObject, duration, lazy) {
 			var me = this;
 


### PR DESCRIPTION
When an event triggers an update while the bufferedUpdate state is true, we need to do that render with priority over any other renders that take place for animations and tooltips. 

@simonbrunel this fixes the animation issue you noticed.