### PR TITLE
Replace the IFRAME resizer by DIVs

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -731,9 +731,7 @@ module.exports = function(Chart) {
 				listeners[type] = listener;
 			});
 
-			// Responsiveness is currently based on the use of an iframe, however this method causes
-			// performance issues and could be troublesome when used with ad blockers. So make sure
-			// that the user is still able to create a chart without iframe when responsive is false.
+			// Elements used to detect size change should not be injected for non responsive charts.
 			// See https://github.com/chartjs/Chart.js/issues/2210
 			if (me.options.responsive) {
 				listener = function() {

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -420,7 +420,8 @@ describe('Chart', function() {
 
 			waitForResize(chart, function() {
 				var resizer = wrapper.firstChild;
-				expect(resizer.tagName).toBe('IFRAME');
+				expect(resizer.className).toBe('chartjs-size-monitor');
+				expect(resizer.tagName).toBe('DIV');
 				expect(chart).toBeChartOfSize({
 					dw: 455, dh: 355,
 					rw: 455, rh: 355,
@@ -687,7 +688,8 @@ describe('Chart', function() {
 				var wrapper = chart.canvas.parentNode;
 				var resizer = wrapper.firstChild;
 				expect(wrapper.childNodes.length).toBe(2);
-				expect(resizer.tagName).toBe('IFRAME');
+				expect(resizer.className).toBe('chartjs-size-monitor');
+				expect(resizer.tagName).toBe('DIV');
 
 				chart.destroy();
 


### PR DESCRIPTION
Resize detection is now based on scroll events from two divs nested under a main one. Implementation inspired from https://github.com/marcj/css-element-queries.

Replaces #3875
Fixes #2024
Fixes #4534

