### PR TITLE
Fixed vertical alignment in legend text (#3387)

### DIFF
--- a/src/core/core.legend.js
+++ b/src/core/core.legend.js
@@ -404,7 +404,7 @@ module.exports = function(Chart) {
 						}
 					} else if (y + itemHeight > me.bottom) {
 						x = cursor.x = x + me.columnWidths[cursor.line] + labelOpts.padding;
-						y = cursor.y = me.top;
+						y = cursor.y = me.top + labelOpts.padding;
 						cursor.line++;
 					}
 


### PR DESCRIPTION
labelOpts.padding is added to the y location when creating the first column. This fix also adds padding when a subsequent column is created in the legend.
