### PR TITLE
Ignore .gitignore (and more) from Bower packages

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -71,7 +71,15 @@ function bowerTask() {
       homepage: package.homepage,
       license: package.license,
       version: package.version,
-      main: outDir + "Chart.js"
+      main: outDir + "Chart.js",
+      ignore: [
+        '.github',
+        '.codeclimate.yml',
+        '.gitignore',
+        '.npmignore',
+        '.travis.yml',
+        'scripts'
+      ]
     }, null, 2);
 
   return file('bower.json', json, { src: true })


### PR DESCRIPTION
Ignore `.gitignore` (and more) from Bower packages.

Fixes #3801