### PR TITLE
Closes issue #4287

### DIFF
--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -723,7 +723,7 @@ module.exports = function(Chart) {
 	};
 	helpers.addEvent = function(node, eventType, method) {
 		if (node.addEventListener) {
-			node.addEventListener(eventType, method);
+			node.addEventListener(eventType, method, {passive: true});
 		} else if (node.attachEvent) {
 			node.attachEvent('on' + eventType, method);
 		} else {


### PR DESCRIPTION
[BUG] Violation warnings in verbose level chrome dev tools logging.
I hope this closes https://github.com/chartjs/Chart.js/issues/4287

I'm not sure whether this is the way to solve this issue. From https://developers.google.com/web/updates/2016/06/passive-event-listeners it may need to be in `passive` for a better scrolling in touch devices. Please comment and I'll change accordingly. 

Note: This's my first PR to a public repo. :smile: 