### PR TITLE
Fix issue #4441 - y-axis labels partially hidden due to restrictive initial fitting.

### DIFF
--- a/src/core/core.layoutService.js
+++ b/src/core/core.layoutService.js
@@ -194,7 +194,7 @@ module.exports = function(Chart) {
 					minSize = box.update(box.fullWidth ? chartWidth : maxChartAreaWidth, horizontalBoxHeight);
 					maxChartAreaHeight -= minSize.height;
 				} else {
-					minSize = box.update(verticalBoxWidth, chartAreaHeight);
+					minSize = box.update(verticalBoxWidth, maxChartAreaHeight);
 					maxChartAreaWidth -= minSize.width;
 				}
 

--- a/test/specs/core.layoutService.tests.js
+++ b/test/specs/core.layoutService.tests.js
@@ -550,4 +550,34 @@ describe('Test the layout service', function() {
 			expect(isOrderCorrect).toBe(true);
 		});
 	});
+
+	describe('box sizing', function() {
+		it('should correctly compute y-axis width to fit labels', function() {
+			var chart = window.acquireChart({
+				type: 'bar',
+				data: {
+					labels: ['tick 1', 'tick 2', 'tick 3', 'tick 4', 'tick 5'],
+					datasets: [{
+						data: [0, 2.25, 1.5, 1.25, 2.5]
+					}],
+				},
+				options: {
+					legend: {
+						display: false,
+					},
+				},
+			}, {
+				canvas: {
+					height: 256,
+					width: 256
+				}
+			});
+			var yAxis = chart.scales['y-axis-0'];
+
+			// issue #4441: y-axis labels partially hidden.
+			// minimum horizontal space required to fit labels
+			expect(yAxis.width).toBeCloseToPixel(33);
+			expect(yAxis.ticks).toEqual(['2.5', '2.0', '1.5', '1.0', '0.5', '0']);
+		});
+	});
 });

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -905,4 +905,32 @@ describe('Linear Scale', function() {
 		expect(chart.scales['x-axis-0'].min).toEqual(20);
 		expect(chart.scales['x-axis-0'].max).toEqual(21);
 	});
+
+	it('should correctly compute y-axis width to fit labels', function() {
+		var chart = window.acquireChart({
+			type: 'bar',
+			data: {
+				labels: ['tick 1', 'tick 2', 'tick 3', 'tick 4', 'tick 5'],
+				datasets: [{
+					data: [0, 2.25, 1.5, 1.25, 2.5]
+				}],
+			},
+			options: {
+				legend: {
+					display: false,
+				},
+			},
+		}, {
+			canvas: {
+				height: 256,
+				width: 256
+			}
+		});
+		var yAxis = chart.scales['y-axis-0'];
+
+		// issue #4441: y-axis labels partially hidden.
+		// minimum horizontal space required to fit labels
+		expect(yAxis.width).toBeCloseToPixel(33);
+		expect(yAxis.ticks).toEqual(['2.5', '2.0', '1.5', '1.0', '0.5', '0']);
+	});
 });

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -905,32 +905,4 @@ describe('Linear Scale', function() {
 		expect(chart.scales['x-axis-0'].min).toEqual(20);
 		expect(chart.scales['x-axis-0'].max).toEqual(21);
 	});
-
-	it('should correctly compute y-axis width to fit labels', function() {
-		var chart = window.acquireChart({
-			type: 'bar',
-			data: {
-				labels: ['tick 1', 'tick 2', 'tick 3', 'tick 4', 'tick 5'],
-				datasets: [{
-					data: [0, 2.25, 1.5, 1.25, 2.5]
-				}],
-			},
-			options: {
-				legend: {
-					display: false,
-				},
-			},
-		}, {
-			canvas: {
-				height: 256,
-				width: 256
-			}
-		});
-		var yAxis = chart.scales['y-axis-0'];
-
-		// issue #4441: y-axis labels partially hidden.
-		// minimum horizontal space required to fit labels
-		expect(yAxis.width).toBeCloseToPixel(33);
-		expect(yAxis.ticks).toEqual(['2.5', '2.0', '1.5', '1.0', '0.5', '0']);
-	});
 });


### PR DESCRIPTION
Fixes #4441 - y-axis labels partially hidden due to restrictive initial fitting.

The problem is caused by the layout service _Step 4_ being initially trying a chart area height of 50% of the canvas height. When in the initial case there's only enough space for integer ticks, then the y-axis will reserves only the width for integer tick labels. Later in _Steps 5 & 6_ this reserved space isn't allowed to increase, even when the allowed height is increased in this step.
A simple solution would be to increase the allowed height in the initial computation step to be `maxChartAreaHeight` instead of `chartAreaHeight`.

**Issue v2.7**
![issue_y-axis_labels_partially_hidden](https://user-images.githubusercontent.com/33193571/32741303-17137d64-c8a6-11e7-82ce-c7bb428cdbf1.png)
**Proposed fix**
![fix-issue_y-axis_labels_partially_hidden](https://user-images.githubusercontent.com/33193571/32741310-1c415cde-c8a6-11e7-895a-76f7a8f3c79c.png)