### PR TITLE
Only generate ticks we care about

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -324,7 +324,7 @@ module.exports = function(Chart) {
 			me.ticks.push(me.firstTick.clone());
 
 			// For every unit in between the first and last moment, create a moment and add it to the ticks tick
-			for (var i = 1; i <= me.scaleSizeInUnits; ++i) {
+			for (var i = me.unitScale; i <= me.scaleSizeInUnits; i += me.unitScale) {
 				var newTick = roundedStart.clone().add(i, me.tickUnit);
 
 				// Are we greater than the max time
@@ -332,9 +332,7 @@ module.exports = function(Chart) {
 					break;
 				}
 
-				if (i % me.unitScale === 0) {
-					me.ticks.push(newTick);
-				}
+				me.ticks.push(newTick);
 			}
 
 			// Always show the right tick


### PR DESCRIPTION
Improve performance of TimeScale.buildTicks.

Instead of creating `me.scaleSizeInUnits` moments and throwing the vast majority away, only create what we plan to use. 10x speedup in my use case.

Fixes #3208.