### PR TITLE
Enforce spaces around infix/unary words operators

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -197,8 +197,8 @@ rules:
   space-before-blocks: [2, always]
   space-before-function-paren: [2, never]
   space-in-parens: [2, never]
-  space-infix-ops: 0
-  space-unary-ops: 0
+  space-infix-ops: 2
+  space-unary-ops: [2, {words: true, nonwords: false}]
   spaced-comment: [2, always]
   unicode-bom: 0
   wrap-regex: 2

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,7 +23,6 @@ var package = require('./package.json');
 
 var srcDir = './src/';
 var outDir = './dist/';
-var testDir = './test/';
 
 var header = "/*!\n" +
   " * Chart.js\n" +
@@ -128,8 +127,9 @@ function packageTask() {
 
 function lintTask() {
   var files = [
-    srcDir + '**/*.js',
-    testDir + '**/*.js'
+    'samples/**/*.js',
+    'src/**/*.js',
+    'test/**/*.js'
   ];
 
   // NOTE(SB) codeclimate has 'complexity' and 'max-statements' eslint rules way too strict
@@ -174,8 +174,8 @@ function startTest() {
     './test/jasmine.index.js',
     './src/**/*.js',
   ].concat(
-    argv.inputs?
-      argv.inputs.split(';'):
+    argv.inputs ?
+      argv.inputs.split(';') :
       ['./test/specs/**/*.js']
   );
 }

--- a/samples/charts/area/analyser.js
+++ b/samples/charts/area/analyser.js
@@ -20,7 +20,7 @@
 				return;
 			}
 
