### PR TITLE
Adding hooks "beforeTooltipDraw" and "afterTooltipDraw" to plugins

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -530,7 +530,7 @@ module.exports = function(Chart) {
 			me.drawDatasets(easingValue);
 
 			// notify before drawing tooltips
-			plugins.notify(me, 'beforeTooltips', [easingValue]);
+			plugins.notify(me, 'beforeTooltipDraw', [easingValue]);
 
 			// Finally draw the tooltip
 			me.tooltip.draw();

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -528,12 +528,7 @@ module.exports = function(Chart) {
 			}
 
 			me.drawDatasets(easingValue);
-
-			// notify before drawing tooltips
-			plugins.notify(me, 'beforeTooltipDraw', [easingValue]);
-
-			// Finally draw the tooltip
-			me.tooltip.draw();
+			me.drawTooltip(easingValue);
 
 			plugins.notify(me, 'afterDraw', [easingValue]);
 		},
@@ -596,6 +591,28 @@ module.exports = function(Chart) {
 			meta.controller.draw(easingValue);
 
 			plugins.notify(me, 'afterDatasetDraw', [args]);
+		},
+
+		/**
+		 * Draws tooltip unless a plugin returns `false` to the `beforeTooltipDraw`
+		 * hook, in which case, plugins will not be called on `afterTooltipDraw`.
+		 * @private
+		 */
+		drawTooltip: function(easingValue) {
+			var me = this;
+			var tooltip = me.tooltip;
+			var args = {
+				tooltip: tooltip,
+				easingValue: easingValue
+			};
+
+			if (plugins.notify(me, 'beforeTooltipDraw', [args]) === false) {
+				return;
+			}
+
+			tooltip.draw();
+
+			plugins.notify(me, 'afterTooltipDraw', [args]);
 		},
 
 		// Get the single element that was clicked on

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -528,7 +528,7 @@ module.exports = function(Chart) {
 			}
 
 			me.drawDatasets(easingValue);
-			me.drawTooltip(easingValue);
+			me._drawTooltip(easingValue);
 
 			plugins.notify(me, 'afterDraw', [easingValue]);
 		},
