### PR TITLE
Improve title of generated documentation

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,5 +1,6 @@
 {
   "root": "./docs",
+  "title": "Chart.js documentation",
   "author": "chartjs",
   "gitbook": "3.2.2",
   "plugins": ["-lunr", "-search", "search-plus", "anchorjs", "chartjs", "ga"],


### PR DESCRIPTION
I found the GitBook API to inject the own title template 'Chart.js documentation'.

Fixes #5193

> **Edit(SB):** smart linking to associated issue