### PR TITLE
[Plugin] HTML Legend plugin (deprecate options.legendCallback)

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -18,6 +18,7 @@
   * [Animations](configuration/animations.md)
   * [Layout](configuration/layout.md)
   * [Legend](configuration/legend.md)
+  * [HTML Legend](configuration/htmllegend.md)
   * [Title](configuration/title.md)
   * [Tooltip](configuration/tooltip.md)
   * [Elements](configuration/elements.md)

--- a/docs/configuration/htmllegend.md
+++ b/docs/configuration/htmllegend.md
@@ -1,0 +1,275 @@
+# HTML Legend Configuration
+
+Sometimes you need a very complex legend. In these cases, it makes sense to generate an HTML legend. Charts provide a `generateLegend()` method on their prototype that returns an HTML string/ DOM node for the legend. This function is a wrapper for `chart.htmllegend.generate()`.
+
+The output of `generateLegend()` is configurable. See the [Configuration options](#configuration-options) section below.
+
+Without any configuration options the `generateLegend()` will output legacy `'HTML'` output. Whenever the `options.htmllegend` is set, the default output will become `'DOM'`, which generates a DOM node.
+
+Note that by default the HTML legend is not called automatically and you will have to call `generateLegend()` yourself. By setting the `target` option however the legend will be automatically inserted.
+
+When these configuration options don't suffice, you can set the `options.htmllegend` or `options.htmllegend.callback` property with your own function, to configure how this legend is generated.
+
+```javascript
+var chart = new Chart(ctx, {
+    type: 'line',
+    data: data,
+    options: {
+        htmllegend: function(chart, options, optional) {
+            // @param {Object} chart - The chart object.
+            // @param {Object} options - The chart.options.htmllegend options.
+            // @param {Array} optional - optional arguments your callback needs.
+            // Return the HTML string or DOM node here.
+        }
+    }
+});
+var legend = chart.generateLegend(); // HTML legend
+```
+
+The html legend is configurable.
+
+```javascript
+var chart = new Chart(ctx, {
+    type: 'line',
+    data: data,
+    options: {
+        htmllegend: {
+            callback: function(chart, options, optional) {
+                // Return the HTML string or DOM node here.
+            }
+        }
+    }
+});
+```
+
+## Configuration options
+
+The HTML legend configuration is passed into the `options.htmllegend` namespace. The global options for the chart legend is defined in `Chart.defaults.global.htmllegend`.
+The default legend options need to be configured in `options.legend` which will be used by the default callback function.
+
+| Name | Type | Default | Description
+| -----| ---- | --------| -----------
+| `callback` | `Function` | | User-defined callback function. Doing so will ignore the `output`, `nodes` and `hiddenClass` options.
+| `hiddenClass` | `String` | `'hidden'` | Class to set on hidden legend elements.
+| `listeners` | `Function` / `Object` | | Listeners to bind to container element. See [Event listeners](#html-event-listeners) section below.
+| `nodes` | `Object` | | See the [Legend Node Tags Configuration](#html-legend-node-tags-configuration) section below.
+| `output` | `String` | `'HTML'` / `'DOM'` | By default the returned output is a HTML string. When a configuration is passed, the default will be a DOM node.
+| `target` | `DOM node` | | When present the legend will be auto-generated on chart creation.
+
+## HTML Legend Node Tags Configuration
+
+| Name | Type | Default | Description
+| -----| ---- | --------| -----------
+| `container` | `String` / `Object` | `'ul'` | Container element [Tag Configuration](#html-tag-elements-configuration).
+| `items` | `String` / `Object` | `'li'` | Items element [Tag Configuration](#html-tag-elements-configuration).
+| `box` | `String` / `Object` | `'span'` | Box element [Tag Configuration](#html-tag-elements-configuration).
+| `label` | `String` / `Object` | `'textnode'` | Label element [Tag Configuration](#html-tag-elements-configuration).
+
+## HTML Tag Elements Configuration
+
+| Name | Type | Default | Description
+| -----| ---- | --------| -----------
+| `tag` | `String` | `'div'` | HTML tag.
+| `attributes` | `Object` | | HTML node attributes, like `id`, `style` (String / Object) and `classList` (String / Array). See the [examples](#html-legend-examples) section below.
+
+The `attributes` values can contain certain escape-values, which will be set on generation; e.g. the default class `{chartId}-legend`, which will be replaced by `0-legend` for the first chart. Allowed escape values are:
+
+| Name | Description
+| -----| -----------
+| `{chartId}` | The chart id.
+| `{id}` | The legend item index. Only allowed for `items`, `box` and `label`.
+| `{datesetIndex}` | The `legendItem.datasetIndex` value, might be `undefined`.
+| `{index}` | The `legendItem.index` value, might be `undefined`.
+
+## HTML event Listeners
+
+The list of event listeners to bind to legend container, where the key is the event listener name and the value the listener function or object.
+For Example `click: function(e) {}` or `click: {listener: function(e) {}, options: {passive: true}}`.
+Listeners can only be bound when the returned output is a DOM node. The `htmllegend` triggers the `afterUpdate` event on the `container`-node.
+
+| Name | Type | Default | Description
+| -----| ---- | --------| -----------
+| `listener` | `Function` | | The event function.
+| `options` | `Object` | false | Options to be bound by addEventListener.
+
+## HTML Legend Examples
+
+Generate a basic (legacy) HTML Unordered List (UL) with `{chartId}-legend` class.
+
+```javascript
+var legend = chart.generateLegend();
+document.getElementById('legend-container').innerHTML = legend;
+```
+
+This example would generate something like the following.
+
+```html
+<ul class="0-legend">
+    <li><span style="background-color: red;"></span>First Item</li>
+    <li><span style="background-color: green;"></span>Second Item</li>
+    <li><span style="background-color: blue;"></span>Third Item</li>
+</ul>
+```
+
+Generate a personalized HTML legend.
+
+```javascript
+var chart = new Chart(ctx, {
+    type: 'bar',
+    data: data,
+    options: {
+        htmllegend: {
+            nodes: {
+                container: { // object syntax
+                    tag: 'div',
+                    attributes: {
+                        id: 'legend-{chartId}',
+                        classList: ['chartjs-legend', '{chartId}-legend'] // pass multiple classes as array
+                    }
+                },
+                items: 'div', // string syntax
+                box: {
+                    tag: 'span',
+                    attributes: {
+                        style: {
+                            border: 'none' // remove the default border
+                        }
+                    }
+                },
+                label: {
+                    tag: 'span',
+                    attributes: {
+                        classList: 'label'
+                    }
+                }
+            },
+            hiddenClass: 'notVisible',
+            target: document.getElementById('legend-container') // auto-generate HTML legend after chart construction
+        }
+    }
+});
+```
+
+This example would generate something like the following.
+Passing a DOM node as the `target` option will auto-generate the legend on chart creation.
+
+```html
+<div id="legend-container">
+    <div id="legend-0" class="chartjs-legend 0-legend">
+        <div>
+            <span style="background-color: red; border: medium none;"></span>
+            <span class="label">First Item</span>
+        </div>
+        <div>
+            <span style="background-color: green; border: medium none;"></span>
+            <span class="label">Second Item</span>
+        </div>
+        <div class="notVisible">
+            <span style="background-color: blue; border: medium none;"></span>
+            <span class="label">Third Item</span>
+        </div>
+    </div>
+</div>
+```
+
+Generate an interactive DOM node. For this to work the `output` option has to be cannot be set to `'HTML'`.
+
+```javascript
+function onClickCallback(event) {
+    event = event || window.event;
+
+    var target = event.target || event.srcElement;
+    if (target.nodeName === 'UL') {
+        return; // event has been fired on parent
+    }
+
+    // find a direct descendant from the parent element
+    while (target && target.nodeName !== 'LI') {
+        target = target.parentElement;
+    }
+
+    if (!target) {
+      return; // something went wrong, no target found
+    }
+
+    var parent = target.parentElement;
+    var chartId = parseInt(parent.classList[0].split('-')[0], 10);
+    var chart = Chart.instances[chartId];
+    var index = Array.prototype.slice.call(parent.children).indexOf(target);
+
+    // invoke the ChartJS legend onClick event
+    chart.legend.options.onClick.call(chart, event, chart.legend.legendItems[index]);
+
+    var hidden = chart.legend.legendItems[index].hidden; // legend item has been updated
+    target.classList.toggle('hidden', hidden);
+}
+
+var chart = new Chart(ctx, {
+    type: 'bar',
+    data: data,
+    options: {
+        htmllegend: {
+            listeners: {
+                click: onClickCallback
+            }
+        }
+    }
+});
+
+// create the HTML legend and attach to target
+var targetNode = document.getElementById('legend-container');
+chart.generateLegend(legendNode); // create legend and attach to target
+
+// or you could chose to have the legendNode returned and attach it later
+var targetNode = document.getElementById('legend-container');
+var legendNode = chart.generateLegend(); // create legend
+targetNode.appendChild(legendNode); // attach to target
+```
+
+The above example isn't any different from the following.
+
+```javascript
+var chart = new Chart(ctx, {
+    type: 'bar',
+    data: data
+});
+
+var targetNode = document.getElementById('legend-container');
+var legend = chart.generateLegend();
+targetNode.innerHTML = legend;
+targetNode.childNodes[0].addEventListener('click', onClickCallback, false);
+```
+
+## Styling HTML Legend
+
+Style sheet configuration to style the default HTML legend.
+
+```css
+[class$="-legend"] {
+    background-color: rgba(255, 255, 255, 0.55);
+    border: 1px solid #666;
+    color: #666;
+    display: inline-block;
+    font-family: 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+    font-size: 12px;
+    list-style: none;
+    margin: 0;
+    padding: 5px 6px;
+}
+[class$="-legend"] > li {
+    cursor: pointer;
+    vertical-align: middle;
+}
+[class$="-legend"] > li.hidden {
+    text-decoration: line-through;
+}
+[class$="-legend"] > li > span:first-child {
+    background-clip: padding-box;
+    box-sizing: border-box;
+    display: inline-block;
+    height: 14px;
+    margin-right: 6px;
+    width: 40px;
+    vertical-align: middle;
+}
+```

--- a/docs/configuration/legend.md
+++ b/docs/configuration/legend.md
@@ -1,6 +1,6 @@
 # Legend Configuration
 
-The chart legend displays data about the datasets that area appearing on the chart.
+The chart legend displays data about the datasets that are appearing on the chart.
 
 ## Configuration options
 The legend configuration is passed into the `options.legend` namespace. The global options for the chart legend is defined in `Chart.defaults.global.legend`.
@@ -10,7 +10,7 @@ The legend configuration is passed into the `options.legend` namespace. The glob
 | `display` | `Boolean` | `true` | is the legend shown
 | `position` | `String` | `'top'` | Position of the legend. [more...](#position)
 | `fullWidth` | `Boolean` | `true` | Marks that this box should take the full width of the canvas (pushing down other boxes). This is unlikely to need to be changed in day-to-day use.
-| `onClick` | `Function` | | A callback that is called when a click event is registered on a label item 
+| `onClick` | `Function` | | A callback that is called when a click event is registered on a label item
 | `onHover` | `Function` | | A callback that is called when a 'mousemove' event is registered on top of a label item
 | `reverse` | `Boolean` | `false` | Legend will show datasets in reverse order.
 | `labels` | `Object` | | See the [Legend Label Configuration](#legend-label-configuration) section below.
@@ -146,25 +146,3 @@ var chart = new Chart(ctx, {
 ```
 
 Now when you click the legend in this chart, the visibility of the first two datasets will be linked together.
-
-## HTML Legends
-
-Sometimes you need a very complex legend. In these cases, it makes sense to generate an HTML legend. Charts provide a `generateLegend()` method on their prototype that returns an HTML string for the legend.
-
-To configure how this legend is generated, you can change the `legendCallback` config property.
-
-```javascript
-var chart = new Chart(ctx, {
-    type: 'line',
-    data: data,
-    options: {
-        legendCallback: function(chart) {
-            // Return the HTML string here.
-        }
-    }
-});
-```
-
-Note that legendCallback is not called automatically and you must call `generateLegend()` yourself in code when creating a legend using this method.
-
-

--- a/samples/legend/html-legend.html
+++ b/samples/legend/html-legend.html
@@ -1,0 +1,208 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>HTML Legend Positions</title>
+    <script src="../../dist/Chart.bundle.js"></script>
+    <script src="../utils.js"></script>
+    <style>
+        canvas {
+            -moz-user-select: none;
+            -webkit-user-select: none;
+            -ms-user-select: none;
+        }
+        .chart-container {
+            width: 500px;
+            margin-left: 40px;
+            margin-right: 40px;
+            position: relative;
+        }
+        .container {
+            display: flex;
+            flex-direction: row;
+            flex-wrap: wrap;
+            justify-content: center;
+        }
+        .legend-container {
+            position: absolute;
+        }
+        .position-top-left {
+            left: 70px;
+            top: 45px;
+        }
+        .position-top-right {
+            right: 25px;
+            top: 45px;
+        }
+        .position-bottom-left {
+            left: 70px;
+            bottom: 60px;
+        }
+        .position-bottom-right {
+            right: 25px;
+            bottom: 60px;
+        }
+        [class$="-legend"] {
+            background-color: rgba(255, 255, 255, 0.55);
+            border: 1px solid #666;
+            color: #666;
+            display: inline-block;
+            font-family: 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+            font-size: 12px;
+            list-style: none;
+            margin: 0;
+            padding: 5px 6px;
+        }
+        [class$="-legend"] > li {
+            cursor: pointer;
+            vertical-align: middle;
+        }
+        [class$="-legend"] > li.hidden {
+            text-decoration: line-through;
+        }
+        [class$="-legend"] > li > span:first-child {
+            background-clip: padding-box;
+            box-sizing: border-box;
+            display: inline-block;
+            height: 14px;
+            margin-right: 6px;
+            width: 40px;
+            vertical-align: middle;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="container">
+        <div class="chart-container">
+            <canvas id="chart-legend-top-left"></canvas>
+            <div class="legend-container position-top-left"></div>
+        </div>
+        <div class="chart-container">
+            <canvas id="chart-legend-top-right"></canvas>
+            <div class="legend-container position-top-right"></div>
+        </div>
+        <div class="chart-container">
+            <canvas id="chart-legend-bottom-left"></canvas>
+            <div class="legend-container position-bottom-left"></div>
+        </div>
+        <div class="chart-container">
+            <canvas id="chart-legend-bottom-right"></canvas>
+            <div class="legend-container position-bottom-right"></div>
+        </div>
+    </div>
+    <script>
+        var color = Chart.helpers.color;
+        function onClickCallback(event) {
+            event = event || window.event;
+
+            var target = event.target || event.srcElement;
+            if (target.nodeName === 'UL') {
+                return; // event has been fired on parent
+            }
+
+            // find a direct descendant from the parent element
+            while (target && target.nodeName !== 'LI') {
+                target = target.parentElement;
+            }
+
+            if (!target) {
+              return; // something went wrong, no target found
+            }
+
+            var parent = target.parentElement;
+            var chartId = parseInt(parent.classList[0].split('-')[0], 10);
+            var chart = Chart.instances[chartId];
+            var index = Array.prototype.slice.call(parent.children).indexOf(target);
+
+            chart.legend.options.onClick.call(chart, event, chart.legend.legendItems[index]);
+
+            var hidden = chart.legend.legendItems[index].hidden; // legend item has been updated
+            target.classList.toggle('hidden', hidden);
+        }
+        function createConfig(legendPosition, colorName) {
+            return {
+                type: 'line',
+                data: {
+                    labels: ["January", "February", "March", "April", "May", "June", "July"],
+                    datasets: [{
+                        label: "My First dataset",
+                        data: [
+                            randomScalingFactor(),
+                            randomScalingFactor(),
+                            randomScalingFactor(),
+                            randomScalingFactor(),
+                            randomScalingFactor(),
+                            randomScalingFactor(),
+                            randomScalingFactor()
+                        ],
+                        backgroundColor: color(window.chartColors[colorName]).alpha(0.5).rgbString(),
+                        borderColor: window.chartColors[colorName],
+                        borderWidth: 1
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    legend: {
+                        display: false,
+                    },
+                    htmllegend: {
+                        listeners: {
+                            click: onClickCallback
+                        }
+                    },
+                    scales: {
+                        xAxes: [{
+                            display: true,
+                            scaleLabel: {
+                                display: true,
+                                labelString: 'Month'
+                            }
+                        }],
+                        yAxes: [{
+                            display: true,
+                            scaleLabel: {
+                                display: true,
+                                labelString: 'Value'
+                            }
+                        }]
+                    },
+                    title: {
+                        display: true,
+                        text: 'HTML Legend Position: ' + legendPosition
+                    }
+                }
+            };
+        }
+
+
+        window.onload = function() {
+            [{
+                id: 'chart-legend-top-left',
+                legendPosition: 'top-left',
+                color: 'red'
+            }, {
+                id: 'chart-legend-top-right',
+                legendPosition: 'top-right',
+                color: 'blue'
+            }, {
+                id: 'chart-legend-bottom-left',
+                legendPosition: 'bottom-left',
+                color: 'green'
+            }, {
+                id: 'chart-legend-bottom-right',
+                legendPosition: 'bottom-right',
+                color: 'yellow'
+            }].forEach(function(details) {
+                var canvas = document.getElementById(details.id);
+                var legendContainer = canvas.parentElement.getElementsByClassName('legend-container')[0];
+                var config = createConfig(details.legendPosition, details.color);
+                var chart = new Chart(canvas, config);
+                chart.generateLegend(legendContainer);
+            })
+        };
+    </script>
+</body>
+
+</html>

--- a/samples/samples.js
+++ b/samples/samples.js
@@ -146,6 +146,9 @@
 			title: 'Positioning',
 			path: 'legend/positioning.html'
 		}, {
+			title: 'HTML legend',
+			path: 'legend/html-legend.html'
+		}, {
 			title: 'Point style',
 			path: 'legend/point-style.html'
 		}]

--- a/src/chart.js
+++ b/src/chart.js
@@ -54,6 +54,7 @@ var plugins = [];
 plugins.push(
 	require('./plugins/plugin.filler')(Chart),
 	require('./plugins/plugin.legend')(Chart),
+	require('./plugins/plugin.htmllegend')(Chart),
 	require('./plugins/plugin.title')(Chart)
 );
 

--- a/src/controllers/controller.doughnut.js
+++ b/src/controllers/controller.doughnut.js
@@ -14,27 +14,6 @@ defaults._set('doughnut', {
 	hover: {
 		mode: 'single'
 	},
-	legendCallback: function(chart) {
-		var text = [];
-		text.push('<ul class="' + chart.id + '-legend">');
-
-		var data = chart.data;
-		var datasets = data.datasets;
-		var labels = data.labels;
-
-		if (datasets.length) {
-			for (var i = 0; i < datasets[0].data.length; ++i) {
-				text.push('<li><span style="background-color:' + datasets[0].backgroundColor[i] + '"></span>');
-				if (labels[i]) {
-					text.push(labels[i]);
-				}
-				text.push('</li>');
-			}
-		}
-
-		text.push('</ul>');
-		return text.join('');
-	},
 	legend: {
 		labels: {
 			generateLabels: function(chart) {

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -28,27 +28,7 @@ defaults._set('polarArea', {
 	},
 
 	startAngle: -0.5 * Math.PI,
-	legendCallback: function(chart) {
-		var text = [];
-		text.push('<ul class="' + chart.id + '-legend">');
 
-		var data = chart.data;
-		var datasets = data.datasets;
-		var labels = data.labels;
-
-		if (datasets.length) {
-			for (var i = 0; i < datasets[0].data.length; ++i) {
-				text.push('<li><span style="background-color:' + datasets[0].backgroundColor[i] + '"></span>');
-				if (labels[i]) {
-					text.push(labels[i]);
-				}
-				text.push('</li>');
-			}
-		}
-
-		text.push('</ul>');
-		return text.join('');
-	},
 	legend: {
 		labels: {
 			generateLabels: function(chart) {

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -722,7 +722,7 @@ module.exports = function(Chart) {
 		},
 
 		generateLegend: function() {
-			return this.options.legendCallback(this);
+			return this.htmllegend.generate.apply(this.htmllegend, arguments);
 		},
 
 		/**

--- a/src/plugins/plugin.htmllegend.js
+++ b/src/plugins/plugin.htmllegend.js
@@ -1,0 +1,301 @@
+'use strict';
+
+var defaults = require('../core/core.defaults');
+var Element = require('../core/core.element');
+var helpers = require('../helpers/index');
+
+// don't set defaults to preserve legacy behaviour of legendCallback
+
+/**
+ * Returns value at the given `index` in object if defined, else returns `defaultValue`.
+ * @param {Object} value - The object to lookup for value at `index`.
+ * @param {String} / {Number} index - The index in `value` to lookup for value.
+ * @param {*} defaultValue - The value to return if `value[index]` is undefined.
+ * @returns {*}
+ */
+function optionOrDefault(value, index, defaultValue) {
+	return helpers.isObject(value) && value.hasOwnProperty(index) ? value[index] : defaultValue;
+}
+
+/**
+ * Returns evaluated string (replace '{variable}' with options[variable] value)
+ * @param {String} str - template string containing '{variable}' parameters
+ * @param {Object} options - object containing 'variable: "replacement string"' entries
+ * @return {Object} The evaluated string
+ */
+function evalString(str, options) {
+	return typeof str === 'string' && helpers.isObject(options)
+		? str.replace(/{(\w+)}/g, function(match, prop) {
+			return (options && options.hasOwnProperty(prop)) ? options[prop] : prop;
+		})
+		: str;
+}
+
+/**
+ * Returns formatted DOM node
+ * @param {String}/{Object} tag - tag string or object containing the tag and attributes
+ * @param {String}/{Object} attributes - textContent string or default element attributes
+ * @return {Object} The DOM node
+ */
+var createElement = function(type, attributes, replace) {
+	var node;
+
+	if (!helpers.isObject(attributes)) {
+		attributes = {textContent: attributes};
+	}
+
+	if (helpers.isObject(type)) {
+		attributes = helpers.merge(attributes, type.attributes);
+		type = optionOrDefault(type, 'tag', 'div');
+	}
+
+	if (type === 'textnode') {
+		var textContent = optionOrDefault(attributes, 'textContent', '');
+		node = document.createTextNode(textContent);
+	} else {
+		node = document.createElement(type);
+
+		helpers.each(attributes, function(value, key) {
+			// allow nested properties like node.style
+			if (helpers.isObject(value)) {
+				helpers.each(value, function(subValue, subKey) {
+					node[key][subKey] = subValue;
+				});
+			} else {
+				value = evalString(value, replace);
+				switch (key) {
+				case 'classList':
+					if (helpers.isArray(value)) {
+						helpers.each(value, function(className) {
+							className = evalString(className, replace);
+							node.classList.add(className);
+						});
+					} else {
+						node.classList.add(value);
+					}
+					break;
+				default:
+					node[key] = value;
+				}
+			}
+		});
+	}
+
+	return node;
+};
+
+module.exports = function(Chart) {
+	Chart.HTMLLegend = Element.extend({
+		/**
+		 * Returns HTML formatted string or DOM node of the legend
+		 * @param {Object} chart - The chart object.
+		 * @param {Object} options - The configuration options.
+		 * @param {Array} - The optional arguments array passed by user (ignored by default).
+		 * @returns {String/DOM node} HTML legend string/node.
+		 */
+		create: function(chart, options) {
+			// in legacy mode:
+			// - generate html output
+			// - do not set the box border (only box background-color)
+			// - use default container: UL, items: LI, box: SPAN and label tags: TEXTNODE
+			// - set container class '{charId}-legend'
+			// - do not set 'hidden'-class
+			var legacy = options === undefined;
+			var output = optionOrDefault(options, 'output', legacy ? 'HTML' : 'DOM');
+			var nodes = optionOrDefault(options, 'nodes', {});
+			var containerTag = optionOrDefault(nodes, 'container', 'ul');
+			var itemsTag = optionOrDefault(nodes, 'items', 'li');
+			var boxTag = optionOrDefault(nodes, 'box', 'span');
+			var labelTag = optionOrDefault(nodes, 'label', 'textnode');
+			var replaceOpts = optionOrDefault(options, 'replace', {});
+
+			replaceOpts.chartId = chart.id;
+
+			// add `{chartId}-legend` class for legacy purposes
+			var container = createElement(containerTag, {classList: '{chartId}-legend'}, replaceOpts);
+
+			// allow for hiddenClass not to be set on hidden items setting empty option
+			var hiddenClass = optionOrDefault(options, 'hiddenClass', legacy ? '' : 'hidden');
+			var items = chart.legend.legendItems;
+			helpers.each(items, function(item, id) {
+				var globalDefault = defaults.global;
+				var lineDefault = globalDefault.elements.line;
+				var valueOrDefault = helpers.valueOrDefault;
+
+				// add {identifier} replacement for legend items
+				replaceOpts.id = id;
+				replaceOpts.datasetIndex = item.datasetIndex; // might be undefined
+				replaceOpts.index = item.index; // might be undefined
+
+				var element = createElement(itemsTag, {}, replaceOpts);
+
+				if (item.hidden && hiddenClass) {
+					element.classList.add(hiddenClass);
+				}
+
+				var fillStyle = valueOrDefault(item.fillStyle, globalDefault.defaultColor);
+				var lineDash = valueOrDefault(item.lineDash, lineDefault.borderDash);
+				var lineWidth = valueOrDefault(item.lineWidth, lineDefault.borderWidth);
+				var strokeStyle = valueOrDefault(item.strokeStyle, globalDefault.defaultColor);
+
+				var boxAttributes = {
+					style: {
+						backgroundColor: fillStyle
+					}
+				};
+				if (!legacy && strokeStyle && lineWidth > 0) {
+					boxAttributes.style.borderStyle = (lineDash.length > 0) ? 'dotted' : 'solid';
+					boxAttributes.style.borderColor = strokeStyle;
+					boxAttributes.style.borderWidth = lineWidth + 'px';
+				}
+				var box = createElement(boxTag, boxAttributes, replaceOpts);
+				element.appendChild(box);
+
+				var label = createElement(labelTag, item.text, replaceOpts);
+				element.appendChild(label);
+
+				container.appendChild(element);
+			});
+
+			if (output === 'HTML') {
+				container = container.outerHTML; // output html by default for legacy purposes
+			}
+			return container;
+		},
+
+		/**
+		 * Returns a HTML legend (wrapper for generateLegend)
+		 * @param {DOM node/*} defaultTarget - The defaultTarget or optional parameter if not DOM node.
+		 * @param {*} optional - The optional arguments from `generateLegend()`, to be passed to callback function.
+		 * @returns {String/DOM node} HTML legend string/node.
+		 */
+		generate: function(defaultTarget) {
+			var options = this.chart.options.htmllegend;
+			var legendFn;
+
+			if (typeof this.chart.options.legendCallback === 'function') {
+				legendFn = this.options.legendCallback;
+				console.warn('options.legendCallback is deprecated, replace by options.htmllegend or options.htmllegend.callback');
+			} else {
+				legendFn = this.create;
+				if (typeof options === 'function') {
+					legendFn = options;
+					options = undefined;
+				} else if (options && typeof options.callback === 'function') {
+					legendFn = options.callback;
+				}
+			}
+
+			// remove default target from optional arguments
+			var args = defaultTarget && defaultTarget.nodeType === Node.ELEMENT_NODE
+				? Array.prototype.slice.call(arguments, 1)
+				: Array.prototype.slice.call(arguments);
+			var legend = legendFn.call(this, this.chart, options, args);
+
+			// attach legend to DOM and bind event listeners
+			var legendNode = legend;
+			var target = optionOrDefault(options, 'target', defaultTarget);
+			if (target && target.nodeType === Node.ELEMENT_NODE) {
+				if (typeof legend === 'string') {
+					target.innerHTML = legend;
+					legendNode = target.childNodes[0];
+				} else {
+					target.appendChild(legend);
+				}
+
+			}
+
+			// save a link to the legend to fire afterUpdate event
+			if (legendNode.nodeType === Node.ELEMENT_NODE) {
+				var listeners = optionOrDefault(options, 'listeners');
+				this.bindEventListeners(legendNode, listeners);
+
+				this.chart.htmllegend.container = legendNode;
+			}
+
+			return legend;
+		},
+
+		/**
+		 * Binds event listeners to legend
+		 * @param {Object} node - The DOM node
+		 * @param {Object} node - The listeners object
+		 * @returns undefined
+		 */
+		bindEventListeners: function(node, listeners) {
+			if (node.nodeType === Node.ELEMENT_NODE) {
+				helpers.each(listeners, function(listener, type) {
+					var options = optionOrDefault(listener, 'options', false);
+					listener = optionOrDefault(listener, 'listener', listener);
+
+					node.addEventListener(type, listener, options);
+				});
+			}
+		}
+	});
+
+
+	function createNewLegendAndAttach(chart, legendOpts) {
+		var htmllegend = new Chart.HTMLLegend({
+			options: legendOpts,
+			chart: chart,
+			_construct: true // temporary flag to auto-generate legend
+		});
+
+		chart.htmllegend = htmllegend;
+	}
+
+	return {
+		id: 'htmllegend',
+
+		beforeInit: function(chart) {
+			// extends default legend
+			if (chart.legend) {
+				var legendOpts = chart.options.htmllegend;
+				createNewLegendAndAttach(chart, legendOpts);
+			}
+		},
+
+		beforeUpdate: function(chart) {
+			if (chart.legend) {
+				var legendOpts = chart.options.htmllegend;
+				var htmllegend = chart.htmllegend;
+
+				helpers.mergeIf(legendOpts, defaults.global.htmllegend);
+
+				if (htmllegend) {
+					htmllegend.options = legendOpts;
+				} else {
+					createNewLegendAndAttach(chart, legendOpts);
+				}
+			} else if (htmllegend) {
+				delete chart.htmllegend;
+			}
+		},
+
+		afterUpdate: function(chart) {
+			var legendOpts = chart.options.htmllegend;
+			var htmllegend = chart.htmllegend;
+			// do not fire event when not loaded or in legacy mode
+			if (!htmllegend || !legendOpts) {
+				return;
+			}
+
+			if (htmllegend.hasOwnProperty('_construct')) {
+				delete htmllegend._construct; // remove flag to prevent misuse
+
+				var target = optionOrDefault(legendOpts, 'target');
+				if (chart.legend && target) {
+					htmllegend.generate(); // auto-generate and attach html legend
+				}
+			} else {
+				// trigger afterUpdate on html legend in case some items have been hidden
+				var container = htmllegend.container;
+				if (container) {
+					var event = new Event('afterUpdate');
+					container.dispatchEvent(event);
+				}
+			}
+		},
+	};
+};

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -62,20 +62,6 @@ defaults._set('global', {
 				}, this) : [];
 			}
 		}
-	},
-
-	legendCallback: function(chart) {
-		var text = [];
-		text.push('<ul class="' + chart.id + '-legend">');
-		for (var i = 0; i < chart.data.datasets.length; i++) {
-			text.push('<li><span style="background-color:' + chart.data.datasets[i].backgroundColor + '"></span>');
-			if (chart.data.datasets[i].label) {
-				text.push(chart.data.datasets[i].label);
-			}
-			text.push('</li>');
-		}
-		text.push('</ul>');
-		return text.join('');
 	}
 });
 

--- a/test/specs/global.defaults.tests.js
+++ b/test/specs/global.defaults.tests.js
@@ -103,7 +103,7 @@ describe('Default Configs', function() {
 				options: config
 			});
 
-			var expectedLegend = '<ul class="' + chart.id + '-legend"><li><span style="background-color:red"></span>label1</li><li><span style="background-color:green"></span>label2</li></ul>';
+			var expectedLegend = '<ul class="' + chart.id + '-legend"><li><span style="background-color: red;"></span>label1</li><li><span style="background-color: green;"></span>label2</li></ul>';
 			expect(chart.generateLegend()).toBe(expectedLegend);
 		});
 
@@ -219,7 +219,7 @@ describe('Default Configs', function() {
 				options: config
 			});
 
-			var expectedLegend = '<ul class="' + chart.id + '-legend"><li><span style="background-color:red"></span>label1</li><li><span style="background-color:green"></span>label2</li></ul>';
+			var expectedLegend = '<ul class="' + chart.id + '-legend"><li><span style="background-color: red;"></span>label1</li><li><span style="background-color: green;"></span>label2</li></ul>';
 			expect(chart.generateLegend()).toBe(expectedLegend);
 		});
 

--- a/test/specs/plugin.htmllegend.tests.js
+++ b/test/specs/plugin.htmllegend.tests.js
@@ -105,30 +105,21 @@ describe('HTML Legend block tests', function() {
 			type: 'bar',
 			data: {},
 			options: {
-				htmllegend: function() {
-					return '<div>HTML legend</div>';
-				}
-			}
-		});
-
-		var expectedLegend = '<div>HTML legend</div>';
-		expect(chart.generateLegend()).toBe(expectedLegend);
-	});
-
-	it('should use user defined callback function', function() {
-		var chart = window.acquireChart({
-			type: 'bar',
-			data: {},
-			options: {
 				htmllegend: {
 					callback: function() {
-						return '<div>HTML legend</div>';
+						return '<div>options.htmllegend.callback</div>';
 					}
 				}
 			}
 		});
 
-		var expectedLegend = '<div>HTML legend</div>';
-		expect(chart.generateLegend()).toBe(expectedLegend);
+		// check callback function
+		expect(chart.generateLegend()).toBe('<div>options.htmllegend.callback</div>');
+
+		// set direct callback function setting
+		chart.options.htmllegend = function() {
+			return '<div>options.htmllegend</div>';
+		};
+		expect(chart.generateLegend()).toBe('<div>options.htmllegend</div>');
 	});
 });

--- a/test/specs/plugin.htmllegend.tests.js
+++ b/test/specs/plugin.htmllegend.tests.js
@@ -86,7 +86,7 @@ describe('HTML Legend block tests', function() {
 
 		// check manually created DOM legend
 		legendContainer.innerHTML = ''; // remove legend
-		var legend = chart.generateLegend(legendContainer); // should recreate legend
+		legend = chart.generateLegend(legendContainer); // should recreate legend
 		expect(legend.nodeType).toBe(Node.ELEMENT_NODE); // should return DOM node
 		expect(legend.nodeName).toBe('DIV');
 		expect(legend).toBe(legendContainer.childNodes[0]); // container should contain legend
@@ -95,7 +95,7 @@ describe('HTML Legend block tests', function() {
 		// check if HTML generated legend still is attached to DOM
 		legendContainer.innerHTML = ''; // remove legend
 		chart.options.htmllegend.output = 'HTML';
-		var legend = chart.generateLegend(legendContainer); // should recreate HTML legend
+		legend = chart.generateLegend(legendContainer); // should recreate HTML legend
 		expect(legend).toBe(legendContainer.childNodes[0].outerHTML); // container should contain legend
 		expect(legend).toBe(expectedLegend);
 	});
@@ -105,7 +105,9 @@ describe('HTML Legend block tests', function() {
 			type: 'bar',
 			data: {},
 			options: {
-				htmllegend: function() { return '<div>HTML legend</div>'; }
+				htmllegend: function() {
+					return '<div>HTML legend</div>';
+				}
 			}
 		});
 
@@ -119,7 +121,9 @@ describe('HTML Legend block tests', function() {
 			data: {},
 			options: {
 				htmllegend: {
-					callback: function() { return '<div>HTML legend</div>'; }
+					callback: function() {
+						return '<div>HTML legend</div>';
+					}
 				}
 			}
 		});

--- a/test/specs/plugin.htmllegend.tests.js
+++ b/test/specs/plugin.htmllegend.tests.js
@@ -1,0 +1,130 @@
+// Test the HTML Legend plugin
+describe('HTML Legend block tests', function() {
+	it('Should be constructed', function() {
+		var htmllegend = new Chart.HTMLLegend({});
+		expect(htmllegend).not.toBe(undefined);
+	});
+
+	it('should have the correct default config', function() {
+		expect(Chart.defaults.global.htmllegend).toEqual(undefined);
+	});
+
+	it('should auto-generate user-configured filtered legend and attach to DOM', function() {
+		var legendContainer = document.createElement('div');
+		var chart = window.acquireChart({
+			type: 'bar',
+			data: {
+				datasets: [{
+					label: 'dataset1',
+					backgroundColor: '#f31',
+					borderCapStyle: 'butt',
+					borderDash: [2, 2],
+					borderDashOffset: 5.5,
+					data: []
+				}, {
+					label: 'dataset2',
+					hidden: true,
+					borderJoinStyle: 'miter',
+					data: [],
+					legendHidden: true
+				}, {
+					// label undefined should create empty label
+					borderWidth: 10,
+					borderColor: 'green',
+					pointStyle: 'crossRot',
+					data: [],
+					hidden: true
+				}],
+				labels: []
+			},
+			options: {
+				htmllegend: {
+					hiddenClass: 'notVisible',
+					nodes: {
+						container: { // missing tag-property should default to 'div'
+							attributes: {
+								id: 'legend-{chartId}',
+								classList: ['chartjs-legend', '{chartId}-legend'] // pass multiple classes as array
+							}
+						},
+						items: {
+							tag: 'li',
+							attributes: {
+								classList: ['dataset-{datasetIndex}', 'id-{id}', '{unknow}-property']
+							}
+						},
+						box: {
+							tag: 'span',
+							attributes: {
+								style: {
+									borderStyle: 'dotted' // override border-style
+								}
+							}
+						},
+						label: 'span', // simple syntax
+					},
+					target: legendContainer // should auto-generate
+				},
+				legend: {
+					labels: {
+						filter: function(legendItem, data) {
+							var dataset = data.datasets[legendItem.datasetIndex];
+							return !dataset.legendHidden;
+						}
+					}
+				}
+			}
+		});
+
+		var expectedLegend = '<div class="chartjs-legend ' + chart.id + '-legend" id="legend-' + chart.id + '"><li class="dataset-0 id-0 unknow-property"><span style="background-color: rgb(255, 51, 17); border-style: dotted; border-color: rgba(0, 0, 0, 0.1); border-width: 3px;"></span><span>dataset1</span></li><li class="dataset-2 id-1 unknow-property notVisible"><span style="background-color: rgba(0, 0, 0, 0.1); border-style: dotted; border-color: green; border-width: 10px;"></span><span></span></li></div>';
+
+		// check auto-generated legend
+		var legend = legendContainer.childNodes[0];
+		expect(legend.nodeType).toBe(Node.ELEMENT_NODE); // should return DOM node
+		expect(legend.nodeName).toBe('DIV');
+		expect(legend.outerHTML).toBe(expectedLegend);
+
+		// check manually created DOM legend
+		legendContainer.innerHTML = ''; // remove legend
+		var legend = chart.generateLegend(legendContainer); // should recreate legend
+		expect(legend.nodeType).toBe(Node.ELEMENT_NODE); // should return DOM node
+		expect(legend.nodeName).toBe('DIV');
+		expect(legend).toBe(legendContainer.childNodes[0]); // container should contain legend
+		expect(legend.outerHTML).toBe(expectedLegend);
+
+		// check if HTML generated legend still is attached to DOM
+		legendContainer.innerHTML = ''; // remove legend
+		chart.options.htmllegend.output = 'HTML';
+		var legend = chart.generateLegend(legendContainer); // should recreate HTML legend
+		expect(legend).toBe(legendContainer.childNodes[0].outerHTML); // container should contain legend
+		expect(legend).toBe(expectedLegend);
+	});
+
+	it('should use user defined function', function() {
+		var chart = window.acquireChart({
+			type: 'bar',
+			data: {},
+			options: {
+				htmllegend: function() { return '<div>HTML legend</div>'; }
+			}
+		});
+
+		var expectedLegend = '<div>HTML legend</div>';
+		expect(chart.generateLegend()).toBe(expectedLegend);
+	});
+
+	it('should use user defined callback function', function() {
+		var chart = window.acquireChart({
+			type: 'bar',
+			data: {},
+			options: {
+				htmllegend: {
+					callback: function() { return '<div>HTML legend</div>'; }
+				}
+			}
+		});
+
+		var expectedLegend = '<div>HTML legend</div>';
+		expect(chart.generateLegend()).toBe(expectedLegend);
+	});
+});


### PR DESCRIPTION
Introduce a new configurable HTML Legend Plugin
 - deprecate options.legendCallback (still available displays a console.warn message)
 - introduce configurable html legend through options.htmllegend
 - add documentation/samples/unittests

**samples screenshot**
![pr-html-legend](https://user-images.githubusercontent.com/33193571/34446091-c596c64c-ecd8-11e7-9cb6-f6d05b616dc8.png)
