### PR TITLE
Remove unused Chart.Ticks.generators.time

### DIFF
--- a/src/chart.js
+++ b/src/chart.js
@@ -13,7 +13,6 @@ Chart.Element = require('./core/core.element');
 Chart.elements = require('./elements/index');
 Chart.Interaction = require('./core/core.interaction');
 Chart.platform = require('./platforms/platform');
-Chart.Ticks = require('./core/core.ticks');
 
 require('./core/core.plugin')(Chart);
 require('./core/core.animation')(Chart);

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -407,10 +407,6 @@ module.exports = function(Chart) {
 		}
 	};
 
-	Chart.Ticks.generators.time = function(opts, range) {
-		return generate(range.min, range.max, opts.unit, opts.majorUnit, opts.stepSize, opts.timeOpts);
-	};
-
 	var TimeScale = Chart.Scale.extend({
 		initialize: function() {
 			if (!moment) {


### PR DESCRIPTION
Turns out this is unused since https://github.com/chartjs/Chart.js/pull/4549

Fixes https://github.com/chartjs/Chart.js/issues/4599