### PR TITLE
Fix chart having hidden right padding

### DIFF
--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -304,8 +304,8 @@ module.exports = function(Chart) {
 				halfBorderWidth = (meta.dataset._model.borderWidth || 0) / 2;
 
 				helpers.canvas.clipArea(chart.ctx, {
-					left: area.left,
-					right: area.right,
+					left: area.left - halfBorderWidth,
+					right: area.right + halfBorderWidth,
 					top: area.top - halfBorderWidth,
 					bottom: area.bottom + halfBorderWidth
 				});


### PR DESCRIPTION
This PR fixes an issue wherein a chart displayed without ticks allows a point to go halfway out of the chart canvas area. Instead of adding padding when ticks are enabled (see removed lines) we add a small offset to the available axis area so 5px is reserved at the end of the axis. 

Two things:
* I'm not sure if this change needs to be made per scale type.
* I'm not sure if using a static offset is sufficient. Given that point width is customizable, it would be better to offset the axis by the max point width + 1.

Before:
https://codepen.io/anon/pen/baXVWX
![image](https://user-images.githubusercontent.com/7771519/35426202-c9f214b8-0226-11e8-9d47-6340dbdd67aa.png)


After:
![image](https://user-images.githubusercontent.com/7771519/35408483-e53fa67e-01d4-11e8-871d-91f6aa52080a.png)
