### PR TITLE
Support configurable update

### DIFF
--- a/docs/developers/api.md
+++ b/docs/developers/api.md
@@ -17,7 +17,7 @@ This must be called before the canvas is reused for a new chart.
 myLineChart.destroy();
 ```
 
-## .update(duration, lazy)
+## .update(config)
 
 Triggers an update of the chart. This can be safely called after updating the data object. This will update all scales, legends, and then re-render the chart.
 
@@ -29,6 +29,23 @@ myLineChart.update(); // Calling update now animates the position of March from 
 ```
 
 > **Note:** replacing the data reference (e.g. `myLineChart.data = {datasets: [...]}` only works starting **version 2.6**. Prior that, replacing the entire data object could be achieved with the following workaround: `myLineChart.config.data = {datasets: [...]}`.
+
+A `config` object can be provided with additional configuration for the update process. This is useful when `update` is manually called inside an event handler and some different animation is desired.
+
+The following properties are supported:
+* **duration** (number): Time for the animation of the redraw in milliseconds
+* **lazy** (boolean): If true, the animation can be interrupted by other animations
+* **easing** (string): The animation easing function. See [Animation Easing](../configuration/animations.md) for possible values.
+
+Example:
+```javascript
+myChart.update({
+    duration: 800,
+    easing: 'easeOutBounce'
+})
+```
+
+> **Note:** `.update(duration, lazy)` is still supported in backwards compatibility mode.
 
 See [Updating Charts](updates.md) for more details.
 

--- a/docs/developers/api.md
+++ b/docs/developers/api.md
@@ -45,8 +45,6 @@ myChart.update({
 })
 ```
 
-> **Note:** `.update(duration, lazy)` is still supported in backwards compatibility mode.
-
 See [Updating Charts](updates.md) for more details.
 
 ## .reset()
@@ -72,8 +70,6 @@ myLineChart.render({
 	easing: 'easeOutBounce'
 });
 ```
-
-> **Note:** `.render(duration, lazy)` is still supported in backwards compatibility mode.
 
 ## .stop()
 

--- a/docs/developers/api.md
+++ b/docs/developers/api.md
@@ -57,15 +57,23 @@ Reset the chart to it's state before the initial animation. A new animation can 
 myLineChart.reset();
 ```
 
-## .render(duration, lazy)
+## .render(config)
 
 Triggers a redraw of all chart elements. Note, this does not update elements for new data. Use `.update()` in that case.
+
+See `.update(config)` for more details on the config object.
 
 ```javascript
 // duration is the time for the animation of the redraw in milliseconds
 // lazy is a boolean. if true, the animation can be interrupted by other animations
-myLineChart.render(duration, lazy);
+myLineChart.render({
+	duration: 800,
+	lazy: false,
+	easing: 'easeOutBounce'
+});
 ```
+
+> **Note:** `.render(duration, lazy)` is still supported in backwards compatibility mode.
 
 ## .stop()
 

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -334,8 +334,16 @@ module.exports = function(Chart) {
 			this.tooltip.initialize();
 		},
 
-		update: function(animationDuration, lazy) {
+		update: function(config) {
 			var me = this;
+
+			if (!config || typeof config !== 'object') {
+				// backwards compatibility
+				config = {
+					duration: config,
+					lazy: arguments[1]
+				};
+			}
 
 			updateConfig(me);
 
@@ -368,11 +376,12 @@ module.exports = function(Chart) {
 
 			if (me._bufferedRender) {
 				me._bufferedRequest = {
-					lazy: lazy,
-					duration: animationDuration
+					duration: config.duration,
+					easing: config.easing,
+					lazy: config.lazy
 				};
 			} else {
-				me.render(animationDuration, lazy);
+				me.render(config);
 			}
 		},
 
@@ -442,8 +451,19 @@ module.exports = function(Chart) {
 			plugins.notify(me, 'afterDatasetUpdate', [args]);
 		},
 
-		render: function(duration, lazy) {
+		render: function(config) {
 			var me = this;
+
+			if (!config || typeof config !== 'object') {
+				// backwards compatibility
+				config = {
+					duration: config,
+					lazy: arguments[1]
+				};
+			}
+
+			var duration = config.duration;
+			var lazy = config.lazy;
 
 			if (plugins.notify(me, 'beforeRender') === false) {
 				return;
@@ -458,7 +478,7 @@ module.exports = function(Chart) {
 			if (animationOptions && ((typeof duration !== 'undefined' && duration !== 0) || (typeof duration === 'undefined' && animationOptions.duration !== 0))) {
 				var animation = new Chart.Animation({
 					numSteps: (duration || animationOptions.duration) / 16.66, // 60 fps
-					easing: animationOptions.easing,
+					easing: config.easing || animationOptions.easing,
 
 					render: function(chart, animationObject) {
 						var easingFunction = helpers.easingEffects[animationObject.easing];
@@ -771,7 +791,7 @@ module.exports = function(Chart) {
 			var bufferedRequest = me._bufferedRequest;
 			if (bufferedRequest) {
 				// If we have an update that was triggered, we need to do a normal render
-				me.render(bufferedRequest.duration, bufferedRequest.lazy);
+				me.render(bufferedRequest);
 			} else if (changed && !me.animating) {
 				// If entering, leaving, or changing elements, animate the change via pivot
 				me.stop();

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -809,20 +809,10 @@ describe('Chart', function() {
 	});
 
 	describe('controller.update', function() {
-		var chart;
-		var addAnimationSpy;
-
 		beforeEach(function() {
-			chart = acquireChart({
+			this.chart = acquireChart({
 				type: 'doughnut',
-				data: {
-					labels: ['A', 'B', 'C', 'D'],
-					datasets: [{
-						data: [10, 20, 30, 100]
-					}]
-				},
 				options: {
-					cutoutPercentage: 85,
 					animation: {
 						easing: 'linear',
 						duration: 500
@@ -830,14 +820,14 @@ describe('Chart', function() {
 				}
 			});
 
-			addAnimationSpy = spyOn(Chart.animationService, 'addAnimation');
+			this.addAnimationSpy = spyOn(Chart.animationService, 'addAnimation');
 		});
 
 		it('adds an animation with the default options', function() {
-			chart.update();
+			this.chart.update();
 
-			expect(addAnimationSpy).toHaveBeenCalledWith(
-				chart,
+			expect(this.addAnimationSpy).toHaveBeenCalledWith(
+				this.chart,
 				jasmine.objectContaining({easing: 'linear'}),
 				undefined,
 				undefined
@@ -845,14 +835,14 @@ describe('Chart', function() {
 		});
 
 		it('adds an animation with the provided options', function() {
-			chart.update({
+			this.chart.update({
 				duration: 800,
 				easing: 'easeOutBounce',
 				lazy: false,
 			});
 
-			expect(addAnimationSpy).toHaveBeenCalledWith(
-				chart,
+			expect(this.addAnimationSpy).toHaveBeenCalledWith(
+				this.chart,
 				jasmine.objectContaining({easing: 'easeOutBounce'}),
 				800,
 				false

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -807,4 +807,107 @@ describe('Chart', function() {
 			]);
 		});
 	});
+
+	describe('controller.update', function() {
+		var chart;
+		var renderSpy;
+
+		beforeEach(function() {
+			chart = acquireChart({
+				type: 'line',
+				data: {
+					labels: ['A', 'B', 'C', 'D'],
+					datasets: [{
+						data: [10, 20, 30, 100]
+					}]
+				},
+				options: {
+					responsive: true
+				}
+			});
+
+			renderSpy = spyOn(chart, 'render');
+		});
+
+		describe('when _bufferedRender is true', function() {
+			beforeEach(function() {
+				chart._bufferedRender = true;
+			});
+
+			it('does not call render', function() {
+				chart.update({
+					duration: 800,
+					easing: 'easeOutBounce'
+				});
+
+				expect(renderSpy).not.toHaveBeenCalled();
+			});
+
+			it('builds _bufferedRequest with config properties', function() {
+				chart.update({
+					duration: 800,
+					easing: 'easeOutBounce'
+				});
+
+				expect(chart._bufferedRequest).toEqual({
+					duration: 800,
+					lazy: undefined,
+					easing: 'easeOutBounce'
+				});
+			});
+		});
+
+		describe('when _bufferedRender is false', function() {
+			beforeEach(function() {
+				chart._bufferedRender = false;
+			});
+
+			it('calls render with the config object', function() {
+				chart.update({
+					duration: 800,
+					easing: 'easeOutBounce'
+				});
+
+				expect(renderSpy).toHaveBeenCalledWith({
+					duration: 800,
+					easing: 'easeOutBounce'
+				});
+			});
+		});
+
+		describe('when using backwards compatibility', function() {
+			describe('when _bufferedRender is true', function() {
+				beforeEach(function() {
+					chart._bufferedRender = true;
+				});
+
+				it('does not call render', function() {
+					chart.update(800, false);
+
+					expect(renderSpy).not.toHaveBeenCalled();
+				});
+
+				it('builds _bufferedRequest with duration and lazy properties', function() {
+					chart.update(800, false);
+
+					expect(chart._bufferedRequest).toEqual({
+						duration: 800,
+						lazy: false,
+						easing: undefined
+					});
+				});
+			});
+
+			describe('when _bufferedRender is false', function() {
+				it('calls render with duration and lazy properties', function() {
+					chart.update(800, true);
+
+					expect(renderSpy).toHaveBeenCalledWith({
+						duration: 800,
+						lazy: true
+					});
+				});
+			});
+		});
+	});
 });

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -810,11 +810,11 @@ describe('Chart', function() {
 
 	describe('controller.update', function() {
 		var chart;
-		var renderSpy;
+		var addAnimationSpy;
 
 		beforeEach(function() {
 			chart = acquireChart({
-				type: 'line',
+				type: 'doughnut',
 				data: {
 					labels: ['A', 'B', 'C', 'D'],
 					datasets: [{
@@ -822,92 +822,41 @@ describe('Chart', function() {
 					}]
 				},
 				options: {
-					responsive: true
+					cutoutPercentage: 85,
+					animation: {
+						easing: 'linear',
+						duration: 500
+					}
 				}
 			});
 
-			renderSpy = spyOn(chart, 'render');
+			addAnimationSpy = spyOn(Chart.animationService, 'addAnimation');
 		});
 
-		describe('when _bufferedRender is true', function() {
-			beforeEach(function() {
-				chart._bufferedRender = true;
-			});
+		it('adds an animation with the default options', function() {
+			chart.update();
 
-			it('does not call render', function() {
-				chart.update({
-					duration: 800,
-					easing: 'easeOutBounce'
-				});
-
-				expect(renderSpy).not.toHaveBeenCalled();
-			});
-
-			it('builds _bufferedRequest with config properties', function() {
-				chart.update({
-					duration: 800,
-					easing: 'easeOutBounce'
-				});
-
-				expect(chart._bufferedRequest).toEqual({
-					duration: 800,
-					lazy: undefined,
-					easing: 'easeOutBounce'
-				});
-			});
+			expect(addAnimationSpy).toHaveBeenCalledWith(
+				chart,
+				jasmine.objectContaining({easing: 'linear'}),
+				undefined,
+				undefined
+			);
 		});
 
-		describe('when _bufferedRender is false', function() {
-			beforeEach(function() {
-				chart._bufferedRender = false;
+		it('adds an animation with the provided options', function() {
+			chart.update({
+				duration: 800,
+				easing: 'easeOutBounce',
+				lazy: false,
 			});
 
-			it('calls render with the config object', function() {
-				chart.update({
-					duration: 800,
-					easing: 'easeOutBounce'
-				});
-
-				expect(renderSpy).toHaveBeenCalledWith({
-					duration: 800,
-					easing: 'easeOutBounce'
-				});
-			});
-		});
-
-		describe('when using backwards compatibility', function() {
-			describe('when _bufferedRender is true', function() {
-				beforeEach(function() {
-					chart._bufferedRender = true;
-				});
-
-				it('does not call render', function() {
-					chart.update(800, false);
-
-					expect(renderSpy).not.toHaveBeenCalled();
-				});
-
-				it('builds _bufferedRequest with duration and lazy properties', function() {
-					chart.update(800, false);
-
-					expect(chart._bufferedRequest).toEqual({
-						duration: 800,
-						lazy: false,
-						easing: undefined
-					});
-				});
-			});
-
-			describe('when _bufferedRender is false', function() {
-				it('calls render with duration and lazy properties', function() {
-					chart.update(800, true);
-
-					expect(renderSpy).toHaveBeenCalledWith({
-						duration: 800,
-						lazy: true
-					});
-				});
-			});
+			expect(addAnimationSpy).toHaveBeenCalledWith(
+				chart,
+				jasmine.objectContaining({easing: 'easeOutBounce'}),
+				800,
+				false
+			);
 		});
 	});
 });

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -823,7 +823,7 @@ describe('Chart', function() {
 			this.addAnimationSpy = spyOn(Chart.animationService, 'addAnimation');
 		});
 
-		it('adds an animation with the default options', function() {
+		it('should add an animation with the default options', function() {
 			this.chart.update();
 
 			expect(this.addAnimationSpy).toHaveBeenCalledWith(
@@ -834,7 +834,7 @@ describe('Chart', function() {
 			);
 		});
 
-		it('adds an animation with the provided options', function() {
+		it('should add an animation with the provided options', function() {
 			this.chart.update({
 				duration: 800,
 				easing: 'easeOutBounce',

--- a/test/specs/global.deprecations.tests.js
+++ b/test/specs/global.deprecations.tests.js
@@ -1,20 +1,10 @@
 describe('Deprecations', function() {
 	describe('Version 2.7.0', function() {
 		describe('Chart.Controller.update(duration, lazy)', function() {
-			var chart;
-			var addAnimationSpy;
-
 			beforeEach(function() {
-				chart = acquireChart({
+				this.chart = acquireChart({
 					type: 'doughnut',
-					data: {
-						labels: ['A', 'B', 'C', 'D'],
-						datasets: [{
-							data: [10, 20, 30, 100]
-						}]
-					},
 					options: {
-						cutoutPercentage: 85,
 						animation: {
 							easing: 'linear',
 							duration: 500
@@ -22,14 +12,14 @@ describe('Deprecations', function() {
 					}
 				});
 
-				addAnimationSpy = spyOn(Chart.animationService, 'addAnimation');
+				this.addAnimationSpy = spyOn(Chart.animationService, 'addAnimation');
 			});
 
 			it('adds an animation with the provided options', function() {
-				chart.update(800, false);
+				this.chart.update(800, false);
 
-				expect(addAnimationSpy).toHaveBeenCalledWith(
-					chart,
+				expect(this.addAnimationSpy).toHaveBeenCalledWith(
+					this.chart,
 					jasmine.objectContaining({easing: 'linear'}),
 					800,
 					false
@@ -38,20 +28,10 @@ describe('Deprecations', function() {
 		});
 
 		describe('Chart.Controller.render(duration, lazy)', function() {
-			var chart;
-			var addAnimationSpy;
-
 			beforeEach(function() {
-				chart = acquireChart({
+				this.chart = acquireChart({
 					type: 'doughnut',
-					data: {
-						labels: ['A', 'B', 'C', 'D'],
-						datasets: [{
-							data: [10, 20, 30, 100]
-						}]
-					},
 					options: {
-						cutoutPercentage: 85,
 						animation: {
 							easing: 'linear',
 							duration: 500
@@ -59,14 +39,14 @@ describe('Deprecations', function() {
 					}
 				});
 
-				addAnimationSpy = spyOn(Chart.animationService, 'addAnimation');
+				this.addAnimationSpy = spyOn(Chart.animationService, 'addAnimation');
 			});
 
 			it('adds an animation with the provided options', function() {
-				chart.render(800, true);
+				this.chart.render(800, true);
 
-				expect(addAnimationSpy).toHaveBeenCalledWith(
-					chart,
+				expect(this.addAnimationSpy).toHaveBeenCalledWith(
+					this.chart,
 					jasmine.objectContaining({easing: 'linear'}),
 					800,
 					true

--- a/test/specs/global.deprecations.tests.js
+++ b/test/specs/global.deprecations.tests.js
@@ -1,4 +1,80 @@
 describe('Deprecations', function() {
+	describe('Version 2.7.0', function() {
+		describe('Chart.Controller.update(duration, lazy)', function() {
+			var chart;
+			var addAnimationSpy;
+
+			beforeEach(function() {
+				chart = acquireChart({
+					type: 'doughnut',
+					data: {
+						labels: ['A', 'B', 'C', 'D'],
+						datasets: [{
+							data: [10, 20, 30, 100]
+						}]
+					},
+					options: {
+						cutoutPercentage: 85,
+						animation: {
+							easing: 'linear',
+							duration: 500
+						}
+					}
+				});
+
+				addAnimationSpy = spyOn(Chart.animationService, 'addAnimation');
+			});
+
+			it('adds an animation with the provided options', function() {
+				chart.update(800, false);
+
+				expect(addAnimationSpy).toHaveBeenCalledWith(
+					chart,
+					jasmine.objectContaining({easing: 'linear'}),
+					800,
+					false
+				);
+			});
+		});
+
+		describe('Chart.Controller.render(duration, lazy)', function() {
+			var chart;
+			var addAnimationSpy;
+
+			beforeEach(function() {
+				chart = acquireChart({
+					type: 'doughnut',
+					data: {
+						labels: ['A', 'B', 'C', 'D'],
+						datasets: [{
+							data: [10, 20, 30, 100]
+						}]
+					},
+					options: {
+						cutoutPercentage: 85,
+						animation: {
+							easing: 'linear',
+							duration: 500
+						}
+					}
+				});
+
+				addAnimationSpy = spyOn(Chart.animationService, 'addAnimation');
+			});
+
+			it('adds an animation with the provided options', function() {
+				chart.render(800, true);
+
+				expect(addAnimationSpy).toHaveBeenCalledWith(
+					chart,
+					jasmine.objectContaining({easing: 'linear'}),
+					800,
+					true
+				);
+			});
+		});
+	});
+
 	describe('Version 2.6.0', function() {
 		// https://github.com/chartjs/Chart.js/issues/2481
 		describe('Chart.Controller', function() {

--- a/test/specs/global.deprecations.tests.js
+++ b/test/specs/global.deprecations.tests.js
@@ -15,7 +15,7 @@ describe('Deprecations', function() {
 				this.addAnimationSpy = spyOn(Chart.animationService, 'addAnimation');
 			});
 
-			it('adds an animation with the provided options', function() {
+			it('should add an animation with the provided options', function() {
 				this.chart.update(800, false);
 
 				expect(this.addAnimationSpy).toHaveBeenCalledWith(
@@ -42,7 +42,7 @@ describe('Deprecations', function() {
 				this.addAnimationSpy = spyOn(Chart.animationService, 'addAnimation');
 			});
 
-			it('adds an animation with the provided options', function() {
+			it('should add an animation with the provided options', function() {
 				this.chart.render(800, true);
 
 				expect(this.addAnimationSpy).toHaveBeenCalledWith(


### PR DESCRIPTION
See discussion in the issue for context and possible approaches.

When invoking `update()` inside an event handler, such as onHover, `options.hover.animationDuration` was not being respected. Given that some use cases may require additional animation properties for the manual update call, this commit changes that method signature to accept a configuration object.

This object provides backwards compatibility with `duration` and `lazy` properties, and also introduces the `easing` property so that the event animation is different from the global one.

Issue #4300