### PR TITLE
Fix a bar overlap issue with unordered labels

### DIFF
--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -257,6 +257,8 @@ module.exports = function(Chart) {
 				}
 			}
 
+			// The ordered pixels and the index translation table are stored in the ruler.
+			// They are used for bar width calculation.
 			pixels.sort(function(a, b) {
 				return a.value - b.value;
 			});
@@ -333,6 +335,7 @@ module.exports = function(Chart) {
 			var end = ruler.end;
 			var base, leftSampleSize, rightSampleSize, leftCategorySize, rightCategorySize, fullBarSize, size;
 
+			// The index is translated so that it points to the ordered pixel
 			index = ruler.order[index];
 			base = pixels[index];
 

--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -243,17 +243,31 @@ module.exports = function(Chart) {
 			var stackCount = me.getStackCount();
 			var datasetIndex = me.index;
 			var pixels = [];
+			var orderedPixels = [];
+			var order = [];
 			var isHorizontal = scale.isHorizontal();
 			var start = isHorizontal ? scale.left : scale.top;
 			var end = start + (isHorizontal ? scale.width : scale.height);
-			var i, ilen;
+			var i, ilen, pixel;
 
 			for (i = 0, ilen = me.getMeta().data.length; i < ilen; ++i) {
-				pixels.push(scale.getPixelForValue(null, i, datasetIndex));
+				pixel = scale.getPixelForValue(null, i, datasetIndex);
+				if (pixel !== undefined) {
+					pixels.push({index: i, value: pixel});
+				}
+			}
+
+			pixels.sort(function(a, b) {
+				return a.value - b.value;
+			});
+			for (i = 0, ilen = pixels.length; i < ilen; ++i) {
+				orderedPixels.push(pixels[i].value);
+				order[pixels[i].index] = i;
 			}
 
 			return {
-				pixels: pixels,
+				pixels: orderedPixels,
+				order: order,
 				start: start,
 				end: end,
 				stackCount: stackCount,
@@ -314,11 +328,13 @@ module.exports = function(Chart) {
 			var options = ruler.scale.options;
 			var stackIndex = me.getStackIndex(datasetIndex);
 			var pixels = ruler.pixels;
-			var base = pixels[index];
 			var length = pixels.length;
 			var start = ruler.start;
 			var end = ruler.end;
-			var leftSampleSize, rightSampleSize, leftCategorySize, rightCategorySize, fullBarSize, size;
+			var base, leftSampleSize, rightSampleSize, leftCategorySize, rightCategorySize, fullBarSize, size;
+
+			index = ruler.order[index];
+			base = pixels[index];
 
 			if (length === 1) {
 				leftSampleSize = base > start ? base - start : end - base;


### PR DESCRIPTION
When a time scale is used and labels or datasets for bars are unordered, bars will overlap each other. This PR fixes the issue by sorting bar positions when creating the ruler.

Current version: https://jsfiddle.net/msL6xL83/
Proposed  version: https://jsfiddle.net/xdajx1mb/