### PR TITLE
Don't render tooltips when they are disabled

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -867,10 +867,11 @@ module.exports = function(Chart) {
 			plugins.notify(me, 'afterEvent', [e]);
 
 			var bufferedRequest = me._bufferedRequest;
+			var valueOrDefault = helpers.valueOrDefault;
 			if (bufferedRequest) {
 				// If we have an update that was triggered, we need to do a normal render
 				me.render(bufferedRequest);
-			} else if (changed && !me.animating && me.options.tooltips.enabled) {
+			} else if (changed && !me.animating && (valueOrDefault(me.options.tooltips.enabled, true) || valueOrDefault(me.options.hover.enabled, true))) {
 				// If entering, leaving, or changing elements, animate the change via pivot
 				me.stop();
 

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -924,7 +924,7 @@ module.exports = function(Chart) {
 			}
 
 			// Built in hover styling
-			if (me.active.length && hoverOptions.mode) {
+			if (me.active.length && hoverOptions.mode && helpers.valueOrDefault(hoverOptions.enabled, true)) {
 				me.updateHoverStyle(me.active, hoverOptions.mode, true);
 			}
 

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -870,7 +870,7 @@ module.exports = function(Chart) {
 			if (bufferedRequest) {
 				// If we have an update that was triggered, we need to do a normal render
 				me.render(bufferedRequest);
-			} else if (changed && !me.animating) {
+			} else if (changed && !me.animating && me.options.tooltips.enabled) {
 				// If entering, leaving, or changing elements, animate the change via pivot
 				me.stop();
 


### PR DESCRIPTION
When hovering over a point tooltips are displayed/animated, but this can be skipped when tooltips have been disabled in the chart options.

This was causing multiple unnecessary redraws as the user moves the mouse over the chart.