### PR TITLE
Optimization: prevent double ticks array reverse for logarithmic scale

### DIFF
--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -161,6 +161,7 @@ module.exports = function(Chart) {
 			var me = this;
 			var opts = me.options;
 			var tickOpts = opts.ticks;
+			var reverse = !me.isHorizontal();
 
 			var generationOptions = {
 				min: tickOpts.min,
@@ -168,24 +169,21 @@ module.exports = function(Chart) {
 			};
 			var ticks = me.ticks = Ticks.generators.logarithmic(generationOptions, me);
 
-			if (!me.isHorizontal()) {
-				// We are in a vertical orientation. The top value is the highest. So reverse the array
-				ticks.reverse();
-			}
-
 			// At this point, we need to update our max and min given the tick values since we have expanded the
 			// range of the scale
 			me.max = helpers.max(ticks);
 			me.min = helpers.min(ticks);
 
 			if (tickOpts.reverse) {
-				ticks.reverse();
-
+				reverse = !reverse;
 				me.start = me.max;
 				me.end = me.min;
 			} else {
 				me.start = me.min;
 				me.end = me.max;
+			}
+			if (reverse) {
+				ticks.reverse();
 			}
 		},
 		convertTicksToLabels: function() {


### PR DESCRIPTION
Currently the logarithmic scale reverses the ticks for vertical axis and then checks if the axis is reverse and reverse it again.
The optimization sets the reverse flag for vertical axis and inverts the flag for the reverse ticks option, so that the reverse action is only applied once.