### PR TITLE
Explicitly check if tooltip callback is undefined before ignoring value

### DIFF
--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -104,7 +104,7 @@ module.exports = function(Chart) {
 
 	// Helper to push or concat based on if the 2nd parameter is an array or not
 	function pushOrConcat(base, toPush) {
-		if (toPush) {
+		if (toPush !== undefined && toPush !== null) {
 			if (helpers.isArray(toPush)) {
 				// base = base.concat(toPush);
 				Array.prototype.push.apply(base, toPush);

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -104,7 +104,7 @@ module.exports = function(Chart) {
 
 	// Helper to push or concat based on if the 2nd parameter is an array or not
 	function pushOrConcat(base, toPush) {
-		if (toPush !== undefined && toPush !== null) {
+		if (!helpers.isNullOrUndef(toPush)) {
 			if (helpers.isArray(toPush)) {
 				// base = base.concat(toPush);
 				Array.prototype.push.apply(base, toPush);


### PR DESCRIPTION
The current implementation incorrectly dismisses values returned from tooltip callback methods if they are falsy rather than explicitly checking that they are missing. See the following example:

```
...
label: (tooltipItem) => {
  return 0; // Assume a more realistic situation resulting in the label being 0.
},
```

With this fix we will instead check for undefined or null values, and otherwise use the return value.