### PR TITLE
Ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /gh-pages
 /jsdoc
 /node_modules
+/package-lock.json
 .DS_Store
 .idea
 .vscode


### PR DESCRIPTION
Following [this comment](/chartjs/Chart.js/pull/5134#discussion_r160879415) and #4337, let's ignore `package-lock.json` until we really need it. If it's already the case, please elaborate.

/cc @benmccann