### PR TITLE
Enhancement: Responsive scaling to parent node.

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -187,13 +187,13 @@ module.exports = function(Chart) {
 
 			canvas.width = me.width = newWidth;
 			canvas.height = me.height = newHeight;
-      if (me.options.responsiveScaleToParent) {
-        canvas.style.width = '100%';
-        canvas.style.height = '100%';
-      } else {
-        canvas.style.width = newWidth + 'px';
-        canvas.style.height = newHeight + 'px';
-      }
+			if (me.options.responsiveScaleToParent) {
+				canvas.style.width = '100%';
+				canvas.style.height = '100%';
+			} else {
+				canvas.style.width = newWidth + 'px';
+				canvas.style.height = newHeight + 'px';
+			}
 
 			helpers.retinaScale(me, options.devicePixelRatio, me.options.responsiveScaleToParent);
 

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -187,10 +187,15 @@ module.exports = function(Chart) {
 
 			canvas.width = me.width = newWidth;
 			canvas.height = me.height = newHeight;
-			canvas.style.width = newWidth + 'px';
-			canvas.style.height = newHeight + 'px';
+      if (me.options.responsiveScaleToParent) {
+        canvas.style.width = '100%';
+        canvas.style.height = '100%';
+      } else {
+        canvas.style.width = newWidth + 'px';
+        canvas.style.height = newHeight + 'px';
+      }
 
-			helpers.retinaScale(me, options.devicePixelRatio);
+			helpers.retinaScale(me, options.devicePixelRatio, me.options.responsiveScaleToParent);
 
 			if (!silent) {
 				// Notify any plugins about the resize

--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -495,7 +495,7 @@ module.exports = function(Chart) {
 			el.currentStyle[property] :
 			document.defaultView.getComputedStyle(el, null).getPropertyValue(property);
 	};
-	helpers.retinaScale = function(chart, forceRatio) {
+	helpers.retinaScale = function(chart, forceRatio, scaleToParent) {
 		var pixelRatio = chart.currentDevicePixelRatio = forceRatio || window.devicePixelRatio || 1;
 		if (pixelRatio === 1) {
 			return;
@@ -513,8 +513,13 @@ module.exports = function(Chart) {
 		// making the chart visually bigger, so let's enforce it to the "correct" values.
 		// See https://github.com/chartjs/Chart.js/issues/3575
 		if (!canvas.style.height && !canvas.style.width) {
-			canvas.style.height = height + 'px';
-			canvas.style.width = width + 'px';
+      if (scaleToParent) {
+        canvas.style.width = '100%';
+        canvas.style.height = '100%';
+      } else {
+        canvas.style.height = height + 'px';
+        canvas.style.width = width + 'px';
+      }
 		}
 	};
 	// -- Canvas methods

--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -513,13 +513,13 @@ module.exports = function(Chart) {
 		// making the chart visually bigger, so let's enforce it to the "correct" values.
 		// See https://github.com/chartjs/Chart.js/issues/3575
 		if (!canvas.style.height && !canvas.style.width) {
-      if (scaleToParent) {
-        canvas.style.width = '100%';
-        canvas.style.height = '100%';
-      } else {
-        canvas.style.height = height + 'px';
-        canvas.style.width = width + 'px';
-      }
+			if (scaleToParent) {
+				canvas.style.width = '100%';
+				canvas.style.height = '100%';
+			} else {
+				canvas.style.height = height + 'px';
+				canvas.style.width = width + 'px';
+			}
 		}
 	};
 	// -- Canvas methods

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -4,7 +4,7 @@ var defaults = require('./core.defaults');
 
 defaults._set('global', {
 	responsive: true,
-  responsiveScaleToParent: false,
+	responsiveScaleToParent: false,
 	responsiveAnimationDuration: 0,
 	maintainAspectRatio: true,
 	events: ['mousemove', 'mouseout', 'click', 'touchstart', 'touchmove'],

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -4,6 +4,7 @@ var defaults = require('./core.defaults');
 
 defaults._set('global', {
 	responsive: true,
+  responsiveScaleToParent: false,
 	responsiveAnimationDuration: 0,
 	maintainAspectRatio: true,
 	events: ['mousemove', 'mouseout', 'click', 'touchstart', 'touchmove'],


### PR DESCRIPTION
Introduction of a new option 'responsiveScaleToParent' (default: false).
If set to true, the canvas CSS style will be always set to 100% width
and height. However, the canvas width and height will be set to the
resulting px width and height due to the chartjs-size-monitor.