### PR TITLE
Upgraded dependency gulp-uglify to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "gulp-replace": "^0.5.4",
     "gulp-size": "~0.4.0",
     "gulp-streamify": "^1.0.2",
-    "gulp-uglify": "~0.2.x",
+    "gulp-uglify": "~2.0.x",
     "gulp-util": "~2.2.x",
     "gulp-zip": "~3.2.0",
     "jasmine": "^2.3.2",


### PR DESCRIPTION
Upgrading this dependency cuts gulp build times by ~2 seconds