### PR TITLE
Trianglerot point style

### DIFF
--- a/docs/configuration/elements.md
+++ b/docs/configuration/elements.md
@@ -39,6 +39,7 @@ The following values are supported:
 - `'rectRot'`
 - `'star'`
 - `'triangle'`
+- `'triangleRot'`
 
 If the value is an image, that image is drawn on the canvas using [drawImage](https://developer.mozilla.org/en/docs/Web/API/CanvasRenderingContext2D/drawImage).
 

--- a/src/helpers/helpers.canvas.js
+++ b/src/helpers/helpers.canvas.js
@@ -77,6 +77,16 @@ var exports = module.exports = {
 			ctx.closePath();
 			ctx.fill();
 			break;
+		case 'triangleRot':
+			ctx.beginPath();
+			edgeLength = 3 * radius / Math.sqrt(3);
+			height = edgeLength * Math.sqrt(3) / 2;
+			ctx.moveTo(x - edgeLength / 2, y - height / 3);
+			ctx.lineTo(x + edgeLength / 2, y - height / 3);
+			ctx.lineTo(x, y + 2 * height / 3);
+			ctx.closePath();
+			ctx.fill();
+			break;
 		case 'rect':
 			size = 1 / Math.SQRT2 * radius;
 			ctx.beginPath();


### PR DESCRIPTION
Added a new point style: a downward-facing triangle.
An example of a use case is to show any variation in a line chart monotonicity, alongside the 'triangle' point style (which is facing upwards).

Fiddle: https://jsfiddle.net/cLtwonnn/1/