### PR TITLE
Fixes Tooltips Showing Outside Minimum Time Bounds

### DIFF
--- a/samples/charts/doughnut.html
+++ b/samples/charts/doughnut.html
@@ -23,6 +23,7 @@
 	<button id="removeDataset">Remove Dataset</button>
 	<button id="addData">Add Data</button>
 	<button id="removeData">Remove Data</button>
+	<button id="changeCircleSize">Semi/Full Circle</button>
 	<script>
 		var randomScalingFactor = function() {
 			return Math.round(Math.random() * 100);
@@ -135,6 +136,18 @@
 				dataset.data.pop();
 				dataset.backgroundColor.pop();
 			});
+
+			window.myDoughnut.update();
+		});
+
+		document.getElementById('changeCircleSize').addEventListener('click', function() {
+			if (window.myDoughnut.options.circumference === Math.PI) {
+				window.myDoughnut.options.circumference = 2 * Math.PI;
+				window.myDoughnut.options.rotation = -Math.PI / 2;
+			} else {
+				window.myDoughnut.options.circumference = Math.PI;
+				window.myDoughnut.options.rotation = -Math.PI;
+			}
 
 			window.myDoughnut.update();
 		});

--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -502,7 +502,7 @@ module.exports = function(Chart) {
 			document.defaultView.getComputedStyle(el, null).getPropertyValue(property);
 	};
 	helpers.retinaScale = function(chart, forceRatio) {
-		var pixelRatio = chart.currentDevicePixelRatio = forceRatio || window.devicePixelRatio || 1;
+		var pixelRatio = chart.currentDevicePixelRatio = forceRatio || (typeof window !== 'undefined' && window.devicePixelRatio) || 1;
 		if (pixelRatio === 1) {
 			return;
 		}

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -98,7 +98,6 @@ defaults._set('global', {
 
 module.exports = function(Chart) {
 
-	var globalChartArea = 0;
 	/**
  	 * Helper method to merge the opacity into a color
  	 */
@@ -268,7 +267,6 @@ module.exports = function(Chart) {
 		var model = tooltip._model;
 		var chart = tooltip._chart;
 		var chartArea = tooltip._chart.chartArea;
-		globalChartArea = chartArea.left;
 		var xAlign = 'center';
 		var yAlign = 'center';
 
@@ -847,7 +845,7 @@ module.exports = function(Chart) {
 			// Find Active Elements for tooltips
 			if (e.type === 'mouseout') {
 				me._active = [];
-			} else if (e.x > globalChartArea) {
+			} else if (e.x > me._chart.chartArea.left) {
 				me._active = me._chart.getElementsAtEventForMode(e, options.mode, options);
 			}
 

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -844,7 +844,7 @@ module.exports = function(Chart) {
 			me._lastActive = me._lastActive || [];
 
 			// Find Active Elements for tooltips
-			if (e.type === 'mouseout' || e.x < area.left || e.x > area.right || e.y < area.top || e.y > area.bottom) {
+			if (e.type === 'mouseout' || e.x < area.left || e.x > area.right) {
 				me._active = [];
 			} else {
 				me._active = me._chart.getElementsAtEventForMode(e, options.mode, options);

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -98,6 +98,7 @@ defaults._set('global', {
 
 module.exports = function(Chart) {
 
+	var globalChartArea = 0;
 	/**
  	 * Helper method to merge the opacity into a color
  	 */
@@ -267,6 +268,7 @@ module.exports = function(Chart) {
 		var model = tooltip._model;
 		var chart = tooltip._chart;
 		var chartArea = tooltip._chart.chartArea;
+		globalChartArea = chartArea.left;
 		var xAlign = 'center';
 		var yAlign = 'center';
 
@@ -848,9 +850,10 @@ module.exports = function(Chart) {
 			// Find Active Elements for tooltips
 			if (e.type === 'mouseout') {
 				me._active = [];
-			} else {
+			} else if (e.x > globalChartArea) {
 				me._active = me._chart.getElementsAtEventForMode(e, options.mode, options);
 			}
+
 
 			// Remember Last Actives
 			changed = !helpers.arrayEquals(me._active, me._lastActive);

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -839,13 +839,14 @@ module.exports = function(Chart) {
 			var me = this;
 			var options = me._options;
 			var changed = false;
+			var border = me._chart.chartArea;
 
 			me._lastActive = me._lastActive || [];
 
 			// Find Active Elements for tooltips
 			if (e.type === 'mouseout') {
 				me._active = [];
-			} else if (e.x > me._chart.chartArea.left) {
+			} else if (e.x > border.left && e.x < border.right) {
 				me._active = me._chart.getElementsAtEventForMode(e, options.mode, options);
 			}
 

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -507,11 +507,8 @@ module.exports = function(Chart) {
 				tooltipPosition = Chart.Tooltip.positioners[opts.position].call(me, active, me._eventPosition);
 
 				var tooltipItems = [];
-				var border = active[0]._xScale.left + 7; // 7 used for graph offset
-				if (existingModel.x > border) {
-					for (i = 0, len = active.length; i < len; ++i) {
-						tooltipItems.push(createTooltipItem(active[i]));
-					}
+				for (i = 0, len = active.length; i < len; ++i) {
+					tooltipItems.push(createTooltipItem(active[i]));
 				}
 
 				// If the user provided a filter function, use it to modify the tooltip items
@@ -853,7 +850,6 @@ module.exports = function(Chart) {
 			} else if (e.x > globalChartArea) {
 				me._active = me._chart.getElementsAtEventForMode(e, options.mode, options);
 			}
-
 
 			// Remember Last Actives
 			changed = !helpers.arrayEquals(me._active, me._lastActive);

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -844,7 +844,7 @@ module.exports = function(Chart) {
 			me._lastActive = me._lastActive || [];
 
 			// Find Active Elements for tooltips
-			if (e.type === 'mouseout' || e.x < area.left || e.x > area.right) {
+			if (e.type === 'mouseout' || e.x < area.left || e.x > area.right || e.y < area.top || e.y > area.bottom) {
 				me._active = [];
 			} else {
 				me._active = me._chart.getElementsAtEventForMode(e, options.mode, options);

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -505,8 +505,11 @@ module.exports = function(Chart) {
 				tooltipPosition = Chart.Tooltip.positioners[opts.position].call(me, active, me._eventPosition);
 
 				var tooltipItems = [];
-				for (i = 0, len = active.length; i < len; ++i) {
-					tooltipItems.push(createTooltipItem(active[i]));
+				var border = active[0]._xScale.left + 7; // 7 used for graph offset
+				if (existingModel.x > border) {
+					for (i = 0, len = active.length; i < len; ++i) {
+						tooltipItems.push(createTooltipItem(active[i]));
+					}
 				}
 
 				// If the user provided a filter function, use it to modify the tooltip items

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -839,14 +839,14 @@ module.exports = function(Chart) {
 			var me = this;
 			var options = me._options;
 			var changed = false;
-			var border = me._chart.chartArea;
+			var area = me._chart.chartArea;
 
 			me._lastActive = me._lastActive || [];
 
 			// Find Active Elements for tooltips
-			if (e.type === 'mouseout') {
+			if (e.type === 'mouseout' || e.x < area.left || e.x > area.right || e.y < area.top || e.y > area.bottom) {
 				me._active = [];
-			} else if (e.x > border.left && e.x < border.right) {
+			} else {
 				me._active = me._chart.getElementsAtEventForMode(e, options.mode, options);
 			}
 

--- a/test/specs/core.tooltip.tests.js
+++ b/test/specs/core.tooltip.tests.js
@@ -68,7 +68,7 @@ describe('Core.Tooltip', function() {
 				bubbles: true,
 				cancelable: true,
 				clientX: rect.left + point._model.x,
-				clientY: 0
+				clientY: rect.left + point._model.y
 			});
 
 			// Manually trigger rather than having an async test


### PR DESCRIPTION
Fixes #5228 by checking if x is outside the minimum border of the graph then allowing no tooltips to be created if so. 

[JSFiddle](https://jsfiddle.net/mqL0jrr2/3/)

## Result 
![tooltip](https://user-images.githubusercontent.com/27080760/36459894-d979c89c-1683-11e8-8a41-1cd2fea29723.gif)
