### PR TITLE
Axis default positions

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -56,6 +56,10 @@ module.exports = function(Chart) {
 		chart.tooltip._options = newOptions.tooltips;
 	}
 
+	function positionIsHorizontal(position) {
+		return position === 'top' || position === 'bottom';
+	}
+
 	helpers.extend(Chart.prototype, /** @lends Chart */ {
 		/**
 		 * @private
@@ -220,16 +224,21 @@ module.exports = function(Chart) {
 			if (options.scales) {
 				items = items.concat(
 					(options.scales.xAxes || []).map(function(xAxisOptions) {
-						return {options: xAxisOptions, dtype: 'category'};
+						return {options: xAxisOptions, dtype: 'category', dposition: 'bottom'};
 					}),
 					(options.scales.yAxes || []).map(function(yAxisOptions) {
-						return {options: yAxisOptions, dtype: 'linear'};
+						return {options: yAxisOptions, dtype: 'linear', dposition: 'left'};
 					})
 				);
 			}
 
 			if (options.scale) {
-				items.push({options: options.scale, dtype: 'radialLinear', isDefault: true});
+				items.push({
+					options: options.scale,
+					dtype: 'radialLinear',
+					isDefault: true,
+					dposition: 'chartArea'
+				});
 			}
 
 			helpers.each(items, function(item) {
@@ -238,6 +247,10 @@ module.exports = function(Chart) {
 				var scaleClass = Chart.scaleService.getScaleConstructor(scaleType);
 				if (!scaleClass) {
 					return;
+				}
+
+				if (positionIsHorizontal(scaleOptions.position) !== positionIsHorizontal(item.dposition)) {
+					scaleOptions.position = item.dposition;
 				}
 
 				var scale = new scaleClass({

--- a/test/core.controller.tests.js
+++ b/test/core.controller.tests.js
@@ -105,6 +105,26 @@ describe('Chart', function() {
 			expect(options.hover.mode).toBe('dataset');
 			expect(options.title.position).toBe('bottom');
 		});
+
+		it('should override axis positions that are incorrect', function() {
+			var chart = acquireChart({
+				type: 'line',
+				options: {
+					scales: {
+						xAxes: [{
+							position: 'left',
+						}],
+						yAxes: [{
+							position: 'bottom'
+						}]
+					}
+				}
+			});
+
+			var scaleOptions = chart.options.scales;
+			expect(scaleOptions.xAxes[0].position).toBe('bottom');
+			expect(scaleOptions.yAxes[0].position).toBe('left');
+		});
 	});
 
 	describe('config.options.responsive: false', function() {

--- a/test/scale.logarithmic.tests.js
+++ b/test/scale.logarithmic.tests.js
@@ -690,22 +690,21 @@ describe('Logarithmic Scale tests', function() {
 
 	it('should get the correct pixel value for a point', function() {
 		var chart = window.acquireChart({
-			type: 'bar',
+			type: 'line',
 			data: {
 				datasets: [{
 					xAxisID: 'xScale', // for the horizontal scale
 					yAxisID: 'yScale',
-					data: [10, 5, 1, 25, 78]
+					data: [{x: 10, y: 10}, {x: 5, y: 5}, {x: 1, y: 1}, {x: 25, y: 25}, {x: 78, y: 78}]
 				}],
-				labels: []
 			},
 			options: {
 				scales: {
-					yAxes: [{
+					xAxes: [{
 						id: 'xScale',
-						type: 'logarithmic',
-						position: 'bottom'
-					}, {
+						type: 'logarithmic'
+					}],
+					yAxes: [{
 						id: 'yScale',
 						type: 'logarithmic'
 					}]
@@ -714,24 +713,24 @@ describe('Logarithmic Scale tests', function() {
 		});
 
 		var xScale = chart.scales.xScale;
-		expect(xScale.getPixelForValue(80, 0, 0)).toBeCloseToPixel(482);  // right - paddingRight
+		expect(xScale.getPixelForValue(80, 0, 0)).toBeCloseToPixel(495);  // right - paddingRight
 		expect(xScale.getPixelForValue(1, 0, 0)).toBeCloseToPixel(37);   // left + paddingLeft
-		expect(xScale.getPixelForValue(10, 0, 0)).toBeCloseToPixel(270);  // halfway
+		expect(xScale.getPixelForValue(10, 0, 0)).toBeCloseToPixel(278);  // halfway
 		expect(xScale.getPixelForValue(0, 0, 0)).toBeCloseToPixel(37);   // 0 is invalid, put it on the left.
 
-		expect(xScale.getValueForPixel(481.5)).toBeCloseToPixel(80);
+		expect(xScale.getValueForPixel(495)).toBeCloseToPixel(80);
 		expect(xScale.getValueForPixel(48)).toBeCloseTo(1, 1e-4);
-		expect(xScale.getValueForPixel(270)).toBeCloseTo(10, 1e-4);
+		expect(xScale.getValueForPixel(278)).toBeCloseTo(10, 1e-4);
 
 		var yScale = chart.scales.yScale;
 		expect(yScale.getPixelForValue(80, 0, 0)).toBeCloseToPixel(32);   // top + paddingTop
-		expect(yScale.getPixelForValue(1, 0, 0)).toBeCloseToPixel(456);  // bottom - paddingBottom
-		expect(yScale.getPixelForValue(10, 0, 0)).toBeCloseToPixel(234);  // halfway
+		expect(yScale.getPixelForValue(1, 0, 0)).toBeCloseToPixel(484);  // bottom - paddingBottom
+		expect(yScale.getPixelForValue(10, 0, 0)).toBeCloseToPixel(246);  // halfway
 		expect(yScale.getPixelForValue(0, 0, 0)).toBeCloseToPixel(32);   // 0 is invalid. force it on top
 
 		expect(yScale.getValueForPixel(32)).toBeCloseTo(80, 1e-4);
-		expect(yScale.getValueForPixel(456)).toBeCloseTo(1, 1e-4);
-		expect(yScale.getValueForPixel(234)).toBeCloseTo(10, 1e-4);
+		expect(yScale.getValueForPixel(484)).toBeCloseTo(1, 1e-4);
+		expect(yScale.getValueForPixel(246)).toBeCloseTo(10, 1e-4);
 	});
 
 	it('should get the correct pixel value for a point when 0 values are present', function() {


### PR DESCRIPTION
This PR contains 2 changes.

1. Removed the references to Chart.Controller from the JSDoc comments
2. When creating axes, we now define the default position for axes. If the position option of the axis does not match the actual location, we change the position. This prevents incorrectly formed charts and has been heavily requested.

Example:
```javascript
let options = {
  scales: {
    xAxes: [{
      type: 'linear',
      position: 'right' // will be changed to 'bottom' since 'right' is not an x axis
    }],
    yScales: [{
      position: 'bottom' // will be changed to 'left' since 'bottom' is not a y axis position
    }]
  }
};
```