### PR TITLE
Use element-resize-detect for resize detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "chartjs-color": "^2.0.0",
-    "moment": "^2.10.6"
+    "moment": "^2.10.6",
+    "element-resize-detector": "^1.1.10"
   }
 }

--- a/src/platforms/platform.dom.js
+++ b/src/platforms/platform.dom.js
@@ -4,7 +4,7 @@ var elementResizeDetectorMaker = require('element-resize-detector');
 // Chart.Platform implementation for targeting a web browser
 module.exports = function(Chart) {
 	var helpers = Chart.helpers;
-	var erd = null;
+	var elementResizeDetector = null;
 
 	// DOM event types -> Chart.js event types.
 	// Note: only events with different types are mapped.
@@ -128,13 +128,13 @@ module.exports = function(Chart) {
 			}
 		};
 
-		if (!erd) {
-			erd = elementResizeDetectorMaker({
+		if (!elementResizeDetector) {
+			elementResizeDetector = elementResizeDetectorMaker({
 				strategy: 'scroll',
 			});
 		}
 
-		erd.listenTo(node, notify);
+		elementResizeDetector.listenTo(node, notify);
 		stub.resizer = true;
 	}
 
@@ -143,7 +143,7 @@ module.exports = function(Chart) {
 			return;
 		}
 
-		erd.uninstall(node);
+		elementResizeDetector.uninstall(node);
 
 		delete node._chartjs.resizer;
 		delete node._chartjs;

--- a/test/core.controller.tests.js
+++ b/test/core.controller.tests.js
@@ -1,16 +1,7 @@
 describe('Chart.Controller', function() {
 
 	function waitForResize(chart, callback) {
-		var resizer = chart.chart.canvas.parentNode._chartjs.resizer;
-		var content = resizer.contentWindow || resizer;
-		var state = content.document.readyState || 'complete';
-		var handler = function() {
-			Chart.helpers.removeEvent(content, 'load', handler);
-			Chart.helpers.removeEvent(content, 'resize', handler);
-			setTimeout(callback, 50);
-		};
-
-		Chart.helpers.addEvent(content, state !== 'complete'? 'load' : 'resize', handler);
+		setTimeout(callback, 50);
 	}
 
 	describe('config initialization', function() {
@@ -480,23 +471,27 @@ describe('Chart.Controller', function() {
 	});
 
 	describe('controller.destroy', function() {
-		it('should remove the resizer element when responsive: true', function() {
+		it('should remove the resizer element when responsive: true', function(done) {
 			var chart = acquireChart({
 				options: {
 					responsive: true
 				}
 			});
 
-			var wrapper = chart.chart.canvas.parentNode;
-			var resizer = wrapper.firstChild;
+			setTimeout(function() {
+				var wrapper = chart.chart.canvas.parentNode;
+				var resizer = wrapper.lastChild;
 
-			expect(wrapper.childNodes.length).toBe(2);
-			expect(resizer.tagName).toBe('IFRAME');
+				expect(wrapper.childNodes.length).toBe(2);
+				expect(resizer.tagName).toBe('DIV');
 
-			chart.destroy();
+				chart.destroy();
 
-			expect(wrapper.childNodes.length).toBe(1);
-			expect(wrapper.firstChild.tagName).toBe('CANVAS');
+				expect(wrapper.childNodes.length).toBe(1);
+				expect(wrapper.firstChild.tagName).toBe('CANVAS');
+
+				done();
+			}, 0);
 		});
 	});
 

--- a/test/platform.dom.tests.js
+++ b/test/platform.dom.tests.js
@@ -1,16 +1,7 @@
 describe('Platform.dom', function() {
 
 	function waitForResize(chart, callback) {
-		var resizer = chart.chart.canvas.parentNode._chartjs.resizer;
-		var content = resizer.contentWindow || resizer;
-		var state = content.document.readyState || 'complete';
-		var handler = function() {
-			Chart.helpers.removeEvent(content, 'load', handler);
-			Chart.helpers.removeEvent(content, 'resize', handler);
-			setTimeout(callback, 50);
-		};
-
-		Chart.helpers.addEvent(content, state !== 'complete'? 'load' : 'resize', handler);
+		setTimeout(callback, 50);
 	}
 
 	describe('context acquisition', function() {


### PR DESCRIPTION
Hi,

We have screens in our application that have 20+ charts and on these pages we've noticed severe performance issues with chart.js initialization times. The whole page blocks for a noticeable amount of time. This issue has already been reported here: #2024.

This pull request fixes the issue by using the element-resize-detector library. We're using this library for other purposes in our app so it seemed like the easiest fix. Using this library we've noticed a 10-20x improvement in initialization time.

Here are the jsfiddles for demonstrating this issue. Click the button a few times to render 20 charts.

Without this fix (2.4.0): http://jsfiddle.net/236rzj1h/1/
With this fix (master + fix): http://jsfiddle.net/qrzdLruu/

The tests are ok, but `waitForResize` probably could use some more work.

I'd love to hear what you think about this.

Kind regards,
Amir