### PR TITLE
Added Patch to update tooltip only when active element has changed

### DIFF
--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -782,6 +782,12 @@ module.exports = function(Chart) {
 
 			// Remember Last Actives
 			changed = !helpers.arrayEquals(me._active, me._lastActive);
+
+			// If tooltip didn't change, do not handle the target event
+			if (!changed) {
+				return false;
+			}
+
 			me._lastActive = me._active;
 
 			if (options.enabled || options.custom) {


### PR DESCRIPTION
As title states, added patch for Issue #3746 with test cases. Please review when you have a chance! @etimberg or @simonbrunel. 

