### PR TITLE
Increase ESLint complexity and add config for tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -44,7 +44,7 @@ rules:
   accessor-pairs: 2
   array-callback-return: 0
   block-scoped-var: 0
-  complexity: [2, 6]
+  complexity: [2, 10]
   consistent-return: 0
   curly: [2, all]
   default-case: 2

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -137,25 +137,9 @@ function lintTask() {
   // to fix, let's turn them as warnings and rewrite code later progressively.
   var options = {
     rules: {
-      'complexity': [1, 6],
+      'complexity': [1, 10],
       'max-statements': [1, 30]
-    },
-    globals: [
-      'Chart',
-      'acquireChart',
-      'afterAll',
-      'afterEach',
-      'beforeAll',
-      'beforeEach',
-      'describe',
-      'expect',
-      'fail',
-      'it',
-      'jasmine',
-      'moment',
-      'spyOn',
-      'xit'
-    ]
+    }
   };
 
   return gulp.src(files)

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,12 @@
+env:
+  jasmine: true
+
+globals:
+  acquireChart: true
+  Chart: true
+  moment: true
+
+# http://eslint.org/docs/rules/
+rules:
+  # Best Practices
+  complexity: 0


### PR DESCRIPTION
Raise the cyclomatic complexity to 10 which seems to better match the project coding style and still reasonable (6 being quite low). Also move unit tests specific eslint rules in the cascaded `./test/.eslintrc` file (previously in `gulp.js`).
