### PR TITLE
Adds a better error message when the chart type is incorrect

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -293,7 +293,12 @@ module.exports = function(Chart) {
 				if (meta.controller) {
 					meta.controller.updateIndex(datasetIndex);
 				} else {
-					meta.controller = new Chart.controllers[meta.type](me, datasetIndex);
+					var ControllerClass = Chart.controllers[meta.type];
+					if (ControllerClass === undefined) {
+						throw new Error('"' + meta.type + '" is not a chart type.');
+					}
+
+					meta.controller = new ControllerClass(me, datasetIndex);
 					newControllers.push(meta.controller);
 				}
 			}, me);

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -144,6 +144,32 @@ describe('Chart', function() {
 			expect(scaleOptions.xAxes[0].position).toBe('bottom');
 			expect(scaleOptions.yAxes[0].position).toBe('left');
 		});
+
+		it('should throw an error if the chart type is incorrect', function() {
+			function createChart() {
+				acquireChart({
+					type: 'area',
+					data: {
+						datasets: [{
+							label: 'first',
+							data: [10, 20]
+						}],
+						labels: ['0', '1'],
+					},
+					options: {
+						scales: {
+							xAxes: [{
+								position: 'left',
+							}],
+							yAxes: [{
+								position: 'bottom'
+							}]
+						}
+					}
+				});
+			}
+			expect(createChart).toThrow(new Error('"area" is not a chart type.'));
+		});
 	});
 
 	describe('config.options.responsive: false', function() {


### PR DESCRIPTION
Previously the user got a message about `type` being undefined.
This gives something that's easier to understand and debug.

Resolves #3873 