### PR TITLE
Update chartjs-color dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "main": "Chart.js"
   },
   "dependencies": {
-    "chartjs-color": "^2.1.0",
-    "moment": "^2.18.1"
+    "chartjs-color": "~2.2.0",
+    "moment": "~2.18.0"
   }
 }


### PR DESCRIPTION
I think that's a good practice to enforce dependencies minor versions (tilde symbol: include everything greater than a particular version in the same minor range).
