### PR TITLE
Auto skip last

### DIFF
--- a/docs/axes/cartesian/README.md
+++ b/docs/axes/cartesian/README.md
@@ -27,6 +27,7 @@ The following options are common to all cartesian axes but do not apply to other
 | -----| ---- | --------| -----------
 | `autoSkip` | `Boolean` | `true` | If true, automatically calculates how many labels that can be shown and hides labels accordingly. Turn it off to show all labels no matter what
 | `autoSkipPadding` | `Number` | `0` | Padding between the ticks on the horizontal axis when `autoSkip` is enabled. *Note: Only applicable to horizontal scales.*
+| `autoSkipLast` | `Boolean` | `true` | If true, automatically replace the last evenly spaced label and with a label at the end of the scale. Turn if off to only show evenly spaced labels.
 | `labelOffset` | `Number` | `0` | Distance in pixels to offset the label from the centre point of the tick (in the y direction for the x axis, and the x direction for the y axis). *Note: this can cause labels at the edges to be cropped by the edge of the canvas*
 | `maxRotation` | `Number` | `90` | Maximum rotation for tick labels when rotating to condense labels. Note: Rotation doesn't occur until necessary. *Note: Only applicable to horizontal scales.*
 | `minRotation` | `Number` | `0` | Minimum rotation for tick labels. *Note: Only applicable to horizontal scales.*

--- a/samples/scales/auto-skip-last-label.html
+++ b/samples/scales/auto-skip-last-label.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html>
+
+<head>
+    <title>Chart with xAxis Filtering</title>
+    <script src="../../dist/Chart.bundle.js"></script>
+    <script src="../utils.js"></script>
+    <style>
+    canvas {
+        -moz-user-select: none;
+        -webkit-user-select: none;
+        -ms-user-select: none;
+    }
+    </style>
+</head>
+
+<body>
+    <div style="width:75%;">
+        <canvas id="canvas"></canvas>
+    </div>
+    <script>
+		var days = [];
+		var data = [];
+
+		for(var day = 1; day < 31; day++) {
+			days.push('Jan ' + day);
+			data.push(day);
+		}
+
+        var config = {
+            type: 'bar',
+            data: {
+                labels: days,
+                datasets: [{
+                    label: "My First dataset",
+                    borderColor: window.chartColors.red,
+                    backgroundColor: window.chartColors.red,
+                    data: data
+                }]
+            },
+            options: {
+                responsive: true,
+                title:{
+                    display:true,
+                    text:"Chart.js Bar Chart - Disable AutoSkipLast"
+                },
+                scales: {
+                    xAxes: [{
+						gridLines: {
+							display: false,
+							offsetGridLines: true
+						},
+                        display: true,
+                        ticks: {
+							maxTicksLimit: 5,
+							autoSkip: true,
+							autoSkipLast: false
+                        }
+                    }],
+                    yAxes: [{
+                        display: true,
+                        beginAtZero: true
+                    }]
+                }
+            }
+        };
+
+        window.onload = function() {
+            var ctx = document.getElementById("canvas").getContext("2d");
+            window.myLine = new Chart(ctx, config);
+        };
+    </script>
+</body>
+
+</html>

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -580,11 +580,11 @@ module.exports = function(Chart) {
 					return;
 				}
 
-				var isLastTick = me.ticks.length === index + 1 && optionTicks.autoSkipLast;
+				var autoSkip = index % skipRatio > 0;
+				var autoSkipLastTick = index + skipRatio >= me.ticks.length && optionTicks.autoSkipLast;
+				var includeLastTick = me.ticks.length === index + 1 && optionTicks.autoSkipLast;
 
