### PR TITLE
Fixed issue #3788 — documentation update on requiring Chart.js using commonJS

### DIFF
--- a/docs/00-Getting-Started.md
+++ b/docs/00-Getting-Started.md
@@ -44,11 +44,11 @@ To import Chart.js using an awesome module loader:
 ```javascript
 
 // Using CommonJS
-var Chart = require('src/chart.js')
+var Chart = require('chart.js')
 var myChart = new Chart({...})
 
 // ES6
-import Chart from 'src/chart.js'
+import Chart from 'chart.js'
 let myChart = new Chart({...})
 
 // Using requirejs


### PR DESCRIPTION
as title states, main config `src/chart.js` is specified in `package.json`. So, we can require using `require('chart.js');` I've updated the documentation, I ran a quick test locally and it works! 