### PR TITLE
Sometimes controller is null and has no property 'draw' which throws …

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -457,7 +457,7 @@ module.exports = function(Chart) {
 
 			// Draw each dataset via its respective controller (reversed to support proper line stacking)
 			helpers.each(me.data.datasets, function(dataset, datasetIndex) {
-				if (me.isDatasetVisible(datasetIndex)) {
+				if (me.isDatasetVisible(datasetIndex) && me.isDatasetVisible(datasetIndex).hasOwnProperty('controller')) {
 					me.getDatasetMeta(datasetIndex).controller.draw(ease);
 				}
 			}, me, true);


### PR DESCRIPTION
When using Chart.js with AngularJS, occasionally - what I believe is just changing scope causes an error to be thrown,

```
Chart.js:4192 Uncaught TypeError: Cannot read property 'draw' of null
    at Chart.Controller.<anonymous> (Chart.js:4192)
    at Object.helpers.each (Chart.js:4808)
    at Chart.Controller.draw (Chart.js:4189)
    at ChartElement.animation.render (Chart.js:4154)
    at Object.startDigest (Chart.js:3694)
    at Chart.js:3667
(anonymous) @ Chart.js:4192
helpers.each @ Chart.js:4808
draw @ Chart.js:4189
animation.render @ Chart.js:4154
startDigest @ Chart.js:3694
(anonymous) @ Chart.js:3667
2017-01-13 18:04:48.577 ```

This simple check stops those errors from being thrown.