### PR TITLE
Fix : Tooltip label for category scale.

### DIFF
--- a/src/scales/scale.category.js
+++ b/src/scales/scale.category.js
@@ -54,10 +54,10 @@ module.exports = function(Chart) {
 			var data = me.chart.data;
 			var isHorizontal = me.isHorizontal();
 
-			if ((data.xLabels && isHorizontal) || (data.yLabels && !isHorizontal)) {
+			if (data.yLabels && !isHorizontal) {
 				return me.getRightValue(data.datasets[datasetIndex].data[index]);
 			}
-			return me.ticks[index];
+			return me.ticks[index - me.minIndex];
 		},
 
 		// Used to get data value locations.  Value can either be an index or a numerical value


### PR DESCRIPTION
Fixed tooltip labelling on Bar chart when min option was set.
In addition, Fixed the tooltip label problem when 'xLabel' , 'yLabel' was set.

Resolves #3618


## Before
![issue3618-before](https://cloud.githubusercontent.com/assets/22541770/20648780/e8c0d788-b4ea-11e6-945d-d7c4411797a2.png)
All tooltip labels should be `May`.
https://jsfiddle.net/T_SAiTO/bvo2bc5f/1/

## After
![issue3618-after](https://cloud.githubusercontent.com/assets/22541770/20648781/f14498cc-b4ea-11e6-9aa8-7b0661547a2d.png)

https://jsfiddle.net/T_SAiTO/6f3hbLr1/2/

## When added plugin
![issue3618-plugin](https://cloud.githubusercontent.com/assets/22541770/20648782/f7331a06-b4ea-11e6-9524-9c0ff64a7010.png)

https://jsfiddle.net/T_SAiTO/6f3hbLr1/3/