### PR TITLE
Add the ability to pass in a function(index, dataset) as a pointstyle for linegraphs.

### DIFF
--- a/docs/charts/line.md
+++ b/docs/charts/line.md
@@ -62,7 +62,7 @@ All point* properties can be specified as an array. If these are set to an array
 | `pointBorderColor` | `Color/Color[]` | The border color for points.
 | `pointBorderWidth` | `Number/Number[]` | The width of the point border in pixels.
 | `pointRadius` | `Number/Number[]` | The radius of the point shape. If set to 0, the point is not rendered.
-| `pointStyle` | `String/String[]/Image/Image[]` | Style of the point. [more...](#pointStyle)
+| `pointStyle` | `String/String[]/Image/Image[]/Function` | Style of the point. [more...](#pointStyle)
 | `pointHitRadius` | `Number/Number[]` | The pixel size of the non-displayed point that reacts to mouse events.
 | `pointHoverBackgroundColor` | `Color/Color[]` | Point background color when hovered.
 | `pointHoverBorderColor` | `Color/Color[]` | Point border color when hovered.
@@ -97,6 +97,8 @@ The style of point. Options are:
 * 'triangle'
 
 If the option is an image, that image is drawn on the canvas using [drawImage](https://developer.mozilla.org/en/docs/Web/API/CanvasRenderingContext2D/drawImage).
+
+If the option is a Function, it must take in two parameters - index and dataset - and return a pointStyle of either one of the above point options or an image. This can be used to draw a different point depending on the index of the point.
 
 ### Stepped Line
 The following values are supported for `steppedLine`:

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -184,7 +184,7 @@ module.exports = function(Chart) {
 				skip: custom.skip || isNaN(x) || isNaN(y),
 				// Appearance
 				radius: custom.radius || helpers.valueAtIndexOrDefault(dataset.pointRadius, index, pointOptions.radius),
-				pointStyle: custom.pointStyle || helpers.valueAtIndexOrDefault(dataset.pointStyle, index, pointOptions.pointStyle),
+				pointStyle: me.getPointStyle(custom, dataset, index, pointOptions),
 				backgroundColor: me.getPointBackgroundColor(point, index),
 				borderColor: me.getPointBorderColor(point, index),
 				borderWidth: me.getPointBorderWidth(point, index),
@@ -328,6 +328,16 @@ module.exports = function(Chart) {
 			model.backgroundColor = me.getPointBackgroundColor(point, index);
 			model.borderColor = me.getPointBorderColor(point, index);
 			model.borderWidth = me.getPointBorderWidth(point, index);
+		},
+
+		getPointStyle: function(custom, dataset, index, pointOptions) {
+			var pointStyle = custom.pointStyle || dataset.pointStyle;
+
+			if (pointStyle instanceof Function) {
+				return pointStyle(index, dataset);
+			}
+
+			return helpers.valueAtIndexOrDefault(pointStyle, index, pointOptions.pointStyle);
 		}
 	});
 };

--- a/test/specs/controller.line.tests.js
+++ b/test/specs/controller.line.tests.js
@@ -730,4 +730,34 @@ describe('Line controller tests', function() {
 
 		expect(point._model.borderWidth).toBe(0);
 	});
+
+	it('should use the correct point style when provided a function', function() {
+		var chart = window.acquireChart({
+			type: 'line',
+			data: {
+				datasets: [{
+					data: [10, 15, 0, -4],
+					label: 'dataset1',
+					pointStyle: function(index, dataset) {
+						if (index === 0) {
+							return 'triangle';
+						} else if (index === dataset.data.length - 1) {
+							return 'square';
+						}
+						return 'circle';
+					}
+				}],
+				labels: ['label1', 'label2', 'label3', 'label4']
+			}
+		});
+
+		var meta = chart.getDatasetMeta(0);
+		var firstPoint = meta.data[0];
+		var secondPoint = meta.data[1];
+		var lastPoint = meta.data[3];
+
+		expect(firstPoint._model.pointStyle).toBe('triangle');
+		expect(secondPoint._model.pointStyle).toBe('circle');
+		expect(lastPoint._model.pointStyle).toBe('square');
+	});
 });


### PR DESCRIPTION
This enhancement adds the ability to ~~style the first and last data points of a line graph dataset differently than the middle points. For example (pulled from the new unit test):~~ pass in a function taking in an index and dataset, and returning a point style. For example:
```
type: 'line',
data: {
	datasets: [{
		data: [10, 15, 0, -4],
		label: 'dataset1',
		pointStyle: function(index, dataset) {
			if (index === 0) {
				return 'circle''
			}
			return 'square';
		}
	}],
	labels: ['label1', 'label2', 'label3', 'label4']
}
```

Our use case is in the medical field (Fortune 500 company looking to utilize this) where we need to visually differentiate the first and last data point as the start and stop points of medication dosages. This is to avoid any possible mistake by a clinician when looking at which dose (X-axis would be date/time of doses on a dosing schedule) is the start and stop.