### PR TITLE
Scales: add axis to `convertTicksToLabels` callback

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -298,7 +298,7 @@ module.exports = function(Chart) {
 			var me = this;
 			// Convert ticks to strings
 			var tickOpts = me.options.ticks;
-			me.ticks = me.ticks.map(tickOpts.userCallback || tickOpts.callback);
+			me.ticks = me.ticks.map(tickOpts.userCallback || tickOpts.callback, this);
 		},
 		afterTickToLabelConversion: function() {
 			helpers.callback(this.options.afterTickToLabelConversion, [this]);


### PR DESCRIPTION
For tick formatting it can be beneficial to have access to the axis. This PR adds the axis as `this` parameter- apparently this is amongst the few callbacks that didn't have `this` yet.

Note: all other scale events are passing `[this]` which is an array of `ChartElement`. I couldn't figure why the array notation but it might make sense to use the same here instead of the blunt `this`.