### PR TITLE
Add the ability to reverse the order of tooltip items

### DIFF
--- a/docs/configuration/tooltip.md
+++ b/docs/configuration/tooltip.md
@@ -41,6 +41,7 @@ The tooltip configuration is passed into the `options.tooltips` namespace. The g
 | `displayColors` | `Boolean` | `true` | if true, color boxes are shown in the tooltip
 | `borderColor` | Color | `'rgba(0,0,0,0)'` | Color of the border
 | `borderWidth` | `Number` | `0` | Size of the border
+| `reverse` | `Boolean` | `false` | if true, reverses the order of the items in the tooltip
 
 ### Position Modes
  Possible modes are:

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -41,6 +41,7 @@ module.exports = function(Chart) {
 		displayColors: true,
 		borderColor: 'rgba(0,0,0,0)',
 		borderWidth: 0,
+		reverse: false,
 		callbacks: {
 			// Args are: (tooltipItems, data)
 			beforeTitle: helpers.noop,
@@ -423,6 +424,10 @@ module.exports = function(Chart) {
 				bodyItems.push(bodyItem);
 			});
 
+			if (me._options.reverse) {
+				bodyItems.reverse();
+			}
+
 			return bodyItems;
 		},
 
@@ -512,6 +517,10 @@ module.exports = function(Chart) {
 				helpers.each(tooltipItems, function(tooltipItem) {
 					labelColors.push(opts.callbacks.labelColor.call(me, tooltipItem, me._chart));
 				});
+
+				if (opts.reverse) {
+					labelColors.reverse();
+				}
 
 				// Build the Text Lines
 				model.title = me.getTitle(tooltipItems, data);


### PR DESCRIPTION
This new functionality will allow you to reverse the order of datasets in tooltips, similar to how the **reverse** parameter on legend allows you to reverse the order of datasets in the legend.