### PR TITLE
Bugfix: Improve polyfill function of log10 to return whole powers of 10

### DIFF
--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -163,7 +163,7 @@ module.exports = function(Chart) {
 			// Check for whole powers of 10,
 			// which due to floating point rounding error should be corrected.
 			var powerOf10 = Math.round(exponent);
-			var isPowerOf10 = (x / Math.pow(10, powerOf10)) === 1;
+			var isPowerOf10 = x === Math.pow(10, powerOf10);
 
 			return isPowerOf10 ? powerOf10 : exponent;
 		};

--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -159,7 +159,13 @@ module.exports = function(Chart) {
 			return Math.log10(x);
 		} :
 		function(x) {
-			return Math.log(x) / Math.LN10;
+			var exponent = Math.log(x) * Math.LOG10E; // Math.LOG10E = 1 / Math.LN10.
+			// Check for whole powers of 10,
+			// which due to floating point rounding error should be corrected.
+			var powerOf10 = Math.round(exponent);
+			var isPowerOf10 = (x / Math.pow(10, powerOf10)) === 1;
+
+			return isPowerOf10 ? powerOf10 : exponent;
 		};
 	helpers.toRadians = function(degrees) {
 		return degrees * (Math.PI / 180);

--- a/test/specs/core.helpers.tests.js
+++ b/test/specs/core.helpers.tests.js
@@ -194,8 +194,12 @@ describe('Core helper tests', function() {
 
 	it('should do a log10 operation', function() {
 		expect(helpers.log10(0)).toBe(-Infinity);
-		expect(helpers.log10(1)).toBe(0);
-		expect(helpers.log10(1000)).toBeCloseTo(3, 1e-9);
+
+		// Check all allowed powers of 10, which should return integer values
+		var maxPowerOf10 = Math.floor(helpers.log10(Number.MAX_VALUE));
+		for (var i = 0; i < maxPowerOf10; i += 1) {
+			expect(helpers.log10(Math.pow(10, i))).toBe(i);
+		}
 	});
 
 	it('should correctly determine if two numbers are essentially equal', function() {


### PR DESCRIPTION
The `helpers.log10` polyfill function doesn't return precise integer values for all whole powers of 10.
This can cause an infinite loop as issued in #5264 
The proposed PR uses a multiplication with `Math.LOG10E` instead of a division by `Math.LN10`. This improves the accuracy, however as is shown in the table below, not all computed powers are correct, thus leading to the extra check, which is slower, but more accurate.

| exponent | Math.log(x) / Math.LN10 | Math.log(x) * Math.LOG10E | PR
| -------- | ----------------------- | ------------------------- | --
| 3 | 2.9999999999999996 | 3 | 3
| 6 | 5.999999999999999 | 6 | 6
| 9 | 8.999999999999998 | 9 | 9
| 12 | 11.999999999999998 | 12 | 12
| 13 | 12.999999999999998 | 13 | 13
| 15 | 14.999999999999998 | 14.999999999999998 | 15
| 18 | 17.999999999999996 | 18 | 18
| 21 | 20.999999999999996 | 21 | 21
| 23 | 22.999999999999996 | 23 | 23
| 24 | 23.999999999999996 | 24 | 24
| 26 | 25.999999999999996 | 26 | 26
| 27 | 26.999999999999996 | 27 | 27
| 29 | 28.999999999999993 | 28.999999999999996 | 29
| 30 | 29.999999999999996 | 29.999999999999996 | 30
| 31 | 30.999999999999996 | 31 | 31
| 33 | 32.99999999999999 | 33 | 33
| 36 | 35.99999999999999 | 36 | 36
| 39 | 38.99999999999999 | 39 | 39
| 42 | 41.99999999999999 | 42 | 42
| 45 | 44.99999999999999 | 45 | 45
| 46 | 45.99999999999999 | 46 | 46
| 48 | 47.99999999999999 | 48 | 48
| 49 | 48.99999999999999 | 49 | 49
| 51 | 50.99999999999999 | 51 | 51
| 52 | 51.99999999999999 | 52 | 52
| 54 | 53.99999999999999 | 54 | 54
| 55 | 54.99999999999999 | 55 | 55
| 57 | 56.99999999999999 | 57 | 57
| 58 | 57.999999999999986 | 57.99999999999999 | 58
| 60 | 59.99999999999999 | 59.99999999999999 | 60
| 61 | 61 | 61.00000000000001 | 61
| 62 | 61.99999999999999 | 62 | 62
| 63 | 62.99999999999999 | 62.99999999999999 | 63
| 66 | 65.99999999999999 | 66 | 66
| 69 | 68.99999999999999 | 69 | 69
| 72 | 71.99999999999999 | 72 | 72
| 75 | 74.99999999999999 | 75 | 75
| 78 | 77.99999999999999 | 78 | 78
| 81 | 80.99999999999999 | 81 | 81
| 84 | 83.99999999999999 | 84 | 84
| 87 | 86.99999999999999 | 87 | 87
| 89 | 88.99999999999999 | 89 | 89
| 90 | 89.99999999999999 | 90 | 90
| 92 | 91.99999999999999 | 92 | 92
| 93 | 92.99999999999999 | 93 | 93
| 95 | 94.99999999999999 | 95 | 95
| 96 | 95.99999999999999 | 96 | 96
| 98 | 97.99999999999999 | 98 | 98
| 99 | 98.99999999999999 | 99 | 99
| 101 | 100.99999999999999 | 101 | 101
| 102 | 101.99999999999999 | 102 | 102
| 104 | 103.99999999999999 | 104 | 104
| 105 | 104.99999999999999 | 105 | 105
| 107 | 106.99999999999999 | 107 | 107
| 108 | 107.99999999999999 | 108 | 108
| 110 | 109.99999999999999 | 110 | 110
| 111 | 110.99999999999999 | 111 | 111
| 113 | 112.99999999999999 | 113 | 113
| 114 | 113.99999999999999 | 114 | 114
| 115 | 114.99999999999999 | 114.99999999999999 | 115
| 116 | 115.99999999999997 | 115.99999999999999 | 116
| 119 | 118.99999999999999 | 119 | 119
| 120 | 119.99999999999999 | 119.99999999999999 | 120
| 121 | 120.99999999999999 | 120.99999999999999 | 121
| 122 | 122 | 122.00000000000001 | 122
| 124 | 123.99999999999999 | 124 | 124
| 125 | 124.99999999999999 | 125 | 125
| 126 | 125.99999999999999 | 125.99999999999999 | 126
| 127 | 126.99999999999999 | 126.99999999999999 | 127
| 132 | 131.99999999999997 | 132 | 132
| 133 | 132.99999999999997 | 133 | 133
| 138 | 137.99999999999997 | 138 | 138
| 139 | 138.99999999999997 | 139 | 139
| 143 | 142.99999999999997 | 143 | 143
| 144 | 143.99999999999997 | 144 | 144
| 145 | 144.99999999999997 | 145 | 145
| 149 | 148.99999999999997 | 149 | 149
| 150 | 149.99999999999997 | 150 | 150
| 151 | 150.99999999999997 | 151 | 151
| 155 | 154.99999999999997 | 155 | 155
| 156 | 155.99999999999997 | 156 | 156
| 157 | 156.99999999999997 | 157 | 157
| 161 | 160.99999999999997 | 161 | 161
| 162 | 161.99999999999997 | 162 | 162
| 163 | 162.99999999999997 | 163 | 163
| 167 | 166.99999999999997 | 167 | 167
| 168 | 167.99999999999997 | 168 | 168
| 169 | 168.99999999999997 | 169 | 169
| 173 | 172.99999999999997 | 173 | 173
| 174 | 173.99999999999997 | 174 | 174
| 175 | 174.99999999999997 | 174.99999999999997 | 175
| 178 | 177.99999999999997 | 178 | 178
| 179 | 178.99999999999997 | 179 | 179
| 180 | 179.99999999999997 | 180 | 180
| 181 | 180.99999999999997 | 180.99999999999997 | 181
| 184 | 183.99999999999997 | 184 | 184
| 185 | 184.99999999999997 | 185 | 185
| 186 | 185.99999999999997 | 186 | 186
| 187 | 186.99999999999997 | 186.99999999999997 | 187
| 190 | 189.99999999999997 | 190 | 190
| 191 | 190.99999999999997 | 191 | 191
| 192 | 191.99999999999997 | 192 | 192
| 193 | 192.99999999999997 | 192.99999999999997 | 193
| 196 | 195.99999999999997 | 196 | 196
| 197 | 196.99999999999997 | 197 | 197
| 198 | 197.99999999999997 | 198 | 198
| 199 | 198.99999999999997 | 198.99999999999997 | 199
| 202 | 201.99999999999997 | 202 | 202
| 203 | 202.99999999999997 | 203 | 203
| 204 | 203.99999999999997 | 204 | 204
| 205 | 204.99999999999997 | 204.99999999999997 | 205
| 207 | 206.99999999999997 | 207 | 207
| 208 | 207.99999999999997 | 208 | 208
| 209 | 208.99999999999997 | 209 | 209
| 210 | 209.99999999999997 | 210 | 210
| 211 | 210.99999999999997 | 210.99999999999997 | 211
| 213 | 212.99999999999997 | 213 | 213
| 214 | 213.99999999999997 | 214 | 214
| 215 | 214.99999999999997 | 215 | 215
| 216 | 215.99999999999997 | 216 | 216
| 217 | 216.99999999999997 | 216.99999999999997 | 217
| 219 | 218.99999999999997 | 219 | 219
| 220 | 219.99999999999997 | 220 | 220
| 221 | 220.99999999999997 | 221 | 221
| 222 | 221.99999999999997 | 222 | 222
| 225 | 224.99999999999997 | 225 | 225
| 226 | 225.99999999999997 | 226 | 226
| 227 | 226.99999999999997 | 227 | 227
| 228 | 227.99999999999997 | 228 | 228
| 229 | 228.99999999999997 | 228.99999999999997 | 229
| 230 | 229.99999999999997 | 229.99999999999997 | 230
| 231 | 230.99999999999997 | 230.99999999999997 | 231
| 232 | 231.99999999999994 | 231.99999999999997 | 232
| 233 | 233 | 233.00000000000003 | 233
| 237 | 236.99999999999997 | 237 | 237
| 238 | 237.99999999999997 | 238 | 238
| 239 | 238.99999999999997 | 239 | 239
| 240 | 239.99999999999997 | 239.99999999999997 | 240
| 241 | 240.99999999999997 | 240.99999999999997 | 241
| 242 | 241.99999999999997 | 241.99999999999997 | 242
| 243 | 242.99999999999994 | 242.99999999999997 | 243
| 244 | 244 | 244.00000000000003 | 244
| 248 | 247.99999999999997 | 248 | 248
| 249 | 248.99999999999997 | 249 | 249
| 250 | 249.99999999999997 | 250 | 250
| 251 | 250.99999999999997 | 251 | 251
| 252 | 251.99999999999997 | 251.99999999999997 | 252
| 253 | 252.99999999999997 | 252.99999999999997 | 253
| 254 | 253.99999999999997 | 253.99999999999997 | 254
| 255 | 254.99999999999994 | 254.99999999999997 | 255
| 263 | 262.99999999999994 | 263 | 263
| 264 | 263.99999999999994 | 264 | 264
| 265 | 264.99999999999994 | 265 | 265
| 266 | 265.99999999999994 | 266 | 266
| 267 | 266.99999999999994 | 267 | 267
| 275 | 274.99999999999994 | 275 | 275
| 276 | 275.99999999999994 | 276 | 276
| 277 | 276.99999999999994 | 277 | 277
| 278 | 277.99999999999994 | 278 | 278
| 279 | 278.99999999999994 | 278.99999999999994 | 279
| 286 | 285.99999999999994 | 286 | 286
| 287 | 286.99999999999994 | 287 | 287
| 288 | 287.99999999999994 | 288 | 288
| 289 | 288.99999999999994 | 289 | 289
| 290 | 289.99999999999994 | 290 | 290
| 291 | 290.99999999999994 | 290.99999999999994 | 291
| 298 | 297.99999999999994 | 298 | 298
| 299 | 298.99999999999994 | 299 | 299
| 300 | 299.99999999999994 | 300 | 300
| 301 | 300.99999999999994 | 301 | 301
| 302 | 301.99999999999994 | 302 | 302