### PR TITLE
Reset only when animating

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -365,9 +365,11 @@ module.exports = function(Chart) {
 			me.updateLayout();
 
 			// Can only reset the new controllers after the scales have been updated
-			helpers.each(newControllers, function(controller) {
-				controller.reset();
-			});
+			if (me.options.animation && me.options.animation.duration) {
+				helpers.each(newControllers, function(controller) {
+					controller.reset();
+				});
+			}
 
 			me.updateDatasets();
 


### PR DESCRIPTION
This is a performance improvement for charts that are not animated as discussed in https://github.com/chartjs/Chart.js/issues/4865