### PR TITLE
Fix onHover event not being triggered

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -797,7 +797,6 @@ module.exports = function(Chart) {
 			var me = this;
 			var options = me.options || {};
 			var hoverOptions = options.hover;
-			var hoverCallback = options.onHover || options.hover.onHover;
 			var changed = false;
 
 			me.lastActive = me.lastActive || [];
@@ -809,11 +808,9 @@ module.exports = function(Chart) {
 				me.active = me.getElementsAtEventForMode(e, hoverOptions.mode, hoverOptions);
 			}
 
-			// On Hover hook
-			if (hoverCallback) {
-				// Need to call with native event here to not break backwards compatibility
-				hoverCallback.call(me, e.native, me.active);
-			}
+			// Invoke onHover hook
+			// Need to call with native event here to not break backwards compatibility
+			helpers.callback(options.onHover || options.hover.onHover, [e.native, me.active], me);
 
 			if (e.type === 'mouseup' || e.type === 'click') {
 				if (options.onClick) {

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -797,6 +797,7 @@ module.exports = function(Chart) {
 			var me = this;
 			var options = me.options || {};
 			var hoverOptions = options.hover;
+			var hoverCallback = options.onHover || options.hover.onHover;
 			var changed = false;
 
 			me.lastActive = me.lastActive || [];
@@ -809,9 +810,9 @@ module.exports = function(Chart) {
 			}
 
 			// On Hover hook
-			if (hoverOptions.onHover) {
+			if (hoverCallback) {
 				// Need to call with native event here to not break backwards compatibility
-				hoverOptions.onHover.call(me, e.native, me.active);
+				hoverCallback.call(me, e.native, me.active);
 			}
 
 			if (e.type === 'mouseup' || e.type === 'click') {


### PR DESCRIPTION
The core controller was looking at the wrong object (options.hover) to find the function to be called on hover. The function is provided on the top level options object (options.onHover).

Fixes #4296