### PR TITLE
Fixed an Uncaught TypeError

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -605,6 +605,11 @@ module.exports = function(Chart) {
 		getDatasetMeta: function(datasetIndex) {
 			var me = this;
 			var dataset = me.data.datasets[datasetIndex];
+			
+			if (typeof dataset == "undefined"){
+				return {};
+			}
+			
 			if (!dataset._meta) {
 				dataset._meta = {};
 			}


### PR DESCRIPTION
Uncaught TypeError: Cannot read property '_meta' of undefined
    at Chart.getDatasetMeta (https://localhost/rmdb/res/libs.js:4351:16)
    at Chart.updateHoverStyle (https://localhost/rmdb/res/libs.js:4489:11)
    at Chart.handleEvent (https://localhost/rmdb/res/libs.js:4569:8)
    at Chart.eventHandler (https://localhost/rmdb/res/libs.js:4509:21)
    at listener (https://localhost/rmdb/res/libs.js:4444:21)
    at HTMLCanvasElement.proxies.(anonymous function) (https://localhost/rmdb/res/libs.js:9916:5)
getDatasetMeta @ libs.js:4351
updateHoverStyle @ libs.js:4489
handleEvent @ libs.js:4569
eventHandler @ libs.js:4509
listener @ libs.js:4444
proxies.(anonymous function) @ libs.js:9916
libs.js:4351 Uncaught TypeError: Cannot read property '_meta' of undefined
    at Chart.getDatasetMeta (https://localhost/rmdb/res/libs.js:4351:16)
    at Chart.updateHoverStyle (https://localhost/rmdb/res/libs.js:4489:11)
    at Chart.handleEvent (https://localhost/rmdb/res/libs.js:4569:8)
    at Chart.eventHandler (https://localhost/rmdb/res/libs.js:4509:21)
    at listener (https://localhost/rmdb/res/libs.js:4444:21)
    at HTMLCanvasElement.proxies.(anonymous function) (https://localhost/rmdb/res/libs.js:9916:5)
getDatasetMeta @ libs.js:4351
updateHoverStyle @ libs.js:4489
handleEvent @ libs.js:4569
eventHandler @ libs.js:4509
listener @ libs.js:4444
proxies.(anonymous function) @ libs.js:9916

Edit: Video of error (https://www.youtube.com/watch?v=twbyqVw8n4M&feature=youtu.be)

Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/CONTRIBUTING.md

Example of changes on an interactive website such as the following:
- http://jsbin.com/
- http://jsfiddle.net/
- http://codepen.io/pen/
- Premade template: http://codepen.io/pen?template=JXVYzq