### PR TITLE
Avoid fails from serverside renderings

### DIFF
--- a/src/chart.js
+++ b/src/chart.js
@@ -56,4 +56,7 @@ plugins.push(require('./plugins/plugin.filler.js')(Chart));
 
 Chart.plugins.register(plugins);
 
-window.Chart = module.exports = Chart;
+module.exports = Chart;
+if (typeof window !== 'undefined') {
+	window.Chart = Chart;
+}

--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -669,6 +669,11 @@ module.exports = function(Chart) {
 	};
 	// Request animation polyfill - http://www.paulirish.com/2011/requestanimationframe-for-smart-animating/
 	helpers.requestAnimFrame = (function() {
+		if (typeof window === 'undefined') {
+			return function(callback) {
+				callback();
+			};
+		}
 		return window.requestAnimationFrame ||
 			window.webkitRequestAnimationFrame ||
 			window.mozRequestAnimationFrame ||


### PR DESCRIPTION
Hi!

I'm using Chart.js in my project and I also use server-side rendering. And if my page contains Chart.js rendering is failing (expectedly). I tried to wrap usage of Chart.js with something like:

```javascript
if (typeof window !== 'undefined') {
 // use Chart.js
}
```

But it still fails because Chart.js has been imported before and has tried to use `window` already.

I came up with the fix in PR, please take a look.

Here are some links to issues with the problem similar to mine:

* https://github.com/gor181/react-chartjs-2/issues/43
* https://github.com/reactjs/react-chartjs/issues/57

P.S. Thanks for your great work!