### PR TITLE
Fix copy paste error in new docs with respect to settings for lines

### DIFF
--- a/docs/charts/line.md
+++ b/docs/charts/line.md
@@ -48,9 +48,9 @@ All point* properties can be specified as an array. If these are set to an array
 | `label` | `String` | The label for the dataset which appears in the legend and tooltips.
 | `xAxisID` | `String` | The ID of the x axis to plot this dataset on. If not specified, this defaults to the ID of the first found x axis
 | `yAxisID` | `String` | The ID of the y axis to plot this dataset on. If not specified, this defaults to the ID of the first found y axis.
-| `backgroundColor` | `Color/Color[]` | The fill color under the line. See [Colors](../general/colors.md#colors)
-| `borderColor` | `Color/Color[]` | The color of the line. See [Colors](../general/colors.md#colors)
-| `borderWidth` | `Number/Number[]` | The width of the line in pixels.
+| `backgroundColor` | `Color` | The fill color under the line. See [Colors](../general/colors.md#colors)
+| `borderColor` | `Color` | The color of the line. See [Colors](../general/colors.md#colors)
+| `borderWidth` | `Number/` | The width of the line in pixels.
 | `borderDash` | `Number[]` | Length and spacing of dashes. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash)
 | `borderDashOffset` | `Number` | Offset for line dashes. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineDashOffset)
 | `borderCapStyle` | `String` | Cap style of the line. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineCap)

--- a/docs/charts/radar.md
+++ b/docs/charts/radar.md
@@ -69,9 +69,9 @@ All point* properties can be specified as an array. If these are set to an array
 | Name | Type | Description
 | ---- | ---- | -----------
 | `label` | `String` | The label for the dataset which appears in the legend and tooltips.
-| `backgroundColor` | `Color/Color[]` | The fill color under the line. See [Colors](../general/colors.md#colors)
-| `borderColor` | `Color/Color[]` | The color of the line. See [Colors](../general/colors.md#colors)
-| `borderWidth` | `Number/Number[]` | The width of the line in pixels.
+| `backgroundColor` | `Color` | The fill color under the line. See [Colors](../general/colors.md#colors)
+| `borderColor` | `Color` | The color of the line. See [Colors](../general/colors.md#colors)
+| `borderWidth` | `Number` | The width of the line in pixels.
 | `borderDash` | `Number[]` | Length and spacing of dashes. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash)
 | `borderDashOffset` | `Number` | Offset for line dashes. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineDashOffset)
 | `borderCapStyle` | `String` | Cap style of the line. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineCap)


### PR DESCRIPTION
Fixes a minor copy paste error. For a line and radar charts, `borderColor`, backgroundColor`, and `borderWidth` cannot be arrays.