### PR TITLE
split radial scale lineArc setting into two settings

### DIFF
--- a/docs/02-Scales.md
+++ b/docs/02-Scales.md
@@ -310,14 +310,14 @@ The following additional configuration options are provided by the radial linear
 
 Name | Type | Default | Description
 --- | --- | --- | ---
-lineArc | Boolean | false | If true, circular arcs are used else straight lines are used. The former is used by the polar area chart and the latter by the radar chart
+*gridLines*.circular | Boolean | false | if true, radial lines are circular. If false, they are straight lines connecting the the different angle line locations.
 angleLines | Object | - | See the Angle Line Options section below for details.
 pointLabels | Object | - | See the Point Label Options section below for details.
 ticks | Object | - | See the Ticks table below for options.
 
 #### Angle Line Options
 
-The following options are used to configure angled lines that radiate from the center of the chart to the point labels. They can be found in the `angleLines` sub options. Note that these options only apply if `lineArc` is false.
+The following options are used to configure angled lines that radiate from the center of the chart to the point labels. They can be found in the `angleLines` sub options. Note that these options only apply if `angleLines.display` is true.
 
 Name | Type | Default | Description
 --- | --- | --- | ---
@@ -327,10 +327,11 @@ lineWidth | Number | 1 | Width of angled lines
 
 #### Point Label Options
 
-The following options are used to configure the point labels that are shown on the perimeter of the scale. They can be found in the `pointLabels` sub options. Note that these options only apply if `lineArc` is false.
+The following options are used to configure the point labels that are shown on the perimeter of the scale. They can be found in the `pointLabels` sub options. Note that these options only apply if `pointLabels.display` is true.
 
 Name | Type | Default | Description
 --- | --- | --- | ---
+display | Boolean | true | If true, point labels are shown
 callback | Function | - | Callback function to transform data label to axis label
 fontColor | Color | '#666' | Font color
 fontFamily | String | "'Helvetica Neue', 'Helvetica', 'Arial', sans-serif" | Font family to render

--- a/docs/06-Polar-Area-Chart.md
+++ b/docs/06-Polar-Area-Chart.md
@@ -79,7 +79,6 @@ Name | Type | Default | Description
 startAngle | Number | -0.5 * Math.PI | Sets the starting angle for the first item in a dataset
 scale | Object | [See Scales](#scales) and [Defaults for Radial Linear Scale](#scales-radial-linear-scale) | Options for the one scale used on the chart. Use this to style the ticks, labels, and grid.
 *scale*.type | String |"radialLinear" | As defined in ["Radial Linear"](#scales-radial-linear-scale).
-*scale*.lineArc | Boolean | true | When true, lines are circular.
 *animation*.animateRotate | Boolean |true | If true, will animate the rotation of the chart.
 *animation*.animateScale | Boolean | true | If true, will animate scaling the chart.
 *legend*.*labels*.generateLabels | Function | `function(data) {} ` | Returns labels for each the legend

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -8,7 +8,15 @@ module.exports = function(Chart) {
 
 		scale: {
 			type: 'radialLinear',
-			lineArc: true, // so that lines are circular
+			angleLines: {
+				display: false
+			},
+			gridLines: {
+				circular: true
+			},
+			pointLabels: {
+				display: false
+			},
 			ticks: {
 				beginAtZero: true
 			}

--- a/test/scale.radialLinear.tests.js
+++ b/test/scale.radialLinear.tests.js
@@ -17,6 +17,7 @@ describe('Test the radial linear scale', function() {
 			animate: true,
 			display: true,
 			gridLines: {
+				circular: false,
 				color: 'rgba(0, 0, 0, 0.1)',
 				drawBorder: true,
 				drawOnChartArea: true,
@@ -30,8 +31,8 @@ describe('Test the radial linear scale', function() {
 				borderDash: [],
 				borderDashOffset: 0.0
 			},
-			lineArc: false,
 			pointLabels: {
+				display: true,
 				fontSize: 10,
 				callback: defaultConfig.pointLabels.callback, // make this nicer, then check explicitly below
 			},


### PR DESCRIPTION
`labelPoints` controls the visibility of angle lines and point labels
`gridLines.circular` toggles how the radial lines are drawn. When false, straight lines are drawn. When true, circular lines are drawn.

Allows creating charts that look like:
![circular radar](https://cloud.githubusercontent.com/assets/6757853/21831318/e9dace14-d770-11e6-8c99-93f257a143b0.png)

Resolves #3082 

## API Change
This is technically a breaking API change since the old setting, `lineArc` is no longer used. I don't know if this will cause problems since I think this setting is only used internally and it is not well documented.