### PR TITLE
Handle incoming model values on element transition

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "main": "Chart.js"
   },
   "dependencies": {
-    "chartjs-color": "~2.0.0",
+    "chartjs-color": "^2.1.0",
     "moment": "^2.10.6"
   }
 }

--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -911,19 +911,21 @@ module.exports = function(Chart) {
 		ctx.quadraticCurveTo(x, y, x + radius, y);
 		ctx.closePath();
 	};
-	helpers.color = function(c) {
-		if (!color) {
+
+	helpers.color = !color?
+		function(value) {
 			console.error('Color.js not found!');
-			return c;
-		}
+			return value;
+		} :
+		function(value) {
+			/* global CanvasGradient */
+			if (value instanceof CanvasGradient) {
+				value = Chart.defaults.global.defaultColor;
+			}
 
-		/* global CanvasGradient */
-		if (c instanceof CanvasGradient) {
-			return color(Chart.defaults.global.defaultColor);
-		}
+			return color(value);
+		};
 
-		return color(c);
-	};
 	helpers.isArray = Array.isArray?
 		function(obj) {
 			return Array.isArray(obj);

--- a/test/core.element.tests.js
+++ b/test/core.element.tests.js
@@ -16,11 +16,9 @@ describe('Core element tests', function() {
 
 		// First transition clones model into view
 		element.transition(0.25);
-		expect(element._view).toEqual(element._model);
-		expect(element._start).toEqual(element._model); // also cloned
 
+		expect(element._view).toEqual(element._model);
 		expect(element._view.objectProp).toBe(element._model.objectProp); // not cloned
-		expect(element._start.objectProp).toEqual(element._model.objectProp); // not cloned
 
 		element._model.numberProp = 100;
 		element._model.numberProp2 = 250;
@@ -30,6 +28,7 @@ describe('Core element tests', function() {
 		element._model.colorProp = 'rgb(255, 255, 0)';
 
 		element.transition(0.25);
+
 		expect(element._view).toEqual({
 			numberProp: 25,
 			numberProp2: 137.5,


### PR DESCRIPTION
If a value is set on the model after `pivot()` has been called, the view wasn't initialized and the animation started from 0. Now, `_start` and incomplete `_view` are initialized to the model value during the transition (no initial implicit transition).

Also remove exception handling when animating a string (color), which is faster when string are not valid colors (e.g. tooltip position). It requires to update `chartjs-color` to version 2.1.0.