### PR TITLE
Add aria-hidden=true attribute to hidden iframe for resizing

### DIFF
--- a/src/platforms/platform.dom.js
+++ b/src/platforms/platform.dom.js
@@ -129,6 +129,10 @@ module.exports = function(Chart) {
 		// Prevent the iframe to gain focus on tab.
 		// https://github.com/chartjs/Chart.js/issues/3090
 		iframe.tabIndex = -1;
+		
+		// Prevent iframe from gaining focus on ItemMode keyboard navigation
+		// Accessibility bug fix
+		iframe.setAttribute("aria-hidden", "true");
 
 		// If the iframe is re-attached to the DOM, the resize listener is removed because the
 		// content is reloaded, so make sure to install the handler after the iframe is loaded.

--- a/src/platforms/platform.dom.js
+++ b/src/platforms/platform.dom.js
@@ -129,10 +129,10 @@ module.exports = function(Chart) {
 		// Prevent the iframe to gain focus on tab.
 		// https://github.com/chartjs/Chart.js/issues/3090
 		iframe.tabIndex = -1;
-		
+
 		// Prevent iframe from gaining focus on ItemMode keyboard navigation
 		// Accessibility bug fix
-		iframe.setAttribute("aria-hidden", "true");
+		iframe.setAttribute('aria-hidden', 'true');
 
 		// If the iframe is re-attached to the DOM, the resize listener is removed because the
 		// content is reloaded, so make sure to install the handler after the iframe is loaded.


### PR DESCRIPTION
Add aria-hidden=true attribute to hidden iframe for resizing. This prevents screen readers in ItemMode from navigating to the hidden iframe