### PR TITLE
Add custom angles to polar area graph

### DIFF
--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -146,16 +146,19 @@ module.exports = function(Chart) {
 			var animationOpts = opts.animation;
 			var scale = chart.scale;
 			var labels = chart.data.labels;
+			var customAngles = opts.customAngles;
 
-			var circumference = me.calculateCircumference(dataset.data[index]);
+			var circumference = me.calculateCircumference(dataset.data[index], index);
 			var centerX = scale.xCenter;
 			var centerY = scale.yCenter;
 
 			// If there is NaN data before us, we need to calculate the starting angle correctly.
 			// We could be way more efficient here, but its unlikely that the polar area chart will have a lot of data
+			var previousAngle = 0
 			var visibleCount = 0;
 			var meta = me.getMeta();
 			for (var i = 0; i < index; ++i) {
+				previousAngle += customAngles[visibleCount]
 				if (!isNaN(dataset.data[i]) && !meta.data[i].hidden) {
 					++visibleCount;
 				}
@@ -164,7 +167,7 @@ module.exports = function(Chart) {
 			// var negHalfPI = -0.5 * Math.PI;
 			var datasetStartAngle = opts.startAngle;
 			var distance = arc.hidden ? 0 : scale.getDistanceFromCenterForValue(dataset.data[index]);
-			var startAngle = datasetStartAngle + (circumference * visibleCount);
+			var startAngle = datasetStartAngle + previousAngle
 			var endAngle = startAngle + (arc.hidden ? 0 : circumference);
 
 			var resetRadius = animationOpts.animateScale ? 0 : scale.getDistanceFromCenterForValue(dataset.data[index]);
@@ -211,12 +214,14 @@ module.exports = function(Chart) {
 			return count;
 		},
 
-		calculateCircumference: function(value) {
+		calculateCircumference: function (value, index) {
+			var me = this;
+			var chart = me.chart;
+			var opts = chart.options;
+			var customAngles = opts.customAngles;
 			var count = this.getMeta().count;
 			if (count > 0 && !isNaN(value)) {
-				return (2 * Math.PI) / count;
+				return count == 1 ? 2 * Math.PI : customAngles[index];
 			}
-			return 0;
-		}
 	});
 };

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -154,11 +154,11 @@ module.exports = function(Chart) {
 
 			// If there is NaN data before us, we need to calculate the starting angle correctly.
 			// We could be way more efficient here, but its unlikely that the polar area chart will have a lot of data
-			var previousAngle = 0
+			var previousAngle = 0;
 			var visibleCount = 0;
 			var meta = me.getMeta();
 			for (var i = 0; i < index; ++i) {
-				previousAngle += customAngles[visibleCount]
+				previousAngle += customAngles[visibleCount];
 				if (!isNaN(dataset.data[i]) && !meta.data[i].hidden) {
 					++visibleCount;
 				}
@@ -167,7 +167,7 @@ module.exports = function(Chart) {
 			// var negHalfPI = -0.5 * Math.PI;
 			var datasetStartAngle = opts.startAngle;
 			var distance = arc.hidden ? 0 : scale.getDistanceFromCenterForValue(dataset.data[index]);
-			var startAngle = datasetStartAngle + previousAngle
+			var startAngle = datasetStartAngle + previousAngle;
 			var endAngle = startAngle + (arc.hidden ? 0 : circumference);
 
 			var resetRadius = animationOpts.animateScale ? 0 : scale.getDistanceFromCenterForValue(dataset.data[index]);
@@ -214,14 +214,14 @@ module.exports = function(Chart) {
 			return count;
 		},
 
-		calculateCircumference: function (value, index) {
+		calculateCircumference: function(value, index) {
 			var me = this;
 			var chart = me.chart;
 			var opts = chart.options;
 			var customAngles = opts.customAngles;
 			var count = this.getMeta().count;
 			if (count > 0 && !isNaN(value)) {
-				return count == 1 ? 2 * Math.PI : customAngles[index];
+				return count === 1 ? 2 * Math.PI : customAngles[index];
 			}
 			return 0;
 		}

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -223,6 +223,7 @@ module.exports = function(Chart) {
 			if (count > 0 && !isNaN(value)) {
 				return count == 1 ? 2 * Math.PI : customAngles[index];
 			}
+			return 0;
 		}
 	});
 };

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -223,5 +223,6 @@ module.exports = function(Chart) {
 			if (count > 0 && !isNaN(value)) {
 				return count == 1 ? 2 * Math.PI : customAngles[index];
 			}
+		}
 	});
 };


### PR DESCRIPTION
## Old Behavior
Every angle is 360/#values °

## New Behavior
Provide custom value for each angle of the polar graph.

## Solution

```
  	var options = {
 		type: 'polarArea',
 		data: {
 		labels: ["A", "B", "C", "D", "E"],
 		datasets: [{}]
 		},
 		options: {
 			customAngles: [
 				1.0566, 1.7566, 1.0566, 2.1566, 0.2566
 			]
 		}
 	}
```

Live demo:
https://codepen.io/anon/pen/ZXEmQm