### PR TITLE
Add description on new dataset update and draw plugin hooks

### DIFF
--- a/docs/developers/plugins.md
+++ b/docs/developers/plugins.md
@@ -106,7 +106,7 @@ var chart = new Chart(ctx, {
 
 ## Plugin Core API
 
-Available hooks (as of version 2.5):
+Available hooks (as of version 2.6):
 
 * beforeInit
 * afterInit
@@ -116,12 +116,16 @@ Available hooks (as of version 2.5):
 * afterLayout
 * beforeDatasetsUpdate *(cancellable)*
 * afterDatasetsUpdate
+* beforeDatasetUpdate *(cancellable)*
+* afterDatasetUpdate
 * beforeRender *(cancellable)*
 * afterRender
 * beforeDraw *(cancellable)*
 * afterDraw
 * beforeDatasetsDraw *(cancellable)*
 * afterDatasetsDraw
+* beforeDatasetDraw *(cancellable)*
+* afterDatasetDraw
 * beforeEvent *(cancellable)*
 * afterEvent
 * resize


### PR DESCRIPTION
Added description on the following plugin hooks to the list:
- beforeDatasetUpdate
- afterDatasetUpdate
- beforeDatasetDraw
- afterDatasetDraw