### PR TITLE
Remove copy-pasta error in polar area and doughnut chart docs

### DIFF
--- a/docs/charts/doughnut.md
+++ b/docs/charts/doughnut.md
@@ -55,7 +55,6 @@ The doughnut/pie chart allows a number of properties to be specified for each da
 
 | Name | Type | Description
 | ---- | ---- | -----------
-| `label` | `String` | The label for the dataset which appears in the legend and tooltips.
 | `backgroundColor` | `Color[]` | The fill color of the arcs in the dataset. See [Colors](../general/colors.md#colors)
 | `borderColor` | `Color[]` | The border color of the arcs in the dataset. See [Colors](../general/colors.md#colors)
 | `borderWidth` | `Number[]` | The border width of the arcs in the dataset.

--- a/docs/charts/polar.md
+++ b/docs/charts/polar.md
@@ -46,7 +46,6 @@ The following options can be included in a polar area chart dataset to configure
 
 | Name | Type | Description
 | ---- | ---- | -----------
-| `label` | `String` | The label for the dataset which appears in the legend and tooltips.
 | `backgroundColor` | `Color[]` | The fill color of the arcs in the dataset. See [Colors](../general/colors.md#colors)
 | `borderColor` | `Color[]` | The border color of the arcs in the dataset. See [Colors](../general/colors.md#colors)
 | `borderWidth` | `Number[]` | The border width of the arcs in the dataset.


### PR DESCRIPTION
The `dataset.label` property is not used in polar area and doughnut charts. Removed from the documentation.

Resolves #4902 