### PR TITLE
📝 Add vue-chartjs to docs

### DIFF
--- a/docs/10-Notes.md
+++ b/docs/10-Notes.md
@@ -109,3 +109,6 @@ There are many extensions which are available for use with popular frameworks. S
 
 #### Laravel
  - <a href="https://github.com/fxcosta/laravel-chartjs" target="_blank">laravel-chartjs</a>
+
+#### Vue.js
+ - <a href="https://github.com/apertureless/vue-chartjs/" target="_blank">vue-chartjs</a>


### PR DESCRIPTION
# Update notes.md

- Add [vue-chartjs](https://github.com/apertureless/vue-chartjs/) to popular extensions in docs.


Thanks for the suggestion @etimberg !





