### PR TITLE
Chart inside bootstrap 'collapse' element

### DIFF
--- a/src/elements/element.arc.js
+++ b/src/elements/element.arc.js
@@ -88,8 +88,8 @@ module.exports = Element.extend({
 
 		ctx.beginPath();
 
-		ctx.arc(vm.x, vm.y, vm.outerRadius, sA, eA);
-		ctx.arc(vm.x, vm.y, vm.innerRadius, eA, sA, true);
+		ctx.arc(vm.x, vm.y, Math.abs(vm.outerRadius), sA, eA);
+		ctx.arc(vm.x, vm.y, Math.abs(vm.innerRadius), eA, sA, true);
 
 		ctx.closePath();
 		ctx.strokeStyle = vm.borderColor;

--- a/src/helpers/helpers.canvas.js
+++ b/src/helpers/helpers.canvas.js
@@ -63,7 +63,7 @@ var exports = module.exports = {
 		// Default includes circle
 		default:
 			ctx.beginPath();
-			ctx.arc(x, y, radius, 0, Math.PI * 2);
+			ctx.arc(x, y, Math.abs(radius), 0, Math.PI * 2);
 			ctx.closePath();
 			ctx.fill();
 			break;

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -288,7 +288,7 @@ module.exports = function(Chart) {
 		if (scale.options.gridLines.circular) {
 			// Draw circular arcs between the points
 			ctx.beginPath();
-			ctx.arc(scale.xCenter, scale.yCenter, radius, 0, Math.PI * 2);
+			ctx.arc(scale.xCenter, scale.yCenter, Math.abs(radius), 0, Math.PI * 2);
 			ctx.closePath();
 			ctx.stroke();
 		} else {


### PR DESCRIPTION
When chart is inside a bootstrap 'collapse' element the width and height are zero and the chart 'draw' function throws an IndexSizeError because the outer/inner radius are computed using a zero width/height and when subtracting padding it results in a negative value.
When element is collapsed it does not show anyway so adding Math.abs() to the radius will have no effect on the drawing itself but will eliminate the error.

here is a jsFiddle to demonstrate the issue https://jsfiddle.net/4s09skz9