### PR TITLE
Bug: Avoid updating Chart when `responsive: true` and Chart is hidden.

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -192,6 +192,10 @@ module.exports = function(Chart) {
 
 			helpers.retinaScale(me, options.devicePixelRatio);
 
+			if (newWidth === 0 || newHeight === 0) {
+				return;
+			}
+
 			if (!silent) {
 				// Notify any plugins about the resize
 				var newSize = {width: newWidth, height: newHeight};

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -177,7 +177,7 @@ module.exports = function(Chart) {
 			// the canvas render width and height will be casted to integers so make sure that
 			// the canvas display style uses the same integer values to avoid blurring effect.
 
-			// Set to 0 instead of canvas.size because the size defaults to 300x150 if the element is collased
+			// Set to 0 instead of canvas.size because the size defaults to 300x150 if the element is collapsed
 			var newWidth = Math.max(0, Math.floor(helpers.getMaximumWidth(canvas)));
 			var newHeight = Math.max(0, Math.floor(aspectRatio ? newWidth / aspectRatio : helpers.getMaximumHeight(canvas)));
 
@@ -191,10 +191,6 @@ module.exports = function(Chart) {
 			canvas.style.height = newHeight + 'px';
 
 			helpers.retinaScale(me, options.devicePixelRatio);
-
-			if (newWidth === 0 || newHeight === 0) {
-				return;
-			}
 
 			if (!silent) {
 				// Notify any plugins about the resize
@@ -560,6 +556,10 @@ module.exports = function(Chart) {
 			}
 
 			me.transition(easingValue);
+
+			if (me.width <= 0 || me.height <= 0) {
+				return;
+			}
 
 			if (plugins.notify(me, 'beforeDraw', [easingValue]) === false) {
 				return;


### PR DESCRIPTION
As proposed in PR #4968 a fix to avoid resizing errors when the Chart is hidden.