### PR TITLE
Update codeclimate.yml

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -14,6 +14,7 @@ ratings:
   - "src/**/*.js"
 exclude_paths:
 - '.github/'
+- 'dist/'
 - 'test/'
 - 'docs/'
 - 'samples/'

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,8 +4,6 @@ engines:
     config:
       languages:
       - javascript
-    exclude_paths:
-    - "samples/samples.js"
   eslint:
     enabled: true
     channel: "eslint-3"
@@ -15,7 +13,12 @@ ratings:
   paths:
   - "src/**/*.js"
 exclude_paths:
-- dist/**/*
-- node_modules/**/*
-- test/**/*
-- coverage/**/*
+- '.github/'
+- 'test/'
+- 'docs/'
+- 'samples/'
+- 'scripts/'
+- '**.md'
+- '**.json'
+- 'gulpfile.js'
+- 'karma.conf.js'


### PR DESCRIPTION
Updates codeclimate to only include files that are actually being scored. Currently there are many files that do not contribute to the overall score (such as markdown docs) but they add clutter to the codeclimate interface. This change removes those documents from showing up on codeclimate.