### PR TITLE
Allow dynamic bubble chart point styles

### DIFF
--- a/src/controllers/controller.bubble.js
+++ b/src/controllers/controller.bubble.js
@@ -96,7 +96,7 @@ module.exports = function(Chart) {
 		},
 
 		getRadius: function(value) {
-			return value.r || this.chart.options.elements.point.radius;
+			return (value && typeof value.r !== 'undefined') ? value.r : this.chart.options.elements.point.radius;
 		},
 
 		setHoverStyle: function(point) {

--- a/src/controllers/controller.bubble.js
+++ b/src/controllers/controller.bubble.js
@@ -80,6 +80,7 @@ module.exports = function(Chart) {
 					y: reset ? yScale.getBasePixel() : yScale.getPixelForValue(data, index, dsIndex),
 					// Appearance
 					radius: reset ? 0 : custom.radius ? custom.radius : me.getRadius(data),
+					pointStyle: reset ? pointElementOptions.pointStyle : custom.pointStyle ? custom.pointStyle : helpers.getValueAtIndexOrDefault(dataset.pointStyle, index, pointElementOptions.pointStyle),
 
 					// Tooltip
 					hitRadius: custom.hitRadius ? custom.hitRadius : helpers.valueAtIndexOrDefault(dataset.hitRadius, index, pointElementOptions.hitRadius)


### PR DESCRIPTION
Bubble charts did not allow setting the pointStyle attribute when updating a dataset.