### PR TITLE
Add `ticks.integerSteps` option to linear scale. 

### DIFF
--- a/docs/axes/cartesian/linear.md
+++ b/docs/axes/cartesian/linear.md
@@ -9,6 +9,7 @@ The following options are provided by the linear scale. They are all located in 
 | Name | Type | Default | Description
 | -----| ---- | --------| -----------
 | `beginAtZero` | `Boolean` | | if true, scale will include 0 if it is not already included.
+| `integerSteps` | `Boolean` | | if true and `stepSize` is not specified, the step size will be increased to the next integer value.
 | `min` | `Number` | | User defined minimum number for the scale, overrides minimum value from data. [more...](#axis-range-settings)
 | `max` | `Number` | | User defined maximum number for the scale, overrides maximum value from data. [more...](#axis-range-settings)
 | `maxTicksLimit` | `Number` | `11` | Maximum number of ticks and gridlines to show.

--- a/docs/axes/cartesian/linear.md
+++ b/docs/axes/cartesian/linear.md
@@ -9,10 +9,10 @@ The following options are provided by the linear scale. They are all located in 
 | Name | Type | Default | Description
 | -----| ---- | --------| -----------
 | `beginAtZero` | `Boolean` | | if true, scale will include 0 if it is not already included.
-| `integerSteps` | `Boolean` | | if true and `stepSize` is not specified, the step size will be increased to the next integer value.
 | `min` | `Number` | | User defined minimum number for the scale, overrides minimum value from data. [more...](#axis-range-settings)
 | `max` | `Number` | | User defined maximum number for the scale, overrides maximum value from data. [more...](#axis-range-settings)
 | `maxTicksLimit` | `Number` | `11` | Maximum number of ticks and gridlines to show.
+| `precision` | `Number` | | if defined and `stepSize` is not specified, the step size will be rounded to this many decimal places.
 | `stepSize` | `Number` | | User defined fixed step size for the scale. [more...](#step-size)
 | `suggestedMax` | `Number` | | Adjustment used when calculating the maximum data value. [more...](#axis-range-settings)
 | `suggestedMin` | `Number` | | Adjustment used when calculating the minimum data value. [more...](#axis-range-settings)

--- a/docs/axes/radial/linear.md
+++ b/docs/axes/radial/linear.md
@@ -24,6 +24,7 @@ The following options are provided by the linear scale. They are all located in 
 | `backdropPaddingX` | `Number` | `2` | Horizontal padding of label backdrop.
 | `backdropPaddingY` | `Number` | `2` | Vertical padding of label backdrop.
 | `beginAtZero` | `Boolean` | `false` | if true, scale will include 0 if it is not already included.
+| `integerSteps` | `Boolean` | | if true and `stepSize` is not specified, the step size will be increased to the next integer value.
 | `min` | `Number` | | User defined minimum number for the scale, overrides minimum value from data. [more...](#axis-range-settings)
 | `max` | `Number` | | User defined maximum number for the scale, overrides maximum value from data. [more...](#axis-range-settings)
 | `maxTicksLimit` | `Number` | `11` | Maximum number of ticks and gridlines to show.

--- a/docs/axes/radial/linear.md
+++ b/docs/axes/radial/linear.md
@@ -24,10 +24,10 @@ The following options are provided by the linear scale. They are all located in 
 | `backdropPaddingX` | `Number` | `2` | Horizontal padding of label backdrop.
 | `backdropPaddingY` | `Number` | `2` | Vertical padding of label backdrop.
 | `beginAtZero` | `Boolean` | `false` | if true, scale will include 0 if it is not already included.
-| `integerSteps` | `Boolean` | | if true and `stepSize` is not specified, the step size will be increased to the next integer value.
 | `min` | `Number` | | User defined minimum number for the scale, overrides minimum value from data. [more...](#axis-range-settings)
 | `max` | `Number` | | User defined maximum number for the scale, overrides maximum value from data. [more...](#axis-range-settings)
 | `maxTicksLimit` | `Number` | `11` | Maximum number of ticks and gridlines to show.
+| `precision` | `Number` | | if defined and `stepSize` is not specified, the step size will be rounded to this many decimal places.
 | `stepSize` | `Number` | | User defined fixed step size for the scale. [more...](#step-size)
 | `suggestedMax` | `Number` | | Adjustment used when calculating the maximum data value. [more...](#axis-range-settings)
 | `suggestedMin` | `Number` | | Adjustment used when calculating the minimum data value. [more...](#axis-range-settings)

--- a/src/scales/scale.linearbase.js
+++ b/src/scales/scale.linearbase.js
@@ -15,16 +15,17 @@ function generateTicks(generationOptions, dataRange) {
 	// for details.
 
 	var spacing;
+
 	if (generationOptions.stepSize && generationOptions.stepSize > 0) {
 		spacing = generationOptions.stepSize;
 	} else {
 		var niceRange = helpers.niceNum(dataRange.max - dataRange.min, false);
 		spacing = helpers.niceNum(niceRange / (generationOptions.maxTicks - 1), true);
 
-		var precision = generationOptions.precision;
-		if (precision !== undefined) {
+		var spacingPrecision = generationOptions.precision;
+		if (spacingPrecision !== undefined) {
 			// If the user specified a precision, round to that number of decimal places
-			var factor = Math.pow(10, precision);
+			var factor = Math.pow(10, spacingPrecision);
 			spacing = Math.ceil(spacing * factor) / factor;
 		}
 	}

--- a/src/scales/scale.linearbase.js
+++ b/src/scales/scale.linearbase.js
@@ -21,9 +21,11 @@ function generateTicks(generationOptions, dataRange) {
 		var niceRange = helpers.niceNum(dataRange.max - dataRange.min, false);
 		spacing = helpers.niceNum(niceRange / (generationOptions.maxTicks - 1), true);
 
-		if (generationOptions.integerSteps && spacing !== Math.round(spacing)) {
-			// If forcing integer steps, and our step is not an integer, scale up
-			spacing = Math.ceil(spacing);
+		var precision = generationOptions.precision;
+		if (precision !== undefined) {
+			// If the user specified a precision, round to that number of decimal places
+			var factor = Math.pow(10, precision);
+			spacing = Math.ceil(spacing * factor) / factor;
 		}
 	}
 	var niceMin = Math.floor(dataRange.min / spacing) * spacing;
@@ -159,7 +161,7 @@ module.exports = function(Chart) {
 				maxTicks: maxTicks,
 				min: tickOpts.min,
 				max: tickOpts.max,
-				integerSteps: tickOpts.integerSteps,
+				precision: tickOpts.precision,
 				stepSize: helpers.valueOrDefault(tickOpts.fixedStepSize, tickOpts.stepSize)
 			};
 			var ticks = me.ticks = generateTicks(numericGeneratorOptions, me);

--- a/src/scales/scale.linearbase.js
+++ b/src/scales/scale.linearbase.js
@@ -20,6 +20,11 @@ function generateTicks(generationOptions, dataRange) {
 	} else {
 		var niceRange = helpers.niceNum(dataRange.max - dataRange.min, false);
 		spacing = helpers.niceNum(niceRange / (generationOptions.maxTicks - 1), true);
+
+		if (generationOptions.integerSteps && spacing !== Math.round(spacing)) {
+			// If forcing integer steps, and our step is not an integer, scale up
+			spacing = Math.ceil(spacing);
+		}
 	}
 	var niceMin = Math.floor(dataRange.min / spacing) * spacing;
 	var niceMax = Math.ceil(dataRange.max / spacing) * spacing;
@@ -154,6 +159,7 @@ module.exports = function(Chart) {
 				maxTicks: maxTicks,
 				min: tickOpts.min,
 				max: tickOpts.max,
+				integerSteps: tickOpts.integerSteps,
 				stepSize: helpers.valueOrDefault(tickOpts.fixedStepSize, tickOpts.stepSize)
 			};
 			var ticks = me.ticks = generateTicks(numericGeneratorOptions, me);

--- a/src/scales/scale.linearbase.js
+++ b/src/scales/scale.linearbase.js
@@ -14,6 +14,8 @@ function generateTicks(generationOptions, dataRange) {
 	// "nice number" algorithm. See http://stackoverflow.com/questions/8506881/nice-label-algorithm-for-charts-with-minimum-ticks
 	// for details.
 
+	var factor;
+	var precision;
 	var spacing;
 
 	if (generationOptions.stepSize && generationOptions.stepSize > 0) {
@@ -22,10 +24,10 @@ function generateTicks(generationOptions, dataRange) {
 		var niceRange = helpers.niceNum(dataRange.max - dataRange.min, false);
 		spacing = helpers.niceNum(niceRange / (generationOptions.maxTicks - 1), true);
 
-		var spacingPrecision = generationOptions.precision;
-		if (spacingPrecision !== undefined) {
+		precision = generationOptions.precision;
+		if (precision !== undefined) {
 			// If the user specified a precision, round to that number of decimal places
-			var factor = Math.pow(10, spacingPrecision);
+			factor = Math.pow(10, precision);
 			spacing = Math.ceil(spacing * factor) / factor;
 		}
 	}
@@ -49,7 +51,7 @@ function generateTicks(generationOptions, dataRange) {
 		numSpaces = Math.ceil(numSpaces);
 	}
 
-	var precision = 1;
+	precision = 1;
 	if (spacing < 1) {
 		precision = Math.pow(10, spacing.toString().length - 2);
 		niceMin = Math.round(niceMin * precision) / precision;

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -548,6 +548,34 @@ describe('Linear Scale', function() {
 		expect(chart.scales.yScale0.ticks).toEqual(['11', '9', '7', '5', '3', '1']);
 	});
 
+	it('Should create integer steps if integerSteps is true', function() {
+		var chart = window.acquireChart({
+			type: 'bar',
+			data: {
+				datasets: [{
+					yAxisID: 'yScale0',
+					data: [0, 1, 2, 1, 0, 1]
+				}],
+				labels: ['a', 'b', 'c', 'd', 'e', 'f']
+			},
+			options: {
+				scales: {
+					yAxes: [{
+						id: 'yScale0',
+						type: 'linear',
+						ticks: {
+							integerSteps: true
+						}
+					}]
+				}
+			}
+		});
+
+		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
+		expect(chart.scales.yScale0.min).toBe(0);
+		expect(chart.scales.yScale0.max).toBe(2);
+		expect(chart.scales.yScale0.ticks).toEqual(['2', '1', '0']);
+	});
 
 	it('should forcibly include 0 in the range if the beginAtZero option is used', function() {
 		var chart = window.acquireChart({

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -548,34 +548,66 @@ describe('Linear Scale', function() {
 		expect(chart.scales.yScale0.ticks).toEqual(['11', '9', '7', '5', '3', '1']);
 	});
 
-	it('Should create integer steps if integerSteps is true', function() {
-		var chart = window.acquireChart({
-			type: 'bar',
-			data: {
-				datasets: [{
-					yAxisID: 'yScale0',
-					data: [0, 1, 2, 1, 0, 1]
-				}],
-				labels: ['a', 'b', 'c', 'd', 'e', 'f']
-			},
-			options: {
-				scales: {
-					yAxes: [{
-						id: 'yScale0',
-						type: 'linear',
-						ticks: {
-							integerSteps: true
-						}
-					}]
+	describe('precision', function() {
+		it('Should create integer steps if precision is 0', function() {
+			var chart = window.acquireChart({
+				type: 'bar',
+				data: {
+					datasets: [{
+						yAxisID: 'yScale0',
+						data: [0, 1, 2, 1, 0, 1]
+					}],
+					labels: ['a', 'b', 'c', 'd', 'e', 'f']
+				},
+				options: {
+					scales: {
+						yAxes: [{
+							id: 'yScale0',
+							type: 'linear',
+							ticks: {
+								precision: 0
+							}
+						}]
+					}
 				}
-			}
+			});
+
+			expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
+			expect(chart.scales.yScale0.min).toBe(0);
+			expect(chart.scales.yScale0.max).toBe(2);
+			expect(chart.scales.yScale0.ticks).toEqual(['2', '1', '0']);
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min).toBe(0);
-		expect(chart.scales.yScale0.max).toBe(2);
-		expect(chart.scales.yScale0.ticks).toEqual(['2', '1', '0']);
+		it('Should round the step size to the given number of decimal places', function() {
+			var chart = window.acquireChart({
+				type: 'bar',
+				data: {
+					datasets: [{
+						yAxisID: 'yScale0',
+						data: [0, 0.001, 0.002, 0.003, 0, 0.001]
+					}],
+					labels: ['a', 'b', 'c', 'd', 'e', 'f']
+				},
+				options: {
+					scales: {
+						yAxes: [{
+							id: 'yScale0',
+							type: 'linear',
+							ticks: {
+								precision: 2
+							}
+						}]
+					}
+				}
+			});
+
+			expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
+			expect(chart.scales.yScale0.min).toBe(0);
+			expect(chart.scales.yScale0.max).toBe(0.01);
+			expect(chart.scales.yScale0.ticks).toEqual(['0.01', '0']);
+		});
 	});
+
 
 	it('should forcibly include 0 in the range if the beginAtZero option is used', function() {
 		var chart = window.acquireChart({


### PR DESCRIPTION
When true, and `stepSize`, is not specified, the generated step size will be increased
to the nearest integer value.

Resolves #4103 