### PR TITLE
fix colour settings of BeforeLabel and BeforeBody

### DIFF
--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -677,6 +677,7 @@ module.exports = function(Chart) {
 			};
 
 			// Before body lines
+			ctx.fillStyle = mergeOpacity(vm.bodyFontColor, opacity);
 			helpers.each(vm.beforeBody, fillLineOfText);
 
 			var drawColorBoxes = vm.displayColors;
@@ -684,6 +685,9 @@ module.exports = function(Chart) {
 
 			// Draw body lines now
 			helpers.each(body, function(bodyItem, i) {
+				var labelTextColor = mergeOpacity(vm.labelTextColors[i], opacity);
+
+				ctx.fillStyle = labelTextColor;
 				helpers.each(bodyItem.before, fillLineOfText);
 
 				helpers.each(bodyItem.lines, function(line) {

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -685,7 +685,8 @@ module.exports = function(Chart) {
 
 			// Draw body lines now
 			helpers.each(body, function(bodyItem, i) {
-				ctx.fillStyle = mergeOpacity(vm.labelTextColors[i], opacity);
+				var textColor = mergeOpacity(vm.labelTextColors[i], opacity);
+				ctx.fillStyle = textColor;
 				helpers.each(bodyItem.before, fillLineOfText);
 
 				helpers.each(bodyItem.lines, function(line) {
@@ -703,7 +704,6 @@ module.exports = function(Chart) {
 						// Inner square
 						ctx.fillStyle = mergeOpacity(vm.labelColors[i].backgroundColor, opacity);
 						ctx.fillRect(pt.x + 1, pt.y + 1, bodyFontSize - 2, bodyFontSize - 2);
-						var textColor = mergeOpacity(vm.labelTextColors[i], opacity);
 						ctx.fillStyle = textColor;
 					}
 

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -685,9 +685,7 @@ module.exports = function(Chart) {
 
 			// Draw body lines now
 			helpers.each(body, function(bodyItem, i) {
-				var labelTextColor = mergeOpacity(vm.labelTextColors[i], opacity);
-
-				ctx.fillStyle = labelTextColor;
+				ctx.fillStyle = mergeOpacity(vm.labelTextColors[i], opacity);
 				helpers.each(bodyItem.before, fillLineOfText);
 
 				helpers.each(bodyItem.lines, function(line) {


### PR DESCRIPTION
Hello. 
I have found font colour problem when rendering beforeLabel and beforeBody.

## Problem
The beforeLabel and beforeBody don't use own colour settings(bodyFontColur,labelTextColor). They use titleFontColor.

jsfiddle:
https://jsfiddle.net/Rittyan/rxhpdyqt/

## How fix
It seems missing colour setting before rendering.
I add it.

----------
Sorry I'm not native speaker. so my english broken. 
Thanks.  :pray:
