### PR TITLE
Add tests related to showLines for controller.scatter

### DIFF
--- a/test/specs/controller.scatter.test.js
+++ b/test/specs/controller.scatter.test.js
@@ -1,4 +1,4 @@
-describe('Chart.controllers.line', function() {
+describe('Chart.controllers.scatter', function() {
 
 	it('should not draw a line if the options showLines is not set', function() {
 		var chart = window.acquireChart({

--- a/test/specs/controller.scatter.test.js
+++ b/test/specs/controller.scatter.test.js
@@ -1,0 +1,77 @@
+describe('Chart.controllers.line', function() {
+
+	fit('should not draw a line if the options showLines is not set', function() {
+		var chart = window.acquireChart({
+			type: 'scatter',
+			data: {
+				datasets: [{
+					data: [
+						{x: 10, y: 15},
+						{x: 0, y: -8},
+						{x: -50, y: -6},
+						{x: 12, y: -4},
+						{x: -9, y: 8}
+					],
+					label: 'dataset1'
+				}],
+			},
+			options: {}
+		});
+
+		var meta = chart.getDatasetMeta(0);
+		spyOn(meta.dataset, 'draw');
+		spyOn(meta.data[0], 'draw');
+		spyOn(meta.data[1], 'draw');
+		spyOn(meta.data[2], 'draw');
+		spyOn(meta.data[3], 'draw');
+		spyOn(meta.data[4], 'draw');
+
+		chart.update();
+
+		expect(meta.dataset.draw.calls.count()).toBe(0);
+		expect(meta.data[0].draw.calls.count()).toBe(1);
+		expect(meta.data[1].draw.calls.count()).toBe(1);
+		expect(meta.data[2].draw.calls.count()).toBe(1);
+		expect(meta.data[3].draw.calls.count()).toBe(1);
+		expect(meta.data[4].draw.calls.count()).toBe(1);
+	});
+
+	fit('should draw a line if the options showLines is set to true', function() {
+		var chart = window.acquireChart({
+			type: 'scatter',
+			data: {
+				datasets: [{
+					data: [
+						{x: 10, y: 15},
+						{x: 0, y: -8},
+						{x: -50, y: -6},
+						{x: 12, y: -4},
+						{x: -9, y: 8}
+					],
+					label: 'dataset1'
+				}],
+			},
+			options: {
+				showLines: true
+			}
+		});
+
+		var meta = chart.getDatasetMeta(0);
+		spyOn(meta.dataset, 'draw');
+		spyOn(meta.data[0], 'draw');
+		spyOn(meta.data[1], 'draw');
+		spyOn(meta.data[2], 'draw');
+		spyOn(meta.data[3], 'draw');
+		spyOn(meta.data[4], 'draw');
+
+		chart.update();
+
+		expect(meta.dataset.draw.calls.count()).toBe(1);
+		expect(meta.data[0].draw.calls.count()).toBe(1);
+		expect(meta.data[1].draw.calls.count()).toBe(1);
+		expect(meta.data[2].draw.calls.count()).toBe(1);
+		expect(meta.data[3].draw.calls.count()).toBe(1);
+		expect(meta.data[4].draw.calls.count()).toBe(1);
+	});
+
+});

--- a/test/specs/controller.scatter.test.js
+++ b/test/specs/controller.scatter.test.js
@@ -36,6 +36,44 @@ describe('Chart.controllers.line', function() {
 		expect(meta.data[4].draw.calls.count()).toBe(1);
 	});
 
+	fit('should not draw a line if the options showLines set to false', function() {
+		var chart = window.acquireChart({
+			type: 'scatter',
+			data: {
+				datasets: [{
+					data: [
+						{x: 10, y: 15},
+						{x: 0, y: -8},
+						{x: -50, y: -6},
+						{x: 12, y: -4},
+						{x: -9, y: 8}
+					],
+					label: 'dataset1'
+				}],
+			},
+			options: {
+				showLines: true
+			}
+		});
+
+		var meta = chart.getDatasetMeta(0);
+		spyOn(meta.dataset, 'draw');
+		spyOn(meta.data[0], 'draw');
+		spyOn(meta.data[1], 'draw');
+		spyOn(meta.data[2], 'draw');
+		spyOn(meta.data[3], 'draw');
+		spyOn(meta.data[4], 'draw');
+
+		chart.update();
+
+		expect(meta.dataset.draw.calls.count()).toBe(0);
+		expect(meta.data[0].draw.calls.count()).toBe(1);
+		expect(meta.data[1].draw.calls.count()).toBe(1);
+		expect(meta.data[2].draw.calls.count()).toBe(1);
+		expect(meta.data[3].draw.calls.count()).toBe(1);
+		expect(meta.data[4].draw.calls.count()).toBe(1);
+	});
+
 	fit('should draw a line if the options showLines is set to true', function() {
 		var chart = window.acquireChart({
 			type: 'scatter',

--- a/test/specs/controller.scatter.test.js
+++ b/test/specs/controller.scatter.test.js
@@ -1,6 +1,6 @@
 describe('Chart.controllers.line', function() {
 
-	fit('should not draw a line if the options showLines is not set', function() {
+	it('should not draw a line if the options showLines is not set', function() {
 		var chart = window.acquireChart({
 			type: 'scatter',
 			data: {
@@ -36,7 +36,7 @@ describe('Chart.controllers.line', function() {
 		expect(meta.data[4].draw.calls.count()).toBe(1);
 	});
 
-	fit('should not draw a line if the options showLines set to false', function() {
+	it('should not draw a line if the options showLines set to false', function() {
 		var chart = window.acquireChart({
 			type: 'scatter',
 			data: {
@@ -52,7 +52,7 @@ describe('Chart.controllers.line', function() {
 				}],
 			},
 			options: {
-				showLines: true
+				showLines: false
 			}
 		});
 
@@ -74,7 +74,7 @@ describe('Chart.controllers.line', function() {
 		expect(meta.data[4].draw.calls.count()).toBe(1);
 	});
 
-	fit('should draw a line if the options showLines is set to true', function() {
+	it('should draw a line if the options showLines is set to true', function() {
 		var chart = window.acquireChart({
 			type: 'scatter',
 			data: {


### PR DESCRIPTION
As discussed in https://github.com/chartjs/Chart.js/pull/5134, a PR to add tests for scatter charts.
It tests for 3 values of showLines : default value, true, false.