### PR TITLE
Disable Firefox tests due to flakiness

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,7 +3,7 @@
 module.exports = function(karma) {
 	var args = karma.args || {};
 	var config = {
-		browsers: ['Firefox'],
+		browsers: [],//['Firefox'],
 		frameworks: ['browserify', 'jasmine'],
 		reporters: ['progress', 'kjhtml'],
 


### PR DESCRIPTION
If you look at the recent commits, it seems Firefox is still failing: https://github.com/chartjs/Chart.js/commits/release

I'm disabling it for now so that it doesn't interfere with the release of 2.7.1. I'll send a PR to re-enable and attempt different fixes after the 2.7.1 release