### PR TITLE
Allow category label definition at axis level

### DIFF
--- a/docs/axes/cartesian/category.md
+++ b/docs/axes/cartesian/category.md
@@ -1,12 +1,12 @@
 # Category Cartesian Axis
 
-The category scale will be familiar to those who have used v1.0. Labels are drawn from one of the label arrays included in the chart data. If only `data.labels` is defined, this will be used. If `data.xLabels` is defined and the axis is horizontal, this will be used. Similarly, if `data.yLabels` is defined and the axis is vertical, this property will be used. Using both `xLabels` and `yLabels` together can create a chart that uses strings for both the X and Y axes.
+The category scale will be familiar to those who have used v1.0. If global configuration is used, labels are drawn from one of the label arrays included in the chart data. If only `data.labels` is defined, this will be used. If `data.xLabels` is defined and the axis is horizontal, this will be used. Similarly, if `data.yLabels` is defined and the axis is vertical, this property will be used. Using both `xLabels` and `yLabels` together can create a chart that uses strings for both the X and Y axes.
 
-Specifying any of the settings above implicitly defines the x axis as `type: category`if not defined otherwise. For more fine-grained control of category labels, it is (as of 2.7) also possible to add `labels` as part of the explicit category axis definition.
+Specifying any of the settings above implicitly defines the x axis as `type: category`if not defined otherwise. For more fine-grained control of category labels it is also possible to add `labels` as part of the category axis definition. Doing so does not apply the global defaults for bar charts.
 
 ## Category Axis Definition
 
-Implicit:
+Globally:
 
 ```javascript
 let chart = new Chart(ctx, {
@@ -17,7 +17,7 @@ let chart = new Chart(ctx, {
     },
 });
 ```
