### PR TITLE
Fix GitBook error with the shared ESLint config

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "child-process-promise": "^2.2.1",
     "coveralls": "^3.0.0",
     "eslint": "^4.9.0",
-    "eslint-config-chartjs": "git+https://github.com/chartjs/eslint-config-chartjs.git",
+    "eslint-config-chartjs": "^0.1.0",
     "gitbook-cli": "^2.3.2",
     "gulp": "3.9.x",
     "gulp-concat": "~2.6.x",


### PR DESCRIPTION
`gitbook-cli install` failed when trying to fetch `eslint-config-chartjs` because of the way it was installed (ie. using the GitHub repository URL). The shared config is now [published on npmjs](https://www.npmjs.com/package/eslint-config-chartjs).
