### PR TITLE
Fix shorthand `legend: false` and `title: false`

### DIFF
--- a/src/core/core.layoutService.js
+++ b/src/core/core.layoutService.js
@@ -74,10 +74,10 @@ module.exports = function(Chart) {
 		 * @param {Object} layoutItem - the item to remove from the layout
 		 */
 		removeBox: function(chart, layoutItem) {
-			if (!chart.boxes) {
-				return;
+			var index = chart.boxes? chart.boxes.indexOf(layoutItem) : -1;
+			if (index !== -1) {
+				chart.boxes.splice(index, 1);
 			}
-			chart.boxes.splice(chart.boxes.indexOf(layoutItem), 1);
 		},
 
 		/**

--- a/src/core/core.legend.js
+++ b/src/core/core.legend.js
@@ -509,6 +509,8 @@ module.exports = function(Chart) {
 
 	// Register the legend plugin
 	Chart.plugins.register({
+		id: 'legend',
+
 		beforeInit: function(chart) {
 			var legendOpts = chart.options.legend;
 
@@ -518,17 +520,18 @@ module.exports = function(Chart) {
 		},
 		beforeUpdate: function(chart) {
 			var legendOpts = chart.options.legend;
+			var legend = chart.legend;
 
 			if (legendOpts) {
 				legendOpts = helpers.configMerge(Chart.defaults.global.legend, legendOpts);
 
-				if (chart.legend) {
-					chart.legend.options = legendOpts;
+				if (legend) {
+					legend.options = legendOpts;
 				} else {
 					createNewLegendAndAttach(chart, legendOpts);
 				}
-			} else {
-				Chart.layoutService.removeBox(chart, chart.legend);
+			} else if (legend) {
+				Chart.layoutService.removeBox(chart, legend);
 				delete chart.legend;
 			}
 		},

--- a/src/core/core.title.js
+++ b/src/core/core.title.js
@@ -18,7 +18,6 @@ module.exports = function(Chart) {
 
 	var noop = helpers.noop;
 	Chart.Title = Chart.Element.extend({
-
 		initialize: function(config) {
 			var me = this;
 			helpers.extend(me, config);
@@ -198,6 +197,8 @@ module.exports = function(Chart) {
 
 	// Register the title plugin
 	Chart.plugins.register({
+		id: 'title',
+
 		beforeInit: function(chart) {
 			var titleOpts = chart.options.title;
 
@@ -207,17 +208,18 @@ module.exports = function(Chart) {
 		},
 		beforeUpdate: function(chart) {
 			var titleOpts = chart.options.title;
+			var titleBlock = chart.titleBlock;
 
 			if (titleOpts) {
 				titleOpts = helpers.configMerge(Chart.defaults.global.title, titleOpts);
 
-				if (chart.titleBlock) {
-					chart.titleBlock.options = titleOpts;
+				if (titleBlock) {
+					titleBlock.options = titleOpts;
 				} else {
 					createNewTitleBlockAndAttach(chart, titleOpts);
 				}
-			} else {
-				Chart.layoutService.removeBox(chart, chart.titleBlock);
+			} else if (titleBlock) {
+				Chart.layoutService.removeBox(chart, titleBlock);
 				delete chart.titleBlock;
 			}
 		}


### PR DESCRIPTION
Prevent attempt to remove the legend or title layout items if they haven't been created but also check if the item to remove is registered with the layout manager to avoid removing the wrong box `splice(-1, 1)`. Add ids to the legend and title plugins to allow to fully disable them:

```javascript
options: {
    plugins: {
        legend: false,
        title: false
    }
}
```