### PR TITLE
Bugfix: Maximum width on responsive columns

### DIFF
--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -469,12 +469,12 @@ module.exports = function(Chart) {
 	helpers.getMaximumWidth = function(domNode) {
 		var container = domNode.parentNode;
 		if (!container) {
-			return domNode.clientWidth;
+			return domNode.clientWidth - 1;
 		}
 
 		var paddingLeft = parseInt(helpers.getStyle(container, 'padding-left'), 10);
 		var paddingRight = parseInt(helpers.getStyle(container, 'padding-right'), 10);
-		var w = container.clientWidth - paddingLeft - paddingRight;
+		var w = container.clientWidth - paddingLeft - paddingRight - 1;
 		var cw = helpers.getConstraintWidth(domNode);
 		return isNaN(cw) ? w : Math.min(w, cw);
 	};


### PR DESCRIPTION
Using Chart.js with responsive charts fails sometimes with Bootstrap 4.
My chart's div container is, for example, 1034.61px width (in Chrome) but after responsive resize it is 1035px width. 

My PR fix this erroneous behavior by reducing the maximum width by 1px.

Probably the root cause is somewhere else. However, please consider this PR or give me a hint where the root cause could be.