### PR TITLE
fix scale options update error

### DIFF
--- a/docs/developers/updates.md
+++ b/docs/developers/updates.md
@@ -1,6 +1,6 @@
 # Updating Charts
 
-It's pretty common to want to update charts after they've been created. When the chart data is changed, Chart.js will animate to the new data values. 
+It's pretty common to want to update charts after they've been created. When the chart data or options are changed, Chart.js will animate to the new data values and options.
 
 ## Adding or Removing Data
 
@@ -14,9 +14,7 @@ function addData(chart, label, data) {
     });
     chart.update();
 }
-```
 
-```javascript
 function removeData(chart) {
     chart.data.labels.pop();
     chart.data.datasets.forEach((dataset) => {
@@ -25,6 +23,67 @@ function removeData(chart) {
     chart.update();
 }
 ```
+
+## Updating Options
+
+To update the options, mutating the options property in place or passing in a new options object are supported.
+
+- If the options are mutated in place, other option properties would be preserved.
+- If created as a new object, it would be like creating a new chart with the options - old options would be discarded.
+
+```javascript
+function updateConfigByMutating(chart) {
+    chart.options.title.text = 'new title';
+    chart.update();
+}
+
+function updateConfigAsNewObject(chart) {
+    chart.options = {
+        responsive: true,
+        title:{
+            display:true,
+            text: 'Chart.js'
+        },
+        scales: {
+            xAxes: [{
+                display: true
+            }],
+            yAxes: [{
+                display: true
+            }]
+        }
+    }
+    chart.update();
+}
+```
+
+Scales can be updated separately without changing other options.
+To update the scales, pass in an object containing all the customization including those unchanged ones.
+
+Variables referencing any one from `chart.scales` would be lost after updating scales with a new id or the changed type.
+
+```javascript
+function updateScales(chart) {
+    var xScale = chart.scales['x-axis-0'];
+    var yScale = chart.scales['y-axis-0'];
+    chart.options.scales = {
+        xAxes: [{
+            id: 'newId',
+            display: true
+        }],
+        yAxes: [{
+            display: true,
+            type: 'logarithmic'
+        }]
+    }
+    chart.update();
+    // need to update the reference
+    xScale = chart.scales['newId'];
+    yScale = chart.scales['y-axis-0'];
+}
+```
+
+Code sample for updating options can be found in [toggle-scale-type.html](../../samples/scales/toggle-scale-type.html).
 
 ## Preventing Animations
 

--- a/docs/developers/updates.md
+++ b/docs/developers/updates.md
@@ -28,7 +28,7 @@ function removeData(chart) {
 
 To update the options, mutating the options property in place or passing in a new options object are supported.
 
-- If the options are mutated in place, other option properties would be preserved.
+- If the options are mutated in place, other option properties would be preserved, including those calculated by Chart.js.
 - If created as a new object, it would be like creating a new chart with the options - old options would be discarded.
 
 ```javascript
@@ -60,7 +60,7 @@ function updateConfigAsNewObject(chart) {
 Scales can be updated separately without changing other options.
 To update the scales, pass in an object containing all the customization including those unchanged ones.
 
-Variables referencing any one from `chart.scales` would be lost after updating scales with a new id or the changed type.
+Variables referencing any one from `chart.scales` would be lost after updating scales with a new `id` or the changed `type`.
 
 ```javascript
 function updateScales(chart) {
@@ -80,6 +80,17 @@ function updateScales(chart) {
     // need to update the reference
     xScale = chart.scales['newId'];
     yScale = chart.scales['y-axis-0'];
+}
+```
+
+You can also update a specific scale either by specifying its index or id.
+
+```javascript
+function updateScale(chart) {
+    chart.options.scales.yAxes[0] = {
+        type: 'logarithmic'
+    }
+    chart.update();
 }
 ```
 

--- a/samples/samples.js
+++ b/samples/samples.js
@@ -136,6 +136,9 @@
 		}, {
 			title: 'Non numeric Y Axis',
 			path: 'scales/non-numeric-y.html'
+		}, {
+			title: 'Toggle Scale Type',
+			path: 'scales/toggle-scale-type.html'
 		}]
 	}, {
 		title: 'Legend',

--- a/samples/scales/toggle-scale-type.html
+++ b/samples/scales/toggle-scale-type.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html>
+
+<head>
+    <title>Toggle Scale Type</title>
+    <script src="../../dist/Chart.bundle.js"></script>
+    <script src="../utils.js"></script>
+    <style>
+    canvas {
+        -moz-user-select: none;
+        -webkit-user-select: none;
+        -ms-user-select: none;
+    }
+    </style>
+</head>
+
+<body>
+    <div style="width:75%;">
+        <canvas id="canvas"></canvas>
+    </div>
+    <button id="toggleScale">Toggle Scale Type</button>
+    <script>
+    var randomScalingFactor = function() {
+        return Math.ceil(Math.random() * 10.0) * Math.pow(10, Math.ceil(Math.random() * 5));
+    };
+
+    var type = 'linear';
+
+    var config = {
+        type: 'line',
+        data: {
+            labels: ["January", "February", "March", "April", "May", "June", "July"],
+            datasets: [{
+                label: "My First dataset",
+                backgroundColor: window.chartColors.red,
+                borderColor: window.chartColors.red,
+                fill: false,
+                data: [
+                    randomScalingFactor(),
+                    randomScalingFactor(),
+                    randomScalingFactor(),
+                    randomScalingFactor(),
+                    randomScalingFactor(),
+                    randomScalingFactor(),
+                    randomScalingFactor()
+                ],
+            }, {
+                label: "My Second dataset",
+                backgroundColor: window.chartColors.blue,
+                borderColor: window.chartColors.blue,
+                fill: false,
+                data: [
+                    randomScalingFactor(),
+                    randomScalingFactor(),
+                    randomScalingFactor(),
+                    randomScalingFactor(),
+                    randomScalingFactor(),
+                    randomScalingFactor(),
+                    randomScalingFactor()
+                ],
+            }]
+        },
+        options: {
+            responsive: true,
+            title:{
+                display: true,
+                text: 'Chart.js Line Chart - ' + type
+            },
+            scales: {
+                xAxes: [{
+                    display: true,
+                }],
+                yAxes: [{
+                    display: true,
+                    type: type
+                }]
+            }
+        }
+    };
+
+    window.onload = function() {
+        var ctx = document.getElementById("canvas").getContext("2d");
+        window.myLine = new Chart(ctx, config);
+    };
+
+    document.getElementById('toggleScale').addEventListener('click', function() {
+        type = type === 'linear' ? 'logarithmic' : 'linear';
+        window.myLine.options.title.text = 'Chart.js Line Chart - ' + type;
+        window.myLine.options.scales = {
+          xAxes: [{
+            display: true
+          }],
+          yAxes: [{
+            display: true,
+            type: type
+          }]
+        }
+
+        window.myLine.update();
+    });
+    </script>
+</body>
+
+</html>

--- a/samples/scales/toggle-scale-type.html
+++ b/samples/scales/toggle-scale-type.html
@@ -86,14 +86,9 @@
     document.getElementById('toggleScale').addEventListener('click', function() {
         type = type === 'linear' ? 'logarithmic' : 'linear';
         window.myLine.options.title.text = 'Chart.js Line Chart - ' + type;
-        window.myLine.options.scales = {
-          xAxes: [{
-            display: true
-          }],
-          yAxes: [{
+        window.myLine.options.scales.yAxes[0] = {
             display: true,
             type: type
-          }]
         }
 
         window.myLine.update();

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -111,10 +111,10 @@ module.exports = function(Chart) {
 			var meta = me.getMeta();
 			var dataset = me.getDataset();
 
-			if (meta.xAxisID === null) {
+			if (meta.xAxisID === null || !(meta.xAxisID in me.chart.scales)) {
 				meta.xAxisID = dataset.xAxisID || me.chart.options.scales.xAxes[0].id;
 			}
-			if (meta.yAxisID === null) {
+			if (meta.yAxisID === null || !(meta.yAxisID in me.chart.scales)) {
 				meta.yAxisID = dataset.yAxisID || me.chart.options.scales.yAxes[0].id;
 			}
 		},

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -775,6 +775,38 @@ describe('Chart', function() {
 	});
 
 	describe('config update', function() {
+		it ('should update options', function() {
+			var chart = acquireChart({
+				type: 'line',
+				data: {
+					labels: ['A', 'B', 'C', 'D'],
+					datasets: [{
+						data: [10, 20, 30, 100]
+					}]
+				},
+				options: {
+					responsive: true
+				}
+			});
+
+			chart.options = {
+				responsive: false,
+				scales: {
+					yAxes: [{
+						ticks: {
+							min: 0,
+							max: 10
+						}
+					}]
+				}
+			};
+			chart.update();
+
+			var yScale = chart.scales['y-axis-0'];
+			expect(yScale.options.ticks.min).toBe(0);
+			expect(yScale.options.ticks.max).toBe(10);
+		});
+
 		it ('should update scales options', function() {
 			var chart = acquireChart({
 				type: 'line',
@@ -796,6 +828,79 @@ describe('Chart', function() {
 			var yScale = chart.scales['y-axis-0'];
 			expect(yScale.options.ticks.min).toBe(0);
 			expect(yScale.options.ticks.max).toBe(10);
+		});
+
+		it ('should update scales options from new object', function() {
+			var chart = acquireChart({
+				type: 'line',
+				data: {
+					labels: ['A', 'B', 'C', 'D'],
+					datasets: [{
+						data: [10, 20, 30, 100]
+					}]
+				},
+				options: {
+					responsive: true
+				}
+			});
+
+			var newScalesConfig = {
+				yAxes: [{
+					ticks: {
+						min: 0,
+						max: 10
+					}
+				}]
+			};
+			chart.options.scales = newScalesConfig;
+
+			chart.update();
+
+			var yScale = chart.scales['y-axis-0'];
+			expect(yScale.options.ticks.min).toBe(0);
+			expect(yScale.options.ticks.max).toBe(10);
+		});
+
+		it ('should remove discarded scale', function() {
+			var chart = acquireChart({
+				type: 'line',
+				data: {
+					labels: ['A', 'B', 'C', 'D'],
+					datasets: [{
+						data: [10, 20, 30, 100]
+					}]
+				},
+				options: {
+					responsive: true,
+					scales: {
+						yAxes: [{
+							id: 'yAxis0',
+							ticks: {
+								min: 0,
+								max: 10
+							}
+						}]
+					}
+				}
+			});
+
+			var newScalesConfig = {
+				yAxes: [{
+					ticks: {
+						min: 0,
+						max: 10
+					}
+				}]
+			};
+			chart.options.scales = newScalesConfig;
+
+			chart.update();
+
+			var yScale = chart.scales.yAxis0;
+			expect(yScale).toBeUndefined();
+			var newyScale = chart.scales['y-axis-0'];
+			expect(newyScale.options.ticks.min).toBe(0);
+			expect(newyScale.options.ticks.max).toBe(10);
 		});
 
 		it ('should update tooltip options', function() {


### PR DESCRIPTION
#4197 
When updating the options, should merge with the default value and add ids before setting them, just like when initializing.

And I think the function name should updateOptions since it really only touched the options.