### PR TITLE
Update license year and copyright holders

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013-2017 Nick Downie
+Copyright (c) 2018 Chart.js Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,7 +29,7 @@ var header = "/*!\n" +
   " * http://chartjs.org/\n" +
   " * Version: {{ version }}\n" +
   " *\n" +
-  " * Copyright 2017 Nick Downie\n" +
+  " * Copyright " + (new Date().getFullYear()) + " Chart.js Contributors\n" +
   " * Released under the MIT license\n" +
   " * https://github.com/chartjs/Chart.js/blob/master/LICENSE.md\n" +
   " */\n";


### PR DESCRIPTION
We discussed this point some time ago with @etimberg and were thinking to replace the copyright holder for `Chart.js Contributors`, which seems more in line with the current state of this project. @nnnick what do you think?

(saving a commit by upgrading to 2018)