### PR TITLE
Fix monotone cubic interpolation when two adjacent points are at the same X

### DIFF
--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -361,7 +361,10 @@ module.exports = function(Chart) {
 			pointBefore = i > 0 ? pointsWithTangents[i - 1] : null;
 			pointAfter = i < pointsLen - 1 ? pointsWithTangents[i + 1] : null;
 			if (pointAfter && !pointAfter.model.skip) {
-				pointCurrent.deltaK = (pointAfter.model.y - pointCurrent.model.y) / (pointAfter.model.x - pointCurrent.model.x);
+				var slopeDeltaX = (pointAfter.model.x - pointCurrent.model.x);
+
+				// In the case of two points that appear at the same x pixel, slopeDeltaX is 0
+				pointCurrent.deltaK = slopeDeltaX !== 0 ? (pointAfter.model.y - pointCurrent.model.y) / slopeDeltaX : 0;
 			}
 
 			if (!pointBefore || pointBefore.model.skip) {

--- a/test/core.helpers.tests.js
+++ b/test/core.helpers.tests.js
@@ -412,6 +412,7 @@ describe('Core helper tests', function() {
 			{_model: {x: 27, y: 125, skip: false}},
 			{_model: {x: 30, y: 105, skip: false}},
 			{_model: {x: 33, y: 110, skip: false}},
+			{_model: {x: 33, y: 110, skip: false}},
 			{_model: {x: 36, y: 170, skip: false}}
 		];
 		helpers.splineCurveMonotone(dataPoints);
@@ -532,9 +533,20 @@ describe('Core helper tests', function() {
 				y: 110,
 				skip: false,
 				controlPointPreviousX: 32,
-				controlPointPreviousY: 105,
+				controlPointPreviousY: 110,
+				controlPointNextX: 33,
+				controlPointNextY: 110
+			}
+		},
+		{
+			_model: {
+				x: 33,
+				y: 110,
+				skip: false,
+				controlPointPreviousX: 33,
+				controlPointPreviousY: 110,
 				controlPointNextX: 34,
-				controlPointNextY: 115
+				controlPointNextY: 110
 			}
 		},
 		{


### PR DESCRIPTION
When two adjacent points in a line were at the same X value the monotone cubic interpolation would break because the differential slope would be `NaN`. This change adds logic to detect this and correctly set the `deltaK` property.

Resolves #3408

## Testing
I updated the unit test to test this case. I manually tested that the fiddle from the bug is solved including in cases where the points at the same X are at different Y values

## Before
![screen shot 2016-11-26 at 12 33 39 pm](https://cloud.githubusercontent.com/assets/6757853/20642107/9b2158de-b3d4-11e6-8bd2-3819ceabe1a2.png)

## After
![screen shot 2016-11-26 at 12 26 55 pm](https://cloud.githubusercontent.com/assets/6757853/20642093/571130ec-b3d4-11e6-82bb-b78f35b23f35.png)

### Testing with 2nd point above first one but at the same X
![screen shot 2016-11-26 at 12 27 10 pm](https://cloud.githubusercontent.com/assets/6757853/20642095/5bb4a192-b3d4-11e6-834f-9a564557b30e.png)

### Testing with 2nd point below the second one but at the same X
![screen shot 2016-11-26 at 12 27 22 pm](https://cloud.githubusercontent.com/assets/6757853/20642099/7421fc52-b3d4-11e6-9994-0eaafa753aef.png)

