### PR TITLE
Add platform fallback implementation

### DIFF
--- a/src/platforms/platform.basic.js
+++ b/src/platforms/platform.basic.js
@@ -1,0 +1,15 @@
+/**
+ * Platform fallback implementation (minimal).
+ * @see https://github.com/chartjs/Chart.js/pull/4591#issuecomment-319575939
+ */
+
+module.exports = {
+	acquireContext: function(item) {
+		if (item && item.canvas) {
+			// Support for any object associated to a canvas (including a context2d)
+			item = item.canvas;
+		}
+
+		return item && item.getContext('2d') || null;
+	}
+};

--- a/src/platforms/platform.dom.js
+++ b/src/platforms/platform.dom.js
@@ -305,6 +305,13 @@ function injectCSS(platform, css) {
 }
 
 module.exports = {
+	/**
+	 * This property holds whether this platform is enabled for the current environment.
+	 * Currently used by platform.js to select the proper implementation.
+	 * @private
+	 */
+	_enabled: typeof window !== 'undefined' && typeof document !== 'undefined',
+
 	initialize: function() {
 		var keyframes = 'from{opacity:0.99}to{opacity:1}';
 

--- a/src/platforms/platform.js
+++ b/src/platforms/platform.js
@@ -1,10 +1,11 @@
 'use strict';
 
 var helpers = require('../helpers/index');
+var basic = require('./platform.basic');
+var dom = require('./platform.dom');
 
-// By default, select the browser (DOM) platform.
 // @TODO Make possible to select another platform at build time.
-var implementation = require('./platform.dom');
+var implementation = dom._enabled ? dom : basic;
 
 /**
  * @namespace Chart.platform


### PR DESCRIPTION
If `window` or `document` are `undefined`, a minimal platform implementation is used instead, which one only returns a context2d read from the given canvas/context.

Relates to #4591
