### PR TITLE
Fixes Label Array Tick alignment and Centering

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -859,10 +859,8 @@ module.exports = function(Chart) {
 					if (helpers.isArray(label)) {
 						var lineCount = label.length / 2;
 						var lineHeight = tickFont.size * 1.5;
-						var y = 0;
-						if (!me.isHorizontal()) {
-							y = -tickFont.size * lineCount;
-						}
+						var y = me.isHorizontal() ? 0 : -lineHeight * lineCount / 1.2;
+
 						for (var i = 0; i < label.length; ++i) {
 							// We just make sure the multiline element is a string here..
 							context.fillText('' + label[i], 0, y);

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -857,11 +857,11 @@ module.exports = function(Chart) {
 
 					var label = itemToDraw.label;
 					if (helpers.isArray(label)) {
-						var lineCount = label.length / 2;
+						var lineCount = label.length;
 						var lineHeight = tickFont.size * 1.5;
-						var y = me.isHorizontal() ? 0 : -lineHeight * lineCount / 1.2;
+						var y = me.isHorizontal() ? 0 : -lineHeight * (lineCount - 1) / 2;
 
-						for (var i = 0; i < label.length; ++i) {
+						for (var i = 0; i < lineCount; ++i) {
 							// We just make sure the multiline element is a string here..
 							context.fillText('' + label[i], 0, y);
 							// apply same lineSpacing as calculated @ L#320

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -857,6 +857,11 @@ module.exports = function(Chart) {
 
 					var label = itemToDraw.label;
 					if (helpers.isArray(label)) {
+						if (label.length % 2 === 0) {
+							context.translate(0, (-tickFont.size * (label.length / 2)) / 2);
+						} else {
+							context.translate(0, -tickFont.size * (label.length / 2));
+						}
 						for (var i = 0, y = 0; i < label.length; ++i) {
 							// We just make sure the multiline element is a string here..
 							context.fillText('' + label[i], 0, y);

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -857,16 +857,17 @@ module.exports = function(Chart) {
 
 					var label = itemToDraw.label;
 					if (helpers.isArray(label)) {
-						if (label.length % 2 === 0) {
-							context.translate(0, (-tickFont.size * (label.length / 2)) / 2);
-						} else {
-							context.translate(0, -tickFont.size * (label.length / 2));
+						var lineCount = label.length / 2;
+						var lineHeight = tickFont.size * 1.5;
+						var y = 0;
+						if (!me.isHorizontal()) {
+							y = -tickFont.size * lineCount;
 						}
-						for (var i = 0, y = 0; i < label.length; ++i) {
+						for (var i = 0; i < label.length; ++i) {
 							// We just make sure the multiline element is a string here..
 							context.fillText('' + label[i], 0, y);
 							// apply same lineSpacing as calculated @ L#320
-							y += (tickFont.size * 1.5);
+							y += lineHeight;
 						}
 					} else {
 						context.fillText(label, 0, 0);


### PR DESCRIPTION
Fixes #5211 by centering the array tick labels depending on if they are even or odd. 

## Before 
[Example JSFiddle](https://jsfiddle.net/qL4rm9an/3/) curtosy of @Moghul

![before](https://user-images.githubusercontent.com/27080760/35938565-7f2f0062-0c17-11e8-9925-682fbf680d84.JPG)


## After 

![chart js result](https://user-images.githubusercontent.com/27080760/35938572-83faf970-0c17-11e8-926b-fa95270fe264.JPG)

**Note:** I show an even number of labels on the second bar to show how the code adjusts for this 
