### PR TITLE
Fix an issue with steppedLine in the filler plugin

### DIFF
--- a/src/helpers/helpers.canvas.js
+++ b/src/helpers/helpers.canvas.js
@@ -165,7 +165,7 @@ var exports = module.exports = {
 
 	lineTo: function(ctx, previous, target, flip) {
 		if (target.steppedLine) {
-			if (target.steppedLine === 'after') {
+			if ((target.steppedLine === 'after' && !flip) || (target.steppedLine !== 'after' && flip)) {
 				ctx.lineTo(previous.x, target.y);
 			} else {
 				ctx.lineTo(target.x, previous.y);


### PR DESCRIPTION
- Add a check for `flip` when building a stepped line path.
- This fixes #4696.