### PR TITLE
Move extend and inherits helpers in helpers.core.js

### DIFF
--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -10,16 +10,6 @@ module.exports = function(Chart) {
 
 	// -- Basic js utility methods
 
-	helpers.extend = function(base) {
-		var setFn = function(value, key) {
-			base[key] = value;
-		};
-		for (var i = 1, ilen = arguments.length; i < ilen; i++) {
-			helpers.each(arguments[i], setFn);
-		}
-		return base;
-	};
-
 	helpers.configMerge = function(/* objects ... */) {
 		return helpers.merge(helpers.clone(arguments[0]), [].slice.call(arguments, 1), {
 			merger: function(key, target, source, options) {
@@ -125,29 +115,7 @@ module.exports = function(Chart) {
 			}
 		}
 	};
-	helpers.inherits = function(extensions) {
-		// Basic javascript inheritance based on the model created in Backbone.js
-		var me = this;
-		var ChartElement = (extensions && extensions.hasOwnProperty('constructor')) ? extensions.constructor : function() {
-			return me.apply(this, arguments);
-		};
 
-		var Surrogate = function() {
-			this.constructor = ChartElement;
-		};
-		Surrogate.prototype = me.prototype;
-		ChartElement.prototype = new Surrogate();
-
-		ChartElement.extend = helpers.inherits;
-
-		if (extensions) {
-			helpers.extend(ChartElement.prototype, extensions);
-		}
-
-		ChartElement.__super__ = me.prototype;
-
-		return ChartElement;
-	};
 	// -- Math methods
 	helpers.isNumber = function(n) {
 		return !isNaN(parseFloat(n)) && isFinite(n);

--- a/src/helpers/helpers.core.js
+++ b/src/helpers/helpers.core.js
@@ -250,6 +250,48 @@ var helpers = {
 	 */
 	mergeIf: function(target, source) {
 		return helpers.merge(target, source, {merger: helpers._mergerIf});
+	},
+
+	/**
+	 * Applies the contents of two or more objects together into the first object.
+	 * @param {Object} target - The target object in which all objects are merged into.
+	 * @param {Object} arg1 - Object containing additional properties to merge in target.
+	 * @param {Object} argN - Additional objects containing properties to merge in target.
+	 * @returns {Object} The `target` object.
+	 */
+	extend: function(target) {
+		var setFn = function(value, key) {
+			target[key] = value;
+		};
+		for (var i = 1, ilen = arguments.length; i < ilen; ++i) {
+			helpers.each(arguments[i], setFn);
+		}
+		return target;
+	},
+
+	/**
+	 * Basic javascript inheritance based on the model created in Backbone.js
+	 */
+	inherits: function(extensions) {
+		var me = this;
+		var ChartElement = (extensions && extensions.hasOwnProperty('constructor')) ? extensions.constructor : function() {
+			return me.apply(this, arguments);
+		};
+
+		var Surrogate = function() {
+			this.constructor = ChartElement;
+		};
+
+		Surrogate.prototype = me.prototype;
+		ChartElement.prototype = new Surrogate();
+		ChartElement.extend = helpers.inherits;
+
+		if (extensions) {
+			helpers.extend(ChartElement.prototype, extensions);
+		}
+
+		ChartElement.__super__ = me.prototype;
+		return ChartElement;
 	}
 };
 

--- a/test/specs/core.helpers.tests.js
+++ b/test/specs/core.helpers.tests.js
@@ -6,26 +6,6 @@ describe('Core helper tests', function() {
 		helpers = window.Chart.helpers;
 	});
 
-	it('should extend an object', function() {
-		var original = {
-			myProp1: 'abc',
-			myProp2: 56
-		};
-
-		var extension = {
-			myProp3: [2, 5, 6],
-			myProp2: 0
-		};
-
-		helpers.extend(original, extension);
-
-		expect(original).toEqual({
-			myProp1: 'abc',
-			myProp2: 0,
-			myProp3: [2, 5, 6],
-		});
-	});
-
 	it('should merge a normal config without scales', function() {
 		var baseConfig = {
 			valueProp: 5,

--- a/test/specs/helpers.core.tests.js
+++ b/test/specs/helpers.core.tests.js
@@ -369,4 +369,57 @@ describe('Chart.helpers.core', function() {
 			expect(output.o.a).not.toBe(a1);
 		});
 	});
+
+	describe('extend', function() {
+		it('should merge object properties in target and return target', function() {
+			var target = {a: 'abc', b: 56};
+			var object = {b: 0, c: [2, 5, 6]};
+			var result = helpers.extend(target, object);
+
+			expect(result).toBe(target);
+			expect(target).toEqual({a: 'abc', b: 0, c: [2, 5, 6]});
+		});
+		it('should merge multiple objects properties in target', function() {
+			var target = {a: 0, b: 1};
+			var o0 = {a: 2, c: 3, d: 4};
+			var o1 = {a: 5, c: 6};
+			var o2 = {a: 7, e: 8};
+
+			helpers.extend(target, o0, o1, o2);
+
+			expect(target).toEqual({a: 7, b: 1, c: 6, d: 4, e: 8});
+		});
+		it('should not deeply merge object properties in target', function() {
+			var target = {a: {b: 0, c: 1}};
+			var object = {a: {b: 2, d: 3}};
+
+			helpers.extend(target, object);
+
+			expect(target).toEqual({a: {b: 2, d: 3}});
+			expect(target.a).toBe(object.a);
+		});
+	});
+
+	describe('inherits', function() {
+		it('should return a derived class', function() {
+			var A = function() {};
+			A.prototype.p0 = 41;
+			A.prototype.p1 = function() {
+				return '42';
+			};
+
+			A.inherits = helpers.inherits;
+			var B = A.inherits({p0: 43, p2: [44]});
+			var C = A.inherits({p3: 45, p4: [46]});
+			var b = new B();
+
+			expect(b instanceof A).toBeTruthy();
+			expect(b instanceof B).toBeTruthy();
+			expect(b instanceof C).toBeFalsy();
+
+			expect(b.p0).toBe(43);
+			expect(b.p1()).toBe('42');
+			expect(b.p2).toEqual([44]);
+		});
+	});
 });


### PR DESCRIPTION
Fix Rollup issue caused by early access of the `extend` and `inherits` helpers not yet part of the `helpers/index` import. Also added (basic) unit tests for those methods.

Relates to #4478
Fixes #4746