### PR TITLE
Don't draw tick across axis/border

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -909,7 +909,7 @@ module.exports = function(Chart) {
 				var x1 = me.left;
 				var x2 = me.right + axisWidth;
 				var y1 = me.top;
-				var y2 = me.bottom;
+				var y2 = me.bottom + axisWidth;
 
 				var aliasPixel = helpers.aliasPixel(context.lineWidth);
 				if (isHorizontal) {

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -705,10 +705,11 @@ module.exports = function(Chart) {
 
 			var itemsToDraw = [];
 
-			var xTickStart = options.position === 'right' ? me.left : me.right - tl;
-			var xTickEnd = options.position === 'right' ? me.left + tl : me.right;
-			var yTickStart = options.position === 'bottom' ? me.top : me.bottom - tl;
-			var yTickEnd = options.position === 'bottom' ? me.top + tl : me.bottom;
+			var axisWidth = me.options.gridLines.lineWidth;
+			var xTickStart = options.position === 'right' ? me.right : me.right - axisWidth - tl;
+			var xTickEnd = options.position === 'right' ? me.right + tl : me.right;
+			var yTickStart = options.position === 'bottom' ? me.top + axisWidth : me.bottom - tl - axisWidth;
+			var yTickEnd = options.position === 'bottom' ? me.top + axisWidth + tl : me.bottom + axisWidth;
 
 			helpers.each(ticks, function(tick, index) {
 				// autoskipper skipped this tick (#4635)
@@ -764,7 +765,7 @@ module.exports = function(Chart) {
 					ty1 = yTickStart;
 					ty2 = yTickEnd;
 					y1 = chartArea.top;
-					y2 = chartArea.bottom;
+					y2 = chartArea.bottom + axisWidth;
 				} else {
 					var isLeft = options.position === 'left';
 					var labelXOffset;
@@ -790,7 +791,7 @@ module.exports = function(Chart) {
 					tx1 = xTickStart;
 					tx2 = xTickEnd;
 					x1 = chartArea.left;
-					x2 = chartArea.right;
+					x2 = chartArea.right + axisWidth;
 					ty1 = ty2 = y1 = y2 = yLineValue;
 				}
 
@@ -906,7 +907,7 @@ module.exports = function(Chart) {
 				context.lineWidth = helpers.valueAtIndexOrDefault(gridLines.lineWidth, 0);
 				context.strokeStyle = helpers.valueAtIndexOrDefault(gridLines.color, 0);
 				var x1 = me.left;
-				var x2 = me.right;
+				var x2 = me.right + axisWidth;
 				var y1 = me.top;
 				var y2 = me.bottom;
 


### PR DESCRIPTION
In the current version of chartjs, drawing ticks overlaps the tick line with the border or axis line, making those intersections darker. This PR takes that into account when drawing ticks or borders and offsets them appropriately.

Before:
https://codepen.io/anon/pen/dJLaje
![image](https://user-images.githubusercontent.com/7771519/35298475-e75fed1c-0047-11e8-9948-ef69cc1dbefd.png)


I know it's small but you can probably see the darker pixel where the tick overlaps with the border.

After:
![image](https://user-images.githubusercontent.com/7771519/35298295-53398c2e-0047-11e8-90f0-eece8b01316f.png)

As you can see, no dark pixel!

In the future, I suggest spending even more time keeping lines from overlapping, even when gridlines intersect. This work is a small step in that direction.