### PR TITLE
Improve framerate once animations finish

### DIFF
--- a/src/core/core.element.js
+++ b/src/core/core.element.js
@@ -79,7 +79,7 @@ helpers.extend(Element.prototype, {
 		var view = me._view;
 
 		// No animation -> No Transition
-		if (!model || ease === 1 || ( this._chart && this._chart.animating == false ) ) {
+		if (!model || ease === 1 || (this._chart && this._chart.animating === false)) {
 			me._view = model;
 			me._start = null;
 			return me;

--- a/src/core/core.element.js
+++ b/src/core/core.element.js
@@ -79,7 +79,7 @@ helpers.extend(Element.prototype, {
 		var view = me._view;
 
 		// No animation -> No Transition
-		if (!model || ease === 1) {
+		if (!model || ease === 1 || ( this._chart && this._chart.animating == false ) ) {
 			me._view = model;
 			me._start = null;
 			return me;

--- a/src/core/core.element.js
+++ b/src/core/core.element.js
@@ -79,7 +79,7 @@ helpers.extend(Element.prototype, {
 		var view = me._view;
 
 		// No animation -> No Transition
-		if (!model || ease === 1 || (this._chart && this._chart.animating === false)) {
+		if (!model || ease === 1 || (me._chart && me._chart.animating === false && me !== me._chart.tooltip)) {
 			me._view = model;
 			me._start = null;
 			return me;


### PR DESCRIPTION
Interpolate was still being fired after animations stop... this corrects that. All tests passed and works as intended on my end. This will be most noticeable on large datasets.