### PR TITLE
[BUG] Use time.unit option to create default min/max for empty chart

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -504,6 +504,7 @@ module.exports = function(Chart) {
 			var me = this;
 			var chart = me.chart;
 			var timeOpts = me.options.time;
+			var unit = timeOpts.unit || 'day';
 			var min = MAX_INTEGER;
 			var max = MIN_INTEGER;
 			var timestamps = [];
@@ -555,9 +556,9 @@ module.exports = function(Chart) {
 			min = parse(timeOpts.min, me) || min;
 			max = parse(timeOpts.max, me) || max;
 
-			// In case there is no valid min/max, let's use today limits
-			min = min === MAX_INTEGER ? +moment().startOf('day') : min;
-			max = max === MIN_INTEGER ? +moment().endOf('day') + 1 : max;
+			// In case there is no valid min/max, set limits based on unit time option
+			min = min === MAX_INTEGER ? +moment().startOf(unit) : min;
+			max = max === MIN_INTEGER ? +moment().endOf(unit) + 1 : max;
 
 			// Make sure that max is strictly higher than min (required by the lookup table)
 			me.min = Math.min(min, max);

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -703,7 +703,7 @@ describe('Time scale tests', function() {
 				expect(getTicksLabels(scale)).toEqual([
 					'2017', '2019', '2020', '2025', '2042']);
 			});
-			it ('should correctly handle empty `data.labels`', function() {
+			it ('should correctly handle empty `data.labels` using "day" if `time.unit` is undefined`', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
 
@@ -712,6 +712,19 @@ describe('Time scale tests', function() {
 
 				expect(scale.min).toEqual(+moment().startOf('day'));
 				expect(scale.max).toEqual(+moment().endOf('day') + 1);
+				expect(getTicksLabels(scale)).toEqual([]);
+			});
+			it ('should correctly handle empty `data.labels` using `time.unit`', function() {
+				var chart = this.chart;
+				var scale = chart.scales.x;
+				var options = chart.options.scales.xAxes[0];
+
+				options.time.unit = 'year';
+				chart.data.labels = [];
+				chart.update();
+
+				expect(scale.min).toEqual(+moment().startOf('year'));
+				expect(scale.max).toEqual(+moment().endOf('year') + 1);
 				expect(getTicksLabels(scale)).toEqual([]);
 			});
 		});
@@ -784,7 +797,7 @@ describe('Time scale tests', function() {
 				expect(getTicksLabels(scale)).toEqual([
 					'2017', '2018', '2019', '2020', '2025', '2042', '2043']);
 			});
-			it ('should correctly handle empty `data.labels`', function() {
+			it ('should correctly handle empty `data.labels` using "day" if `time.unit` is undefined`', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
 
@@ -795,6 +808,21 @@ describe('Time scale tests', function() {
 				expect(scale.max).toEqual(+moment('2043', 'YYYY'));
 				expect(getTicksLabels(scale)).toEqual([
 					'2018', '2020', '2043']);
+			});
+			it ('should correctly handle empty `data.labels` and hidden datasets using `time.unit`', function() {
+				var chart = this.chart;
+				var scale = chart.scales.x;
+				var options = chart.options.scales.xAxes[0];
+
+				options.time.unit = 'year';
+				chart.data.labels = [];
+				var meta = chart.getDatasetMeta(1);
+				meta.hidden = true;
+				chart.update();
+
+				expect(scale.min).toEqual(+moment().startOf('year'));
+				expect(scale.max).toEqual(+moment().endOf('year') + 1);
+				expect(getTicksLabels(scale)).toEqual([]);
 			});
 		});
 	});


### PR DESCRIPTION
Currently the default `min/max` values for the time scale are create with the `day` unit.
If the user has set the `time.unit` option and has hidden all the datasets, the scale will be empty (no tick labels).
Using the `time.unit` option will show the labels as selected.
![pr-empty-time-chart-default-scale-unit](https://user-images.githubusercontent.com/33193571/34038556-12b0ec34-e18d-11e7-8137-9914a98709db.png)
 