### PR TITLE
Fix bug when calculating if steps fit into scale as a whole number th…

### DIFF
--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -237,6 +237,10 @@ module.exports = function(Chart) {
 	helpers.almostEquals = function(x, y, epsilon) {
 		return Math.abs(x - y) < epsilon;
 	};
+	helpers.almostWhole = function(x, epsilon) {
+		var rounded = Math.round(x);
+		return (((rounded - epsilon) < x) && ((rounded + epsilon) > x));
+	};
 	helpers.max = function(array) {
 		return array.reduce(function(max, value) {
 			if (!isNaN(value)) {

--- a/src/core/core.ticks.js
+++ b/src/core/core.ticks.js
@@ -67,8 +67,8 @@ module.exports = function(Chart) {
 
 				// If min, max and stepSize is set and they make an evenly spaced scale use it.
 				if (generationOptions.min && generationOptions.max && generationOptions.stepSize) {
-					var minMaxDeltaDivisibleByStepSize = ((generationOptions.max - generationOptions.min) % generationOptions.stepSize) === 0;
-					if (minMaxDeltaDivisibleByStepSize) {
+					// If very close to our whole number, use it.
+					if (helpers.almostWhole((generationOptions.max - generationOptions.min) / generationOptions.stepSize, spacing / 1000)) {
 						niceMin = generationOptions.min;
 						niceMax = generationOptions.max;
 					}

--- a/test/core.helpers.tests.js
+++ b/test/core.helpers.tests.js
@@ -301,6 +301,11 @@ describe('Core helper tests', function() {
 		expect(helpers.almostEquals(1e30, 1e30 + Number.EPSILON, 2 * Number.EPSILON)).toBe(true);
 	});
 
+	it('should correctly determine if a numbers are essentially whole', function() {
+		expect(helpers.almostWhole(0.99999, 0.0001)).toBe(true);
+		expect(helpers.almostWhole(0.9, 0.0001)).toBe(false);
+	});
+
 	it('should generate integer ids', function() {
 		var uid = helpers.uid();
 		expect(uid).toEqual(jasmine.any(Number));


### PR DESCRIPTION
This PR fixes an error where if  `generationOptions.max` or `generationOptions.min` is calculated to an almost whole number (ie 9.999) then we display the number as 10 on the scale,  but calculating an evenly spaced  scale is not possible (eg stepSize is 2) as the check fails.  

By applying an almost whole check we are able to mitigate for FP arithmetic inconsistencies that would cause this behaviour
 
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/CONTRIBUTING.md

Example of changes on an interactive website such as the following:
- http://jsbin.com/
- http://jsfiddle.net/
- http://codepen.io/pen/
- Premade template: http://codepen.io/pen?template=JXVYzq
