### PR TITLE
Prevent infinite loop while generating logarithmic ticks

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -494,7 +494,7 @@ module.exports = function(Chart) {
 			var tickFontColor = helpers.getValueOrDefault(optionTicks.fontColor, globalDefaults.defaultFontColor);
 			var tickFont = parseFontOptions(optionTicks);
 
-			var tl = gridLines.tickMarkLength;
+			var tl = gridLines.drawTicks ? gridLines.tickMarkLength : 0;
 			var borderDash = helpers.getValueOrDefault(gridLines.borderDash, globalDefaults.borderDash);
 			var borderDashOffset = helpers.getValueOrDefault(gridLines.borderDashOffset, globalDefaults.borderDashOffset);
 

--- a/src/core/core.ticks.js
+++ b/src/core/core.ticks.js
@@ -109,27 +109,33 @@ module.exports = function(Chart) {
 				// the graph
 				var tickVal = getValueOrDefault(generationOptions.min, Math.pow(10, Math.floor(helpers.log10(dataRange.min))));
 
-				while (tickVal < dataRange.max) {
+				var endExp = Math.floor(helpers.log10(dataRange.max));
+				var endSignificand = Math.ceil(dataRange.max / Math.pow(10, endExp));
+				var exp;
+				var significand;
+
+				if (tickVal === 0) {
+					exp = Math.floor(helpers.log10(dataRange.minNotZero));
+					significand = Math.floor(dataRange.minNotZero / Math.pow(10, exp));
+
+					ticks.push(tickVal);
+					tickVal = significand * Math.pow(10, exp);
+				} else {
+					exp = Math.floor(helpers.log10(tickVal));
+					significand = Math.floor(tickVal / Math.pow(10, exp));
+				}
+
+				do {
 					ticks.push(tickVal);
 
-					var exp;
-					var significand;
-
-					if (tickVal === 0) {
-						exp = Math.floor(helpers.log10(dataRange.minNotZero));
-						significand = Math.round(dataRange.minNotZero / Math.pow(10, exp));
-					} else {
-						exp = Math.floor(helpers.log10(tickVal));
-						significand = Math.floor(tickVal / Math.pow(10, exp)) + 1;
-					}
-
+					++significand;
 					if (significand === 10) {
 						significand = 1;
 						++exp;
 					}
 
 					tickVal = significand * Math.pow(10, exp);
-				}
+				} while (exp < endExp || (exp === endExp && significand < endSignificand));
 
 				var lastTick = getValueOrDefault(generationOptions.max, tickVal);
 				ticks.push(lastTick);

--- a/test/scale.logarithmic.tests.js
+++ b/test/scale.logarithmic.tests.js
@@ -343,7 +343,7 @@ describe('Logarithmic Scale tests', function() {
 					data: [10, 5, 1, 5, 78, 100]
 				}, {
 					yAxisID: 'yScale1',
-					data: [-1000, 1000],
+					data: [0, 1000],
 				}, {
 					type: 'bar',
 					yAxisID: 'yScale0',
@@ -383,7 +383,7 @@ describe('Logarithmic Scale tests', function() {
 					type: 'bar'
 				}, {
 					yAxisID: 'yScale1',
-					data: [-1000, 1000],
+					data: [0, 1000],
 					type: 'bar'
 				}, {
 					yAxisID: 'yScale0',


### PR DESCRIPTION
Fixes an infinite loop that occurred when generating logarithmic ticks.
Resolves #3381 

Also fixes a newly introduced (v2.5.0 dev) bug when the tick marks are not drawn but the labels are. The labels would be offset as if the tick marks were there which was incorrect. 