### PR TITLE
Fix non-passive event listener warning in Chrome

### DIFF
--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -666,24 +666,6 @@ module.exports = function(Chart) {
 		};
 
 	};
-	helpers.addEvent = function(node, eventType, method) {
-		if (node.addEventListener) {
-			node.addEventListener(eventType, method);
-		} else if (node.attachEvent) {
-			node.attachEvent('on' + eventType, method);
-		} else {
-			node['on' + eventType] = method;
-		}
-	};
-	helpers.removeEvent = function(node, eventType, handler) {
-		if (node.removeEventListener) {
-			node.removeEventListener(eventType, handler, false);
-		} else if (node.detachEvent) {
-			node.detachEvent('on' + eventType, handler);
-		} else {
-			node['on' + eventType] = helpers.noop;
-		}
-	};
 
 	// Private helper function to convert max-width/max-height values that may be percentages into a number
 	function parseMaxStyle(styleValue, node, parentProperty) {

--- a/test/specs/global.deprecations.tests.js
+++ b/test/specs/global.deprecations.tests.js
@@ -101,6 +101,33 @@ describe('Deprecations', function() {
 				expect(Chart.helpers.canvas.roundedRect).toHaveBeenCalledWith(ctx, 10, 20, 30, 40, 5);
 			});
 		});
+
+		describe('Chart.helpers.addEvent', function() {
+			it('should be defined and a function', function() {
+				expect(Chart.helpers.addEvent).toBeDefined();
+				expect(typeof Chart.helpers.addEvent).toBe('function');
+			});
+			it('should correctly add event listener', function() {
+				var listener = jasmine.createSpy('spy');
+				Chart.helpers.addEvent(window, 'test', listener);
+				window.dispatchEvent(new Event('test'));
+				expect(listener).toHaveBeenCalled();
+			});
+		});
+
+		describe('Chart.helpers.removeEvent', function() {
+			it('should be defined and a function', function() {
+				expect(Chart.helpers.removeEvent).toBeDefined();
+				expect(typeof Chart.helpers.removeEvent).toBe('function');
+			});
+			it('should correctly remove event listener', function() {
+				var listener = jasmine.createSpy('spy');
+				Chart.helpers.addEvent(window, 'test', listener);
+				Chart.helpers.removeEvent(window, 'test', listener);
+				window.dispatchEvent(new Event('test'));
+				expect(listener).not.toHaveBeenCalled();
+			});
+		});
 	});
 
 	describe('Version 2.6.0', function() {


### PR DESCRIPTION
Deprecate `addEvent` and `removeEvent`, and move implementation in `platform.dom.js`. Add 'options' feature detection to register event listeners as passive and prevent warning in Chrome.

Replaces #4356
Fixes #4287