### PR TITLE
When the dataset label is not defined, the tooltip label should have no ':'

### DIFF
--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -67,8 +67,13 @@ module.exports = function(Chart) {
 			// Args are: (tooltipItem, data)
 			beforeLabel: helpers.noop,
 			label: function(tooltipItem, data) {
-				var datasetLabel = data.datasets[tooltipItem.datasetIndex].label || '';
-				return datasetLabel + ': ' + tooltipItem.yLabel;
+				var label = data.datasets[tooltipItem.datasetIndex].label || '';
+
+				if (label) {
+					label += ': ';
+				}
+				label += tooltipItem.yLabel;
+				return label;
 			},
 			labelColor: function(tooltipItem, chart) {
 				var meta = chart.getDatasetMeta(tooltipItem.datasetIndex);

--- a/test/core.tooltip.tests.js
+++ b/test/core.tooltip.tests.js
@@ -1,5 +1,31 @@
 // Test the rectangle element
 describe('Core.Tooltip', function() {
+	describe('config', function() {
+		it('should not include the dataset label in the body string if not defined', function() {
+			var data = {
+				datasets: [{
+					data: [10, 20, 30],
+					pointHoverBorderColor: 'rgb(255, 0, 0)',
+					pointHoverBackgroundColor: 'rgb(0, 255, 0)'
+				}],
+				labels: ['Point 1', 'Point 2', 'Point 3']
+			};
+			var tooltipItem = {
+				index: 1,
+				datasetIndex: 0,
+				xLabel: 'Point 2',
+				yLabel: '20'
+			};
+
+			var label = Chart.defaults.global.tooltips.callbacks.label(tooltipItem, data);
+			expect(label).toBe('20');
+
+			data.datasets[0].label = 'My dataset';
+			label = Chart.defaults.global.tooltips.callbacks.label(tooltipItem, data);
+			expect(label).toBe('My dataset: 20');
+		});
+	});
+
 	describe('index mode', function() {
 		it('Should only use x distance when intersect is false', function() {
 			var chart = window.acquireChart({
@@ -463,7 +489,7 @@ describe('Core.Tooltip', function() {
 		expect(tooltip._view.y).toBeCloseToPixel(190);
 	});
 
-	it('Should display information from user callbacks', function() {
+	it('Should allow sorting items', function() {
 		var chart = window.acquireChart({
 			type: 'line',
 			data: {


### PR DESCRIPTION
Added a test to cover this case.
Resolves #3729 