### PR TITLE
Rewrite unit test waitForResize helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,8 @@ sudo: required
 dist: trusty
 
 addons:
+  chrome: stable
   firefox: latest
-  apt:
-    sources:
-      - google-chrome
-    packages:
-      - google-chrome-stable
-
 
 # IMPORTANT: scripts require GITHUB_AUTH_TOKEN and GITHUB_AUTH_EMAIL environment variables
 # IMPORTANT: scripts has to be set executables in the Git repository (error 127)

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -5,6 +5,7 @@ globals:
   acquireChart: true
   Chart: true
   moment: true
+  waitForResize: true
 
 # http://eslint.org/docs/rules/
 rules:

--- a/test/jasmine.index.js
+++ b/test/jasmine.index.js
@@ -24,6 +24,7 @@ var utils = require('./jasmine.utils');
 
 	window.acquireChart = acquireChart;
 	window.releaseChart = releaseChart;
+	window.waitForResize = utils.waitForResize;
 	window.createMockContext = createMockContext;
 
 	// some style initialization to limit differences between browsers across different plateforms.

--- a/test/jasmine.utils.js
+++ b/test/jasmine.utils.js
@@ -149,10 +149,20 @@ function specsFromFixtures(path) {
 	};
 }
 
+function waitForResize(chart, callback) {
+	var override = chart.resize;
+	chart.resize = function() {
+		chart.resize = override;
+		override.apply(this, arguments);
+		callback();
+	};
+}
+
 module.exports = {
 	injectCSS: injectCSS,
 	createCanvas: createCanvas,
 	acquireChart: acquireChart,
 	releaseChart: releaseChart,
-	specsFromFixtures: specsFromFixtures
+	specsFromFixtures: specsFromFixtures,
+	waitForResize: waitForResize
 };

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -1,18 +1,5 @@
 describe('Chart', function() {
 
-	function waitForResize(chart, callback) {
-		var resizer = chart.canvas.parentNode._chartjs.resizer;
-		var content = resizer.contentWindow || resizer;
-		var state = content.document.readyState || 'complete';
-		var handler = function() {
-			Chart.helpers.removeEvent(content, 'load', handler);
-			Chart.helpers.removeEvent(content, 'resize', handler);
-			setTimeout(callback, 50);
-		};
-
-		Chart.helpers.addEvent(content, state !== 'complete' ? 'load' : 'resize', handler);
-	}
-
 	// https://github.com/chartjs/Chart.js/issues/2481
 	// See global.deprecations.tests.js for backward compatibility
 	it('should be defined and prototype of chart instances', function() {

--- a/test/specs/platform.dom.tests.js
+++ b/test/specs/platform.dom.tests.js
@@ -1,18 +1,5 @@
 describe('Platform.dom', function() {
 
-	function waitForResize(chart, callback) {
-		var resizer = chart.canvas.parentNode._chartjs.resizer;
-		var content = resizer.contentWindow || resizer;
-		var state = content.document.readyState || 'complete';
-		var handler = function() {
-			Chart.helpers.removeEvent(content, 'load', handler);
-			Chart.helpers.removeEvent(content, 'resize', handler);
-			setTimeout(callback, 50);
-		};
-
-		Chart.helpers.addEvent(content, state !== 'complete' ? 'load' : 'resize', handler);
-	}
-
 	describe('context acquisition', function() {
 		var canvasId = 'chartjs-canvas';
 


### PR DESCRIPTION
The original implementation tries to intercept events from the chart internal iframe, which ones [failing on Chrome 60](4564). Checking internals doesn't seem the best approach, instead we could consider that a chart has been resized after the resize method has been called and processed. So let's hook `Chart.resize` and callback once it's done.

This PR would replace #4564 since it doesn't force us to switch on Chrome beta (even temporary) and also fixes running unit test locally.

@benmccann 