### PR TITLE
fix missing link in area.md

### DIFF
--- a/docs/charts/area.md
+++ b/docs/charts/area.md
@@ -2,7 +2,7 @@
 
 Both [line](line.md) and [radar](radar.md) charts support a `fill` option on the dataset object which can be used to create area between two datasets or a dataset and a boundary, i.e. the scale `origin`, `start` or `end` (see [filling modes](#filling-modes)).
 
-> **Note:** this feature is implemented by the [`filler` plugin](/chartjs/Chart.js/blob/master/src/plugins/plugin.filler.js).
+> **Note:** this feature is implemented by the [`filler` plugin](https://github.com/chartjs/Chart.js/blob/master/src/plugins/plugin.filler.js).
 
 ## Filling modes
 


### PR DESCRIPTION
[Ducoment for area](https://github.com/chartjs/Chart.js/blob/master/docs/charts/area.md) has a wrong link for filler plugin.