### PR TITLE
Avoid tooltip truncation in x axis if there is enough space

### DIFF
--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -299,10 +299,10 @@ module.exports = function(Chart) {
 		}
 
 		olf = function(x) {
-			return x + size.width + model.caretSize > chart.width;
+			return x + size.width + model.caretSize + model.caretPadding > chart.width;
 		};
 		orf = function(x) {
-			return x - size.width - model.caretSize < 0;
+			return x - size.width - model.caretSize - model.caretPadding < 0;
 		};
 		yf = function(y) {
 			return y <= midY ? 'top' : 'bottom';

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -299,10 +299,10 @@ module.exports = function(Chart) {
 		}
 
 		olf = function(x) {
-			return x + size.width > chart.width;
+			return x + size.width + model.caretSize > chart.width;
 		};
 		orf = function(x) {
-			return x - size.width < 0;
+			return x - size.width - model.caretSize < 0;
 		};
 		yf = function(y) {
 			return y <= midY ? 'top' : 'bottom';

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -336,9 +336,10 @@ module.exports = function(Chart) {
 	/**
 	 * @Helper to get the location a tooltip needs to be placed at given the initial position (via the vm) and the size and alignment
 	 */
-	function getBackgroundPoint(vm, size, alignment) {
+	function getBackgroundPoint(vm, size, alignment, chart) {
 		// Background Position
 		var x = vm.x;
+		var xCaret;
 		var y = vm.y;
 
 		var caretSize = vm.caretSize;
@@ -353,6 +354,13 @@ module.exports = function(Chart) {
 			x -= size.width;
 		} else if (xAlign === 'center') {
 			x -= (size.width / 2);
+			xCaret = x;
+			if (x + size.width > chart.width) {
+				x = chart.width - size.width;
+			}
+			if (x < 0) {
+				x = 0;
+			}
 		}
 
 		if (yAlign === 'top') {
@@ -377,6 +385,7 @@ module.exports = function(Chart) {
 
 		return {
 			x: x,
+			xCaret: xCaret,
 			y: y
 		};
 	}
@@ -478,6 +487,7 @@ module.exports = function(Chart) {
 			};
 			var backgroundPoint = {
 				x: existingModel.x,
+				xCaret: existingModel.xCaret,
 				y: existingModel.y
 			};
 			var tooltipSize = {
@@ -545,7 +555,7 @@ module.exports = function(Chart) {
 				tooltipSize = getTooltipSize(this, model);
 				alignment = determineAlignment(this, tooltipSize);
 				// Final Size and Position
-				backgroundPoint = getBackgroundPoint(model, tooltipSize, alignment);
+				backgroundPoint = getBackgroundPoint(model, tooltipSize, alignment, me._chart);
 			} else {
 				model.opacity = 0;
 			}
@@ -553,6 +563,7 @@ module.exports = function(Chart) {
 			model.xAlign = alignment.xAlign;
 			model.yAlign = alignment.yAlign;
 			model.x = backgroundPoint.x;
+			model.xCaret = backgroundPoint.xCaret;
 			model.y = backgroundPoint.y;
 			model.width = tooltipSize.width;
 			model.height = tooltipSize.height;
@@ -617,7 +628,11 @@ module.exports = function(Chart) {
 					x1 = x2 - caretSize;
 					x3 = x2 + caretSize;
 				} else {
-					x2 = ptX + (width / 2);
+					if (tooltipPoint.xCaret) {
+						x2 = tooltipPoint.xCaret + (width / 2);
+					} else {
+						x2 = ptX + (width / 2);
+					}
 					x1 = x2 - caretSize;
 					x3 = x2 + caretSize;
 				}
@@ -795,6 +810,7 @@ module.exports = function(Chart) {
 			};
 			var pt = {
 				x: vm.x,
+				xCaret: vm.xCaret,
 				y: vm.y
 			};
 

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -339,7 +339,6 @@ module.exports = function(Chart) {
 	function getBackgroundPoint(vm, size, alignment, chart) {
 		// Background Position
 		var x = vm.x;
-		var xCaret;
 		var y = vm.y;
 
 		var caretSize = vm.caretSize;
@@ -354,7 +353,6 @@ module.exports = function(Chart) {
 			x -= size.width;
 		} else if (xAlign === 'center') {
 			x -= (size.width / 2);
-			xCaret = x;
 			if (x + size.width > chart.width) {
 				x = chart.width - size.width;
 			}
@@ -385,7 +383,6 @@ module.exports = function(Chart) {
 
 		return {
 			x: x,
-			xCaret: xCaret,
 			y: y
 		};
 	}
@@ -487,7 +484,6 @@ module.exports = function(Chart) {
 			};
 			var backgroundPoint = {
 				x: existingModel.x,
-				xCaret: existingModel.xCaret,
 				y: existingModel.y
 			};
 			var tooltipSize = {
@@ -563,7 +559,6 @@ module.exports = function(Chart) {
 			model.xAlign = alignment.xAlign;
 			model.yAlign = alignment.yAlign;
 			model.x = backgroundPoint.x;
-			model.xCaret = backgroundPoint.xCaret;
 			model.y = backgroundPoint.y;
 			model.width = tooltipSize.width;
 			model.height = tooltipSize.height;
@@ -628,11 +623,7 @@ module.exports = function(Chart) {
 					x1 = x2 - caretSize;
 					x3 = x2 + caretSize;
 				} else {
-					if (tooltipPoint.xCaret) {
-						x2 = tooltipPoint.xCaret + (width / 2);
-					} else {
-						x2 = ptX + (width / 2);
-					}
+					x2 = vm.caretX;
 					x1 = x2 - caretSize;
 					x3 = x2 + caretSize;
 				}
@@ -810,7 +801,6 @@ module.exports = function(Chart) {
 			};
 			var pt = {
 				x: vm.x,
-				xCaret: vm.xCaret,
 				y: vm.y
 			};
 

--- a/test/specs/core.tooltip.tests.js
+++ b/test/specs/core.tooltip.tests.js
@@ -913,7 +913,7 @@ describe('Core.Tooltip', function() {
 		});
 
 		// Trigger an event over top of the slice
-		for (var slice=0; slice<2; slice++) {
+		for (var slice = 0; slice < 2; slice++) {
 			var meta = chart.getDatasetMeta(0);
 			var point = meta.data[slice].getCenterPoint();
 			var tooltipPosition = meta.data[slice].tooltipPosition();
@@ -931,7 +931,7 @@ describe('Core.Tooltip', function() {
 
 			// Lets cycle while tooltip is narrower than chart area
 			var infiniteCycleDefense = 70;
-			for (var i=0; i<infiniteCycleDefense; i++) {
+			for (var i = 0; i < infiniteCycleDefense; i++) {
 				chart.config.data.labels[slice] = chart.config.data.labels[slice] + 'l';
 				chart.update();
 				node.dispatchEvent(mouseOutEvent);

--- a/test/specs/core.tooltip.tests.js
+++ b/test/specs/core.tooltip.tests.js
@@ -882,4 +882,71 @@ describe('Core.Tooltip', function() {
 			expect(fn.calls.first().object instanceof Chart.Tooltip).toBe(true);
 		});
 	});
+
+	it('Should avoid tooltip truncation in x axis if there is enough space to show tooltip without truncation', function() {
+		var chart = window.acquireChart({
+			type: 'pie',
+			data: {
+				datasets: [{
+					data: [
+						50,
+						50
+					],
+					backgroundColor: [
+						'rgb(255, 0, 0)',
+						'rgb(0, 255, 0)'
+					],
+					label: 'Dataset 1'
+				}],
+				labels: [
+					'Red long tooltip text to avoid unnecessary loop steps',
+					'Green long tooltip text to avoid unnecessary loop steps'
+				]
+			},
+			options: {
+				responsive: true,
+				animation: {
+					// without this slice center point is calculated wrong
+					animateRotate: false
+				}
+			}
+		});
+
+		// Trigger an event over top of the slice
+		for (var slice=0; slice<2; slice++) {
+			var meta = chart.getDatasetMeta(0);
+			var point = meta.data[slice].getCenterPoint();
+			var tooltipPosition = meta.data[slice].tooltipPosition();
+			var node = chart.canvas;
+			var rect = node.getBoundingClientRect();
+
+			var mouseMoveEvent = new MouseEvent('mousemove', {
+				view: window,
+				bubbles: true,
+				cancelable: true,
+				clientX: rect.left + point.x,
+				clientY: rect.top + point.y
+			});
+			var mouseOutEvent = new MouseEvent('mouseout');
+
+			// Lets cycle while tooltip is narrower than chart area
+			var infiniteCycleDefense = 70;
+			for (var i=0; i<infiniteCycleDefense; i++) {
+				chart.config.data.labels[slice] = chart.config.data.labels[slice] + 'l';
+				chart.update();
+				node.dispatchEvent(mouseOutEvent);
+				node.dispatchEvent(mouseMoveEvent);
+				var model = chart.tooltip._model;
+				expect(model.x).toBeGreaterThanOrEqual(0);
+				if (model.width <= chart.width) {
+					expect(model.x + model.width).toBeLessThanOrEqual(chart.width);
+				}
+				expect(model.caretX).toBe(tooltipPosition.x);
+				// if tooltip is longer than chart area then all tests done
+				if (model.width > chart.width) {
+					break;
+				}
+			}
+		}
+	});
 });


### PR DESCRIPTION
Truncation up to caretSize pixels could happen if label text produced tooltip element with size width:
* left side tooltip: `width < x` and `width > x - caretSize`
* right side tooltip: `width < chartWidth - x` and `width > chartWidth - x - caretSize`

Default caretSize = 5, so with default configuration truncation up to 5 pixels could happen.

Current problematic behaviour can be viewed in http://codepen.io/kaidohallik/pen/gmLQbN  
'Blue exactly bad labelllll' is truncated.  
After changing `caretSize: 10` to `caretSize: 0` no truncation, all is shown correctly.

It can fix someones problems in #1731  
It's improvement of #1840
