### PR TITLE
Fix broken link to point to correct sample file.

### DIFF
--- a/samples/samples.js
+++ b/samples/samples.js
@@ -111,7 +111,7 @@
 			path: 'scales/time/line.html'
 		}, {
 			title: 'Line (point data)',
-			path: 'scales/time/line.html'
+			path: 'scales/time/line-point-data.html'
 		}, {
 			title: 'Combo',
 			path: 'scales/time/combo.html'


### PR DESCRIPTION
The link pointing to point-data time scaled graph was incorrectly referring to a different graph sample file. The commit points the link to the correct sample now.