### PR TITLE
Add custom angles to polar area graph

### DIFF
--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -146,16 +146,19 @@ module.exports = function(Chart) {
 			var animationOpts = opts.animation;
 			var scale = chart.scale;
 			var labels = chart.data.labels;
+			var customAngles = opts.customAngles;
 
-			var circumference = me.calculateCircumference(dataset.data[index]);
+			var circumference = me.calculateCircumference(dataset.data[index], index);
 			var centerX = scale.xCenter;
 			var centerY = scale.yCenter;
 
 			// If there is NaN data before us, we need to calculate the starting angle correctly.
 			// We could be way more efficient here, but its unlikely that the polar area chart will have a lot of data
+			var previousAngle = 0
 			var visibleCount = 0;
 			var meta = me.getMeta();
 			for (var i = 0; i < index; ++i) {
+				previousAngle += customAngles[visibleCount]
 				if (!isNaN(dataset.data[i]) && !meta.data[i].hidden) {
 					++visibleCount;
 				}
@@ -164,7 +167,7 @@ module.exports = function(Chart) {
 			// var negHalfPI = -0.5 * Math.PI;
 			var datasetStartAngle = opts.startAngle;
 			var distance = arc.hidden ? 0 : scale.getDistanceFromCenterForValue(dataset.data[index]);
-			var startAngle = datasetStartAngle + (circumference * visibleCount);
+			var startAngle = datasetStartAngle + previousAngle
 			var endAngle = startAngle + (arc.hidden ? 0 : circumference);
 
 			var resetRadius = animationOpts.animateScale ? 0 : scale.getDistanceFromCenterForValue(dataset.data[index]);
@@ -211,12 +214,14 @@ module.exports = function(Chart) {
 			return count;
 		},
 
-		calculateCircumference: function(value) {
+		calculateCircumference: function (value, index) {
+			var me = this;
+			var chart = me.chart;
+			var opts = chart.options;
+			var customAngles = opts.customAngles;
 			var count = this.getMeta().count;
 			if (count > 0 && !isNaN(value)) {
-				return (2 * Math.PI) / count;
+				return count == 1 ? 2 * Math.PI : customAngles[index];
 			}
-			return 0;
-		}
 	});
 };

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -169,7 +169,12 @@ module.exports = function(Chart) {
 			// var negHalfPI = -0.5 * Math.PI;
 			var datasetStartAngle = opts.startAngle;
 			var distance = arc.hidden ? 0 : scale.getDistanceFromCenterForValue(dataset.data[index]);
-			var startAngle = customAngles === undefined ? datasetStartAngle + (circumference * visibleCount) : datasetStartAngle + previousAngle
+			var startAngle = 0;
+			if (customAngles === undefined) {
+				startAngle = datasetStartAngle + (circumference * visibleCount);
+			} else {
+				datasetStartAngle + previousAngle
+			}
 			var endAngle = startAngle + (arc.hidden ? 0 : circumference);
 
 			var resetRadius = animationOpts.animateScale ? 0 : scale.getDistanceFromCenterForValue(dataset.data[index]);

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -154,11 +154,11 @@ module.exports = function(Chart) {
 
 			// If there is NaN data before us, we need to calculate the starting angle correctly.
 			// We could be way more efficient here, but its unlikely that the polar area chart will have a lot of data
-			var previousAngle = 0
+			var previousAngle = 0;
 			var visibleCount = 0;
 			var meta = me.getMeta();
 			for (var i = 0; i < index; ++i) {
-				previousAngle += customAngles[visibleCount]
+				previousAngle += customAngles[visibleCount];
 				if (!isNaN(dataset.data[i]) && !meta.data[i].hidden) {
 					++visibleCount;
 				}
@@ -167,7 +167,7 @@ module.exports = function(Chart) {
 			// var negHalfPI = -0.5 * Math.PI;
 			var datasetStartAngle = opts.startAngle;
 			var distance = arc.hidden ? 0 : scale.getDistanceFromCenterForValue(dataset.data[index]);
-			var startAngle = datasetStartAngle + previousAngle
+			var startAngle = datasetStartAngle + previousAngle;
 			var endAngle = startAngle + (arc.hidden ? 0 : circumference);
 
 			var resetRadius = animationOpts.animateScale ? 0 : scale.getDistanceFromCenterForValue(dataset.data[index]);
@@ -214,14 +214,14 @@ module.exports = function(Chart) {
 			return count;
 		},
 
-		calculateCircumference: function (value, index) {
+		calculateCircumference: function(value, index) {
 			var me = this;
 			var chart = me.chart;
 			var opts = chart.options;
 			var customAngles = opts.customAngles;
 			var count = this.getMeta().count;
 			if (count > 0 && !isNaN(value)) {
-				return count == 1 ? 2 * Math.PI : customAngles[index];
+				return count === 1 ? 2 * Math.PI : customAngles[index];
 			}
 			return 0;
 		}

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -223,6 +223,7 @@ module.exports = function(Chart) {
 			if (count > 0 && !isNaN(value)) {
 				return count == 1 ? 2 * Math.PI : customAngles[index];
 			}
+			return 0;
 		}
 	});
 };

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -138,6 +138,31 @@ module.exports = function(Chart) {
 			});
 		},
 
+		getStartAngle: function (customAngles, dataSetData, metaData, datasetStartAngle, index) {
+
+			// If there is NaN data before us, we need to calculate the starting angle correctly.
+			// We could be way more efficient here, but its unlikely that the polar area chart will have a lot of data
+			
+			var previousAngle = 0;
+			var visibleCount = 0;
+
+			for (var i = 0; i < index; ++i) {
+				if (customAngles !== undefined) {
+					previousAngle += customAngles[visibleCount];
+				}
+				if (!isNaN(dataSetData[i]) && !metaData[i].hidden) {
+					++visibleCount;
+				}
+			}
+			var startAngle = 0;
+			if (customAngles === undefined) {
+				startAngle = datasetStartAngle + (circumference * visibleCount);
+			} else {
+				startAngle = datasetStartAngle + previousAngle;
+			}
+
+			return startAngle
+		},
 		updateElement: function(arc, index, reset) {
 			var me = this;
 			var chart = me.chart;
@@ -152,29 +177,11 @@ module.exports = function(Chart) {
 			var centerX = scale.xCenter;
 			var centerY = scale.yCenter;
 
-			// If there is NaN data before us, we need to calculate the starting angle correctly.
-			// We could be way more efficient here, but its unlikely that the polar area chart will have a lot of data
-			var previousAngle = 0;
-			var visibleCount = 0;
-			var meta = me.getMeta();
-			for (var i = 0; i < index; ++i) {
-				if (customAngles !== undefined) {
-					previousAngle += customAngles[visibleCount];
-				}
-				if (!isNaN(dataset.data[i]) && !meta.data[i].hidden) {
-					++visibleCount;
-				}
-			}
-
 			// var negHalfPI = -0.5 * Math.PI;
 			var datasetStartAngle = opts.startAngle;
 			var distance = arc.hidden ? 0 : scale.getDistanceFromCenterForValue(dataset.data[index]);
-			var startAngle = 0;
-			if (customAngles === undefined) {
-				startAngle = datasetStartAngle + (circumference * visibleCount);
-			} else {
-				startAngle = datasetStartAngle + previousAngle;
-			}
+			
+			var startAngle = getStartAngle(customAngles, dataset.data, meta.data, datasetStartAngle, index);
 			var endAngle = startAngle + (arc.hidden ? 0 : circumference);
 
 			var resetRadius = animationOpts.animateScale ? 0 : scale.getDistanceFromCenterForValue(dataset.data[index]);

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -145,8 +145,10 @@ module.exports = function(Chart) {
 
 			var previousAngle = 0;
 			var visibleCount = 0;
+			var startAngle = 0;
+			var i = 0;
 
-			for (var i = 0; i < index; ++i) {
+			for (i = 0; i < index; ++i) {
 				if (customAngles !== undefined) {
 					previousAngle += customAngles[visibleCount];
 				}
@@ -154,7 +156,6 @@ module.exports = function(Chart) {
 					++visibleCount;
 				}
 			}
-			var startAngle = 0;
 			if (customAngles === undefined) {
 				startAngle = datasetStartAngle + (circumference * visibleCount);
 			} else {

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -173,7 +173,7 @@ module.exports = function(Chart) {
 			if (customAngles === undefined) {
 				startAngle = datasetStartAngle + (circumference * visibleCount);
 			} else {
-				datasetStartAngle + previousAngle
+				startAngle = datasetStartAngle + previousAngle;
 			}
 			var endAngle = startAngle + (arc.hidden ? 0 : circumference);
 

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -223,5 +223,6 @@ module.exports = function(Chart) {
 			if (count > 0 && !isNaN(value)) {
 				return count == 1 ? 2 * Math.PI : customAngles[index];
 			}
+		}
 	});
 };

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -158,7 +158,9 @@ module.exports = function(Chart) {
 			var visibleCount = 0;
 			var meta = me.getMeta();
 			for (var i = 0; i < index; ++i) {
-				previousAngle += customAngles[visibleCount];
+				if (customAngles !== undefined) {
+					previousAngle += customAngles[visibleCount];
+				}
 				if (!isNaN(dataset.data[i]) && !meta.data[i].hidden) {
 					++visibleCount;
 				}
@@ -167,7 +169,7 @@ module.exports = function(Chart) {
 			// var negHalfPI = -0.5 * Math.PI;
 			var datasetStartAngle = opts.startAngle;
 			var distance = arc.hidden ? 0 : scale.getDistanceFromCenterForValue(dataset.data[index]);
-			var startAngle = datasetStartAngle + previousAngle;
+			var startAngle = customAngles === undefined ? datasetStartAngle + (circumference * visibleCount) : datasetStartAngle + previousAngle
 			var endAngle = startAngle + (arc.hidden ? 0 : circumference);
 
 			var resetRadius = animationOpts.animateScale ? 0 : scale.getDistanceFromCenterForValue(dataset.data[index]);
@@ -221,6 +223,9 @@ module.exports = function(Chart) {
 			var customAngles = opts.customAngles;
 			var count = this.getMeta().count;
 			if (count > 0 && !isNaN(value)) {
+				if (customAngles === undefined) {
+					return (2 * Math.PI) / count;
+				}
 				return count === 1 ? 2 * Math.PI : customAngles[index];
 			}
 			return 0;

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -138,11 +138,11 @@ module.exports = function(Chart) {
 			});
 		},
 
-		getStartAngle: function (customAngles, dataSetData, metaData, datasetStartAngle, index) {
+		getStartAngle: function(customAngles, dataSetData, metaData, datasetStartAngle, circumference, index) {
 
 			// If there is NaN data before us, we need to calculate the starting angle correctly.
 			// We could be way more efficient here, but its unlikely that the polar area chart will have a lot of data
-			
+
 			var previousAngle = 0;
 			var visibleCount = 0;
 
@@ -161,7 +161,7 @@ module.exports = function(Chart) {
 				startAngle = datasetStartAngle + previousAngle;
 			}
 
-			return startAngle
+			return startAngle;
 		},
 		updateElement: function(arc, index, reset) {
 			var me = this;
@@ -172,6 +172,7 @@ module.exports = function(Chart) {
 			var scale = chart.scale;
 			var labels = chart.data.labels;
 			var customAngles = opts.customAngles;
+			var meta = me.getMeta();
 
 			var circumference = me.calculateCircumference(dataset.data[index], index);
 			var centerX = scale.xCenter;
@@ -180,8 +181,8 @@ module.exports = function(Chart) {
 			// var negHalfPI = -0.5 * Math.PI;
 			var datasetStartAngle = opts.startAngle;
 			var distance = arc.hidden ? 0 : scale.getDistanceFromCenterForValue(dataset.data[index]);
-			
-			var startAngle = getStartAngle(customAngles, dataset.data, meta.data, datasetStartAngle, index);
+
+			var startAngle = me.getStartAngle(customAngles, dataset.data, meta.data, datasetStartAngle, circumference, index);
 			var endAngle = startAngle + (arc.hidden ? 0 : circumference);
 
 			var resetRadius = animationOpts.animateScale ? 0 : scale.getDistanceFromCenterForValue(dataset.data[index]);


### PR DESCRIPTION
## Old Behavior
Every angle is 360/#values °

## New Behavior
Provide custom value for each angle of the polar graph.

## Solution

```
  	var options = {
 		type: 'polarArea',
 		data: {
 		labels: ["A", "B", "C", "D", "E"],
 		datasets: [{}]
 		},
 		options: {
 			customAngles: [
 				1.0566, 1.7566, 1.0566, 2.1566, 0.2566
 			]
 		}
 	}
```

Live demo:
https://codepen.io/anon/pen/ZXEmQm