### PR TITLE
Don’t propagate clicks that are handled internally

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -818,8 +818,9 @@ module.exports = function(Chart) {
 			me._bufferedRender = true;
 			me._bufferedRequest = null;
 
-			var changed = me.handleEvent(e);
+			var changed = legend && legend.handleEvent(e);
 			changed |= tooltip && tooltip.handleEvent(e);
+			if (!changed) changed = me.handleEvent(e);
 
 			plugins.notify(me, 'afterEvent', [e]);
 


### PR DESCRIPTION
Prevents the chart `options.onClick` handler from being called if the user clicks on a legend item, for instance. Calling `event.stopImmediatePropagation()` in the legend item click handler would not fix the issue since it is always called after the chart `options.onClick` handler.