### PR TITLE
replace self closing script tag with open and closing tags

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -11,7 +11,7 @@ First, we need to have a canvas in our page.
 Now that we have a canvas we can use, we need to include Chart.js in our page.
 
 ```html
-<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.4.0/Chart.min.js" />
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.4.0/Chart.min.js"></script>
 ```
 
 Now, we can create a chart. We add a script to our page:


### PR DESCRIPTION
The self closing script tag isn't recognized properly by some browsers. In the latest version of Chrome, all following tags are treated as children of the script tag.

This just replaces it with an open and closing tag.