### PR TITLE
Rotations between 180-360 degrees on x axis labels

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -656,53 +656,8 @@ module.exports = Element.extend({
 			}
 		}
 
-<<<<<<< HEAD
 		for (i = 0; i < tickCount; i++) {
 			tick = ticks[i];
-=======
-			var context = me.ctx;
-			var globalDefaults = defaults.global;
-			var optionTicks = options.ticks.minor;
-			var optionMajorTicks = options.ticks.major || optionTicks;
-			var gridLines = options.gridLines;
-			var scaleLabel = options.scaleLabel;
-
-			var isRotated = me.labelRotation !== 0;
-			var isHorizontal = me.isHorizontal();
-
-			var ticks = optionTicks.autoSkip ? me._autoSkip(me.getTicks()) : me.getTicks();
-			var tickFontColor = helpers.valueOrDefault(optionTicks.fontColor, globalDefaults.defaultFontColor);
-			var tickFont = parseFontOptions(optionTicks);
-			var majorTickFontColor = helpers.valueOrDefault(optionMajorTicks.fontColor, globalDefaults.defaultFontColor);
-			var majorTickFont = parseFontOptions(optionMajorTicks);
-
-			var tl = gridLines.drawTicks ? gridLines.tickMarkLength : 0;
-
-			var scaleLabelFontColor = helpers.valueOrDefault(scaleLabel.fontColor, globalDefaults.defaultFontColor);
-			var scaleLabelFont = parseFontOptions(scaleLabel);
-			var scaleLabelPadding = helpers.options.toPadding(scaleLabel.padding);
-			var labelRotationRadians = helpers.toRadians(me.labelRotation);
-
-			var itemsToDraw = [];
-
-			var axisWidth = me.options.gridLines.lineWidth;
-			var xTickStart = options.position === 'right' ? me.right : me.right - axisWidth - tl;
-			var xTickEnd = options.position === 'right' ? me.right + tl : me.right;
-			var yTickStart = options.position === 'bottom' ? me.top + axisWidth : me.bottom - tl - axisWidth;
-			var yTickEnd = options.position === 'bottom' ? me.top + axisWidth + tl : me.bottom + axisWidth;
-			var yRotationOffset = 0;
-
-			if (me.labelRotation < 0) {
-				var sinRotation = Math.abs(Math.sin(labelRotationRadians));
-				yRotationOffset = sinRotation * me.longestLabelWidth;
-			}
-
-			helpers.each(ticks, function(tick, index) {
-				// autoskipper skipped this tick (#4635)
-				if (helpers.isNullOrUndef(tick.label)) {
-					return;
-				}
->>>>>>> Update core.scale.js
 
 			// Since we always show the last tick,we need may need to hide the last shown one before
 			shouldSkip = (skipRatio > 1 && i % skipRatio > 0) || (i % skipRatio === 0 && i + skipRatio >= tickCount);

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -692,11 +692,11 @@ module.exports = Element.extend({
 			var yTickEnd = options.position === 'bottom' ? me.top + axisWidth + tl : me.bottom + axisWidth;
 			var yRotationOffset = 0;
 
-            if(me.labelRotation < 0){
-                var longestText = helpers.longestText(context, tickFont.font, labelsFromTicks(ticks), me.longestTextCache);
-                var sinRotation = Math.abs(Math.sin(labelRotationRadians));
-                yRotationOffset = sinRotation * longestText;
-            }
+			if (me.labelRotation < 0){
+				var longestText = helpers.longestText(context, tickFont.font, labelsFromTicks(ticks), me.longestTextCache);
+				var sinRotation = Math.abs(Math.sin(labelRotationRadians));
+				yRotationOffset = sinRotation * longestText;
+			}
 
 			helpers.each(ticks, function(tick, index) {
 				// autoskipper skipped this tick (#4635)

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -656,8 +656,54 @@ module.exports = Element.extend({
 			}
 		}
 
+<<<<<<< HEAD
 		for (i = 0; i < tickCount; i++) {
 			tick = ticks[i];
+=======
+			var context = me.ctx;
+			var globalDefaults = defaults.global;
+			var optionTicks = options.ticks.minor;
+			var optionMajorTicks = options.ticks.major || optionTicks;
+			var gridLines = options.gridLines;
+			var scaleLabel = options.scaleLabel;
+
+			var isRotated = me.labelRotation !== 0;
+			var isHorizontal = me.isHorizontal();
+
+			var ticks = optionTicks.autoSkip ? me._autoSkip(me.getTicks()) : me.getTicks();
+			var tickFontColor = helpers.valueOrDefault(optionTicks.fontColor, globalDefaults.defaultFontColor);
+			var tickFont = parseFontOptions(optionTicks);
+			var majorTickFontColor = helpers.valueOrDefault(optionMajorTicks.fontColor, globalDefaults.defaultFontColor);
+			var majorTickFont = parseFontOptions(optionMajorTicks);
+
+			var tl = gridLines.drawTicks ? gridLines.tickMarkLength : 0;
+
+			var scaleLabelFontColor = helpers.valueOrDefault(scaleLabel.fontColor, globalDefaults.defaultFontColor);
+			var scaleLabelFont = parseFontOptions(scaleLabel);
+			var scaleLabelPadding = helpers.options.toPadding(scaleLabel.padding);
+			var labelRotationRadians = helpers.toRadians(me.labelRotation);
+
+			var itemsToDraw = [];
+
+			var axisWidth = me.options.gridLines.lineWidth;
+			var xTickStart = options.position === 'right' ? me.right : me.right - axisWidth - tl;
+			var xTickEnd = options.position === 'right' ? me.right + tl : me.right;
+			var yTickStart = options.position === 'bottom' ? me.top + axisWidth : me.bottom - tl - axisWidth;
+			var yTickEnd = options.position === 'bottom' ? me.top + axisWidth + tl : me.bottom + axisWidth;
+			var yRotationOffset = 0;
+
+            if(me.labelRotation < 0){
+                var longestText = helpers.longestText(context, tickFont.font, labelsFromTicks(ticks), me.longestTextCache);
+                var sinRotation = Math.abs(Math.sin(labelRotationRadians));
+                yRotationOffset = sinRotation * longestText;
+            }
+
+			helpers.each(ticks, function(tick, index) {
+				// autoskipper skipped this tick (#4635)
+				if (helpers.isNullOrUndef(tick.label)) {
+					return;
+				}
+>>>>>>> Update core.scale.js
 
 			// Since we always show the last tick,we need may need to hide the last shown one before
 			shouldSkip = (skipRatio > 1 && i % skipRatio > 0) || (i % skipRatio === 0 && i + skipRatio >= tickCount);

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -692,7 +692,7 @@ module.exports = Element.extend({
 			var yTickEnd = options.position === 'bottom' ? me.top + axisWidth + tl : me.bottom + axisWidth;
 			var yRotationOffset = 0;
 
-			if (me.labelRotation < 0){
+			if (me.labelRotation < 0) {
 				var longestText = helpers.longestText(context, tickFont.font, labelsFromTicks(ticks), me.longestTextCache);
 				var sinRotation = Math.abs(Math.sin(labelRotationRadians));
 				yRotationOffset = sinRotation * longestText;

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -438,8 +438,8 @@ module.exports = Element.extend({
 				me.longestLabelWidth = largestTextWidth;
 
 				var angleRadians = helpers.toRadians(me.labelRotation);
-				var cosRotation = Math.cos(angleRadians);
-				var sinRotation = Math.sin(angleRadians);
+				var cosRotation = Math.abs(Math.cos(angleRadians));
+				var sinRotation = Math.abs(Math.sin(angleRadians));
 
 				// TODO - improve this calculation
 				var labelHeight = (sinRotation * largestTextWidth)
@@ -709,6 +709,12 @@ module.exports = Element.extend({
 		var xTickEnd = options.position === 'right' ? me.left + tl : me.right;
 		var yTickStart = options.position === 'bottom' ? me.top + axisWidth : me.bottom - tl - axisWidth;
 		var yTickEnd = options.position === 'bottom' ? me.top + axisWidth + tl : me.bottom + axisWidth;
+		var yRotationOffset = 0;
+
+		if (me.labelRotation < 0) {
+			var sinRotation = Math.abs(Math.sin(labelRotationRadians));
+			yRotationOffset = sinRotation * me.longestLabelWidth;
+		}
 
 		helpers.each(ticks, function(tick, index) {
 			// autoskipper skipped this tick (#4635)
@@ -738,7 +744,7 @@ module.exports = Element.extend({
 			var tickPadding = optionTicks.padding;
 
 			if (isHorizontal) {
-				var labelYOffset = tl + tickPadding;
+				var labelYOffset = tl + tickPadding + yRotationOffset;
 
 				if (options.position === 'bottom') {
 					// bottom

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -693,9 +693,8 @@ module.exports = Element.extend({
 			var yRotationOffset = 0;
 
 			if (me.labelRotation < 0) {
-				var longestText = helpers.longestText(context, tickFont.font, labelsFromTicks(ticks), me.longestTextCache);
 				var sinRotation = Math.abs(Math.sin(labelRotationRadians));
-				yRotationOffset = sinRotation * longestText;
+				yRotationOffset = sinRotation * me.longestLabelWidth;
 			}
 
 			helpers.each(ticks, function(tick, index) {


### PR DESCRIPTION
Text rotated -90° does not work correctly, example at this fiddle : https://jsfiddle.net/thLyc5wh/7/

Changes are
1) Take abs() of sin/cos when measuring text so that sizes are always positive. Text was measured as having a negative width.
2) Move label drawing offset by the text length so that it is drawn outside the chart area, below the axis.