### PR TITLE
Update moment

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
   },
   "dependencies": {
     "chartjs-color": "^2.1.0",
-    "moment": "^2.10.2"
+    "moment": "^2.19.2"
   }
 }


### PR DESCRIPTION
It's a minor change, but Chart.js using the old version of `moment` prevents it from being deduplicated, resulting in bigger size of bundles (containing multiple versions of `moment`).