### PR TITLE
Fix issue #5029 - infinite loop due to insufficient bounds checking

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -240,7 +240,7 @@ function determineStepSize(min, max, unit, capacity) {
 	var i, ilen, factor;
 
 	if (!steps) {
-		return Math.ceil(range / ((capacity || 1) * milliseconds));
+		return Math.ceil(range / (capacity * milliseconds));
 	}
 
 	for (i = 0, ilen = steps.length; i < ilen; ++i) {
@@ -748,7 +748,8 @@ module.exports = function(Chart) {
 			var tickLabelWidth = me.getLabelWidth(exampleLabel);
 			var innerWidth = me.isHorizontal() ? me.width : me.height;
 
-			return Math.floor(innerWidth / tickLabelWidth);
+			var capacity = Math.floor(innerWidth / tickLabelWidth);
+			return capacity > 0 ? capacity : 1;
 		}
 	});
 


### PR DESCRIPTION
While generating the time axis, a negative `stepSize` will result in an infinite loop.
A negative `stepSize` could be generated by `determineStepSize` when the `capacity` argument is also negative. This PR will have `getLabelCapacity` always return a positive `capacity` and clean up a previous check in `determineStepSize`.

fiddle https://jsfiddle.net/aLk05ptk/10/

Fixes #5029