### PR TITLE
Chart inside bootstrap 'collapse' element

### DIFF
--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -288,7 +288,7 @@ module.exports = function(Chart) {
 		if (scale.options.gridLines.circular) {
 			// Draw circular arcs between the points
 			ctx.beginPath();
-			ctx.arc(scale.xCenter, scale.yCenter, radius, 0, Math.PI * 2);
+			ctx.arc(scale.xCenter, scale.yCenter, Math.abs(radius), 0, Math.PI * 2);
 			ctx.closePath();
 			ctx.stroke();
 		} else {


### PR DESCRIPTION
When chart is inside a bootstrap 'collapse' element the width and height are zero and the chart 'draw' function throws an IndexSizeError because the outer/inner radius are computed using a zero width/height and when subtracting padding it results in a negative value.
When element is collapsed it does not show anyway so adding Math.abs() to the radius will have no effect on the drawing itself but will eliminate the error.

Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- http://jsbin.com/
- http://jsfiddle.net/
- http://codepen.io/pen/
- Premade template: http://codepen.io/pen?template=JXVYzq