### PR TITLE
Update scatter chart default to hide lines

### DIFF
--- a/src/charts/Chart.Scatter.js
+++ b/src/charts/Chart.Scatter.js
@@ -19,6 +19,7 @@ module.exports = function(Chart) {
 				id: 'y-axis-1'
 			}]
 		},
+		showLines: false,
 
 		tooltips: {
 			callbacks: {


### PR DESCRIPTION
Resolves #4372 

Note: This is a potentially breaking change if we think that scatter defaults should show lines. In which case, I will update the two sample files