### PR TITLE
Incorrect conversion of number to boolean

### DIFF
--- a/src/scales/scale.linearbase.js
+++ b/src/scales/scale.linearbase.js
@@ -25,7 +25,7 @@ function generateTicks(generationOptions, dataRange) {
 	var niceMax = Math.ceil(dataRange.max / spacing) * spacing;
 
 	// If min, max and stepSize is set and they make an evenly spaced scale use it.
-	if (generationOptions.min && generationOptions.max && generationOptions.stepSize) {
+	if (generationOptions.min !== undefined && generationOptions.max !== undefined && generationOptions.stepSize !== undefined) {
 		// If very close to our whole number, use it.
 		if (helpers.almostWhole((generationOptions.max - generationOptions.min) / generationOptions.stepSize, spacing / 1000)) {
 			niceMin = generationOptions.min;

--- a/src/scales/scale.linearbase.js
+++ b/src/scales/scale.linearbase.js
@@ -25,7 +25,7 @@ function generateTicks(generationOptions, dataRange) {
 	var niceMax = Math.ceil(dataRange.max / spacing) * spacing;
 
 	// If min, max and stepSize is set and they make an evenly spaced scale use it.
-	if (!helpers.isNullOrUndef(generationOptions.min) && !helpers.isNullOrUndef(generationOptions.max) && !helpers.isNullOrUndef(generationOptions.stepSize)) {
+	if (!helpers.isNullOrUndef(generationOptions.min) && !helpers.isNullOrUndef(generationOptions.max) && generationOptions.stepSize) {
 		// If very close to our whole number, use it.
 		if (helpers.almostWhole((generationOptions.max - generationOptions.min) / generationOptions.stepSize, spacing / 1000)) {
 			niceMin = generationOptions.min;

--- a/src/scales/scale.linearbase.js
+++ b/src/scales/scale.linearbase.js
@@ -25,7 +25,7 @@ function generateTicks(generationOptions, dataRange) {
 	var niceMax = Math.ceil(dataRange.max / spacing) * spacing;
 
 	// If min, max and stepSize is set and they make an evenly spaced scale use it.
-	if (generationOptions.min !== undefined && generationOptions.max !== undefined && generationOptions.stepSize !== undefined) {
+	if (!helpers.isNullOrUndef(generationOptions.min) && !helpers.isNullOrUndef(generationOptions.max) && !helpers.isNullOrUndef(generationOptions.stepSize)) {
 		// If very close to our whole number, use it.
 		if (helpers.almostWhole((generationOptions.max - generationOptions.min) / generationOptions.stepSize, spacing / 1000)) {
 			niceMin = generationOptions.min;

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -906,14 +906,13 @@ describe('Linear Scale', function() {
 		expect(chart.scales['x-axis-0'].max).toEqual(21);
 	});
 
-	it('min/max/stepSize settings should be used if set to zero', function() {
+	it('min settings should be used if set to zero', function() {
 		var barData = {
 			labels: ['S1', 'S2', 'S3'],
 			datasets: [{
 				label: 'dataset 1',
 				backgroundColor: '#382765',
-				data: [-2500, -2000, -1500],
-				hidden: true,
+				data: [2500, 2000, 1500]
 			}]
 		};
 
@@ -925,8 +924,7 @@ describe('Linear Scale', function() {
 					xAxes: [{
 						ticks: {
 							min: 0,
-							max: 0,
-							stepSize: 0
+							max: 3000
 						}
 					}]
 				}
@@ -934,7 +932,33 @@ describe('Linear Scale', function() {
 		});
 
 		expect(chart.scales['x-axis-0'].min).toEqual(0);
+	});
+
+	it('max settings should be used if set to zero', function() {
+		var barData = {
+			labels: ['S1', 'S2', 'S3'],
+			datasets: [{
+				label: 'dataset 1',
+				backgroundColor: '#382765',
+				data: [-2500, -2000, -1500]
+			}]
+		};
+
+		var chart = window.acquireChart({
+			type: 'horizontalBar',
+			data: barData,
+			options: {
+				scales: {
+					xAxes: [{
+						ticks: {
+							min: -3000,
+							max: 0
+						}
+					}]
+				}
+			}
+		});
+
 		expect(chart.scales['x-axis-0'].max).toEqual(0);
-		expect(chart.scales['x-axis-0'].stepSize).toEqual(0);
 	});
 });

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -906,7 +906,7 @@ describe('Linear Scale', function() {
 		expect(chart.scales['x-axis-0'].max).toEqual(21);
 	});
 
-	it('max setting should be used if it set to zero', function() {
+	it('min/max/stepSize settings should be used if set to zero', function() {
 		var barData = {
 			labels: ['S1', 'S2', 'S3'],
 			datasets: [{
@@ -924,14 +924,17 @@ describe('Linear Scale', function() {
 				scales: {
 					xAxes: [{
 						ticks: {
-							min: -3000,
-							max: 0
+							min: 0,
+							max: 0,
+							stepSize: 0
 						}
 					}]
 				}
 			}
 		});
 
+		expect(chart.scales['x-axis-0'].min).toEqual(0);
 		expect(chart.scales['x-axis-0'].max).toEqual(0);
+		expect(chart.scales['x-axis-0'].stepSize).toEqual(0);
 	});
 });

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -905,7 +905,7 @@ describe('Linear Scale', function() {
 		expect(chart.scales['x-axis-0'].min).toEqual(20);
 		expect(chart.scales['x-axis-0'].max).toEqual(21);
 	});
-	
+
 	it('max setting should be used if it set to zero', function() {
 		var barData = {
 			labels: ['S1', 'S2', 'S3'],

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -905,4 +905,33 @@ describe('Linear Scale', function() {
 		expect(chart.scales['x-axis-0'].min).toEqual(20);
 		expect(chart.scales['x-axis-0'].max).toEqual(21);
 	});
+	
+	it('max setting should be used if it set to zero', function() {
+		var barData = {
+			labels: ['S1', 'S2', 'S3'],
+			datasets: [{
+				label: 'dataset 1',
+				backgroundColor: '#382765',
+				data: [-2500, -2000, -1500],
+				hidden: true,
+			}]
+		};
+
+		var chart = window.acquireChart({
+			type: 'horizontalBar',
+			data: barData,
+			options: {
+				scales: {
+					xAxes: [{
+						ticks: {
+							min: -3000,
+							max: 0
+						}
+					}]
+				}
+			}
+		});
+
+		expect(chart.scales['x-axis-0'].max).toEqual(0);
+	});
 });


### PR DESCRIPTION
Check for min/max/stepSize coerces numbers to truthy values. A min setting of 0 is therefore interpreted as falsy, and not being set.

Checking against undefined means settings are correctly detected.