### PR TITLE
Add option to allow square legend symbols at different sizes

### DIFF
--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -91,13 +91,15 @@ module.exports = function(Chart) {
 	 * @return {Number} width of the color box area
 	 */
 	function getBoxWidth(labelOpts, fontSize) {
-		if (labelOpts.useSquareBox) {
-			return Math.min(fontSize, labelOpts.boxWidth);
-		}
-
 		return labelOpts.usePointStyle ?
 			fontSize * Math.SQRT2 :
 			labelOpts.boxWidth;
+	}
+
+	function getBoxHeight(labelOpts, fontSize) {
+		return labelOpts.boxHeight ?
+			labelOpts.boxHeight :
+			fontSize;
 	}
 
 	Chart.Legend = Element.extend({
@@ -350,6 +352,7 @@ module.exports = function(Chart) {
 				ctx.font = labelFont;
 
 				var boxWidth = getBoxWidth(labelOpts, fontSize);
+				var boxHeight = getBoxHeight(labelOpts, fontSize);
 				var hitboxes = me.legendHitBoxes;
 
 				// current position
@@ -385,12 +388,7 @@ module.exports = function(Chart) {
 						// Draw pointStyle as legend symbol
 						helpers.canvas.drawPoint(ctx, legendItem.pointStyle, radius, centerX, centerY);
 					} else {
-						var boxHeight = fontSize;
-
-						if (opts.labels.useSquareBox) {
-							boxHeight = boxWidth;
-							y += (fontSize - boxHeight) / 2;
-						}
+						y += (fontSize - boxHeight) / 2;
 
 						// Draw box as legend symbol
 						if (!isLineWidthZero) {

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -94,7 +94,7 @@ module.exports = function(Chart) {
 		if (labelOpts.useSquareBox) {
 			return Math.min(fontSize, labelOpts.boxWidth);
 		}
-		
+
 		return labelOpts.usePointStyle ?
 			fontSize * Math.SQRT2 :
 			labelOpts.boxWidth;
@@ -391,7 +391,7 @@ module.exports = function(Chart) {
 							boxHeight = boxWidth;
 							y += (fontSize - boxHeight) / 2;
 						}
-						
+
 						// Draw box as legend symbol
 						if (!isLineWidthZero) {
 							ctx.strokeRect(x, y, boxWidth, boxHeight);

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -91,6 +91,10 @@ module.exports = function(Chart) {
 	 * @return {Number} width of the color box area
 	 */
 	function getBoxWidth(labelOpts, fontSize) {
+		if (labelOpts.useSquareBox) {
+			return Math.min(fontSize, labelOpts.boxWidth);
+		}
+		
 		return labelOpts.usePointStyle ?
 			fontSize * Math.SQRT2 :
 			labelOpts.boxWidth;
@@ -381,11 +385,18 @@ module.exports = function(Chart) {
 						// Draw pointStyle as legend symbol
 						helpers.canvas.drawPoint(ctx, legendItem.pointStyle, radius, centerX, centerY);
 					} else {
+						var boxHeight = fontSize;
+
+						if (opts.labels.useSquareBox) {
+							boxHeight = boxWidth;
+							y += (fontSize - boxHeight) / 2;
+						}
+						
 						// Draw box as legend symbol
 						if (!isLineWidthZero) {
-							ctx.strokeRect(x, y, boxWidth, fontSize);
+							ctx.strokeRect(x, y, boxWidth, boxHeight);
 						}
-						ctx.fillRect(x, y, boxWidth, fontSize);
+						ctx.fillRect(x, y, boxWidth, boxHeight);
 					}
 
 					ctx.restore();


### PR DESCRIPTION
If the useSquareBox option is set to true, the height is set to the same as the boxWidth option. It places it vertically central to the label. It also ensures the legend symbol never exceeds the size of the font size.

Demo: https://codepen.io/soniiic/pen/zEgrGb