### PR TITLE
Do not notify plugins when a silent resize occurs

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -312,16 +312,16 @@ module.exports = function(Chart) {
 
 			helpers.retinaScale(chart);
 
-			// Notify any plugins about the resize
-			var newSize = {width: newWidth, height: newHeight};
-			Chart.plugins.notify('resize', [me, newSize]);
-
-			// Notify of resize
-			if (me.options.onResize) {
-				me.options.onResize(me, newSize);
-			}
-
 			if (!silent) {
+				// Notify any plugins about the resize
+				var newSize = {width: newWidth, height: newHeight};
+				Chart.plugins.notify('resize', [me, newSize]);
+
+				// Notify of resize
+				if (me.options.onResize) {
+					me.options.onResize(me, newSize);
+				}
+
 				me.stop();
 				me.update(me.options.responsiveAnimationDuration);
 			}


### PR DESCRIPTION
This changes prevents the `resize` method from notifying plugins if it is a silent resize. A silent resize occurs during startup and we do not want plugins to do anything here because the chart is not set up. In the demo linked below, the legend will always be present at the start regardless of the size. I think the correct solution is to have the plugin in this case use the `beforeInit` call to do this setup.

An alternative solution was to block `update` calls when the resize notification is sent from a silent resize. This still has the possibility that the plugin would try and access uninitialized data objects.

Another alternative solution would be to have the resize plugin notification also send the `silent` parameter. This forces plugins to handle this case, which is non ideal.

This allows us to provide a fix for #1933 
Demo: http://jsfiddle.net/aLLzv3vL/3/