### PR TITLE
Fix bar draw issue with `borderWidth`.

### DIFF
--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -84,6 +84,7 @@ module.exports = function(Chart) {
 				datasetLabel: dataset.label,
 
 				// Appearance
+				horizontal: false,
 				base: reset ? scaleBase : me.calculateBarBase(me.index, index),
 				width: me.calculateBarWidth(ruler),
 				backgroundColor: custom.backgroundColor ? custom.backgroundColor : helpers.getValueAtIndexOrDefault(dataset.backgroundColor, index, rectangleElementOptions.backgroundColor),
@@ -346,15 +347,13 @@ module.exports = function(Chart) {
 				datasetLabel: dataset.label,
 
 				// Appearance
+				horizontal: true,
 				base: reset ? scaleBase : me.calculateBarBase(me.index, index),
 				height: me.calculateBarHeight(ruler),
 				backgroundColor: custom.backgroundColor ? custom.backgroundColor : helpers.getValueAtIndexOrDefault(dataset.backgroundColor, index, rectangleElementOptions.backgroundColor),
 				borderSkipped: custom.borderSkipped ? custom.borderSkipped : rectangleElementOptions.borderSkipped,
 				borderColor: custom.borderColor ? custom.borderColor : helpers.getValueAtIndexOrDefault(dataset.borderColor, index, rectangleElementOptions.borderColor),
 				borderWidth: custom.borderWidth ? custom.borderWidth : helpers.getValueAtIndexOrDefault(dataset.borderWidth, index, rectangleElementOptions.borderWidth)
-			};
-			rectangle.draw = function() {
-				Chart.elements.Rectangle.prototype.draw.call(this, true);
 			};
 
 			rectangle.pivot();

--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -354,60 +354,7 @@ module.exports = function(Chart) {
 				borderWidth: custom.borderWidth ? custom.borderWidth : helpers.getValueAtIndexOrDefault(dataset.borderWidth, index, rectangleElementOptions.borderWidth)
 			};
 			rectangle.draw = function() {
-				var ctx = this._chart.ctx;
-				var vm = this._view;
-
-				var halfHeight = vm.height / 2,
-					topY = vm.y - halfHeight,
-					bottomY = vm.y + halfHeight,
-					right = vm.base - (vm.base - vm.x),
-					halfStroke = vm.borderWidth / 2;
-
-				// Canvas doesn't allow us to stroke inside the width so we can
-				// adjust the sizes to fit if we're setting a stroke on the line
-				if (vm.borderWidth) {
-					topY += halfStroke;
-					bottomY -= halfStroke;
-					right += halfStroke;
-				}
-
-				ctx.beginPath();
-
-				ctx.fillStyle = vm.backgroundColor;
-				ctx.strokeStyle = vm.borderColor;
-				ctx.lineWidth = vm.borderWidth;
-
-				// Corner points, from bottom-left to bottom-right clockwise
-				// | 1 2 |
-				// | 0 3 |
-				var corners = [
-					[vm.base, bottomY],
-					[vm.base, topY],
-					[right, topY],
-					[right, bottomY]
-				];
-
-				// Find first (starting) corner with fallback to 'bottom'
-				var borders = ['bottom', 'left', 'top', 'right'];
-				var startCorner = borders.indexOf(vm.borderSkipped, 0);
-				if (startCorner === -1) {
-					startCorner = 0;
-				}
-
-				function cornerAt(cornerIndex) {
-					return corners[(startCorner + cornerIndex) % 4];
-				}
-
-				// Draw rectangle from 'startCorner'
-				ctx.moveTo.apply(ctx, cornerAt(0));
-				for (var i = 1; i < 4; i++) {
-					ctx.lineTo.apply(ctx, cornerAt(i));
-				}
-
-				ctx.fill();
-				if (vm.borderWidth) {
-					ctx.stroke();
-				}
+				Chart.elements.Rectangle.prototype.draw.call(this, true);
 			};
 
 			rectangle.pivot();

--- a/src/elements/element.rectangle.js
+++ b/src/elements/element.rectangle.js
@@ -50,55 +50,54 @@ module.exports = function(Chart) {
 	}
 
 	Chart.elements.Rectangle = Chart.Element.extend({
-		draw: function(isHorizontalBar) {
+		draw: function(horizontal) {
 
 			var ctx = this._chart.ctx;
 			var vm = this._view;
-			var x1,	x2,	y1,	y2;
-			var sign = {};
+			var left, right, top, bottom, signX, signY, borderSkipped;
 			var borderWidth = vm.borderWidth;
-			var borderSkipped = (vm.borderSkipped !== undefined)? vm.borderSkipped: 'bottom';
 
-			if ((isHorizontalBar === undefined) || (!isHorizontalBar)) {
+			if (!horizontal) {
 				// bar
-				x1 = vm.x - vm.width / 2;
-				x2 = vm.x + vm.width / 2;
-				y1 = vm.y;
-				y2 = vm.base;
-				sign.x = 1;
-				sign.y = (y2 > y1) ? 1:-1;
+				left = vm.x - vm.width / 2;
+				right = vm.x + vm.width / 2;
+				top = vm.y;
+				bottom = vm.base;
+				signX = 1;
+				signY = bottom > top? 1: -1;
+				borderSkipped = vm.borderSkipped || 'bottom';
 			} else {
 				// horizontal bar
-				x1 = vm.base;
-				x2 = vm.x;
-				y1 = vm.y - vm.height /2;
-				y2 = vm.y + vm.height /2;
-				sign.x = (x2 > x1) ? 1:-1;
-				sign.y = 1;
+				left = vm.base;
+				right = vm.x;
+				top = vm.y - vm.height / 2;
+				bottom = vm.y + vm.height / 2;
+				signX = right > left? 1: -1;
+				signY = 1;
+				borderSkipped = vm.borderSkipped || 'left';
 			}
 
 			// Canvas doesn't allow us to stroke inside the width so we can
 			// adjust the sizes to fit if we're setting a stroke on the line
 			if (borderWidth) {
 				// borderWidth shold be less than bar width and bar height.
-				var barSize = Math.min(Math.abs(x1 - x2), Math.abs(y1 - y2));
-				borderWidth = (borderWidth > barSize) ? barSize: borderWidth;
+				var barSize = Math.min(Math.abs(left - right), Math.abs(top - bottom));
+				borderWidth = borderWidth > barSize? barSize: borderWidth;
 				var halfStroke = borderWidth / 2;
 				// Adjust borderWidth when bar top position is near vm.base(zero).
-				var Temp = {};
-				Temp.x1 = x1 + ((borderSkipped !== 'left')? halfStroke * sign.x: 0);
-				Temp.x2 = x2 + ((borderSkipped !== 'right')? -halfStroke * sign.x: 0);
-				Temp.y1 = y1 + ((borderSkipped !== 'top')? halfStroke * sign.y: 0);
-				Temp.y2 = y2 + ((borderSkipped !== 'bottom')? -halfStroke * sign.y: 0);
+				var borderLeft = left + (borderSkipped !== 'left'? halfStroke * signX: 0);
+				var	borderRight = right + (borderSkipped !== 'right'? -halfStroke * signX: 0);
+				var	borderTop = top + (borderSkipped !== 'top'? halfStroke * signY: 0);
+				var	borderBottom = bottom + (borderSkipped !== 'bottom'? -halfStroke * signY: 0);
 				// not become a vertical line?
-				if (Temp.x1 !== Temp.x2) {
-					y1 = Temp.y1;
-					y2 = Temp.y2;
+				if (borderLeft !== borderRight) {
+					top = borderTop;
+					bottom = borderBottom;
 				}
 				// not become a horizontal line?
-				if (Temp.y1 !== Temp.y2) {
-					x1 = Temp.x1;
-					x2 = Temp.x2;
+				if (borderTop !== borderBottom) {
+					left = borderLeft;
+					right = borderRight;
 				}
 			}
 
@@ -111,10 +110,10 @@ module.exports = function(Chart) {
 			// | 1 2 |
 			// | 0 3 |
 			var corners = [
-				[x1, y2],
-				[x1, y1],
-				[x2, y1],
-				[x2, y2]
+				[left, bottom],
+				[left, top],
+				[right, top],
+				[right, bottom]
 			];
 
 			// Find first (starting) corner with fallback to 'bottom'

--- a/src/elements/element.rectangle.js
+++ b/src/elements/element.rectangle.js
@@ -86,9 +86,9 @@ module.exports = function(Chart) {
 				var halfStroke = borderWidth / 2;
 				// Adjust borderWidth when bar top position is near vm.base(zero).
 				var borderLeft = left + (borderSkipped !== 'left'? halfStroke * signX: 0);
-				var	borderRight = right + (borderSkipped !== 'right'? -halfStroke * signX: 0);
-				var	borderTop = top + (borderSkipped !== 'top'? halfStroke * signY: 0);
-				var	borderBottom = bottom + (borderSkipped !== 'bottom'? -halfStroke * signY: 0);
+				var borderRight = right + (borderSkipped !== 'right'? -halfStroke * signX: 0);
+				var borderTop = top + (borderSkipped !== 'top'? halfStroke * signY: 0);
+				var borderBottom = bottom + (borderSkipped !== 'bottom'? -halfStroke * signY: 0);
 				// not become a vertical line?
 				if (borderLeft !== borderRight) {
 					top = borderTop;

--- a/src/elements/element.rectangle.js
+++ b/src/elements/element.rectangle.js
@@ -50,14 +50,14 @@ module.exports = function(Chart) {
 	}
 
 	Chart.elements.Rectangle = Chart.Element.extend({
-		draw: function(horizontal) {
+		draw: function() {
 
 			var ctx = this._chart.ctx;
 			var vm = this._view;
 			var left, right, top, bottom, signX, signY, borderSkipped;
 			var borderWidth = vm.borderWidth;
 
-			if (!horizontal) {
+			if (!vm.horizontal) {
 				// bar
 				left = vm.x - vm.width / 2;
 				right = vm.x + vm.width / 2;

--- a/src/elements/element.rectangle.js
+++ b/src/elements/element.rectangle.js
@@ -51,7 +51,6 @@ module.exports = function(Chart) {
 
 	Chart.elements.Rectangle = Chart.Element.extend({
 		draw: function() {
-
 			var ctx = this._chart.ctx;
 			var vm = this._view;
 			var left, right, top, bottom, signX, signY, borderSkipped;

--- a/src/elements/element.rectangle.js
+++ b/src/elements/element.rectangle.js
@@ -57,10 +57,8 @@ module.exports = function(Chart) {
 			var ctx = this._chart.ctx;
 			var vm = this._view;
 			var x1,	x2,	y1,	y2;
-			var sign = {},
-				barSize = {};
+			var sign = {};
 			var borderWidth = vm.borderWidth;
-			var backgroundColor = vm.backgroundColor;
 
 			if (!isHorizontalBar) {
 				// bar
@@ -79,15 +77,13 @@ module.exports = function(Chart) {
 				sign.x = (x2 > x1) ? 1:-1;
 				sign.y = 1;
 			}
-			barSize.x = Math.abs(x1 - x2);
-			barSize.y = Math.abs(y1 - y2);
 
 			// Canvas doesn't allow us to stroke inside the width so we can
 			// adjust the sizes to fit if we're setting a stroke on the line
 			if (borderWidth) {
 				// borderWidth shold be less than bar width and bar height.
-				var barSizeMin = Math.min(barSize.x, barSize.y);
-				borderWidth = (borderWidth > barSizeMin) ? barSizeMin: borderWidth;
+				var barSize = Math.min(Math.abs(x1 - x2), Math.abs(y1 - y2));
+				borderWidth = (borderWidth > barSize) ? barSize: borderWidth;
 				var halfStroke = borderWidth / 2;
 				// Adjust borderWidth when bar top position is near vm.base(zero).
 				var Temp = {};
@@ -108,7 +104,7 @@ module.exports = function(Chart) {
 			}
 
 			ctx.beginPath();
-			ctx.fillStyle = backgroundColor;
+			ctx.fillStyle = vm.backgroundColor;
 			ctx.strokeStyle = vm.borderColor;
 			ctx.lineWidth = borderWidth;
 

--- a/src/elements/element.rectangle.js
+++ b/src/elements/element.rectangle.js
@@ -52,15 +52,14 @@ module.exports = function(Chart) {
 	Chart.elements.Rectangle = Chart.Element.extend({
 		draw: function(isHorizontalBar) {
 
-			isHorizontalBar = (isHorizontalBar === undefined)? false: isHorizontalBar;
-
 			var ctx = this._chart.ctx;
 			var vm = this._view;
 			var x1,	x2,	y1,	y2;
 			var sign = {};
 			var borderWidth = vm.borderWidth;
+			var borderSkipped = (vm.borderSkipped !== undefined)? vm.borderSkipped: 'bottom';
 
-			if (!isHorizontalBar) {
+			if ((isHorizontalBar === undefined) || (!isHorizontalBar)) {
 				// bar
 				x1 = vm.x - vm.width / 2;
 				x2 = vm.x + vm.width / 2;
@@ -87,10 +86,10 @@ module.exports = function(Chart) {
 				var halfStroke = borderWidth / 2;
 				// Adjust borderWidth when bar top position is near vm.base(zero).
 				var Temp = {};
-				Temp.x1 = x1 + ((vm.borderSkipped !== 'left')? halfStroke * sign.x: 0);
-				Temp.x2 = x2 + ((vm.borderSkipped !== 'right')? -halfStroke * sign.x: 0);
-				Temp.y1 = y1 + ((vm.borderSkipped !== 'top')? halfStroke * sign.y: 0);
-				Temp.y2 = y2 + ((vm.borderSkipped !== 'bottom')? -halfStroke * sign.y: 0);
+				Temp.x1 = x1 + ((borderSkipped !== 'left')? halfStroke * sign.x: 0);
+				Temp.x2 = x2 + ((borderSkipped !== 'right')? -halfStroke * sign.x: 0);
+				Temp.y1 = y1 + ((borderSkipped !== 'top')? halfStroke * sign.y: 0);
+				Temp.y2 = y2 + ((borderSkipped !== 'bottom')? -halfStroke * sign.y: 0);
 				// not become a vertical line?
 				if (Temp.x1 !== Temp.x2) {
 					y1 = Temp.y1;
@@ -120,7 +119,7 @@ module.exports = function(Chart) {
 
 			// Find first (starting) corner with fallback to 'bottom'
 			var borders = ['bottom', 'left', 'top', 'right'];
-			var startCorner = borders.indexOf(vm.borderSkipped, 0);
+			var startCorner = borders.indexOf(borderSkipped, 0);
 			if (startCorner === -1) {
 				startCorner = 0;
 			}

--- a/test/element.rectangle.tests.js
+++ b/test/element.rectangle.tests.js
@@ -186,7 +186,6 @@ describe('Rectangle element tests', function() {
 			width: 4,
 			x: 10,
 			y: 15,
-			borderSkipped: 'bottom',
 		};
 
 		rectangle.draw();

--- a/test/element.rectangle.tests.js
+++ b/test/element.rectangle.tests.js
@@ -186,6 +186,7 @@ describe('Rectangle element tests', function() {
 			width: 4,
 			x: 10,
 			y: 15,
+			borderSkipped: 'bottom',
 		};
 
 		rectangle.draw();
@@ -207,10 +208,10 @@ describe('Rectangle element tests', function() {
 			args: [8.5, 0]
 		}, {
 			name: 'lineTo',
-			args: [8.5, 15.5]
+			args: [8.5, 14.5] // This is a minus bar. Not 15.5
 		}, {
 			name: 'lineTo',
-			args: [11.5, 15.5]
+			args: [11.5, 14.5]
 		}, {
 			name: 'lineTo',
 			args: [11.5, 0]


### PR DESCRIPTION
I changed draw function for bar.
Thank you for your review.

## Summary
1. `Chart.elements.Rectangle.draw` function supports both horizontal and vertical bar.
2. Corrected bar position at minus.
3. Adjust bar size when `borderWidth` is set.
4. Adjust bar size when `borderSkipped` is set.
5. Adjust `borderWidth` with value near 0(base).
6. Update unit test. 

## `borderWidth` = non, 5 ,20
### before
![befor](https://cloud.githubusercontent.com/assets/22541770/20912154/81f8b308-bba8-11e6-9440-c9610f7b6182.png)

https://jsfiddle.net/KoyoSE/k8b3mrb4/
### after
![after](https://cloud.githubusercontent.com/assets/22541770/20912156/893fa6a8-bba8-11e6-9ac6-c60f8f205f74.png)

https://jsfiddle.net/KoyoSE/ovf9w8dy/

## `borderSkipped` = 'right'
### before
![before right](https://cloud.githubusercontent.com/assets/22541770/20912159/91acc4ce-bba8-11e6-8386-b13d1599594d.png)

https://jsfiddle.net/KoyoSE/944rde4k/
### after
![after right](https://cloud.githubusercontent.com/assets/22541770/20912165/9626c446-bba8-11e6-8f97-4ad2d1c97a42.png)

https://jsfiddle.net/KoyoSE/1L9jw9xz/
