### PR TITLE
Correctly handle stacked groups when not adjacent

### DIFF
--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -201,10 +201,12 @@ module.exports = function(Chart) {
 		},
 
 		/**
-		 * Returns the effective number of stacks based on groups and bar visibility.
+		 * Returns the stacks based on groups and bar visibility.
+		 * @param {Number=} [last] - The dataset index
+		 * @returns {Array} The stack list
 		 * @private
 		 */
-		getStackCount: function(last) {
+		_getStacks: function(last) {
 			var me = this;
 			var chart = me.chart;
 			var scale = me.getIndexScale();
@@ -223,15 +225,33 @@ module.exports = function(Chart) {
 				}
 			}
 
-			return stacks.length;
+			return stacks;
+		},
+
+		/**
+		 * Returns the effective number of stacks based on groups and bar visibility.
+		 * @private
+		 */
+		getStackCount: function() {
+			return this._getStacks().length;
 		},
 
 		/**
 		 * Returns the stack index for the given dataset based on groups and bar visibility.
+		 * @param {Number=} [datasetIndex] - The dataset index
+		 * @param {String=} [name] - The stack name to find
+		 * @returns {Number} The stack index
 		 * @private
 		 */
-		getStackIndex: function(datasetIndex) {
-			return this.getStackCount(datasetIndex) - 1;
+		getStackIndex: function(datasetIndex, name) {
+			var stacks = this._getStacks(datasetIndex);
+			var index = (name !== undefined)
+				? stacks.indexOf(name)
+				: -1; // indexOf returns -1 if element is not present
+
+			return (index === -1)
+				? stacks.length - 1
+				: index;
 		},
 
 		/**
@@ -312,7 +332,8 @@ module.exports = function(Chart) {
 		calculateBarIndexPixels: function(datasetIndex, index, ruler) {
 			var me = this;
 			var options = ruler.scale.options;
-			var stackIndex = me.getStackIndex(datasetIndex);
+			var meta = me.getMeta();
+			var stackIndex = me.getStackIndex(datasetIndex, meta.stack);
 			var pixels = ruler.pixels;
 			var base = pixels[index];
 			var length = pixels.length;

--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -202,7 +202,7 @@ module.exports = function(Chart) {
 
 		/**
 		 * Returns the stacks based on groups and bar visibility.
-		 * @param {Number=} [last] - The dataset index
+		 * @param {Number} [last] - The dataset index
 		 * @returns {Array} The stack list
 		 * @private
 		 */
@@ -238,8 +238,8 @@ module.exports = function(Chart) {
 
 		/**
 		 * Returns the stack index for the given dataset based on groups and bar visibility.
-		 * @param {Number=} [datasetIndex] - The dataset index
-		 * @param {String=} [name] - The stack name to find
+		 * @param {Number} [datasetIndex] - The dataset index
+		 * @param {String} [name] - The stack name to find
 		 * @returns {Number} The stack index
 		 * @private
 		 */


### PR DESCRIPTION
Fixes #4897 (stacked group is not rendered correctly when stack group is not adjacent).

Split from PR #4911 

**Problem**
Only the dataset index was used for indexing the stack.

![pr_issue_4897](https://user-images.githubusercontent.com/33193571/32212974-98f89450-be19-11e7-9457-eb48df87641b.png)