### PR TITLE
Handle scaleLabel positioning when simple center would truncate

### DIFF
--- a/docs/axes/labelling.md
+++ b/docs/axes/labelling.md
@@ -10,6 +10,7 @@ The scale label configuration is nested under the scale configuration in the `sc
 | -----| ---- | --------| -----------
 | `display` | `Boolean` | `false` | If true, display the axis title.
 | `labelString` | `String` | `''` | The text for the title. (i.e. "# of People" or "Response Choices").
+| `constrain` | `Boolean` | `false` | If true, reduce labelString truncation by adjusting labelString position to fit in margins.
 | `lineHeight` | `Number` | `` | Height of an individual line of text. If not defined, the font size is used.
 | `fontColor` | Color | `'#666'` | Font color for scale title.
 | `fontFamily` | `String` | `"'Helvetica Neue', 'Helvetica', 'Arial', sans-serif"` | Font family for the scale title, follows CSS font-family options.


### PR DESCRIPTION
In Chart.js version 2.6.0 (and earlier), axis scaleLabel text is centred to the middle of graph body.  Longer label strings will truncate at the edge of the canvas.  Depending on the position of the graph in the canvas, either or both ends can be truncated.  When the graph is not centred in the canvas, better results can be obtained by adjusting the scaleLabel text placement.

This pr changes the scaleLabel positioning from center to start or end, and sets the origin point to the outer edge of the margin **only** when center would truncate the text.  The end is chosen to minimize the movement of the text, and to never truncate the first part of the text.

*  as long as the text does not truncate, leave it centred in the middle of the chart body
* if the start of the text would be truncated (off the edge of the canvas), set the alignment to 'start', and the placement position to the edge of the canvas.
* if the end of the text would be truncated (off the edge of the canvas), set the alignment to 'end', and the placement position to the edge of the canvas.

[Fiddle demonstrating truncation](https://jsfiddle.net/microMerlin/3wfoL7jc/) problem scenarios in v2.6.0 described in #4439 
[Fiddle demonstrating results](https://jsfiddle.net/microMerlin/9qLkwpqq/) for the same scenarios using library built using https://github.com/mMerlin/Chart.js/commit/351db6b2eb4b65f8a5d69e4e96079e5be05e8102

This is my first PR.  I have not seen any coding guidelines beyond what 'gulp lint' shows.  My usual coding style inserts a lot more comments than I see in the code I was looking at.  I figure minify can remove it for production, and the comments are useful when debugging.

I also do not know where my utility functions belong.  They might be better in helpers someplace.

Noted during development.  I do not know if these are bugs or just a lack of function usage documentation.

function computeTextSize() in core.scale.js takes a font as one of it´s parameters. It passes that to helpers.longestText() when the tick input is an array.  If tick is not an array, then it just returns 
```js
context.measureText(tick).width
```
but that is **without** using the passed font.  That means for it to work correctly, the font must be set in the context before calling the function.

helpers.longestText() sets the font in the context before calculating string lengths.  However, it does not wrap that with save and restore, so it would appear to modify the context of the caller.

One of those seems to be wrong.  Either always trust the existing context, always set it, or always save, set, and restore the context.