### PR TITLE
Check for missing values before getting radius

### DIFF
--- a/src/controllers/controller.bubble.js
+++ b/src/controllers/controller.bubble.js
@@ -96,7 +96,7 @@ module.exports = function(Chart) {
 		},
 
 		getRadius: function(value) {
-			return value.r || this.chart.options.elements.point.radius;
+			return (value && typeof value.r !== 'undefined') ? value.r : this.chart.options.elements.point.radius;
 		},
 
 		setHoverStyle: function(point) {


### PR DESCRIPTION
The value object is verified before attempting to access the radius.  This may result in a slight behavior difference since the original code would not allow a radius of zero.  I think that allowing a zero radius is legitimate use though.