### PR TITLE
Add a vertical guideline option and 'besideAxis' positioner for tooltip

### DIFF
--- a/docs/configuration/tooltip.md
+++ b/docs/configuration/tooltip.md
@@ -41,13 +41,16 @@ The tooltip configuration is passed into the `options.tooltips` namespace. The g
 | `displayColors` | `Boolean` | `true` | if true, color boxes are shown in the tooltip
 | `borderColor` | `Color` | `'rgba(0,0,0,0)'` | Color of the border
 | `borderWidth` | `Number` | `0` | Size of the border
+| `verticalGuideBorderColor` | `Color` | `'rgba(0,0,0,0)'` | Color of the vertical guide border
+| `verticalGuideBorderWidth` | `Number` | `0` | Size of the vertical guid border
 
 ### Position Modes
  Possible modes are:
 * 'average'
 * 'nearest'
+* 'besideAxis'
 
-'average' mode will place the tooltip at the average position of the items displayed in the tooltip. 'nearest' will place the tooltip at the position of the element closest to the event position.
+'average' mode will place the tooltip at the average position of the items displayed in the tooltip. 'nearest' will place the tooltip at the position of the element closest to the event position. 'besideAxis' will place tooltip beside the vertical line connecting items displayed in the tooltip.
 
 New modes can be defined by adding functions to the Chart.Tooltip.positioners map.
 

--- a/samples/tooltips/vertical-guide.html
+++ b/samples/tooltips/vertical-guide.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-	<title>Tooltip Interaction Modes</title>
+	<title>Tooltip Vertical Guide</title>
 	<script src="../../dist/Chart.bundle.js"></script>
 	<script src="../utils.js"></script>
 	<style>
@@ -41,18 +41,6 @@
 						backgroundColor: window.chartColors.red,
 						data: [10, 30, 46, 2, 8, 50, 0],
 						fill: false,
-					}, {
-						label: "My Second dataset",
-						borderColor: window.chartColors.blue,
-						backgroundColor: window.chartColors.blue,
-						data: [7, 49, 46, 13, 25, 30, 22],
-						fill: false,
-					}, {
-						label: "My Third dataset",
-						borderColor: window.chartColors.blue,
-						backgroundColor: window.chartColors.blue,
-						data: [7, 49, 46, 13, 25, 30, 22],
-						fill: false,
 					}]
 				},
 				options: {
@@ -65,6 +53,8 @@
 						position: position,
 						mode: 'index',
 						intersect: false,
+						verticalGuideBorderWidth: 1,
+						verticalGuideBorderColor: '#000000'
 					},
 				}
 			};
@@ -73,7 +63,7 @@
 		window.onload = function() {
 			var container = document.querySelector('.container');
 
-			['average', 'nearest', 'besideAxis'].forEach(function(position) {
+			['besideAxis'].forEach(function(position) {
 				var div = document.createElement('div');
 				div.classList.add('chart-container');
 

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -34,6 +34,8 @@ defaults._set('global', {
 		displayColors: true,
 		borderColor: 'rgba(0,0,0,0)',
 		borderWidth: 0,
+		verticalGuideBorderColor: 'rgba(0,0,0,0)',
+		verticalGuideBorderWidth: 0,
 		callbacks: {
 			// Args are: (tooltipItems, data)
 			beforeTitle: helpers.noop,
@@ -188,7 +190,9 @@ module.exports = function(Chart) {
 			legendColorBackground: tooltipOpts.multiKeyBackground,
 			displayColors: tooltipOpts.displayColors,
 			borderColor: tooltipOpts.borderColor,
-			borderWidth: tooltipOpts.borderWidth
+			borderWidth: tooltipOpts.borderWidth,
+			verticalGuideBorderWidth: tooltipOpts.verticalGuideBorderWidth,
+			verticalGuideBorderColor: tooltipOpts.verticalGuideBorderColor
 		};
 	}
 
@@ -787,6 +791,28 @@ module.exports = function(Chart) {
 				ctx.stroke();
 			}
 		},
+		drawVerticalGuideLine: function(vm, ctx, opacity) {
+			if (vm.verticalGuideBorderWidth <= 0) {
+				return;
+			}
+
+			var chart = this._chart;
+			ctx.save();
+
+			ctx.strokeStyle = mergeOpacity(vm.verticalGuideBorderColor, opacity);
+			ctx.lineWidth = vm.verticalGuideBorderWidth;
+
+			var x = vm.caretX;
+			x += helpers.aliasPixel(ctx.lineWidth);
+
+			ctx.beginPath();
+			ctx.moveTo(x, chart.chartArea.top);
+			ctx.lineTo(x, chart.chartArea.bottom);
+			ctx.closePath();
+			ctx.stroke();
+
+			ctx.restore();
+		},
 		draw: function() {
 			var ctx = this._chart.ctx;
 			var vm = this._view;
@@ -811,6 +837,9 @@ module.exports = function(Chart) {
 			var hasTooltipContent = vm.title.length || vm.beforeBody.length || vm.body.length || vm.afterBody.length || vm.footer.length;
 
 			if (this._options.enabled && hasTooltipContent) {
+
+				this.drawVerticalGuideLine(vm, ctx, opacity);
+
 				// Draw Background
 				this.drawBackground(pt, vm, ctx, tooltipSize, opacity);
 
@@ -948,6 +977,34 @@ module.exports = function(Chart) {
 			return {
 				x: x,
 				y: y
+			};
+		},
+		/**
+		 * Gets the tooltip position beside a vertical axis
+		 * @function Chart.Tooltip.positioners.besideAxis
+		 * @param elements {Chart.Element[]} the tooltip elements
+		 * @returns {Point} the tooltip position
+		 */
+		besideAxis: function(elements) {
+			if (!elements.length) {
+				return false;
+			}
+
+			var x = 0;
+
+			var el = elements[0];
+			if (el && el.hasValue()) {
+				var pos = el.tooltipPosition();
+				x += pos.x;
+			} else {
+				return false;
+			}
+
+			var chart = el._chart;
+
+			return {
+				x: Math.round(x),
+				y: Math.round(chart.height / 2)
 			};
 		}
 	};


### PR DESCRIPTION
When tooltip is visible, a vertical guide line is also visible. This vertical guid line let users read current position very easily when the line chart is complex.

Example:
https://codepen.io/anon/pen/JOgQaY