### PR TITLE
Fix variable name error on developer api documentation

### DIFF
--- a/docs/developers/api.md
+++ b/docs/developers/api.md
@@ -132,9 +132,9 @@ To get an item that was clicked on, `getElementAtEvent` can be used.
 
 ```javascript
 function clickHandler(evt) {
-    var item = myChart.getElementAtEvent(evt)[0];
+    var firstPoint = myChart.getElementAtEvent(evt)[0];
 
-    if (item) {
+    if (firstPoint) {
         var label = myChart.data.labels[firstPoint._index];
         var value = myChart.data.datasets[firstPoint._datasetIndex].data[firstPoint._index];
     }


### PR DESCRIPTION
Small changes on the developer `api.md` documentation for the method `.getElementAtEvent(e)`, in the code snippet to get the item that was clicked on.

I believe the variable called here should be `item`, not `firstPoint`.

See [here](http://www.chartjs.org/docs/latest/developers/api.html#getelementatevente)