### PR TITLE
Don't shift timescale bars on barchart

### DIFF
--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -210,6 +210,10 @@ module.exports = function(Chart) {
 				return leftTick + (ruler.categoryWidth / 2) + ruler.categorySpacing;
 			}
 
+			if (xScale.options.type === 'time') {
+				return leftTick;
+			}
+
 			return leftTick +
 				(ruler.barWidth / 2) +
 				ruler.categorySpacing +


### PR DESCRIPTION
**Summary**

This PR (naively) resolves issue with bars alignment on time scale, by early returning. 
Fixes https://github.com/chartjs/Chart.js/issues/2415.