### PR TITLE
Better handling of mixed line / scatter charts

### DIFF
--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -5,7 +5,6 @@ var elements = require('../elements/index');
 var helpers = require('../helpers/index');
 
 defaults._set('line', {
-	showLines: true,
 	spanGaps: false,
 
 	hover: {
@@ -26,10 +25,6 @@ defaults._set('line', {
 
 module.exports = function(Chart) {
 
-	function lineEnabled(dataset, options) {
-		return helpers.valueOrDefault(dataset.showLine, options.showLines);
-	}
-
 	Chart.controllers.line = Chart.DatasetController.extend({
 
 		datasetElementType: elements.Line,
@@ -46,7 +41,7 @@ module.exports = function(Chart) {
 			var scale = me.getScaleForId(meta.yAxisID);
 			var i, ilen, custom;
 			var dataset = me.getDataset();
-			var showLine = lineEnabled(dataset, options);
+			var showLine = me._lineEnabled(dataset, options);
 
 			// Update Line
 			if (showLine) {
@@ -300,7 +295,7 @@ module.exports = function(Chart) {
 			var halfBorderWidth;
 			var i = 0;
 
-			if (lineEnabled(me.getDataset(), chart.options)) {
+			if (me._lineEnabled(me.getDataset(), chart.options)) {
 				halfBorderWidth = (meta.dataset._model.borderWidth || 0) / 2;
 
 				helpers.canvas.clipArea(chart.ctx, {
@@ -340,5 +335,13 @@ module.exports = function(Chart) {
 			model.borderWidth = custom.hoverBorderWidth || helpers.valueAtIndexOrDefault(dataset.pointHoverBorderWidth, index, model.borderWidth);
 			model.radius = custom.hoverRadius || helpers.valueAtIndexOrDefault(dataset.pointHoverRadius, index, this.chart.options.elements.point.hoverRadius);
 		},
+
+        /**
+         * To be called only by scatter chart
+         * @private
+         */
+		_lineEnabled: function(dataset, options) {
+			return helpers.valueOrDefault(dataset.showLine, helpers.valueOrDefault(options.showLines, true));
+		}
 	});
 };

--- a/src/controllers/controller.scatter.js
+++ b/src/controllers/controller.scatter.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var defaults = require('../core/core.defaults');
+var helpers = require('../helpers/index');
 
 defaults._set('scatter', {
 	hover: {
@@ -20,8 +21,6 @@ defaults._set('scatter', {
 		}]
 	},
 
-	showLines: false,
-
 	tooltips: {
 		callbacks: {
 			title: function() {
@@ -36,7 +35,15 @@ defaults._set('scatter', {
 
 module.exports = function(Chart) {
 
-	// Scatter charts use line controllers
-	Chart.controllers.scatter = Chart.controllers.line;
+	Chart.controllers.scatter = Chart.controllers.line.extend({
+
+		/**
+		 * @private
+		 */
+		_lineEnabled: function(dataset, options) {
+			return helpers.valueOrDefault(dataset.showLine, helpers.valueOrDefault(options.showLines, false));
+		}
+
+	});
 
 };

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -19,7 +19,6 @@ defaults._set('global', {
 	defaultFontFamily: "'Helvetica Neue', 'Helvetica', 'Arial', sans-serif",
 	defaultFontSize: 12,
 	defaultFontStyle: 'normal',
-	showLines: true,
 
 	// Element defaults defined in element extensions
 	elements: {},


### PR DESCRIPTION
Allows you to have mixed line and scatter charts

Changes `showLines` from global default to chart-type default. Right now if you have a line chart it turns lines on globally including for scatter charts. Scatter charts by definition don't have lines, so this ends up being confusing. This still allows users to override the defaults while stopping line defaults from being applied to scatter charts and vice versa