-				// Since we always show the last tick,we need may need to hide the last shown one before
-				var shouldSkip = (skipRatio > 1 && index % skipRatio > 0) || (index % skipRatio === 0 && isLastTick);
-				if (shouldSkip && !isLastTick || (label === undefined || label === null)) {
+				if ((autoSkip || autoSkipLastTick) && !includeLastTick) {
 					return;
 				}
 

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -46,6 +46,7 @@ module.exports = function(Chart) {
 			display: true,
 			autoSkip: true,
 			autoSkipPadding: 0,
+			autoSkipLast: true,
 			labelOffset: 0,
 			// We pass through arrays to be rendered as multiline labels, we convert Others to strings here.
 			callback: Chart.Ticks.formatters.values,
@@ -579,10 +580,10 @@ module.exports = function(Chart) {
 					return;
 				}
 
-				var isLastTick = me.ticks.length === index + 1;
+				var isLastTick = me.ticks.length === index + 1 && optionTicks.autoSkipLast;
 
 				// Since we always show the last tick,we need may need to hide the last shown one before
-				var shouldSkip = (skipRatio > 1 && index % skipRatio > 0) || (index % skipRatio === 0 && index + skipRatio >= me.ticks.length);
+				var shouldSkip = (skipRatio > 1 && index % skipRatio > 0) || (index % skipRatio === 0 && isLastTick);
 				if (shouldSkip && !isLastTick || (label === undefined || label === null)) {
 					return;
 				}

--- a/test/specs/core.helpers.tests.js
+++ b/test/specs/core.helpers.tests.js
@@ -214,6 +214,7 @@ describe('Core helper tests', function() {
 						callback: merged.scales.yAxes[1].ticks.callback, // make it nicer, then check explicitly below
 						autoSkip: true,
 						autoSkipPadding: 0,
+						autoSkipLast: true,
 						labelOffset: 0,
 						minor: {},
 						major: {},
@@ -254,6 +255,7 @@ describe('Core helper tests', function() {
 						callback: merged.scales.yAxes[2].ticks.callback, // make it nicer, then check explicitly below
 						autoSkip: true,
 						autoSkipPadding: 0,
+						autoSkipLast: true,
 						labelOffset: 0,
 						minor: {},
 						major: {},

--- a/test/specs/scale.category.tests.js
+++ b/test/specs/scale.category.tests.js
@@ -44,6 +44,7 @@ describe('Category scale tests', function() {
 				callback: defaultConfig.ticks.callback,  // make this nicer, then check explicitly below
 				autoSkip: true,
 				autoSkipPadding: 0,
+				autoSkipLast: true,
 				labelOffset: 0,
 				minor: {},
 				major: {},

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -42,6 +42,7 @@ describe('Linear Scale', function() {
 				callback: defaultConfig.ticks.callback, // make this work nicer, then check below
 				autoSkip: true,
 				autoSkipPadding: 0,
+				autoSkipLast: true,
 				labelOffset: 0,
 				minor: {},
 				major: {},

--- a/test/specs/scale.logarithmic.tests.js
+++ b/test/specs/scale.logarithmic.tests.js
@@ -41,6 +41,7 @@ describe('Logarithmic Scale tests', function() {
 				callback: defaultConfig.ticks.callback, // make this nicer, then check explicitly below
 				autoSkip: true,
 				autoSkipPadding: 0,
+				autoSkipLast: true,
 				labelOffset: 0,
 				minor: {},
 				major: {},

--- a/test/specs/scale.radialLinear.tests.js
+++ b/test/specs/scale.radialLinear.tests.js
@@ -58,6 +58,7 @@ describe('Test the radial linear scale', function() {
 				callback: defaultConfig.ticks.callback, // make this nicer, then check explicitly below
 				autoSkip: true,
 				autoSkipPadding: 0,
+				autoSkipLast: true,
 				labelOffset: 0,
 				minor: {},
 				major: {},

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -89,6 +89,7 @@ describe('Time scale tests', function() {
 				callback: defaultConfig.ticks.callback, // make this nicer, then check explicitly below,
 				autoSkip: false,
 				autoSkipPadding: 0,
+				autoSkipLast: true,
 				labelOffset: 0,
 				minor: {},
 				major: {},


### PR DESCRIPTION
We are currently using the category scale to show dates in a combo bar/line chart and would rather not have a large tick gap with inconsistent spacing between ticks.

Default functionality:
https://codepen.io/anon/pen/GEEqpr

![image](https://user-images.githubusercontent.com/161660/27407393-b7955954-569d-11e7-89a7-3ad5ee9597f8.png)

AutoSkipLast disabled:
https://codepen.io/anon/pen/pwwbex

![image](https://user-images.githubusercontent.com/161660/27407293-62737488-569d-11e7-9de4-b8e94795585b.png)
