### PR TITLE
Fix path in 09-Advanced.md

### DIFF
--- a/docs/09-Advanced.md
+++ b/docs/09-Advanced.md
@@ -182,7 +182,7 @@ var myPieChart = new Chart(ctx, {
 });
 ```
 
-See `sample/line-customTooltips.html` for examples on how to get started.
+See `samples/tooltips/line-customTooltips.html` for examples on how to get started.
 
 ### Writing New Scale Types
 


### PR DESCRIPTION
This fixes a path of an example for custom tooltips in document.