@@ -598,7 +598,7 @@ module.exports = function(Chart) {
 		 * hook, in which case, plugins will not be called on `afterTooltipDraw`.
 		 * @private
 		 */
-		drawTooltip: function(easingValue) {
+		_drawTooltip: function(easingValue) {
 			var me = this;
 			var tooltip = me.tooltip;
 			var args = {

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -530,7 +530,7 @@ module.exports = function(Chart) {
 			me.drawDatasets(easingValue);
 
 			// notify before drawing tooltips
-            plugins.notify(me, 'beforeTooltips', [easingValue]);
+			plugins.notify(me, 'beforeTooltips', [easingValue]);
 
 			// Finally draw the tooltip
 			me.tooltip.draw();

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -529,6 +529,9 @@ module.exports = function(Chart) {
 
 			me.drawDatasets(easingValue);
 
+			// notify before drawing tooltips
+            plugins.notify(me, 'beforeTooltips', [easingValue]);
+
 			// Finally draw the tooltip
 			me.tooltip.draw();
 

--- a/src/core/core.plugin.js
+++ b/src/core/core.plugin.js
@@ -274,16 +274,6 @@ module.exports = function(Chart) {
 	 * @returns {Boolean} `false` to cancel the chart drawing.
 	 */
 	/**
- 	 * @method IPlugin#beforeTooltipDraw
- 	 * @desc Called before drawing `tooltips` at every animation frame specified by the given
- 	 * easing value. If any plugin returns `false`, the frame drawing is cancelled until
- 	 * another `render` is triggered.
- 	 * @param {Chart.Controller} chart - The chart instance.
- 	 * @param {Number} easingValue - The current animation value, between 0.0 and 1.0.
- 	 * @param {Object} options - The plugin options.
- 	 * @returns {Boolean} `false` to cancel the chart drawing.
- 	 */
-	/**
 	 * @method IPlugin#afterDraw
 	 * @desc Called after the `chart` has been drawn for the specific easing value. Note
 	 * that this hook will not be called if the drawing has been previously cancelled.
@@ -333,6 +323,27 @@ module.exports = function(Chart) {
 	 * @param {Number} args.easingValue - The current animation value, between 0.0 and 1.0.
 	 * @param {Object} options - The plugin options.
 	 */
+	 /**
+  	 * @method IPlugin#beforeTooltipDraw
+	 * @desc Called before drawing the `tooltip`. If any plugin returns `false`,
+	 * the tooltip drawing is cancelled until another `render` is triggered.
+	 * @param {Chart} chart - The chart instance.
+	 * @param {Object} args - The call arguments.
+	 * @param {Object} args.tooltip - The tooltip.
+	 * @param {Object} options - The plugin options.
+	 * @param {Number} args.easingValue - The current animation value, between 0.0 and 1.0.
+	 * @returns {Boolean} `false` to cancel the chart tooltip drawing.
+  	 */
+	 /**
+ 	 * @method IPlugin#afterTooltipDraw
+  	 * @desc Called after drawing the `tooltip`. Note that this hook will not
+ 	 * be called if the tooltip drawing has been previously cancelled.
+ 	 * @param {Chart} chart - The chart instance.
+ 	 * @param {Object} args - The call arguments.
+ 	 * @param {Object} args.tooltip - The tooltip.
+	 * @param {Number} args.easingValue - The current animation value, between 0.0 and 1.0.
+ 	 * @param {Object} options - The plugin options.
+ 	 */
 	/**
 	 * @method IPlugin#beforeEvent
  	 * @desc Called before processing the specified `event`. If any plugin returns `false`,

--- a/src/core/core.plugin.js
+++ b/src/core/core.plugin.js
@@ -323,7 +323,7 @@ module.exports = function(Chart) {
 	 * @param {Number} args.easingValue - The current animation value, between 0.0 and 1.0.
 	 * @param {Object} options - The plugin options.
 	 */
-	 /**
+	/**
   	 * @method IPlugin#beforeTooltipDraw
 	 * @desc Called before drawing the `tooltip`. If any plugin returns `false`,
 	 * the tooltip drawing is cancelled until another `render` is triggered.
@@ -334,7 +334,7 @@ module.exports = function(Chart) {
 	 * @param {Number} args.easingValue - The current animation value, between 0.0 and 1.0.
 	 * @returns {Boolean} `false` to cancel the chart tooltip drawing.
   	 */
-	 /**
+	/**
  	 * @method IPlugin#afterTooltipDraw
   	 * @desc Called after drawing the `tooltip`. Note that this hook will not
  	 * be called if the tooltip drawing has been previously cancelled.

--- a/src/core/core.plugin.js
+++ b/src/core/core.plugin.js
@@ -274,7 +274,7 @@ module.exports = function(Chart) {
 	 * @returns {Boolean} `false` to cancel the chart drawing.
 	 */
 	/**
- 	 * @method IPlugin#beforeTooltips
+ 	 * @method IPlugin#beforeTooltipDraw
  	 * @desc Called before drawing `tooltips` at every animation frame specified by the given
  	 * easing value. If any plugin returns `false`, the frame drawing is cancelled until
  	 * another `render` is triggered.

--- a/src/core/core.plugin.js
+++ b/src/core/core.plugin.js
@@ -273,6 +273,16 @@ module.exports = function(Chart) {
 	 * @param {Object} options - The plugin options.
 	 * @returns {Boolean} `false` to cancel the chart drawing.
 	 */
+	 /**
+ 	 * @method IPlugin#beforeTooltips
+ 	 * @desc Called before drawing `tooltips` at every animation frame specified by the given
+ 	 * easing value. If any plugin returns `false`, the frame drawing is cancelled until
+ 	 * another `render` is triggered.
+ 	 * @param {Chart.Controller} chart - The chart instance.
+ 	 * @param {Number} easingValue - The current animation value, between 0.0 and 1.0.
+ 	 * @param {Object} options - The plugin options.
+ 	 * @returns {Boolean} `false` to cancel the chart drawing.
+ 	 */
 	/**
 	 * @method IPlugin#afterDraw
 	 * @desc Called after the `chart` has been drawn for the specific easing value. Note

--- a/src/core/core.plugin.js
+++ b/src/core/core.plugin.js
@@ -273,7 +273,7 @@ module.exports = function(Chart) {
 	 * @param {Object} options - The plugin options.
 	 * @returns {Boolean} `false` to cancel the chart drawing.
 	 */
-	 /**
+	/**
  	 * @method IPlugin#beforeTooltips
  	 * @desc Called before drawing `tooltips` at every animation frame specified by the given
  	 * easing value. If any plugin returns `false`, the frame drawing is cancelled until

--- a/src/core/core.plugin.js
+++ b/src/core/core.plugin.js
@@ -330,8 +330,8 @@ module.exports = function(Chart) {
 	 * @param {Chart} chart - The chart instance.
 	 * @param {Object} args - The call arguments.
 	 * @param {Object} args.tooltip - The tooltip.
-	 * @param {Object} options - The plugin options.
 	 * @param {Number} args.easingValue - The current animation value, between 0.0 and 1.0.
+	 * @param {Object} options - The plugin options.
 	 * @returns {Boolean} `false` to cancel the chart tooltip drawing.
   	 */
 	/**

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -845,6 +845,8 @@ describe('Chart', function() {
 					'beforeDatasetDraw',
 					'afterDatasetDraw',
 					'afterDatasetsDraw',
+					'beforeTooltipDraw',
+					'afterTooltipDraw',
 					'afterDraw',
 					'afterRender',
 				],


### PR DESCRIPTION
Add a call to plugins.notify before tooltip is drawn. This will allow tooltip to show up on top of a plugin when using "beforeTooltipDraw" inside the plugin.

E.g, Use "beforeTooltipDraw" instead of "afterDraw" in this watermark plugin: https://github.com/JewelsJLF/chartjs-plugin-watermark