### PR TITLE
Fix chart not extending to full canvas width

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -459,9 +459,6 @@ module.exports = function(Chart) {
 					if (me.labelRotation !== 0) {
 						me.paddingLeft = opts.position === 'bottom' ? (cosRotation * firstLabelWidth) + 3 : (cosRotation * lineSpace) + 3; // add 3 px to move away from canvas edges
 						me.paddingRight = opts.position === 'bottom' ? (cosRotation * lineSpace) + 3 : (cosRotation * lastLabelWidth) + 3;
-					} else {
-						me.paddingLeft = firstLabelWidth / 2 + 3; // add 3 px to move away from canvas edges
-						me.paddingRight = lastLabelWidth / 2 + 3;
 					}
 				} else {
 					// A vertical axis is more constrained by the width. Labels are the
@@ -705,10 +702,11 @@ module.exports = function(Chart) {
 
 			var itemsToDraw = [];
 
-			var xTickStart = options.position === 'right' ? me.left : me.right - tl;
-			var xTickEnd = options.position === 'right' ? me.left + tl : me.right;
-			var yTickStart = options.position === 'bottom' ? me.top : me.bottom - tl;
-			var yTickEnd = options.position === 'bottom' ? me.top + tl : me.bottom;
+			var axisWidth = me.options.gridLines.lineWidth;
+			var xTickStart = options.position === 'right' ? me.right : me.right - axisWidth - tl;
+			var xTickEnd = options.position === 'right' ? me.right + tl : me.right;
+			var yTickStart = options.position === 'bottom' ? me.top + axisWidth : me.bottom - tl - axisWidth;
+			var yTickEnd = options.position === 'bottom' ? me.top + axisWidth + tl : me.bottom + axisWidth;
 
 			helpers.each(ticks, function(tick, index) {
 				// autoskipper skipped this tick (#4635)
@@ -764,7 +762,7 @@ module.exports = function(Chart) {
 					ty1 = yTickStart;
 					ty2 = yTickEnd;
 					y1 = chartArea.top;
-					y2 = chartArea.bottom;
+					y2 = chartArea.bottom + axisWidth;
 				} else {
 					var isLeft = options.position === 'left';
 					var labelXOffset;
@@ -790,7 +788,7 @@ module.exports = function(Chart) {
 					tx1 = xTickStart;
 					tx2 = xTickEnd;
 					x1 = chartArea.left;
-					x2 = chartArea.right;
+					x2 = chartArea.right + axisWidth;
 					ty1 = ty2 = y1 = y2 = yLineValue;
 				}
 
@@ -906,9 +904,9 @@ module.exports = function(Chart) {
 				context.lineWidth = helpers.valueAtIndexOrDefault(gridLines.lineWidth, 0);
 				context.strokeStyle = helpers.valueAtIndexOrDefault(gridLines.color, 0);
 				var x1 = me.left;
-				var x2 = me.right;
+				var x2 = me.right + axisWidth;
 				var y1 = me.top;
-				var y2 = me.bottom;
+				var y2 = me.bottom + axisWidth;
 
 				var aliasPixel = helpers.aliasPixel(context.lineWidth);
 				if (isHorizontal) {

--- a/src/scales/scale.category.js
+++ b/src/scales/scale.category.js
@@ -80,7 +80,7 @@ module.exports = function(Chart) {
 			}
 
 			if (me.isHorizontal()) {
-				var valueWidth = me.width / offsetAmt;
+				var valueWidth = (me.width - 5) / offsetAmt;
 				var widthOffset = (valueWidth * (index - me.minIndex));
 
 				if (offset) {


### PR DESCRIPTION
This PR fixes an issue wherein a chart displayed without ticks allows a point to go halfway out of the chart canvas area. Instead of adding padding when ticks are enabled (see removed lines) we add a small offset to the available axis area so 5px is reserved at the end of the axis. 

Two things:
* I'm not sure if this change needs to be made per scale type.
* I'm not sure if using a static offset is sufficient. Given that point width is customizable, it would be better to offset the axis by the max point width + 1.

Before:
https://codepen.io/pen?template=JXVYzq
![image](https://user-images.githubusercontent.com/7771519/35408473-d8fdfece-01d4-11e8-9cbe-28802921eb99.png)

After:
![image](https://user-images.githubusercontent.com/7771519/35408483-e53fa67e-01d4-11e8-871d-91f6aa52080a.png)
