### PR TITLE
fix #4216 when dataset empty, set scale min max to default if null

### DIFF
--- a/src/scales/scale.linearbase.js
+++ b/src/scales/scale.linearbase.js
@@ -27,9 +27,6 @@ module.exports = function(Chart) {
 				}
 			}
 
-			var setMin = tickOpts.min !== undefined || tickOpts.suggestedMin !== undefined;
-			var setMax = tickOpts.max !== undefined || tickOpts.suggestedMax !== undefined;
-
 			if (tickOpts.min !== undefined) {
 				me.min = tickOpts.min;
 			} else if (tickOpts.suggestedMin !== undefined) {
@@ -50,24 +47,10 @@ module.exports = function(Chart) {
 				}
 			}
 
-			if (setMin !== setMax) {
-				// We set the min or the max but not both.
-				// So ensure that our range is good
-				// Inverted or 0 length range can happen when
-				// ticks.min is set, and no datasets are visible
-				if (me.min >= me.max) {
-					if (setMin) {
-						me.max = me.min + 1;
-					} else {
-						me.min = me.max - 1;
-					}
-				}
-			}
+			if (me.min >= me.max) {
+				me.max = me.min + 1;
 
-			if (me.min === me.max) {
-				me.max++;
-
-				if (!tickOpts.beginAtZero) {
+				if (tickOpts.min === undefined && !tickOpts.beginAtZero) {
 					me.min--;
 				}
 			}


### PR DESCRIPTION
Currently, when dataset empty, we do not check whether min, max is null.
https://github.com/chartjs/Chart.js/blob/master/src/scales/scale.linear.js#L102-L128

Set it to default if null could prevent axis's ticks array being [0, NaN], which led to the issue #4216 