### PR TITLE
Fixed calculation of scale min and max when dataset contains no values

### DIFF
--- a/src/scales/scale.linearbase.js
+++ b/src/scales/scale.linearbase.js
@@ -31,7 +31,7 @@ module.exports = function(Chart) {
 				me.min = tickOpts.min;
 			} else if (tickOpts.suggestedMin !== undefined) {
 				if (me.min === null) {
-					me.min = tickOpts.suggestedMin;			
+					me.min = tickOpts.suggestedMin;
 				} else {
 					me.min = Math.min(me.min, tickOpts.suggestedMin);
 				}

--- a/src/scales/scale.linearbase.js
+++ b/src/scales/scale.linearbase.js
@@ -30,13 +30,21 @@ module.exports = function(Chart) {
 			if (tickOpts.min !== undefined) {
 				me.min = tickOpts.min;
 			} else if (tickOpts.suggestedMin !== undefined) {
-				me.min = Math.min(me.min, tickOpts.suggestedMin);
+				if (me.min === null) {
+					me.min = tickOpts.suggestedMin;			
+				} else {
+					me.min = Math.min(me.min, tickOpts.suggestedMin);
+				}
 			}
 
 			if (tickOpts.max !== undefined) {
 				me.max = tickOpts.max;
 			} else if (tickOpts.suggestedMax !== undefined) {
-				me.max = Math.max(me.max, tickOpts.suggestedMax);
+				if (me.max === null) {
+					me.max = tickOpts.suggestedMax;
+				} else {
+					me.max = Math.max(me.max, tickOpts.suggestedMax);
+				}
 			}
 
 			if (me.min === me.max) {

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -116,7 +116,7 @@ describe('Linear Scale', function() {
 		expect(chart.scales.yScale0.min).toBe(-100);
 		expect(chart.scales.yScale0.max).toBe(150);
 	});
-	
+
 	it('Should correctly determine the max & min when no values provided and suggested minimum and maximum are set', function() {
 		var chart = window.acquireChart({
 			type: 'bar',

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -116,6 +116,35 @@ describe('Linear Scale', function() {
 		expect(chart.scales.yScale0.min).toBe(-100);
 		expect(chart.scales.yScale0.max).toBe(150);
 	});
+	
+	it('Should correctly determine the max & min when no values provided and suggested minimum and maximum are set', function() {
+		var chart = window.acquireChart({
+			type: 'bar',
+			data: {
+				datasets: [{
+					yAxisID: 'yScale0',
+					data: []
+				}],
+				labels: ['a', 'b', 'c', 'd', 'e', 'f']
+			},
+			options: {
+				scales: {
+					yAxes: [{
+						id: 'yScale0',
+						type: 'linear',
+						ticks: {
+							suggestedMin: -10,
+							suggestedMax: 15
+						}
+					}]
+				}
+			}
+		});
+
+		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
+		expect(chart.scales.yScale0.min).toBe(-10);
+		expect(chart.scales.yScale0.max).toBe(15);
+	});
 
 	it('Should correctly determine the max & min data values ignoring hidden datasets', function() {
 		var chart = window.acquireChart({


### PR DESCRIPTION
Scale does not respect suggestedMin and suggestedMax when dataset contains no values.

jsfiddle: https://jsfiddle.net/o6g51gow/1/