### PR TITLE
Allow line chart to use pointBorderWidth of 0 correctly

### DIFF
--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -139,11 +139,11 @@ module.exports = function(Chart) {
 			var dataset = this.getDataset();
 			var custom = point.custom || {};
 
-			if (custom.borderWidth) {
+			if (!isNaN(custom.borderWidth)) {
 				borderWidth = custom.borderWidth;
-			} else if (dataset.pointBorderWidth) {
+			} else if (!isNaN(dataset.pointBorderWidth)) {
 				borderWidth = helpers.getValueAtIndexOrDefault(dataset.pointBorderWidth, index, borderWidth);
-			} else if (dataset.borderWidth) {
+			} else if (!isNaN(dataset.borderWidth)) {
 				borderWidth = dataset.borderWidth;
 			}
 

--- a/test/controller.line.tests.js
+++ b/test/controller.line.tests.js
@@ -753,4 +753,23 @@ describe('Line controller tests', function() {
 		expect(point._model.borderWidth).toBe(5.5);
 		expect(point._model.radius).toBe(4.4);
 	});
+
+	it('should allow 0 as a point border width', function() {
+		var chart = window.acquireChart({
+			type: 'line',
+			data: {
+				datasets: [{
+					data: [10, 15, 0, -4],
+					label: 'dataset1',
+					pointBorderWidth: 0
+				}],
+				labels: ['label1', 'label2', 'label3', 'label4']
+			}
+		});
+
+		var meta = chart.getDatasetMeta(0);
+		var point = meta.data[0];
+
+		expect(point._model.borderWidth).toBe(0);
+	});
 });

--- a/test/controller.radar.tests.js
+++ b/test/controller.radar.tests.js
@@ -452,4 +452,21 @@ describe('Radar controller tests', function() {
 		expect(point._model.borderWidth).toBe(5.5);
 		expect(point._model.radius).toBe(4.4);
 	});
+
+	it('should allow pointBorderWidth to be set to 0', function() {
+		var chart = window.acquireChart({
+			type: 'radar',
+			data: {
+				datasets: [{
+					data: [10, 15, 0, 4],
+					pointBorderWidth: 0
+				}],
+				labels: ['label1', 'label2', 'label3', 'label4']
+			}
+		});
+
+		var meta = chart.getDatasetMeta(0);
+		var point = meta.data[0];
+		expect(point._model.borderWidth).toBe(0);
+	});
 });


### PR DESCRIPTION
Fixes #3199 
I added 2 tests to cover this. One covers the radar chart and one covers the line chart
