### PR TITLE
Implement clipping

### DIFF
--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -241,12 +241,14 @@ module.exports = function(Chart) {
 			var dataset = me.getDataset();
 			var i, len;
 
+			Chart.canvasHelpers.clipArea(me.chart.chart.ctx, me.chart.chartArea);
 			for (i = 0, len = metaData.length; i < len; ++i) {
 				var d = dataset.data[i];
 				if (d !== null && d !== undefined && !isNaN(d)) {
 					metaData[i].transition(easingDecimal).draw();
 				}
 			}
+			Chart.canvasHelpers.unclipArea(me.chart.chart.ctx);
 		},
 
 		setHoverStyle: function(rectangle) {

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -286,7 +286,6 @@ module.exports = function(Chart) {
 			var points = meta.data || [];
 			var easingDecimal = ease || 1;
 			var i, ilen;
-			var chartArea = me.chart.chartArea;
 
 			// Transition Point Locations
 			for (i=0, ilen=points.length; i<ilen; ++i) {
@@ -302,7 +301,7 @@ module.exports = function(Chart) {
 
 			// Draw the points
 			for (i=0, ilen=points.length; i<ilen; ++i) {
-				points[i].draw(chartArea);
+				points[i].draw(me.chart.chartArea);
 			}
 		},
 

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -286,20 +286,23 @@ module.exports = function(Chart) {
 			var points = meta.data || [];
 			var easingDecimal = ease || 1;
 			var i, ilen;
+			var chartArea = me.chart.chartArea;
 
 			// Transition Point Locations
 			for (i=0, ilen=points.length; i<ilen; ++i) {
 				points[i].transition(easingDecimal);
 			}
 
+			Chart.canvasHelpers.clipArea(me.chart.chart.ctx, me.chart.chartArea);
 			// Transition and Draw the line
 			if (lineEnabled(me.getDataset(), me.chart.options)) {
 				meta.dataset.transition(easingDecimal).draw();
 			}
+			Chart.canvasHelpers.unclipArea(me.chart.chart.ctx);
 
 			// Draw the points
 			for (i=0, ilen=points.length; i<ilen; ++i) {
-				points[i].draw();
+				points[i].draw(chartArea);
 			}
 		},
 

--- a/src/core/core.canvasHelpers.js
+++ b/src/core/core.canvasHelpers.js
@@ -109,4 +109,16 @@ module.exports = function(Chart) {
 
 		ctx.stroke();
 	};
+
+	helpers.clipArea = function(ctx, clipArea) {
+		ctx.save();
+		ctx.beginPath();
+		ctx.rect(clipArea.left, clipArea.top, clipArea.right - clipArea.left, clipArea.bottom - clipArea.top);
+		ctx.clip();
+	};
+
+	helpers.unclipArea = function(ctx) {
+		ctx.restore();
+	};
+
 };

--- a/src/elements/element.point.js
+++ b/src/elements/element.point.js
@@ -58,12 +58,15 @@ module.exports = function(Chart) {
 		},
 		draw: function(chartArea) {
 			var vm = this._view;
+			var model = this._model;
 			var ctx = this._chart.ctx;
 			var pointStyle = vm.pointStyle;
 			var radius = vm.radius;
 			var x = vm.x;
 			var y = vm.y;
 			var color = Chart.helpers.color;
+			var errMargin = 1.01; // 1.01 is margin for Accumulated error. (Especially Edge, IE.)
+			var ratio = 0;
 
 			if (vm.skip) {
 				return;
@@ -74,27 +77,19 @@ module.exports = function(Chart) {
 			ctx.fillStyle = vm.backgroundColor || defaultColor;
 
 			// Cliping for Points.
-			var isOutofChartArea = function(position, area, errMarginPercent) {
-				if ((position.x < area.left) || (area.right*errMarginPercent < position.x) || (position.y < area.top) || (area.bottom*errMarginPercent < position.y)) {
-					return true;
-				}
-				return false;
-			};
-			var errMarginPercent = 1.01; // 1.01 is margin for Accumulated error. (Especially Edge, IE.)
-			var ratio = 0;
 			// going out from inner charArea?
-			if ((chartArea !== undefined)&&(isOutofChartArea(this._view, chartArea, errMarginPercent))&&(isOutofChartArea(this._model, chartArea, errMarginPercent))) {
+			if ((chartArea !== undefined) && ((model.x < chartArea.left) || (chartArea.right*errMargin < model.x) || (model.y < chartArea.top) || (chartArea.bottom*errMargin < model.y))) {
 				// Point fade out
-				if (this._model.x < chartArea.left) {
-					ratio = (x - this._model.x) / (chartArea.left - this._model.x);
-				} else if (chartArea.right*errMarginPercent < this._model.x) {
-					ratio = (this._model.x - x) / (this._model.x - chartArea.right);
-				} else if (this._model.y < chartArea.top) {
-					ratio = (y - this._model.y) / (chartArea.top - this._model.y);
-				} else if (chartArea.bottom*errMarginPercent < this._model.y) {
-					ratio = (this._model.y - y) / (this._model.y - chartArea.bottom);
+				if (model.x < chartArea.left) {
+					ratio = (x - model.x) / (chartArea.left - model.x);
+				} else if (chartArea.right*errMargin < model.x) {
+					ratio = (model.x - x) / (model.x - chartArea.right);
+				} else if (model.y < chartArea.top) {
+					ratio = (y - model.y) / (chartArea.top - model.y);
+				} else if (chartArea.bottom*errMargin < model.y) {
+					ratio = (model.y - y) / (model.y - chartArea.bottom);
 				}
-				ratio = Math.round(ratio*100)/100;
+				ratio = Math.round(ratio*100) / 100;
 				ctx.strokeStyle = color(ctx.strokeStyle).alpha(ratio).rgbString();
 				ctx.fillStyle = color(ctx.fillStyle).alpha(ratio).rgbString();
 			}


### PR DESCRIPTION
I tried implementing clipping chart area.
I would be pleased if you like it.

Resolves #3506, #3491, #2873

## Bar and Line chart.
### Before
![non clip bar line](https://cloud.githubusercontent.com/assets/22541770/20744270/f40c6148-b715-11e6-85dc-8e3ba285b571.png)

https://jsfiddle.net/T_SAiTO/n7ben0fx/
### After
![clip bar line](https://cloud.githubusercontent.com/assets/22541770/20744275/fa63a8bc-b715-11e6-8439-3965ad51074a.png)

https://jsfiddle.net/T_SAiTO/98x7ny4b/
(Note: jsfeddle takes time to execute.This is because I put the built chart.js in the html area.)
Line chart: The point fades out when going out.


## Radar and Scatter chart.
### Before
![non clip radar scatter](https://cloud.githubusercontent.com/assets/22541770/20744279/03825d12-b716-11e6-9b15-af68accc23ea.png)

https://jsfiddle.net/T_SAiTO/fwt4bxcc/
 (Do Radar chart have to consider the drawing of the points below min?)
### After
![clip radar scatter](https://cloud.githubusercontent.com/assets/22541770/20744286/0a75d284-b716-11e6-8238-bbd7b7ae3905.png)

https://jsfiddle.net/T_SAiTO/7v3ehcqt/
(Note: jsfeddle takes time to execute.This is because I put the built chart.js in the html area.)
Radar chart: It works the same before. Clipping is not done.
The Radar chart, the following error is displayed on the console.
'Unable to get property 'xAxes' of undefined or null reference'
This is solved by removing #3620.

## Other
1. It may be better to display the tool tip position in the chart area.
1. Drawing Bezier curve is slightly strange. Especially outside the chart area.


chart.js version v2.4.0