### PR TITLE
Fix Slack invitation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Chart.js
 
-[![travis](https://img.shields.io/travis/chartjs/Chart.js.svg?style=flat-square&maxAge=60)](https://travis-ci.org/chartjs/Chart.js) [![coveralls](https://img.shields.io/coveralls/chartjs/Chart.js.svg?style=flat-square&maxAge=600)](https://coveralls.io/github/chartjs/Chart.js?branch=master) [![codeclimate](https://img.shields.io/codeclimate/maintainability/chartjs/Chart.js.svg?style=flat-square&maxAge=600)](https://codeclimate.com/github/chartjs/Chart.js) [![slack](https://img.shields.io/badge/slack-Chart.js-blue.svg?style=flat-square&maxAge=3600)](https://chart-js-automation.herokuapp.com/)
+[![travis](https://img.shields.io/travis/chartjs/Chart.js.svg?style=flat-square&maxAge=60)](https://travis-ci.org/chartjs/Chart.js) [![coveralls](https://img.shields.io/coveralls/chartjs/Chart.js.svg?style=flat-square&maxAge=600)](https://coveralls.io/github/chartjs/Chart.js?branch=master) [![codeclimate](https://img.shields.io/codeclimate/maintainability/chartjs/Chart.js.svg?style=flat-square&maxAge=600)](https://codeclimate.com/github/chartjs/Chart.js) [![slack](https://img.shields.io/badge/slack-chartjs-blue.svg?style=flat-square&maxAge=3600)](https://chartjs-slack.herokuapp.com/)
 
 *Simple HTML5 Charts using the canvas element* [chartjs.org](http://www.chartjs.org)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Chart.js
 
-[![slack](https://img.shields.io/badge/slack-Chart.js-blue.svg?style=flat-square&maxAge=600)](https://chart-js-automation.herokuapp.com/)
+[![slack](https://img.shields.io/badge/slack-chartjs-blue.svg?style=flat-square&maxAge=3600)](https://chartjs-slack.herokuapp.com/)
 
 ## Installation
 

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -12,7 +12,7 @@ New contributions to the library are welcome, but we ask that you please follow 
 
 # Joining the project
 
- Active committers and contributors are invited to introduce yourself and request commit access to this project. We have a very active Slack community that you can join [here](https://chart-js-automation.herokuapp.com/). If you think you can help, we'd love to have you!
+ Active committers and contributors are invited to introduce yourself and request commit access to this project. We have a very active Slack community that you can join [here](https://chartjs-slack.herokuapp.com/). If you think you can help, we'd love to have you!
 
 # Building and Testing
 


### PR DESCRIPTION
Setup a new Heroku app (http://chartjs-slack.herokuapp.com) based on [rauchg/slackin](rauchg/slackin), using [Slack legacy token](https://api.slack.com/custom-integrations/legacy-tokens) from the Chart.js (chartjs.slack@...) user and [reCAPTCHA](https://www.google.com/recaptcha) from the same Google account.

Fixes [#3139](https://github.com/chartjs/Chart.js/issues/3139#issuecomment-361993966)

![image](https://user-images.githubusercontent.com/3874900/35651216-311c36b6-06df-11e8-962b-df2ce1b7bc4e.png)
