### PR TITLE
remove redundant tooltip initialize

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -727,7 +727,6 @@ module.exports = function(Chart) {
 				_data: me.data,
 				_options: me.options.tooltips
 			}, me);
-			me.tooltip.initialize();
 		},
 
 		/**


### PR DESCRIPTION
`Tooltip` is extended from Element, which already did the [initialize call](https://github.com/chartjs/Chart.js/blob/master/src/core/core.element.js#L57).