### PR TITLE
Typo in a documentation's example

### DIFF
--- a/docs/09-Advanced.md
+++ b/docs/09-Advanced.md
@@ -30,7 +30,7 @@ Triggers an update of the chart. This can be safely called after replacing the e
 ```javascript
 // duration is the time for the animation of the redraw in milliseconds
 // lazy is a boolean. if true, the animation can be interrupted by other animations
-myLineChart.data.datasets[0].data[2] = 50; // Would update the first dataset's value of 'March' to be 50
+myLineChart.config.data.datasets[0].data[2] = 50; // Would update the first dataset's value of 'March' to be 50
 myLineChart.update(); // Calling update now animates the position of March from 90 to 50.
 ```
 


### PR DESCRIPTION
Hello,
I was trying to reproduce the documentation's example and noticed a typo. 
Is that correct ? This structure worked for me.

Thanks !