### PR TITLE
Fix url for Interaction Modes

### DIFF
--- a/docs/configuration/tooltip.md
+++ b/docs/configuration/tooltip.md
@@ -8,7 +8,7 @@ The tooltip configuration is passed into the `options.tooltips` namespace. The g
 | -----| ---- | --------| -----------
 | `enabled` | `Boolean` | `true` | Are tooltips enabled
 | `custom` | `Function` | `null` | See [custom tooltip](#custom-tooltips) section.
-| `mode` | `String` | `'nearest'` | Sets which elements appear in the tooltip. [more...](../general/interactions/modes.md#interaction-modes).
+| `mode` | `String` | `'nearest'` | Sets which elements appear in the tooltip. [more...](../general/interactions/modes.md#chart-configuration-interaction-modes).
 | `intersect` | `Boolean` | `true` | if true, the tooltip mode applies only when the mouse position intersects with an element. If false, the mode will be applied at all times.
 | `position` | `String` | `'average'` | The mode for positioning the tooltip. [more...](#position-modes)
 | `callbacks` | `Object` | | See the [callbacks section](#tooltip-callbacks)

--- a/docs/general/interactions/README.md
+++ b/docs/general/interactions/README.md
@@ -4,6 +4,6 @@ The hover configuration is passed into the `options.hover` namespace. The global
 
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
-| `mode` | `String` | `'nearest'` | Sets which elements appear in the tooltip. See [Interaction Modes](./modes.md#interaction-modes) for details.
+| `mode` | `String` | `'nearest'` | Sets which elements appear in the tooltip. See [Interaction Modes](./modes.md#chart-configuration-interaction-modes) for details.
 | `intersect` | `Boolean` | `true` | if true, the hover mode only applies when the mouse position intersects an item on the chart.
 | `animationDuration` | `Number` | `400` | Duration in milliseconds it takes to animate hover style changes.


### PR DESCRIPTION
Nothing happened when I clicked the Link `Interaction Modes` in the doc.
The ID is not `#interaction-modes` but `#chart-configuration-interaction-modes` I think.