-			for (i=0, ilen=datasets.length; i<ilen; ++i) {
+			for (i = 0, ilen = datasets.length; i < ilen; ++i) {
 				meta = chart.getDatasetMeta(i).$filler;
 				if (meta) {
 					dataset = datasets[i];

--- a/samples/utils.js
+++ b/samples/utils.js
@@ -41,8 +41,8 @@ window.randomScalingFactor = function() {
 
 		rand: function(min, max) {
 			var seed = this._seed;
-			min = min === undefined? 0 : min;
-			max = max === undefined? 1 : max;
+			min = min === undefined ? 0 : min;
+			max = max === undefined ? 1 : max;
 			this._seed = (seed * 9301 + 49297) % 233280;
 			return min + (this._seed / 233280) * (max - min);
 		},
@@ -59,7 +59,7 @@ window.randomScalingFactor = function() {
 			var data = [];
 			var i, value;
 
-			for (i=0; i<count; ++i) {
+			for (i = 0; i < count; ++i) {
 				value = (from[i] || 0) + this.rand(min, max);
 				if (this.rand() <= continuity) {
 					data.push(Math.round(dfactor * value) / dfactor);
@@ -76,14 +76,14 @@ window.randomScalingFactor = function() {
 			var min = cfg.min || 0;
 			var max = cfg.max || 100;
 			var count = cfg.count || 8;
-			var step = (max-min) / count;
+			var step = (max - min) / count;
 			var decimals = cfg.decimals || 8;
 			var dfactor = Math.pow(10, decimals) || 0;
 			var prefix = cfg.prefix || '';
 			var values = [];
 			var i;
 
-			for (i=min; i<max; i+=step) {
+			for (i = min; i < max; i += step) {
 				values.push(prefix + Math.round(dfactor * i) / dfactor);
 			}
 
@@ -97,8 +97,8 @@ window.randomScalingFactor = function() {
 			var values = [];
 			var i, value;
 
-			for (i=0; i<count; ++i) {
-				value = Months[Math.ceil(i)%12];
+			for (i = 0; i < count; ++i) {
+				value = Months[Math.ceil(i) % 12];
 				values.push(value.substring(0, section));
 			}
 
@@ -106,7 +106,7 @@ window.randomScalingFactor = function() {
 		},
 
 		transparentize: function(color, opacity) {
-			var alpha = opacity === undefined? 0.5 : 1 - opacity;
+			var alpha = opacity === undefined ? 0.5 : 1 - opacity;
 			return Chart.helpers.color(color).alpha(alpha).rgbString();
 		},
 

--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -156,11 +156,11 @@ module.exports = function(Chart) {
 			var ipixels = me.calculateBarIndexPixels(me.index, index, ruler);
 
 			model.horizontal = horizontal;
-			model.base = reset? base : vpixels.base;
-			model.x = horizontal? reset? base : vpixels.head : ipixels.center;
-			model.y = horizontal? ipixels.center : reset? base : vpixels.head;
-			model.height = horizontal? ipixels.size : undefined;
-			model.width = horizontal? undefined : ipixels.size;
+			model.base = reset ? base : vpixels.base;
+			model.x = horizontal ? reset ? base : vpixels.head : ipixels.center;
+			model.y = horizontal ? ipixels.center : reset ? base : vpixels.head;
+			model.height = horizontal ? ipixels.size : undefined;
+			model.width = horizontal ? undefined : ipixels.size;
 		},
 
 		/**
@@ -200,7 +200,7 @@ module.exports = function(Chart) {
 			var chart = me.chart;
 			var scale = me.getIndexScale();
 			var stacked = scale.options.stacked;
-			var ilen = last === undefined? chart.data.datasets.length : last + 1;
+			var ilen = last === undefined ? chart.data.datasets.length : last + 1;
 			var stacks = [];
 			var i, meta;
 
@@ -233,7 +233,7 @@ module.exports = function(Chart) {
 			var scale = me.getIndexScale();
 			var options = scale.options;
 			var stackCount = me.getStackCount();
-			var fullSize = scale.isHorizontal()? scale.width : scale.height;
+			var fullSize = scale.isHorizontal() ? scale.width : scale.height;
 			var tickSize = fullSize / scale.ticks.length;
 			var categorySize = tickSize * options.categoryPercentage;
 			var fullBarSize = categorySize / stackCount;
@@ -311,7 +311,7 @@ module.exports = function(Chart) {
 			var base = scale.getPixelForValue(null, index, datasetIndex, isCombo);
 			var size = ruler.barSize;
 
-			base -= isCombo? ruler.tickSize / 2 : 0;
+			base -= isCombo ? ruler.tickSize / 2 : 0;
 			base += ruler.fullBarSize * stackIndex;
 			base += ruler.categorySpacing / 2;
 			base += ruler.barSpacing / 2;
@@ -335,7 +335,7 @@ module.exports = function(Chart) {
 
 			helpers.canvas.clipArea(chart.ctx, chart.chartArea);
 
-			for (; i<ilen; ++i) {
+			for (; i < ilen; ++i) {
 				d = dataset.data[i];
 				if (d !== null && d !== undefined && !isNaN(d)) {
 					rects[i].draw();

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -86,7 +86,7 @@ module.exports = function(Chart) {
 			}
 
 			// Update Points
-			for (i=0, ilen=points.length; i<ilen; ++i) {
+			for (i = 0, ilen = points.length; i < ilen; ++i) {
 				me.updateElement(points[i], i, reset);
 			}
 
@@ -95,7 +95,7 @@ module.exports = function(Chart) {
 			}
 
 			// Now pivot the point for animation
-			for (i=0, ilen=points.length; i<ilen; ++i) {
+			for (i = 0, ilen = points.length; i < ilen; ++i) {
 				points[i].pivot();
 			}
 		},
@@ -296,7 +296,7 @@ module.exports = function(Chart) {
 			helpers.canvas.unclipArea(chart.ctx);
 
 			// Draw the points
-			for (; i<ilen; ++i) {
+			for (; i < ilen; ++i) {
 				points[i].draw(area);
 			}
 		},

--- a/src/core/core.animation.js
+++ b/src/core/core.animation.js
@@ -49,7 +49,7 @@ module.exports = function(Chart) {
 				chart.animating = true;
 			}
 
-			for (i=0, ilen=animations.length; i < ilen; ++i) {
+			for (i = 0, ilen = animations.length; i < ilen; ++i) {
 				if (animations[i].chart === chart) {
 					animations[i] = animation;
 					return;

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -82,7 +82,7 @@ module.exports = function(Chart) {
 			me.config = config;
 			me.width = width;
 			me.height = height;
-			me.aspectRatio = height? width / height : null;
+			me.aspectRatio = height ? width / height : null;
 			me.options = config.options;
 			me._bufferedRender = false;
 
@@ -546,7 +546,7 @@ module.exports = function(Chart) {
 		transition: function(easingValue) {
 			var me = this;
 
-			for (var i=0, ilen=(me.data.datasets || []).length; i<ilen; ++i) {
+			for (var i = 0, ilen = (me.data.datasets || []).length; i < ilen; ++i) {
 				if (me.isDatasetVisible(i)) {
 					me.getDatasetMeta(i).controller.transition(easingValue);
 				}
@@ -568,7 +568,7 @@ module.exports = function(Chart) {
 			}
 
 			// Draw datasets reversed to support proper line stacking
-			for (var i=(me.data.datasets || []).length - 1; i >= 0; --i) {
+			for (var i = (me.data.datasets || []).length - 1; i >= 0; --i) {
 				if (me.isDatasetVisible(i)) {
 					me.drawDataset(i, easingValue);
 				}
@@ -652,7 +652,7 @@ module.exports = function(Chart) {
 
 		getVisibleDatasetCount: function() {
 			var count = 0;
-			for (var i = 0, ilen = this.data.datasets.length; i<ilen; ++i) {
+			for (var i = 0, ilen = this.data.datasets.length; i < ilen; ++i) {
 				if (this.isDatasetVisible(i)) {
 					count++;
 				}
@@ -665,7 +665,7 @@ module.exports = function(Chart) {
 
 			// meta.hidden is a per chart dataset hidden flag override with 3 states: if true or false,
 			// the dataset.hidden value is ignored, else if null, the dataset hidden state is returned.
-			return typeof meta.hidden === 'boolean'? !meta.hidden : !this.data.datasets[datasetIndex].hidden;
+			return typeof meta.hidden === 'boolean' ? !meta.hidden : !this.data.datasets[datasetIndex].hidden;
 		},
 
 		generateLegend: function() {
@@ -762,10 +762,10 @@ module.exports = function(Chart) {
 		},
 
 		updateHoverStyle: function(elements, mode, enabled) {
-			var method = enabled? 'setHoverStyle' : 'removeHoverStyle';
+			var method = enabled ? 'setHoverStyle' : 'removeHoverStyle';
 			var element, i, ilen;
 
-			for (i=0, ilen=elements.length; i<ilen; ++i) {
+			for (i = 0, ilen = elements.length; i < ilen; ++i) {
 				element = elements[i];
 				if (element) {
 					this.getDatasetMeta(element._datasetIndex).controller[method](element);

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -170,7 +170,7 @@ module.exports = function(Chart) {
 			var metaData = meta.data;
 			var i, ilen;
 
-			for (i=0, ilen=data.length; i<ilen; ++i) {
+			for (i = 0, ilen = data.length; i < ilen; ++i) {
 				metaData[i] = metaData[i] || me.createMetaData(i);
 			}
 
@@ -214,7 +214,7 @@ module.exports = function(Chart) {
 			var ilen = elements.length;
 			var i = 0;
 
-			for (; i<ilen; ++i) {
+			for (; i < ilen; ++i) {
 				elements[i].transition(easingValue);
 			}
 
@@ -233,7 +233,7 @@ module.exports = function(Chart) {
 				meta.dataset.draw();
 			}
 
-			for (; i<ilen; ++i) {
+			for (; i < ilen; ++i) {
 				elements[i].draw();
 			}
 		},
@@ -284,7 +284,7 @@ module.exports = function(Chart) {
 		 * @private
 		 */
 		insertElements: function(start, count) {
-			for (var i=0; i<count; ++i) {
+			for (var i = 0; i < count; ++i) {
 				this.addElementAndReset(start + i);
 			}
 		},
@@ -293,7 +293,7 @@ module.exports = function(Chart) {
 		 * @private
 		 */
 		onDataPush: function() {
-			this.insertElements(this.getDataset().data.length-1, arguments.length);
+			this.insertElements(this.getDataset().data.length - 1, arguments.length);
 		},
 
 		/**

--- a/src/core/core.element.js
+++ b/src/core/core.element.js
@@ -7,7 +7,7 @@ function interpolate(start, view, model, ease) {
 	var keys = Object.keys(model);
 	var i, ilen, key, actual, origin, target, type, c0, c1;
 
-	for (i=0, ilen=keys.length; i<ilen; ++i) {
+	for (i = 0, ilen = keys.length; i < ilen; ++i) {
 		key = keys[i];
 
 		target = model[key];
@@ -30,9 +30,9 @@ function interpolate(start, view, model, ease) {
 
 		origin = start[key];
 
-		type = typeof(target);
+		type = typeof target;
 
-		if (type === typeof(origin)) {
+		if (type === typeof origin) {
 			if (type === 'string') {
 				c0 = color(origin);
 				if (c0.valid) {

--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -52,7 +52,7 @@ module.exports = function(Chart) {
 
 					for (i = 0; i < slen; ++i) {
 						scale = source[key][i];
-						type = helpers.valueOrDefault(scale.type, key === 'xAxes'? 'category' : 'linear');
+						type = helpers.valueOrDefault(scale.type, key === 'xAxes' ? 'category' : 'linear');
 
 						if (i >= target[key].length) {
 							target[key].push({});
@@ -88,12 +88,12 @@ module.exports = function(Chart) {
 
 		return filtered;
 	};
-	helpers.findIndex = Array.prototype.findIndex?
+	helpers.findIndex = Array.prototype.findIndex ?
 		function(array, callback, scope) {
 			return array.findIndex(callback, scope);
 		} :
 		function(array, callback, scope) {
-			scope = scope === undefined? array : scope;
+			scope = scope === undefined ? array : scope;
 			for (var i = 0, ilen = array.length; i < ilen; ++i) {
 				if (callback.call(scope, array[i], i, array)) {
 					return i;
@@ -175,7 +175,7 @@ module.exports = function(Chart) {
 			return min;
 		}, Number.POSITIVE_INFINITY);
 	};
-	helpers.sign = Math.sign?
+	helpers.sign = Math.sign ?
 		function(x) {
 			return Math.sign(x);
 		} :
@@ -186,7 +186,7 @@ module.exports = function(Chart) {
 			}
 			return x > 0 ? 1 : -1;
 		};
-	helpers.log10 = Math.log10?
+	helpers.log10 = Math.log10 ?
 		function(x) {
 			return Math.log10(x);
 		} :
@@ -446,7 +446,7 @@ module.exports = function(Chart) {
 	// Private helper function to convert max-width/max-height values that may be percentages into a number
 	function parseMaxStyle(styleValue, node, parentProperty) {
 		var valueInPixels;
-		if (typeof(styleValue) === 'string') {
+		if (typeof styleValue === 'string') {
 			valueInPixels = parseInt(styleValue, 10);
 
 			if (styleValue.indexOf('%') !== -1) {
@@ -484,8 +484,8 @@ module.exports = function(Chart) {
 
 		if (hasCNode || hasCContainer) {
 			return Math.min(
-				hasCNode? parseMaxStyle(constrainedNode, domNode, percentageProperty) : infinity,
-				hasCContainer? parseMaxStyle(constrainedContainer, parentNode, percentageProperty) : infinity);
+				hasCNode ? parseMaxStyle(constrainedNode, domNode, percentageProperty) : infinity,
+				hasCContainer ? parseMaxStyle(constrainedContainer, parentNode, percentageProperty) : infinity);
 		}
 
 		return 'none';
@@ -504,7 +504,7 @@ module.exports = function(Chart) {
 		var paddingRight = parseInt(helpers.getStyle(container, 'padding-right'), 10);
 		var w = container.clientWidth - paddingLeft - paddingRight;
 		var cw = helpers.getConstraintWidth(domNode);
-		return isNaN(cw)? w : Math.min(w, cw);
+		return isNaN(cw) ? w : Math.min(w, cw);
 	};
 	helpers.getMaximumHeight = function(domNode) {
 		var container = domNode.parentNode;
@@ -512,7 +512,7 @@ module.exports = function(Chart) {
 		var paddingBottom = parseInt(helpers.getStyle(container, 'padding-bottom'), 10);
 		var h = container.clientHeight - paddingTop - paddingBottom;
 		var ch = helpers.getConstraintHeight(domNode);
-		return isNaN(ch)? h : Math.min(h, ch);
+		return isNaN(ch) ? h : Math.min(h, ch);
 	};
 	helpers.getStyle = function(el, property) {
 		return el.currentStyle ?
@@ -604,7 +604,7 @@ module.exports = function(Chart) {
 		return numberOfLines;
 	};
 
-	helpers.color = !color?
+	helpers.color = !color ?
 		function(value) {
 			console.error('Color.js not found!');
 			return value;

--- a/src/core/core.layoutService.js
+++ b/src/core/core.layoutService.js
@@ -75,7 +75,7 @@ module.exports = function(Chart) {
 		 * @param {Object} layoutItem - the item to remove from the layout
 		 */
 		removeBox: function(chart, layoutItem) {
-			var index = chart.boxes? chart.boxes.indexOf(layoutItem) : -1;
+			var index = chart.boxes ? chart.boxes.indexOf(layoutItem) : -1;
 			if (index !== -1) {
 				chart.boxes.splice(index, 1);
 			}
@@ -93,7 +93,7 @@ module.exports = function(Chart) {
 			var i = 0;
 			var prop;
 
-			for (; i<ilen; ++i) {
+			for (; i < ilen; ++i) {
 				prop = props[i];
 				if (options.hasOwnProperty(prop)) {
 					item[prop] = options[prop];

--- a/src/core/core.plugin.js
+++ b/src/core/core.plugin.js
@@ -102,7 +102,7 @@ module.exports = function(Chart) {
 			var ilen = descriptors.length;
 			var i, descriptor, plugin, params, method;
 
-			for (i=0; i<ilen; ++i) {
+			for (i = 0; i < ilen; ++i) {
 				descriptor = descriptors[i];
 				plugin = descriptor.plugin;
 				method = plugin[hook];

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -378,8 +378,8 @@ module.exports = function(Chart) {
 					// Ensure that our ticks are always inside the canvas. When rotated, ticks are right aligned which means that the right padding is dominated
 					// by the font height
 					if (me.labelRotation !== 0) {
-						me.paddingLeft = opts.position === 'bottom'? (cosRotation * firstLabelWidth) + 3: (cosRotation * lineSpace) + 3; // add 3 px to move away from canvas edges
-						me.paddingRight = opts.position === 'bottom'? (cosRotation * lineSpace) + 3: (cosRotation * lastLabelWidth) + 3;
+						me.paddingLeft = opts.position === 'bottom' ? (cosRotation * firstLabelWidth) + 3 : (cosRotation * lineSpace) + 3; // add 3 px to move away from canvas edges
+						me.paddingRight = opts.position === 'bottom' ? (cosRotation * lineSpace) + 3 : (cosRotation * lastLabelWidth) + 3;
 					} else {
 						me.paddingLeft = firstLabelWidth / 2 + 3; // add 3 px to move away from canvas edges
 						me.paddingRight = lastLabelWidth / 2 + 3;
@@ -438,7 +438,7 @@ module.exports = function(Chart) {
 				return NaN;
 			}
 			// isNaN(object) returns true, so make sure NaN is checking for a number; Discard Infinite values
-			if (typeof(rawValue) === 'number' && !isFinite(rawValue)) {
+			if (typeof rawValue === 'number' && !isFinite(rawValue)) {
 				return NaN;
 			}
 			// If it is in fact an object, dive in one more level
@@ -627,13 +627,13 @@ module.exports = function(Chart) {
 
 					if (options.position === 'bottom') {
 						// bottom
-						textBaseline = !isRotated? 'top':'middle';
-						textAlign = !isRotated? 'center': 'right';
+						textBaseline = !isRotated ? 'top' : 'middle';
+						textAlign = !isRotated ? 'center' : 'right';
 						labelY = me.top + labelYOffset;
 					} else {
 						// top
-						textBaseline = !isRotated? 'bottom':'middle';
-						textAlign = !isRotated? 'center': 'left';
+						textBaseline = !isRotated ? 'bottom' : 'middle';
+						textAlign = !isRotated ? 'center' : 'left';
 						labelY = me.bottom - labelYOffset;
 					}
 

--- a/src/elements/element.point.js
+++ b/src/elements/element.point.js
@@ -85,18 +85,18 @@ module.exports = Element.extend({
 
 		// Cliping for Points.
 		// going out from inner charArea?
-		if ((chartArea !== undefined) && ((model.x < chartArea.left) || (chartArea.right*errMargin < model.x) || (model.y < chartArea.top) || (chartArea.bottom*errMargin < model.y))) {
+		if ((chartArea !== undefined) && ((model.x < chartArea.left) || (chartArea.right * errMargin < model.x) || (model.y < chartArea.top) || (chartArea.bottom * errMargin < model.y))) {
 			// Point fade out
 			if (model.x < chartArea.left) {
 				ratio = (x - model.x) / (chartArea.left - model.x);
-			} else if (chartArea.right*errMargin < model.x) {
+			} else if (chartArea.right * errMargin < model.x) {
 				ratio = (model.x - x) / (model.x - chartArea.right);
 			} else if (model.y < chartArea.top) {
 				ratio = (y - model.y) / (chartArea.top - model.y);
-			} else if (chartArea.bottom*errMargin < model.y) {
+			} else if (chartArea.bottom * errMargin < model.y) {
 				ratio = (model.y - y) / (model.y - chartArea.bottom);
 			}
-			ratio = Math.round(ratio*100) / 100;
+			ratio = Math.round(ratio * 100) / 100;
 			ctx.strokeStyle = color(ctx.strokeStyle).alpha(ratio).rgbString();
 			ctx.fillStyle = color(ctx.fillStyle).alpha(ratio).rgbString();
 		}

--- a/src/elements/element.rectangle.js
+++ b/src/elements/element.rectangle.js
@@ -66,7 +66,7 @@ module.exports = Element.extend({
 			top = vm.y;
 			bottom = vm.base;
 			signX = 1;
-			signY = bottom > top? 1: -1;
+			signY = bottom > top ? 1 : -1;
 			borderSkipped = vm.borderSkipped || 'bottom';
 		} else {
 			// horizontal bar
@@ -74,7 +74,7 @@ module.exports = Element.extend({
 			right = vm.x;
 			top = vm.y - vm.height / 2;
 			bottom = vm.y + vm.height / 2;
-			signX = right > left? 1: -1;
+			signX = right > left ? 1 : -1;
 			signY = 1;
 			borderSkipped = vm.borderSkipped || 'left';
 		}
@@ -84,13 +84,13 @@ module.exports = Element.extend({
 		if (borderWidth) {
 			// borderWidth shold be less than bar width and bar height.
 			var barSize = Math.min(Math.abs(left - right), Math.abs(top - bottom));
-			borderWidth = borderWidth > barSize? barSize: borderWidth;
+			borderWidth = borderWidth > barSize ? barSize : borderWidth;
 			var halfStroke = borderWidth / 2;
 			// Adjust borderWidth when bar top position is near vm.base(zero).
-			var borderLeft = left + (borderSkipped !== 'left'? halfStroke * signX: 0);
-			var borderRight = right + (borderSkipped !== 'right'? -halfStroke * signX: 0);
-			var borderTop = top + (borderSkipped !== 'top'? halfStroke * signY: 0);
-			var borderBottom = bottom + (borderSkipped !== 'bottom'? -halfStroke * signY: 0);
+			var borderLeft = left + (borderSkipped !== 'left' ? halfStroke * signX : 0);
+			var borderRight = right + (borderSkipped !== 'right' ? -halfStroke * signX : 0);
+			var borderTop = top + (borderSkipped !== 'top' ? halfStroke * signY : 0);
+			var borderBottom = bottom + (borderSkipped !== 'bottom' ? -halfStroke * signY : 0);
 			// not become a vertical line?
 			if (borderLeft !== borderRight) {
 				top = borderTop;

--- a/src/helpers/helpers.canvas.js
+++ b/src/helpers/helpers.canvas.js
@@ -27,8 +27,8 @@ var exports = module.exports = {
 	 */
 	roundedRect: function(ctx, x, y, width, height, radius) {
 		if (radius) {
-			var rx = Math.min(radius, width/2);
-			var ry = Math.min(radius, height/2);
+			var rx = Math.min(radius, width / 2);
+			var ry = Math.min(radius, height / 2);
 
 			ctx.moveTo(x + rx, y);
 			ctx.lineTo(x + width - rx, y);
@@ -180,10 +180,10 @@ var exports = module.exports = {
 		}
 
 		ctx.bezierCurveTo(
-			flip? previous.controlPointPreviousX : previous.controlPointNextX,
-			flip? previous.controlPointPreviousY : previous.controlPointNextY,
-			flip? target.controlPointNextX : target.controlPointPreviousX,
-			flip? target.controlPointNextY : target.controlPointPreviousY,
+			flip ? previous.controlPointPreviousX : previous.controlPointNextX,
+			flip ? previous.controlPointPreviousY : previous.controlPointNextY,
+			flip ? target.controlPointNextX : target.controlPointPreviousX,
+			flip ? target.controlPointNextY : target.controlPointPreviousY,
 			target.x,
 			target.y);
 	}

--- a/src/helpers/helpers.core.js
+++ b/src/helpers/helpers.core.js
@@ -37,7 +37,7 @@ var helpers = {
 	 * @returns {Boolean}
 	 * @function
 	 */
-	isArray: Array.isArray? Array.isArray : function(value) {
+	isArray: Array.isArray ? Array.isArray : function(value) {
 		return Object.prototype.toString.call(value) === '[object Array]';
 	},
 
@@ -58,7 +58,7 @@ var helpers = {
 	 * @returns {*}
 	 */
 	valueOrDefault: function(value, defaultValue) {
-		return typeof value === 'undefined'? defaultValue : value;
+		return typeof value === 'undefined' ? defaultValue : value;
 	},
 
 	/**
@@ -69,7 +69,7 @@ var helpers = {
 	 * @returns {*}
 	 */
 	valueAtIndexOrDefault: function(value, index, defaultValue) {
-		return helpers.valueOrDefault(helpers.isArray(value)? value[index] : value, defaultValue);
+		return helpers.valueOrDefault(helpers.isArray(value) ? value[index] : value, defaultValue);
 	},
 
 	/**
@@ -131,7 +131,7 @@ var helpers = {
 			return false;
 		}
 
-		for (i = 0, ilen=a0.length; i < ilen; ++i) {
+		for (i = 0, ilen = a0.length; i < ilen; ++i) {
 			v0 = a0[i];
 			v1 = a1[i];
 
@@ -164,7 +164,7 @@ var helpers = {
 			var klen = keys.length;
 			var k = 0;
 
-			for (; k<klen; ++k) {
+			for (; k < klen; ++k) {
 				target[keys[k]] = helpers.clone(source[keys[k]]);
 			}
 
@@ -215,7 +215,7 @@ var helpers = {
 	 * @returns {Object} The `target` object.
 	 */
 	merge: function(target, source, options) {
-		var sources = helpers.isArray(source)? source : [source];
+		var sources = helpers.isArray(source) ? source : [source];
 		var ilen = sources.length;
 		var merge, i, keys, klen, k;
 
@@ -226,14 +226,14 @@ var helpers = {
 		options = options || {};
 		merge = options.merger || helpers._merger;
 
-		for (i=0; i<ilen; ++i) {
+		for (i = 0; i < ilen; ++i) {
 			source = sources[i];
 			if (!helpers.isObject(source)) {
 				continue;
 			}
 
 			keys = Object.keys(source);
-			for (k=0, klen = keys.length; k<klen; ++k) {
+			for (k = 0, klen = keys.length; k < klen; ++k) {
 				merge(keys[k], target, source, options);
 			}
 		}

--- a/src/helpers/helpers.options.js
+++ b/src/helpers/helpers.options.js
@@ -15,7 +15,7 @@ module.exports = {
 	 * @since 2.7.0
 	 */
 	toLineHeight: function(value, size) {
-		var matches = (''+value).match(/^(normal|(\d+(?:\.\d+)?)(px|em|%)?)$/);
+		var matches = ('' + value).match(/^(normal|(\d+(?:\.\d+)?)(px|em|%)?)$/);
 		if (!matches || matches[1] === 'normal') {
 			return size * 1.2;
 		}

--- a/src/helpers/helpers.time.js
+++ b/src/helpers/helpers.time.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var moment = require('moment');
-moment = typeof(moment) === 'function' ? moment : window.moment;
+moment = typeof moment === 'function' ? moment : window.moment;
 
 var helpers = require('./helpers.core');
 
@@ -55,7 +55,7 @@ function generateTicksNiceRange(options, dataRange, niceRange) {
 	var ticks = [];
 	if (options.maxTicks) {
 		var stepSize = options.stepSize;
-		var startTick = helpers.isNullOrUndef(options.min)? niceRange.min : options.min;
+		var startTick = helpers.isNullOrUndef(options.min) ? niceRange.min : options.min;
 		var majorUnit = options.majorUnit;
 		var majorUnitStart = majorUnit ? moment(startTick).add(1, majorUnit).startOf(majorUnit) : startTick;
 		var startRange = majorUnitStart.valueOf() - startTick;

--- a/src/platforms/platform.dom.js
+++ b/src/platforms/platform.dom.js
@@ -39,7 +39,7 @@ var eventTypeMap = {
 function readUsedSize(element, property) {
 	var value = helpers.getStyle(element, property);
 	var matches = value && value.match(/^(\d+)(\.\d+)?px$/);
-	return matches? Number(matches[1]) : undefined;
+	return matches ? Number(matches[1]) : undefined;
 }
 
 /**
@@ -119,7 +119,7 @@ var supportsEventListenerOptions = (function() {
 
 // Default passive to true as expected by Chrome for 'touchstart' and 'touchend' events.
 // https://github.com/chartjs/Chart.js/issues/4287
-var eventListenerOptions = supportsEventListenerOptions? {passive: true} : false;
+var eventListenerOptions = supportsEventListenerOptions ? {passive: true} : false;
 
 function addEventListener(node, type, listener) {
 	node.addEventListener(type, listener, eventListenerOptions);
@@ -134,8 +134,8 @@ function createEvent(type, chart, x, y, nativeEvent) {
 		type: type,
 		chart: chart,
 		native: nativeEvent || null,
-		x: x !== undefined? x : null,
-		y: y !== undefined? y : null,
+		x: x !== undefined ? x : null,
+		y: y !== undefined ? y : null,
 	};
 }
 
@@ -149,18 +149,18 @@ function createResizer(handler) {
 	var iframe = document.createElement('iframe');
 	iframe.className = 'chartjs-hidden-iframe';
 	iframe.style.cssText =
-		'display:block;'+
-		'overflow:hidden;'+
-		'border:0;'+
-		'margin:0;'+
-		'top:0;'+
-		'left:0;'+
-		'bottom:0;'+
-		'right:0;'+
-		'height:100%;'+
-		'width:100%;'+
-		'position:absolute;'+
-		'pointer-events:none;'+
+		'display:block;' +
+		'overflow:hidden;' +
+		'border:0;' +
+		'margin:0;' +
+		'top:0;' +
+		'left:0;' +
+		'bottom:0;' +
+		'right:0;' +
+		'height:100%;' +
+		'width:100%;' +
+		'position:absolute;' +
+		'pointer-events:none;' +
 		'z-index:-1;';
 
 	// Prevent the iframe to gain focus on tab.

--- a/src/plugins/plugin.filler.js
+++ b/src/plugins/plugin.filler.js
@@ -29,20 +29,20 @@ module.exports = function() {
 			var points = (visible && meta.dataset._children) || [];
 			var length = points.length || 0;
 
-			return !length? null : function(point, i) {
+			return !length ? null : function(point, i) {
 				return (i < length && points[i]._view) || null;
 			};
 		},
 
 		boundary: function(source) {
 			var boundary = source.boundary;
-			var x = boundary? boundary.x : null;
-			var y = boundary? boundary.y : null;
+			var x = boundary ? boundary.x : null;
+			var y = boundary ? boundary.y : null;
 
 			return function(point) {
 				return {
-					x: x === null? point.x : x,
-					y: y === null? point.y : y,
+					x: x === null ? point.x : x,
+					y: y === null ? point.y : y,
 				};
 			};
 		}
@@ -114,9 +114,9 @@ module.exports = function() {
 		// controllers might still use it (e.g. the Smith chart).
 
 		if (fill === 'start') {
-			target = model.scaleBottom === undefined? scale.bottom : model.scaleBottom;
+			target = model.scaleBottom === undefined ? scale.bottom : model.scaleBottom;
 		} else if (fill === 'end') {
-			target = model.scaleTop === undefined? scale.top : model.scaleTop;
+			target = model.scaleTop === undefined ? scale.top : model.scaleTop;
 		} else if (model.scaleZero !== undefined) {
 			target = model.scaleZero;
 		} else if (scale.getBasePosition) {
@@ -133,8 +133,8 @@ module.exports = function() {
 			if (typeof target === 'number' && isFinite(target)) {
 				horizontal = scale.isHorizontal();
 				return {
-					x: horizontal? target : null,
-					y: horizontal? null : target
+					x: horizontal ? target : null,
+					y: horizontal ? null : target
 				};
 			}
 		}
@@ -201,16 +201,16 @@ module.exports = function() {
 
 		// building first area curve (normal)
 		ctx.moveTo(curve0[0].x, curve0[0].y);
-		for (i=1; i<len0; ++i) {
-			helpers.canvas.lineTo(ctx, curve0[i-1], curve0[i]);
+		for (i = 1; i < len0; ++i) {
+			helpers.canvas.lineTo(ctx, curve0[i - 1], curve0[i]);
 		}
 
 		// joining the two area curves
-		ctx.lineTo(curve1[len1-1].x, curve1[len1-1].y);
+		ctx.lineTo(curve1[len1 - 1].x, curve1[len1 - 1].y);
 
 		// building opposite area curve (reverse)
-		for (i=len1-1; i>0; --i) {
-			helpers.canvas.lineTo(ctx, curve1[i], curve1[i-1], true);
+		for (i = len1 - 1; i > 0; --i) {
+			helpers.canvas.lineTo(ctx, curve1[i], curve1[i - 1], true);
 		}
 	}
 
@@ -226,7 +226,7 @@ module.exports = function() {
 		ctx.beginPath();
 
 		for (i = 0, ilen = (count + !!loop); i < ilen; ++i) {
-			index = i%count;
+			index = i % count;
 			p0 = points[index]._view;
 			p1 = mapper(p0, index, view);
 			d0 = isDrawable(p0);
@@ -286,7 +286,7 @@ module.exports = function() {
 				sources.push(source);
 			}
 
-			for (i=0; i<count; ++i) {
+			for (i = 0; i < count; ++i) {
 				source = sources[i];
 				if (!source) {
 					continue;

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -19,7 +19,7 @@ defaults._set('global', {
 			var meta = ci.getDatasetMeta(index);
 
 			// See controller.isDatasetVisible comment
-			meta.hidden = meta.hidden === null? !ci.data.datasets[index].hidden : null;
+			meta.hidden = meta.hidden === null ? !ci.data.datasets[index].hidden : null;
 
 			// We hid a dataset ... rerender the chart
 			ci.update();

--- a/src/plugins/plugin.title.js
+++ b/src/plugins/plugin.title.js
@@ -153,7 +153,7 @@ module.exports = function(Chart) {
 					fontFamily = valueOrDefault(opts.fontFamily, globalDefaults.defaultFontFamily),
 					titleFont = helpers.fontString(fontSize, fontStyle, fontFamily),
 					lineHeight = helpers.options.toLineHeight(opts.lineHeight, fontSize),
-					offset = lineHeight/2 + opts.padding,
+					offset = lineHeight / 2 + opts.padding,
 					rotation = 0,
 					titleX,
 					titleY,

--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -206,7 +206,7 @@ module.exports = function(Chart) {
 					} else if (newVal === me.minNotZero) {
 						pixel = me.bottom - innerDimension * 0.02;
 					} else {
-						pixel = me.bottom - innerDimension * 0.02 - (innerDimension * 0.98/ range * (helpers.log10(newVal)-helpers.log10(me.minNotZero)));
+						pixel = me.bottom - innerDimension * 0.02 - (innerDimension * 0.98 / range * (helpers.log10(newVal) - helpers.log10(me.minNotZero)));
 					}
 				} else if (me.end === 0 && tickOpts.reverse) {
 					range = helpers.log10(me.start) - helpers.log10(me.minNotZero);
@@ -215,7 +215,7 @@ module.exports = function(Chart) {
 					} else if (newVal === me.minNotZero) {
 						pixel = me.top + innerDimension * 0.02;
 					} else {
-						pixel = me.top + innerDimension * 0.02 + (innerDimension * 0.98/ range * (helpers.log10(newVal)-helpers.log10(me.minNotZero)));
+						pixel = me.top + innerDimension * 0.02 + (innerDimension * 0.98 / range * (helpers.log10(newVal) - helpers.log10(me.minNotZero)));
 					}
 				} else if (newVal === 0) {
 					pixel = tickOpts.reverse ? me.top : me.bottom;

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -222,7 +222,7 @@ module.exports = function(Chart) {
 
 			for (var i = 0; i < text.length; ++i) {
 				ctx.fillText(text[i], position.x, y);
-				y+= spacing;
+				y += spacing;
 			}
 		} else {
 			ctx.fillText(text, position.x, position.y);

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -2,7 +2,7 @@
 'use strict';
 
 var moment = require('moment');
-moment = typeof(moment) === 'function' ? moment : window.moment;
+moment = typeof moment === 'function' ? moment : window.moment;
 
 var defaults = require('../core/core.defaults');
 var helpers = require('../helpers/index');
@@ -45,7 +45,7 @@ function buildLookupTable(timestamps, min, max, linear) {
 		items.push(max);
 	}
 
-	for (i = 0, ilen = items.length; i<ilen; ++i) {
+	for (i = 0, ilen = items.length; i < ilen; ++i) {
 		next = items[i + 1];
 		prev = items[i - 1];
 		curr = items[i];
@@ -331,8 +331,8 @@ module.exports = function(Chart) {
 			var majorFormat = me.majorDisplayFormat;
 			var majorTime = tick.clone().startOf(me.majorUnit).valueOf();
 			var major = majorUnit && majorFormat && time === majorTime;
-			var formattedTick = tick.format(major? majorFormat : me.displayFormat);
-			var tickOpts = major? options.ticks.major : options.ticks.minor;
+			var formattedTick = tick.format(major ? majorFormat : me.displayFormat);
+			var tickOpts = major ? options.ticks.major : options.ticks.minor;
 			var formatter = helpers.valueOrDefault(tickOpts.callback, tickOpts.userCallback);
 
 			if (formatter) {

--- a/test/jasmine.matchers.js
+++ b/test/jasmine.matchers.js
@@ -33,7 +33,7 @@ function buildPixelMatchPreview(actual, expected, diff, threshold, tolerance, co
 			'diff: ' + count + 'px ' +
 			'(' + toPercent(ratio) + '%)<br/>' +
 			'thr: ' + toPercent(threshold) + '%, ' +
-			'tol: '+ toPercent(tolerance) + '%'
+			'tol: ' + toPercent(tolerance) + '%'
 		}
 	].forEach(function(values) {
 		var item = document.createElement('div');
@@ -104,7 +104,7 @@ function toBeValidChart() {
 			}
 
 			return {
-				message: message? message : 'Expected ' + actual + ' to be valid chart',
+				message: message ? message : 'Expected ' + actual + ' to be valid chart',
 				pass: !message
 			};
 		}
@@ -149,7 +149,7 @@ function toBeChartOfSize() {
 			}
 
 			return {
-				message: message? message : 'Expected ' + actual + ' to be a chart of size ' + expected,
+				message: message ? message : 'Expected ' + actual + ' to be a chart of size ' + expected,
 				pass: !message
 			};
 		}
@@ -161,8 +161,8 @@ function toEqualImageData() {
 		compare: function(actual, expected, opts) {
 			var message = null;
 			var debug = opts.debug || false;
-			var tolerance = opts.tolerance === undefined? 0.001 : opts.tolerance;
-			var threshold = opts.threshold === undefined? 0.1 : opts.threshold;
+			var tolerance = opts.tolerance === undefined ? 0.001 : opts.tolerance;
+			var threshold = opts.threshold === undefined ? 0.1 : opts.threshold;
 			var ctx, idata, ddata, w, h, count, ratio;
 
 			if (actual instanceof Chart) {

--- a/test/jasmine.utils.js
+++ b/test/jasmine.utils.js
@@ -68,8 +68,8 @@ function acquireChart(config, options) {
 
 	// by default, remove chart animation and auto resize
 	config.options = config.options || {};
-	config.options.animation = config.options.animation === undefined? false : config.options.animation;
-	config.options.responsive = config.options.responsive === undefined? false : config.options.responsive;
+	config.options.animation = config.options.animation === undefined ? false : config.options.animation;
+	config.options.responsive = config.options.responsive === undefined ? false : config.options.responsive;
 	config.options.defaultFontFamily = config.options.defaultFontFamily || 'Arial';
 
 	wrapper.appendChild(canvas);

--- a/test/specs/controller.bubble.tests.js
+++ b/test/specs/controller.bubble.tests.js
@@ -162,7 +162,7 @@ describe('Bubble controller tests', function() {
 
 		chart.update();
 
-		for (var i=0; i<4; ++i) {
+		for (var i = 0; i < 4; ++i) {
 			expect(meta.data[i]._model).toEqual(jasmine.objectContaining({
 				backgroundColor: 'rgb(98, 98, 98)',
 				borderColor: 'rgb(8, 8, 8)',

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -10,7 +10,7 @@ describe('Chart', function() {
 			setTimeout(callback, 50);
 		};
 
-		Chart.helpers.addEvent(content, state !== 'complete'? 'load' : 'resize', handler);
+		Chart.helpers.addEvent(content, state !== 'complete' ? 'load' : 'resize', handler);
 	}
 
 	// https://github.com/chartjs/Chart.js/issues/2481

--- a/test/specs/global.deprecations.tests.js
+++ b/test/specs/global.deprecations.tests.js
@@ -104,7 +104,7 @@ describe('Deprecations', function() {
 
 				var calls = ctx.getCalls();
 				expect(calls[0]).toEqual({name: 'beginPath', args: []});
-				expect(calls[calls.length-1]).toEqual({name: 'closePath', args: []});
+				expect(calls[calls.length - 1]).toEqual({name: 'closePath', args: []});
 				expect(Chart.helpers.canvas.roundedRect).toHaveBeenCalledWith(ctx, 10, 20, 30, 40, 5);
 			});
 		});
@@ -172,7 +172,7 @@ describe('Deprecations', function() {
 				expect(proxy.canvas instanceof HTMLCanvasElement).toBeTruthy();
 				expect(proxy.ctx instanceof CanvasRenderingContext2D).toBeTruthy();
 				expect(proxy.currentDevicePixelRatio).toBe(window.devicePixelRatio || 1);
-				expect(proxy.aspectRatio).toBe(140/320);
+				expect(proxy.aspectRatio).toBe(140 / 320);
 				expect(proxy.height).toBe(320);
 				expect(proxy.width).toBe(140);
 			});

--- a/test/specs/helpers.core.tests.js
+++ b/test/specs/helpers.core.tests.js
@@ -150,7 +150,7 @@ describe('Chart.helpers.core', function() {
 		it('should return the value returned by fn', function() {
 			expect(helpers.callback(helpers.noop, [41])).toBe(undefined);
 			expect(helpers.callback(function(i) {
-				return i+1;
+				return i + 1;
 			}, [41])).toBe(42);
 		});
 	});

--- a/test/specs/helpers.easing.tests.js
+++ b/test/specs/helpers.easing.tests.js
@@ -45,8 +45,8 @@ describe('Chart.helpers.easing', function() {
 			var values = [];
 			var i;
 
-			for (i=0; i<=count; ++i) {
-				values.push(Math.round(accuracy * fn(i/count)) / accuracy);
+			for (i = 0; i <= count; ++i) {
+				values.push(Math.round(accuracy * fn(i / count)) / accuracy);
 			}
 
 			return values;

--- a/test/specs/platform.dom.tests.js
+++ b/test/specs/platform.dom.tests.js
@@ -10,7 +10,7 @@ describe('Platform.dom', function() {
 			setTimeout(callback, 50);
 		};
 
-		Chart.helpers.addEvent(content, state !== 'complete'? 'load' : 'resize', handler);
+		Chart.helpers.addEvent(content, state !== 'complete' ? 'load' : 'resize', handler);
 	}
 
 	describe('context acquisition', function() {


### PR DESCRIPTION
Enable ESLint `space-infix-ops` and `space-unary-ops` (for words only) rules. Also added `samples` to the linting task to match Code Climate expectations.

http://eslint.org/docs/rules/space-infix-ops
http://eslint.org/docs/rules/space-unary
