### PR TITLE
Ensure scale width cannot be greater than maxWidth

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -356,7 +356,7 @@ module.exports = function(Chart) {
 					} else {
 						largestTextWidth += me.options.ticks.padding;
 					}
-					minSize.width += largestTextWidth;
+					minSize.width = Math.min(me.maxWidth, minSize.width + largestTextWidth);
 					me.paddingTop = tickFont.size / 2;
 					me.paddingBottom = tickFont.size / 2;
 				}

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -145,18 +145,19 @@ module.exports = function(Chart) {
 		var unitSizeInMilliSeconds = unitDefinition.size;
 		var sizeInUnits = Math.ceil((max - min) / unitSizeInMilliSeconds);
 		var multiplier = 1;
+		var range = max - min;
 
 		if (unitDefinition.steps) {
 			// Have an array of steps
 			var numSteps = unitDefinition.steps.length;
 			for (var i = 0; i < numSteps && sizeInUnits > maxTicks; i++) {
 				multiplier = unitDefinition.steps[i];
-				sizeInUnits = Math.ceil((max - min) / (unitSizeInMilliSeconds * multiplier));
+				sizeInUnits = Math.ceil(range / (unitSizeInMilliSeconds * multiplier));
 			}
 		} else {
-			while (sizeInUnits > maxTicks) {
+			while (sizeInUnits > maxTicks && maxTicks > 0) {
 				++multiplier;
-				sizeInUnits = Math.ceil((max - min) / (unitSizeInMilliSeconds * multiplier));
+				sizeInUnits = Math.ceil(range / (unitSizeInMilliSeconds * multiplier));
 			}
 		}
 

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -471,4 +471,34 @@ describe('Time scale tests', function() {
 			unit: 'day',
 		});
 	});
+
+	it('does not create a negative width chart when hidden', function() {
+		var chart = window.acquireChart({
+			type: 'line',
+			data: {
+				datasets: [{
+					data: []
+				}]
+			},
+			options: {
+				scales: {
+					xAxes: [{
+						type: 'time',
+						time: {
+							min: moment().subtract(1, 'months'),
+							max: moment(),
+						}
+					}],
+				},
+				responsive: true,
+			},
+		}, {
+			wrapper: {
+				style: 'display: none',
+			},
+		});
+		expect(chart.scales['y-axis-0'].width).toEqual(0);
+		expect(chart.scales['y-axis-0'].maxWidth).toEqual(0);
+		expect(chart.width).toEqual(0);
+	});
 });


### PR DESCRIPTION
Similar to `minSize.height` calculation in same method.

Fixes hidden charts slowing/hanging the browser (#3921).