### PR TITLE
Enable running on node

### DIFF
--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -502,7 +502,7 @@ module.exports = function(Chart) {
 			document.defaultView.getComputedStyle(el, null).getPropertyValue(property);
 	};
 	helpers.retinaScale = function(chart, forceRatio) {
-		var pixelRatio = chart.currentDevicePixelRatio = forceRatio || window.devicePixelRatio || 1;
+		var pixelRatio = chart.currentDevicePixelRatio = forceRatio || (typeof window !== 'undefined' && window.devicePixelRatio) || 1;
 		if (pixelRatio === 1) {
 			return;
 		}


### PR DESCRIPTION
A pretty small change, which allows ChartJS to run on Node using a virtual canvas like [node-canvas](https://github.com/Automattic/node-canvas).

All that is required is that browser specific APIs are not referenced, like `window` or `document`. I only found 1 that was missing an `undefined` guard.

ChartJS can be used on node like so:
```js
const ChartJs = require('chart.js');
const { createCanvas } = require('canvas');

function renderPNG(configuration) {
	
	const canvas = createCanvas(800, 600);	
	// Disable animation (otherwise charts will throw exceptions)
	configuration.options = configuration.options || {};
	configuration.options.responsive = false;
	configuration.options.animation = false;
	canvas.style = {};
	const context = canvas.getContext('2d');
	const chart = new ChartJs(context, configuration);
	return new Promise((resolve, reject) => {
                // or `pngStream` `toDataURL`, etc
		chart.canvas.toBuffer((error, buffer) => {
			if (error) {
				return reject(error);
			}
			return resolve(buffer);
		});
	});
}
```