### PR TITLE
Lock to Firefox 54 until Travis CI is fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ dist: trusty
 
 addons:
   chrome: stable
-  firefox: latest
+  firefox: "54.0"
 
 # IMPORTANT: scripts require GITHUB_AUTH_TOKEN and GITHUB_AUTH_EMAIL environment variables
 # IMPORTANT: scripts has to be set executables in the Git repository (error 127)


### PR DESCRIPTION
Try and get the tests to pass by forcing Travis to use Firefox 54 instead of the latest (56).

The tests seem to be failing with an error:
```
07 10 2017 13:55:53.062:WARN [Firefox 56.0.0 (Linux 0.0.0)]: Disconnected (1 times), because no message in 10000 ms.
  Disconnected, because no message in 10000 ms.
Firefox 56.0.0 (Linux 0.0.0) ERROR
```

These tests pass fine locally with Firefox 56. This is likely related to https://github.com/travis-ci/travis-ci/issues/8242