### PR TITLE
Fix round option for time scales

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -125,7 +125,7 @@ module.exports = function(Chart) {
 			if (timeOpts.min) {
 				var minMoment = timeHelpers.parseTime(me, timeOpts.min);
 				if (timeOpts.round) {
-					minMoment.round(timeOpts.round);
+					minMoment.startOf(timeOpts.round);
 				}
 				minTimestamp = minMoment.valueOf();
 			}


### PR DESCRIPTION
Resolves #4328 and makes the `round` setting match the docs.