### PR TITLE
Use https to load scripts from CDN

### DIFF
--- a/samples/scales/time/combo.html
+++ b/samples/scales/time/combo.html
@@ -3,7 +3,7 @@
 
 <head>
 	<title>Line Chart - Combo Time Scale</title>
-	<script src="http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/moment.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/moment.min.js"></script>
 	<script src="../../../dist/Chart.js"></script>
 	<script src="../../utils.js"></script>
 	<style>

--- a/samples/scales/time/line-point-data.html
+++ b/samples/scales/time/line-point-data.html
@@ -3,7 +3,7 @@
 
 <head>
 	<title>Time Scale Point Data</title>
-	<script src="http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/moment.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/moment.min.js"></script>
 	<script src="../../../dist/Chart.js"></script>
 	<script src="../../utils.js"></script>
 	<style>

--- a/samples/scales/time/line.html
+++ b/samples/scales/time/line.html
@@ -3,7 +3,7 @@
 
 <head>
 	<title>Line Chart</title>
-	<script src="http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/moment.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/moment.min.js"></script>
 	<script src="../../../dist/Chart.js"></script>
 	<script src="../../utils.js"></script>
 	<style>

--- a/samples/tooltips/custom-points.html
+++ b/samples/tooltips/custom-points.html
@@ -5,7 +5,7 @@
 	<title>Custom Tooltips using Data Points</title>
 	<script src="../../dist/Chart.bundle.js"></script>
 	<script src="../utils.js"></script>
-	<script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 	<style>
 		canvas{
 			-moz-user-select: none;


### PR DESCRIPTION
This should help fix the samples. I'm getting an error right now:

Mixed Content: The page at 'https://simonbrunel.github.io/chartjs.github.io/samples/latest/scales/time/line.html' was loaded over HTTPS, but requested an insecure script 'http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/moment.min.js'. This request has been blocked; the content must be served over HTTPS