-Explicit:
+As part of axis definition:
 
 ```javascript
 let chart = new Chart(ctx, {

--- a/docs/axes/cartesian/category.md
+++ b/docs/axes/cartesian/category.md
@@ -40,6 +40,7 @@ The category scale provides the following options for configuring tick marks. Th
 
 | Name | Type | Default | Description
 | -----| ---- | --------| -----------
+| labels | Array[String] | - | An array of labels to display.
 | `min` | `String` | | The minimum item to display. [more...](#min-max-configuration)
 | `max` | `String` | | The maximum item to display. [more...](#min-max-configuration)
 

--- a/docs/axes/cartesian/category.md
+++ b/docs/axes/cartesian/category.md
@@ -2,6 +2,38 @@
 
 The category scale will be familiar to those who have used v1.0. Labels are drawn from one of the label arrays included in the chart data. If only `data.labels` is defined, this will be used. If `data.xLabels` is defined and the axis is horizontal, this will be used. Similarly, if `data.yLabels` is defined and the axis is vertical, this property will be used. Using both `xLabels` and `yLabels` together can create a chart that uses strings for both the X and Y axes.
 
+Specifying any of the settings above implicitly defines the x axis as `type: category`if not defined otherwise. For more fine-grained control of category labels, it is (as of 2.7) also possible to add `labels` as part of the explicit category axis definition.
+
+## Category Axis Definition
+
+Implicit:
+
+```javascript
+let chart = new Chart(ctx, {
+    type: ...
+    data: {
+        labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+        datasets: ...
+    },
+});
+```
+Explicit:
+
+```javascript
+let chart = new Chart(ctx, {
+    type: ...
+    data: ...
+    options: {
+        scales: {
+            xAxes: [{
+                type: 'category',
+                labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+            }]
+        }
+    }
+});
+```
+
 ## Tick Configuration Options
 
 The category scale provides the following options for configuring tick marks. They are nested in the `ticks` sub object. These options extend the [common tick configuration](README.md#tick-configuration).

--- a/docs/axes/cartesian/category.md
+++ b/docs/axes/cartesian/category.md
@@ -1,8 +1,8 @@
 # Category Cartesian Axis
 
-The category scale will be familiar to those who have used v1.0. If global configuration is used, labels are drawn from one of the label arrays included in the chart data. If only `data.labels` is defined, this will be used. If `data.xLabels` is defined and the axis is horizontal, this will be used. Similarly, if `data.yLabels` is defined and the axis is vertical, this property will be used. Using both `xLabels` and `yLabels` together can create a chart that uses strings for both the X and Y axes.
+If global configuration is used, labels are drawn from one of the label arrays included in the chart data. If only `data.labels` is defined, this will be used. If `data.xLabels` is defined and the axis is horizontal, this will be used. Similarly, if `data.yLabels` is defined and the axis is vertical, this property will be used. Using both `xLabels` and `yLabels` together can create a chart that uses strings for both the X and Y axes.
 
-Specifying any of the settings above implicitly defines the x axis as `type: category`if not defined otherwise. For more fine-grained control of category labels it is also possible to add `labels` as part of the category axis definition. Doing so does not apply the global defaults for bar charts.
+Specifying any of the settings above defines the x axis as `type: category` if not defined otherwise. For more fine-grained control of category labels it is also possible to add `labels` as part of the category axis definition. Doing so does not apply the global defaults.
 
 ## Category Axis Definition
 

--- a/src/scales/scale.category.js
+++ b/src/scales/scale.category.js
@@ -15,7 +15,7 @@ module.exports = function(Chart) {
 		*/
 		getLabels: function() {
 			var data = this.chart.data;
-			return (this.isHorizontal() ? data.xLabels : data.yLabels) || data.labels;
+			return this.options.labels || (this.isHorizontal() ? data.xLabels : data.yLabels) || data.labels;
 		},
 
 		determineDataLimits: function() {

--- a/test/specs/scale.category.tests.js
+++ b/test/specs/scale.category.tests.js
@@ -108,7 +108,7 @@ describe('Category scale tests', function() {
 		expect(scale.ticks).toEqual(mockData.xLabels);
 	});
 
-	it('Should generate ticks from the data xLabels', function() {
+	it('Should generate ticks from the data yLabels', function() {
 		var scaleID = 'myScale';
 
 		var mockData = {
@@ -134,6 +134,36 @@ describe('Category scale tests', function() {
 		scale.determineDataLimits();
 		scale.buildTicks();
 		expect(scale.ticks).toEqual(mockData.yLabels);
+	});
+
+	it('Should generate ticks from the axis labels', function() {
+		var scaleID = 'myScale';
+
+		var mockData = {
+			datasets: [{
+				xAxisID: scaleID,
+				data: [10, 5, 0, 25, 78]
+			}]
+		};
+
+		var config = Chart.helpers.clone(Chart.scaleService.getScaleDefaults('category'));
+		config.position = 'left'; // y axis
+		config.id = scaleID;
+		config.labels = ['tick1', 'tick2', 'tick3', 'tick4', 'tick5'];
+
+		var Constructor = Chart.scaleService.getScaleConstructor('category');
+		var scale = new Constructor({
+			ctx: {},
+			options: config,
+			chart: {
+				data: mockData
+			},
+			id: scaleID
+		});
+
+		scale.determineDataLimits();
+		scale.buildTicks();
+		expect(scale.ticks).toEqual(config.labels);
 	});
 
 	it ('should get the correct label for the index', function() {

--- a/test/specs/scale.category.tests.js
+++ b/test/specs/scale.category.tests.js
@@ -148,7 +148,6 @@ describe('Category scale tests', function() {
 
 		var config = Chart.helpers.clone(Chart.scaleService.getScaleDefaults('category'));
 		config.position = 'left'; // y axis
-		config.id = scaleID;
 		config.labels = ['tick1', 'tick2', 'tick3', 'tick4', 'tick5'];
 
 		var Constructor = Chart.scaleService.getScaleConstructor('category');

--- a/test/specs/scale.category.tests.js
+++ b/test/specs/scale.category.tests.js
@@ -137,32 +137,25 @@ describe('Category scale tests', function() {
 	});
 
 	it('Should generate ticks from the axis labels', function() {
-		var scaleID = 'myScale';
-
-		var mockData = {
-			datasets: [{
-				xAxisID: scaleID,
+		var labels = ['tick1', 'tick2', 'tick3', 'tick4', 'tick5'];
+		var chart = window.acquireChart({
+			type: 'line',
+			data: {
 				data: [10, 5, 0, 25, 78]
-			}]
-		};
-
-		var config = Chart.helpers.clone(Chart.scaleService.getScaleDefaults('category'));
-		config.position = 'left'; // y axis
-		config.labels = ['tick1', 'tick2', 'tick3', 'tick4', 'tick5'];
-
-		var Constructor = Chart.scaleService.getScaleConstructor('category');
-		var scale = new Constructor({
-			ctx: {},
-			options: config,
-			chart: {
-				data: mockData
 			},
-			id: scaleID
+			options: {
+				scales: {
+					xAxes: [{
+						id: 'x',
+						type: 'category',
+						labels: labels
+					}]
+				}
+			}
 		});
 
-		scale.determineDataLimits();
-		scale.buildTicks();
-		expect(scale.ticks).toEqual(config.labels);
+		var scale = chart.scales.x;
+		expect(scale.ticks).toEqual(labels);
 	});
 
 	it ('should get the correct label for the index', function() {


### PR DESCRIPTION
Currently category labels can only be fined globally. This implies that

  - the can only be one category axis
  - category labels are applied to all other axis types, e.g. time even if not used

This PR fixes category labels being passed through moment.js when time axis exists (part of https://github.com/chartjs/Chart.js/issues/4498). Fiddle https://jsfiddle.net/andig2/b2a2ddsd/ shows js console warning that is removed by this PR.

Also allows defining multiple category axis which is currently not possible.

I have only limited experience with chartjs right now so I cannot be sure of cross-effects I'm not seeing- please review carefully.