### PR TITLE
Fixed tooltip labelling on Bar Chart when min is defined (#3618)

### DIFF
--- a/src/core/core.element.js
+++ b/src/core/core.element.js
@@ -88,6 +88,24 @@ module.exports = function(Chart) {
 
 		hasValue: function() {
 			return helpers.isNumber(this._model.x) && helpers.isNumber(this._model.y);
+		},
+
+
+		skipIndexAdjustment: function(config) {
+			var moreThanOneAxes = config.options.scales.xAxes.length > 1;
+			var min = config.options.scales.xAxes[0].ticks.min;
+			return this._adjustedIndex || min === undefined || moreThanOneAxes;
+		},
+
+		adjustIndex: function(config) {
+			var min = config.options.scales.xAxes[0].ticks.min;
+
+			if (this.skipIndexAdjustment(config)) {
+				return;
+			}
+
+			this._index -= config.data.labels.indexOf(min);
+			this._adjustedIndex = true;
 		}
 	});
 

--- a/src/core/core.interaction.js
+++ b/src/core/core.interaction.js
@@ -21,6 +21,7 @@ module.exports = function(Chart) {
 			for (j = 0, jlen = meta.data.length; j < jlen; ++j) {
 				var element = meta.data[j];
 				if (!element._view.skip) {
+					element.adjustIndex(chart.config);
 					handler(element);
 				}
 			}

--- a/test/core.element.tests.js
+++ b/test/core.element.tests.js
@@ -42,4 +42,88 @@ describe('Core element tests', function() {
 			colorProp: 'rgb(64, 64, 0)',
 		});
 	});
+
+	it ('should adjust the index of the element passed in', function() {
+		var chartConfig = {
+			options: {
+				scales: {
+					xAxes: [{
+						ticks: {
+							min: 'Point 2'
+						}
+					}]
+				}
+			},
+			data: {
+				labels: ['Point 1', 'Point 2', 'Point 3']
+			}
+		};
+
+		var element = new Chart.Element({
+			_index: 1
+		});
+
+		element.adjustIndex(chartConfig);
+
+		expect(element._adjustedIndex).toEqual(true);
+		expect(element._index).toEqual(0);
+	});
+
+	describe ('skipIndexAdjustment method', function() {
+		var element;
+
+		beforeEach(function() {
+			element = new Chart.Element({});
+		});
+
+		it ('should return true when min is undefined', function() {
+			var chartConfig = {
+				options: {
+					scales: {
+						xAxes: [{
+							ticks: {
+								min: undefined
+							}
+						}]
+					}
+				}
+			};
+			expect(element.skipIndexAdjustment(chartConfig)).toEqual(true);
+		});
+
+		it ('should return true when index is already adjusted (_adjustedIndex = true)', function() {
+			var chartConfig = {
+				options: {
+					scales: {
+						xAxes: [{
+							ticks: {
+								min: 'Point 1'
+							}
+						}]
+					}
+				}
+			};
+			element._adjustedIndex = true;
+			expect(element.skipIndexAdjustment(chartConfig)).toEqual(true);
+		});
+
+		it ('should return true when more than one xAxes is defined', function() {
+			var chartConfig = {
+				options: {
+					scales: {
+						xAxes: [{
+							ticks: {
+								min: 'Point 1'
+							}
+						}, {
+							ticks: {
+								min: 'Point 2'
+							}
+						}]
+					}
+				}
+			};
+			expect(element.skipIndexAdjustment(chartConfig)).toEqual(true);
+		});
+	});
 });

--- a/test/core.interaction.tests.js
+++ b/test/core.interaction.tests.js
@@ -43,6 +43,57 @@ describe('Core.Interaction', function() {
 			expect(elements).toEqual([point, meta1.data[1]]);
 		});
 
+		it ('should start at index 0 within sliced dataset when min is defined', function() {
+			var chartInstance = window.acquireChart({
+				type: 'line',
+				options: {
+					scales: {
+						xAxes: [{
+							ticks: {
+								min: 'March',
+								max: 'May'
+							},
+							categoryPercentage: 1,
+							barPercentage: 1,
+						}]
+					}
+				},
+				data: {
+					datasets: [{
+						label: 'Dataset 1',
+						data: [10, 30, 39, 20, 25, 34, 1],
+					}, {
+						label: 'Dataset 2',
+						data: [10, 30, 39, 20, 25, 34, 1],
+					}],
+					labels: ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
+				}
+			});
+
+			// Trigger an event over top of the
+			var meta0 = chartInstance.getDatasetMeta(0);
+			var point = meta0.data[2];
+
+			var node = chartInstance.chart.canvas;
+			var rect = node.getBoundingClientRect();
+
+			var evt = {
+				view: window,
+				bubbles: true,
+				cancelable: true,
+				clientX: rect.left + point._model.x,
+				clientY: rect.top + point._model.y,
+				currentTarget: node
+			};
+
+			var elements = Chart.Interaction.modes.point(chartInstance, evt);
+
+			elements.forEach(function(element) {
+				expect(element._index).toEqual(0);
+				expect(element._adjustedIndex).toBeTruthy();
+			});
+		});
+
 		it ('should return an empty array when no items are found', function() {
 			var chartInstance = window.acquireChart({
 				type: 'line',


### PR DESCRIPTION
As title states, create a fix for #3618.

**summary of changes:**

- Created a new helper method to map index into sliced array when min is defined
- Added test for helper method
- Added integration test to trigger element to ensure correct index