### PR TITLE
Corrected title lineHeight | entered instead of / in string.

### DIFF
--- a/docs/configuration/title.md
+++ b/docs/configuration/title.md
@@ -14,7 +14,7 @@ The title configuration is passed into the `options.title` namespace. The global
 | `fontColor` | Color | `'#666'` | Font color
 | `fontStyle` | `String` | `'bold'` | Font style
 | `padding` | `Number` | `10` | Number of pixels to add above and below the title text.
-| `lineHeight` | `Number|String` | `1.2` | Height of an individual line of text (see [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height))
+| `lineHeight` | `Number/String` | `1.2` | Height of an individual line of text (see [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height))
 | `text` | `String/String[]`  | `''` | Title text to display. If specified as an array, text is rendered on multiple lines.
 
 ### Position


### PR DESCRIPTION
The website was showing 'Number' and 'String' in separate columns because of the pipe(|) which was used in the string instead of the slash(/).