### PR TITLE
Fix for issues #3917, #4380, #2966 - log scale with min: 0

### DIFF
--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -192,13 +192,13 @@ module.exports = function(Chart) {
 		},
 		getPixelForValue: function(value) {
 			var me = this;
-			var realValue = +me.getRightValue(value);
 			var reverse = me.options.ticks.reverse;
 			var log10 = helpers.log10;
 			var firstTickValue = me.getFirstTickValue(me.minNotZero);
 			var offset = 0;
-			var baseValue, innerDimension, pixel, start, end, sign;
+			var innerDimension, pixel, start, end, sign;
 
+			value = +me.getRightValue(value);
 			if (reverse) {
 				start = me.end;
 				end = me.start;
@@ -208,7 +208,6 @@ module.exports = function(Chart) {
 				end = me.end;
 				sign = 1;
 			}
-			baseValue = start;
 			if (me.isHorizontal()) {
 				innerDimension = me.width;
 				pixel = reverse ? me.right : me.left;
@@ -217,8 +216,8 @@ module.exports = function(Chart) {
 				sign *= -1; // invert, since the upper-left corner of the canvas is at pixel (0, 0)
 				pixel = reverse ? me.top : me.bottom;
 			}
-			if (realValue !== baseValue) {
-				if (baseValue === 0) { // include zero tick
+			if (value !== start) {
+				if (start === 0) { // include zero tick
 					offset = helpers.getValueOrDefault(
 						me.options.ticks.fontSize,
 						Chart.defaults.global.defaultFontSize
@@ -226,8 +225,8 @@ module.exports = function(Chart) {
 					innerDimension -= offset;
 					start = firstTickValue;
 				}
-				if (realValue !== 0) {
-					offset += innerDimension / (log10(end) - log10(start)) * (log10(realValue) - log10(start));
+				if (value !== 0) {
+					offset += innerDimension / (log10(end) - log10(start)) * (log10(value) - log10(start));
 				}
 				pixel += sign * offset;
 			}
@@ -238,7 +237,7 @@ module.exports = function(Chart) {
 			var reverse = me.options.ticks.reverse;
 			var log10 = helpers.log10;
 			var firstTickValue = me.getFirstTickValue(me.minNotZero);
-			var innerDimension, start, end, baseValue, value;
+			var innerDimension, start, end, value;
 
 			if (reverse) {
 				start = me.end;
@@ -247,7 +246,6 @@ module.exports = function(Chart) {
 				start = me.start;
 				end = me.end;
 			}
-			baseValue = start;
 			if (me.isHorizontal()) {
 				innerDimension = me.width;
 				value = reverse ? me.right - pixel : pixel - me.left;
@@ -255,8 +253,8 @@ module.exports = function(Chart) {
 				innerDimension = me.height;
 				value = reverse ? pixel - me.top : me.bottom - pixel;
 			}
-			if (value !== baseValue) {
-				if (baseValue === 0) { // include zero tick
+			if (value !== start) {
+				if (start === 0) { // include zero tick
 					var offset = helpers.getValueOrDefault(
 						me.options.ticks.fontSize,
 						Chart.defaults.global.defaultFontSize

--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -182,9 +182,9 @@ module.exports = function(Chart) {
 		 *
 		 * @Private
 		 * @param {Number} [value] - The minimum not zero value.
-		 * @return {number} [firstTickValu] - The first tick value.
+		 * @return {Number} [firstTickValue] - The first tick value.
 		 */
-		getFirstTickValue(value) {
+		getFirstTickValue: function(value) {
 			var exp = Math.floor(helpers.log10(value));
 			var significand = Math.floor(value / Math.pow(10, exp));
 

--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -178,13 +178,12 @@ module.exports = function(Chart) {
 			return this.getPixelForValue(this.tickValues[index]);
 		},
 		/**
-		 * Returns the value of the first tick
-		 *
-		 * @Private
-		 * @param {Number} [value] - The minimum not zero value.
-		 * @return {Number} [firstTickValue] - The first tick value.
+		 * Returns the value of the first tick.
+		 * @param {Number} value - The minimum not zero value.
+		 * @return {Number} The first tick value.
+		 * @private
 		 */
-		getFirstTickValue: function(value) {
+		_getFirstTickValue: function(value) {
 			var exp = Math.floor(helpers.log10(value));
 			var significand = Math.floor(value / Math.pow(10, exp));
 
@@ -194,7 +193,7 @@ module.exports = function(Chart) {
 			var me = this;
 			var reverse = me.options.ticks.reverse;
 			var log10 = helpers.log10;
-			var firstTickValue = me.getFirstTickValue(me.minNotZero);
+			var firstTickValue = me._getFirstTickValue(me.minNotZero);
 			var offset = 0;
 			var innerDimension, pixel, start, end, sign;
 
@@ -236,7 +235,7 @@ module.exports = function(Chart) {
 			var me = this;
 			var reverse = me.options.ticks.reverse;
 			var log10 = helpers.log10;
-			var firstTickValue = me.getFirstTickValue(me.minNotZero);
+			var firstTickValue = me._getFirstTickValue(me.minNotZero);
 			var innerDimension, start, end, value;
 
 			if (reverse) {

--- a/test/specs/scale.logarithmic.tests.js
+++ b/test/specs/scale.logarithmic.tests.js
@@ -761,9 +761,10 @@ describe('Logarithmic Scale tests', function() {
 		var yScale = chart.scales.yScale;
 		expect(yScale.getPixelForValue(70, 0, 0)).toBeCloseToPixel(32);     // top + paddingTop
 		expect(yScale.getPixelForValue(0, 0, 0)).toBeCloseToPixel(484);     // bottom - paddingBottom
-		expect(yScale.getPixelForValue(0.063, 0, 0)).toBeCloseToPixel(475); // minNotZero 2% from range
-		expect(yScale.getPixelForValue(0.5, 0, 0)).toBeCloseToPixel(344);
-		expect(yScale.getPixelForValue(4, 0, 0)).toBeCloseToPixel(213);
+		expect(yScale.getPixelForValue(0.06, 0, 0)).toBeCloseToPixel(472);  // first tick fontsize from 0
+		expect(yScale.getPixelForValue(0.063, 0, 0)).toBeCloseToPixel(469); // minNotZero
+		expect(yScale.getPixelForValue(0.5, 0, 0)).toBeCloseToPixel(340);
+		expect(yScale.getPixelForValue(4, 0, 0)).toBeCloseToPixel(210);
 		expect(yScale.getPixelForValue(10, 0, 0)).toBeCloseToPixel(155);
 		expect(yScale.getPixelForValue(63, 0, 0)).toBeCloseToPixel(38.5);
 
@@ -772,9 +773,10 @@ describe('Logarithmic Scale tests', function() {
 
 		expect(yScale.getPixelForValue(70, 0, 0)).toBeCloseToPixel(484);   // bottom - paddingBottom
 		expect(yScale.getPixelForValue(0, 0, 0)).toBeCloseToPixel(32);     // top + paddingTop
-		expect(yScale.getPixelForValue(0.063, 0, 0)).toBeCloseToPixel(41); // minNotZero 2% from range
-		expect(yScale.getPixelForValue(0.5, 0, 0)).toBeCloseToPixel(172);
-		expect(yScale.getPixelForValue(4, 0, 0)).toBeCloseToPixel(303);
+		expect(yScale.getPixelForValue(0.06, 0, 0)).toBeCloseToPixel(44);  // first tick fontsize from 0
+		expect(yScale.getPixelForValue(0.063, 0, 0)).toBeCloseToPixel(47); // minNotZero
+		expect(yScale.getPixelForValue(0.5, 0, 0)).toBeCloseToPixel(176);
+		expect(yScale.getPixelForValue(4, 0, 0)).toBeCloseToPixel(306);
 		expect(yScale.getPixelForValue(10, 0, 0)).toBeCloseToPixel(361);
 		expect(yScale.getPixelForValue(63, 0, 0)).toBeCloseToPixel(477);
 	});

--- a/test/specs/scale.logarithmic.tests.js
+++ b/test/specs/scale.logarithmic.tests.js
@@ -735,49 +735,99 @@ describe('Logarithmic Scale tests', function() {
 		expect(yScale.getValueForPixel(246)).toBeCloseTo(10, 1e-4);
 	});
 
-	it('should get the correct pixel value for a point when 0 values are present', function() {
-		var chart = window.acquireChart({
-			type: 'bar',
-			data: {
-				datasets: [{
-					yAxisID: 'yScale',
-					data: [0.063, 4, 0, 63, 10, 0.5]
-				}],
-				labels: []
+	it('should get the correct pixel value for a point when 0 values are present or min: 0', function() {
+		var config = [
+			{
+				dataset: [{x: 0, y: 0}, {x: 10, y: 10}, {x: 1.2, y: 1.2}, {x: 25, y: 25}, {x: 78, y: 78}],
+				firstTick: 1, // value of the first tick
+				lastTick: 80
 			},
-			options: {
-				scales: {
-					yAxes: [{
-						id: 'yScale',
-						type: 'logarithmic',
-						ticks: {
-							reverse: false
-						}
-					}]
+			{
+				dataset: [{x: 0, y: 0}, {x: 10, y: 10}, {x: 6.3, y: 6.3}, {x: 25, y: 25}, {x: 78, y: 78}],
+				firstTick: 6,
+				lastTick: 80
+			},
+			{
+				dataset: [{x: 10, y: 10}, {x: 1.2, y: 1.2}, {x: 25, y: 25}, {x: 78, y: 78}],
+				scale: {ticks: {min: 0}},
+				firstTick: 1,
+				lastTick: 80
+			},
+			{
+				dataset: [{x: 10, y: 10}, {x: 6.3, y: 6.3}, {x: 25, y: 25}, {x: 78, y: 78}],
+				scale: {ticks: {min: 0}},
+				firstTick: 6,
+				lastTick: 80
+			},
+		];
+		Chart.helpers.each(config, function(setup) {
+			var xScaleConfig = {
+				type: 'logarithmic'
+			};
+			var yScaleConfig = {
+				type: 'logarithmic'
+			};
+			Chart.helpers.extend(xScaleConfig, setup.scale);
+			Chart.helpers.extend(yScaleConfig, setup.scale);
+			var chart = window.acquireChart({
+				type: 'line',
+				data: {
+					datasets: [{
+						data: setup.dataset
+					}],
+				},
+				options: {
+					scales: {
+						xAxes: [xScaleConfig],
+						yAxes: [yScaleConfig]
+					}
 				}
-			}
+			});
+
+			var chartArea = chart.chartArea;
+			var expectations = [
+				{
+					id: 'x-axis-0', // horizontal scale
+					axis: 'xAxes',
+					start: chartArea.left,
+					end: chartArea.right
+				},
+				{
+					id: 'y-axis-0', // vertical scale
+					axis: 'yAxes',
+					start: chartArea.bottom,
+					end: chartArea.top
+				}
+			];
+			Chart.helpers.each(expectations, function(expectation) {
+				var scale = chart.scales[expectation.id];
+				var firstTick = setup.firstTick;
+				var lastTick = setup.lastTick;
+				var fontSize = chart.options.defaultFontSize;
+				var start = expectation.start;
+				var end = expectation.end;
+				var sign = scale.isHorizontal() ? 1 : -1;
+
+				expect(scale.getPixelForValue(0, 0, 0)).toBeCloseToPixel(start);
+				expect(scale.getPixelForValue(lastTick, 0, 0)).toBeCloseToPixel(end);
+				expect(scale.getPixelForValue(firstTick, 0, 0)).toBeCloseToPixel(start + sign * fontSize);
+
+				expect(scale.getValueForPixel(start)).toBeCloseTo(0);
+				expect(scale.getValueForPixel(end)).toBeCloseTo(lastTick);
+				expect(scale.getValueForPixel(start + sign * fontSize)).toBeCloseTo(firstTick);
+
+				chart.options.scales[expectation.axis][0].ticks.reverse = true;   // Reverse mode
+				chart.update();
+
+				expect(scale.getPixelForValue(0, 0, 0)).toBeCloseToPixel(end);
+				expect(scale.getPixelForValue(lastTick, 0, 0)).toBeCloseToPixel(start);
+				expect(scale.getPixelForValue(firstTick, 0, 0)).toBeCloseToPixel(end - sign * fontSize);
+
+				expect(scale.getValueForPixel(end)).toBeCloseTo(0);
+				expect(scale.getValueForPixel(start)).toBeCloseTo(lastTick);
+				expect(scale.getValueForPixel(end - sign * fontSize)).toBeCloseTo(firstTick);
+			});
 		});
-
-		var yScale = chart.scales.yScale;
-		expect(yScale.getPixelForValue(70, 0, 0)).toBeCloseToPixel(32);     // top + paddingTop
-		expect(yScale.getPixelForValue(0, 0, 0)).toBeCloseToPixel(484);     // bottom - paddingBottom
-		expect(yScale.getPixelForValue(0.06, 0, 0)).toBeCloseToPixel(472);  // first tick fontsize from 0
-		expect(yScale.getPixelForValue(0.063, 0, 0)).toBeCloseToPixel(469); // minNotZero
-		expect(yScale.getPixelForValue(0.5, 0, 0)).toBeCloseToPixel(340);
-		expect(yScale.getPixelForValue(4, 0, 0)).toBeCloseToPixel(210);
-		expect(yScale.getPixelForValue(10, 0, 0)).toBeCloseToPixel(155);
-		expect(yScale.getPixelForValue(63, 0, 0)).toBeCloseToPixel(38.5);
-
-		chart.options.scales.yAxes[0].ticks.reverse = true;	// Reverse mode
-		chart.update();
-
-		expect(yScale.getPixelForValue(70, 0, 0)).toBeCloseToPixel(484);   // bottom - paddingBottom
-		expect(yScale.getPixelForValue(0, 0, 0)).toBeCloseToPixel(32);     // top + paddingTop
-		expect(yScale.getPixelForValue(0.06, 0, 0)).toBeCloseToPixel(44);  // first tick fontsize from 0
-		expect(yScale.getPixelForValue(0.063, 0, 0)).toBeCloseToPixel(47); // minNotZero
-		expect(yScale.getPixelForValue(0.5, 0, 0)).toBeCloseToPixel(176);
-		expect(yScale.getPixelForValue(4, 0, 0)).toBeCloseToPixel(306);
-		expect(yScale.getPixelForValue(10, 0, 0)).toBeCloseToPixel(361);
-		expect(yScale.getPixelForValue(63, 0, 0)).toBeCloseToPixel(477);
 	});
+
 });


### PR DESCRIPTION
Fixes #3917: Logarithmic Scale Tick Bug for values of 0
Fixes #4380: LogLog plots are impossible (0, 0)
Fixes #2966: chart does not render if data contains value of 0 when using logarithmic scale

v2.7
 - doesn't correctly render: horizontal with min:0 (regular and reversed)
 - in case the significand digit of minNotZero is 1 or 2;
   however the value itself has more significand digits,
   the first tick is displayed outside the chart area or on top of the 0-tick.

Test for all bar plot possibilities (vertical/horizontal, with/without min: 0, default/reversed)
https://codepen.io/anon/pen/zPYMWz

**Examples**
![pr-20171101-log-scale-min-0](https://user-images.githubusercontent.com/33193571/32282638-69da984e-bf22-11e7-9407-b4075e77d84b.png)
