### PR TITLE
Fix issue #4928: linear tick generator doesn't round values to needed precision.

### DIFF
--- a/src/core/core.ticks.js
+++ b/src/core/core.ticks.js
@@ -88,7 +88,7 @@ module.exports = {
 			}
 			ticks.push(generationOptions.min !== undefined ? generationOptions.min : niceMin);
 			for (var j = 1; j < numSpaces; ++j) {
-				ticks.push(niceMin + Math.round(j * spacing * precision) / precision);
+				ticks.push(Math.round((niceMin + j * spacing) * precision) / precision);
 			}
 			ticks.push(generationOptions.max !== undefined ? generationOptions.max : niceMax);
 

--- a/src/core/core.ticks.js
+++ b/src/core/core.ticks.js
@@ -126,6 +126,7 @@ module.exports = {
 				exp = Math.floor(helpers.log10(tickVal));
 				significand = Math.floor(tickVal / Math.pow(10, exp));
 			}
+			var precision = exp < 0 ? Math.pow(10, Math.abs(exp)) : 1;
 
 			do {
 				ticks.push(tickVal);
@@ -134,9 +135,10 @@ module.exports = {
 				if (significand === 10) {
 					significand = 1;
 					++exp;
+					precision = exp >= 0 ? 1 : precision;
 				}
 
-				tickVal = significand * Math.pow(10, exp);
+				tickVal = Math.round(significand * Math.pow(10, exp) * precision) / precision;
 			} while (exp < endExp || (exp === endExp && significand < endSignificand));
 
 			var lastTick = valueOrDefault(generationOptions.max, tickVal);

--- a/src/core/core.ticks.js
+++ b/src/core/core.ticks.js
@@ -82,7 +82,7 @@ module.exports = {
 
 			var precision = 1;
 			if (spacing < 1) {
-				precision = Math.pow(10, spacing.toPrecision().length - 2);
+				precision = Math.pow(10, spacing.toString().length - 2);
 				niceMin = Math.round(niceMin * precision) / precision;
 				niceMax = Math.round(niceMax * precision) / precision;
 			}

--- a/src/core/core.ticks.js
+++ b/src/core/core.ticks.js
@@ -80,10 +80,15 @@ module.exports = {
 				numSpaces = Math.ceil(numSpaces);
 			}
 
-			// Put the values into the ticks array
+			var precision = 1;
+			if (spacing < 1) {
+				precision = Math.pow(10, spacing.toPrecision().length - 2);
+				niceMin = Math.round(niceMin * precision) / precision;
+				niceMax = Math.round(niceMax * precision) / precision;
+			}
 			ticks.push(generationOptions.min !== undefined ? generationOptions.min : niceMin);
 			for (var j = 1; j < numSpaces; ++j) {
-				ticks.push(niceMin + (j * spacing));
+				ticks.push(niceMin + Math.round(j * spacing * precision) / precision);
 			}
 			ticks.push(generationOptions.max !== undefined ? generationOptions.max : niceMax);
 

--- a/test/specs/core.ticks.tests.js
+++ b/test/specs/core.ticks.tests.js
@@ -1,0 +1,87 @@
+describe('Test tick generators', function() {
+	it('Should generate linear spaced ticks with correct precision', function() {
+		var chart = window.acquireChart({
+			type: 'line',
+			data: {
+				datasets: [{
+					data: []
+				}],
+			},
+			options: {
+				legend: {
+					display: false,
+				},
+				scales: {
+					xAxes: [{
+						type: 'linear',
+						position: 'bottom',
+						ticks: {
+							callback: function(value) {
+								return value.toString();
+							}
+						}
+					}],
+					yAxes: [{
+						type: 'linear',
+						ticks: {
+							callback: function(value) {
+								return value.toString();
+							}
+						}
+					}]
+				}
+			}
+		});
+
+		var xAxis = chart.scales['x-axis-0'];
+		var yAxis = chart.scales['y-axis-0'];
+
+		expect(xAxis.ticks).toEqual(['-1', '-0.8', '-0.6', '-0.4', '-0.2', '0', '0.2', '0.4', '0.6', '0.8', '1']);
+		expect(yAxis.ticks).toEqual(['1', '0.8', '0.6', '0.4', '0.2', '0', '-0.2', '-0.4', '-0.6', '-0.8', '-1']);
+	});
+
+	it('Should generate logarithmic spaced ticks with correct precision', function() {
+		var chart = window.acquireChart({
+			type: 'line',
+			data: {
+				datasets: [{
+					data: []
+				}],
+			},
+			options: {
+				legend: {
+					display: false,
+				},
+				scales: {
+					xAxes: [{
+						type: 'logarithmic',
+						position: 'bottom',
+						ticks: {
+							min: 0.1,
+							max: 1,
+							callback: function(value) {
+								return value.toString();
+							}
+						}
+					}],
+					yAxes: [{
+						type: 'logarithmic',
+						ticks: {
+							min: 0.1,
+							max: 1,
+							callback: function(value) {
+								return value.toString();
+							}
+						}
+					}]
+				}
+			}
+		});
+
+		var xAxis = chart.scales['x-axis-0'];
+		var yAxis = chart.scales['y-axis-0'];
+
+		expect(xAxis.ticks).toEqual(['0.1', '0.2', '0.3', '0.4', '0.5', '0.6', '0.7', '0.8', '0.9', '1']);
+		expect(yAxis.ticks).toEqual(['1', '0.9', '0.8', '0.7', '0.6', '0.5', '0.4', '0.3', '0.2', '0.1']);
+	});
+});


### PR DESCRIPTION
Fixes #4928 - linear tick generator doesn't round values to needed precision.

Test case: https://codepen.io/anon/pen/LOLxvL

**v2.7**
![issue_tick_rounding_error_4928](https://user-images.githubusercontent.com/33193571/32744517-01c29620-c8b0-11e7-96bf-9ebd4548eb33.png)
**Proposed fix**
![fix-issue_tick_rounding_error_4928](https://user-images.githubusercontent.com/33193571/32744688-ae473252-c8b0-11e7-9f21-74f1c289fb7f.png)