### PR TITLE
Turn linting on for test and samples in codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -7,6 +7,9 @@ engines:
   eslint:
     enabled: true
     channel: "eslint-4"
+    include_paths:
+    - 'test/'
+    - 'samples/'
   fixme:
     enabled: true
 ratings:


### PR DESCRIPTION
Running `gulp lint` runs it on the samples and tests. Codeclimate should probably match it. I think we should care about the code quality for these directories as well and it's not returning many additional warnings