### PR TITLE
Check for tooltip content before draw

### DIFF
--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -789,10 +789,10 @@ module.exports = function(Chart) {
 			// IE11/Edge does not like very small opacities, so snap to 0
 			var opacity = Math.abs(vm.opacity < 1e-3) ? 0 : vm.opacity;
 
-			// Boolean for empty tooltip
-			var hasToolTipContent = Boolean(vm.title.length || vm.beforeBody.length || vm.body.length || vm.afterBody.length || vm.footer.length);
+			// Truthy/falsey value for empty tooltip
+			var hasTooltipContent = vm.title.length || vm.beforeBody.length || vm.body.length || vm.afterBody.length || vm.footer.length;
 
-			if (this._options.enabled && hasToolTipContent) {
+			if (this._options.enabled && hasTooltipContent) {
 				// Draw Background
 				this.drawBackground(pt, vm, ctx, tooltipSize, opacity);
 

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -789,7 +789,10 @@ module.exports = function(Chart) {
 			// IE11/Edge does not like very small opacities, so snap to 0
 			var opacity = Math.abs(vm.opacity < 1e-3) ? 0 : vm.opacity;
 
-			if (this._options.enabled) {
+			// Boolean for empty tooltip
+			var hasToolTipContent = Boolean(vm.title.length || vm.beforeBody.length || vm.body.length || vm.afterBody.length || vm.footer.length);
+
+			if (this._options.enabled && hasToolTipContent) {
 				// Draw Background
 				this.drawBackground(pt, vm, ctx, tooltipSize, opacity);
 


### PR DESCRIPTION
Tooltips without any content (i.e. no `title`, `beforeBody`, `body`, `afterBody`, `footer`) should not be drawn onto canvas as empty tooltips.

Add check for tooltip content in `Core.Tooltip.draw`.