### PR TITLE
Chart inside bootstrap 'collapse' element

### DIFF
--- a/src/helpers/helpers.canvas.js
+++ b/src/helpers/helpers.canvas.js
@@ -63,7 +63,7 @@ var exports = module.exports = {
 		// Default includes circle
 		default:
 			ctx.beginPath();
-			ctx.arc(x, y, radius, 0, Math.PI * 2);
+			ctx.arc(x, y, Math.abs(radius), 0, Math.PI * 2);
 			ctx.closePath();
 			ctx.fill();
 			break;


### PR DESCRIPTION
When chart is inside a bootstrap 'collapse' element the width and height are zero and the chart 'draw' function throws an IndexSizeError because the outer/inner radius are computed using a zero width/height and when subtracting padding it results in a negative value.
When element is collapsed it does not show anyway so adding Math.abs() to the radius will have no effect on the drawing itself but will eliminate the error.

Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- http://jsbin.com/
- http://jsfiddle.net/
- http://codepen.io/pen/
- Premade template: http://codepen.io/pen?template=JXVYzq