### PR TITLE
Fixed images being used as a pointStyle not rendering at custom dimensions

### DIFF
--- a/src/core/core.canvasHelpers.js
+++ b/src/core/core.canvasHelpers.js
@@ -10,7 +10,7 @@ module.exports = function(Chart) {
 		if (typeof pointStyle === 'object') {
 			type = pointStyle.toString();
 			if (type === '[object HTMLImageElement]' || type === '[object HTMLCanvasElement]') {
-				ctx.drawImage(pointStyle, x - pointStyle.width / 2, y - pointStyle.height / 2);
+				ctx.drawImage(pointStyle, x - pointStyle.width / 2, y - pointStyle.height / 2, pointStyle.width, pointStyle.height);
 				return;
 			}
 		}


### PR DESCRIPTION
Added width + height arguments to ctx.drawImage when using an image as a pointStyle. 

Previous functionality meant that images would be drawn at their source file size regardless of whether custom width or height properties were set.