### PR TITLE
Fix : Scale label display at top and right.

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -338,8 +338,13 @@ module.exports = function(Chart) {
 
 					// Ensure that our ticks are always inside the canvas. When rotated, ticks are right aligned which means that the right padding is dominated
 					// by the font height
-					me.paddingLeft = me.labelRotation !== 0 ? (cosRotation * firstLabelWidth) + 3 : firstLabelWidth / 2 + 3; // add 3 px to move away from canvas edges
-					me.paddingRight = me.labelRotation !== 0 ? (sinRotation * lineSpace) + 3 : lastLabelWidth / 2 + 3; // when rotated
+					if (me.labelRotation !== 0) {
+						me.paddingLeft = opts.position === 'bottom'? (cosRotation * firstLabelWidth) + 3: (cosRotation * lineSpace) + 3; // add 3 px to move away from canvas edges
+						me.paddingRight = opts.position === 'bottom'? (cosRotation * lineSpace) + 3: (cosRotation * lastLabelWidth) + 3;
+					} else {
+						me.paddingLeft = firstLabelWidth / 2 + 3; // add 3 px to move away from canvas edges
+						me.paddingRight = lastLabelWidth / 2 + 3;
+					}
 				} else {
 					// A vertical axis is more constrained by the width. Labels are the dominant factor here, so get that length first
 					// Account for padding
@@ -578,15 +583,21 @@ module.exports = function(Chart) {
 				var textBaseline = 'middle';
 
 				if (isHorizontal) {
-					if (!isRotated) {
-						textBaseline = options.position === 'top' ? 'bottom' : 'top';
-					}
 
-					textAlign = isRotated ? 'right' : 'center';
+					if (options.position === 'bottom') {
+						// bottom
+						textBaseline = !isRotated? 'top':'middle';
+						textAlign = !isRotated? 'center': 'right';
+						labelY = isRotated? me.top + tl: me.top + tl;
+					} else {
+						// top
+						textBaseline = !isRotated? 'bottom':'middle';
+						textAlign = !isRotated? 'center': 'left';
+						labelY = isRotated? me.bottom - tl: me.bottom - tl;
+					}
 
 					var xLineValue = me.getPixelForTick(index) + helpers.aliasPixel(lineWidth); // xvalues for grid lines
 					labelX = me.getPixelForTick(index, gridLines.offsetGridLines) + optionTicks.labelOffset; // x values for optionTicks (need to consider offsetLabel option)
-					labelY = (isRotated) ? me.top + 12 : options.position === 'top' ? me.bottom - tl : me.top + tl;
 
 					tx1 = tx2 = x1 = x2 = xLineValue;
 					ty1 = yTickStart;
@@ -704,7 +715,7 @@ module.exports = function(Chart) {
 					var isLeft = options.position === 'left';
 					scaleLabelX = isLeft ? me.left + (scaleLabelFont.size / 2) : me.right - (scaleLabelFont.size / 2);
 					scaleLabelY = me.top + ((me.bottom - me.top) / 2);
-					rotation = isLeft ? -0.5 * Math.PI : 0.5 * Math.PI;
+					rotation = -0.5 * Math.PI;
 				}
 
 				context.save();

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -588,12 +588,12 @@ module.exports = function(Chart) {
 						// bottom
 						textBaseline = !isRotated? 'top':'middle';
 						textAlign = !isRotated? 'center': 'right';
-						labelY = isRotated? me.top + tl: me.top + tl;
+						labelY = me.top + tl;
 					} else {
 						// top
 						textBaseline = !isRotated? 'bottom':'middle';
 						textAlign = !isRotated? 'center': 'left';
-						labelY = isRotated? me.bottom - tl: me.bottom - tl;
+						labelY = me.bottom - tl;
 					}
 
 					var xLineValue = me.getPixelForTick(index) + helpers.aliasPixel(lineWidth); // xvalues for grid lines

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -715,7 +715,7 @@ module.exports = function(Chart) {
 					var isLeft = options.position === 'left';
 					scaleLabelX = isLeft ? me.left + (scaleLabelFont.size / 2) : me.right - (scaleLabelFont.size / 2);
 					scaleLabelY = me.top + ((me.bottom - me.top) / 2);
-					rotation = -0.5 * Math.PI;
+					rotation = isLeft ? -0.5 * Math.PI : 0.5 * Math.PI;
 				}
 
 				context.save();


### PR DESCRIPTION
The following problem was solved.
1.Rotation of scale label when scale is right
2.Scale position at rotation when scale is top.

## Before
![2016-12-26 15 _li](https://cloud.githubusercontent.com/assets/22541770/21480691/642ab900-cb9a-11e6-834e-c10b02231da1.jpg)
[jsFiddle](https://jsfiddle.net/KoyoSE/smkfz241/)
## After
![2016-12-26 18](https://cloud.githubusercontent.com/assets/22541770/21480693/68595c34-cb9a-11e6-9666-7f145edc8559.png)
[jsFiddle](https://jsfiddle.net/KoyoSE/cejnnLj9/)
