### PR TITLE
Scroll bar width is ignored, preventing resize looping

### DIFF
--- a/docs/general/responsive.md
+++ b/docs/general/responsive.md
@@ -16,6 +16,7 @@ Chart.js provides a [few options](#configuration-options) to enable responsivene
 | `responsive` | `Boolean` | `true` | Resizes the chart canvas when its container does ([important note...](#important-note)).
 | `responsiveAnimationDuration` | `Number` | `0` | Duration in milliseconds it takes to animate to new size after a resize event.
 | `maintainAspectRatio` | `Boolean` | `true` | Maintain the original canvas aspect ratio `(width / height)` when resizing.
+| `ignoreScrollBar` | `Boolean` | `true` | Chart size is not affected by the appearance of a scroll bar..
 | `onResize` | `Function` | `null` | Called when a resize occurs. Gets passed two arguments: the chart instance and the new size.
 
 ## Important Note

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -87,6 +87,7 @@ module.exports = function(Chart) {
 			me.width = width;
 			me.height = height;
 			me.aspectRatio = height ? width / height : null;
+			me.defaultScrollWidth = platform.getDefaultScrollBarWidth();
 			me.options = config.options;
 			me._bufferedRender = false;
 
@@ -178,6 +179,14 @@ module.exports = function(Chart) {
 
 			// Set to 0 instead of canvas.size because the size defaults to 300x150 if the element is collased
 			var newWidth = Math.max(0, Math.floor(helpers.getMaximumWidth(canvas)));
+
+			// If a scroll bar is visible add scroll bar's width to
+			// the chart width to prevent infinite resizing
+			// see https://github.com/chartjs/Chart.js/issues/2127
+			if (options.ignoreScrollBar && platform.detectScrollBarInParents(canvas) && newWidth > 0) {
+				newWidth += me.defaultScrollWidth;
+			}
+
 			var newHeight = Math.max(0, Math.floor(aspectRatio ? newWidth / aspectRatio : helpers.getMaximumHeight(canvas)));
 
 			if (me.width === newWidth && me.height === newHeight) {

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -6,6 +6,7 @@ defaults._set('global', {
 	responsive: true,
 	responsiveAnimationDuration: 0,
 	maintainAspectRatio: true,
+	ignoreScrollBar: true,
 	events: ['mousemove', 'mouseout', 'click', 'touchstart', 'touchmove'],
 	hover: {
 		onHover: null,

--- a/src/platforms/platform.js
+++ b/src/platforms/platform.js
@@ -50,7 +50,20 @@ module.exports = helpers.extend({
 	 * @param {String} type - The ({@link IEvent}) type to remove
 	 * @param {Function} listener - The listener function to remove from the event target.
 	 */
-	removeEventListener: function() {}
+	removeEventListener: function() {},
+
+	/**
+	 * Calculates the browsers default scroll bar width
+	 * @returns {number} the width of the vertical scroll bar in pixles
+	 */
+	getDefaultScrollBarWidth: function() {},
+
+	/**
+	 * Iterates through parent nodes of the given node looking for a toggle-able scroll bar
+	 * @param {Chart} chart - the Chart that is looking for a parent with a scroll bar
+	 * @returns {Boolean} true if a parent node has a visible toggle-able scroll bar
+	 */
+	detectScrollBarInParents: function() {}
 
 }, implementation);
 


### PR DESCRIPTION
This is one way to resolve #2127.

What I do is get the scroll bar width of the users browser using getDefaultScrollBarWidth(). Different browsers on different OSes have different scroll bar width.

Then, when a chart is being resized, detectScrollBarInParents() checks to see if a scroll bar is visible and toggle-able in any parent div or in the window of the browser. If one is found, then the scroll bar width is added to the width of the canvas. In effect, the appearance of a scroll bar is ignored when calculating the width of the chart.

There are a few issues that I can think of with this solution:
1) A number of current tests fail. This is because the tests are looking for a hard coded width and height for the chart, but if a scroll bar is present, the width and height of the chart are now altered.
2) There is no way to detect multiple charts that are next to one another horizontally. This means that if there are two charts, side by side, and a scroll bar is present, both charts will have their width expanded.
3) The current pull request only cares about the default scroll bar width. In webkit browsers the width of the scroll bar can be customized. I am leaving this for a future pull request.

A workding JSbin can be found here: 
http://jsbin.com/wuzuhixabu/edit?html,output