### PR TITLE
Added Django-Jchart link to docs/notes.md

### DIFF
--- a/docs/10-Notes.md
+++ b/docs/10-Notes.md
@@ -102,6 +102,7 @@ There are many extensions which are available for use with popular frameworks. S
  - <a href="https://github.com/gor181/react-chartjs-2" target="_blank">react-chartjs-2</a>
 
 #### Django
+ - <a href="https://github.com/matthisk/django-jchart" target="_blank">Django JChart</a>
  - <a href="https://github.com/novafloss/django-chartjs" target="_blank">Django Chartjs</a>
 
 #### Ruby on Rails


### PR DESCRIPTION
Have been working on a Django app that allows you to configure and render charts directly from your python codebase. The architecture of the current solution listed in the docs wasn't really satisfying my needs. It also seems this solution is more focussed on supporting Highcharts as opposed to Chart.js. It would be cool if a link to my repo could be added to the documentation of Chart.JS. 