### PR TITLE
Fixes Too Many Datapoints being hovered

### DIFF
--- a/src/core/core.interaction.js
+++ b/src/core/core.interaction.js
@@ -37,6 +37,7 @@ function parseVisibleItems(chart, handler) {
 		for (j = 0, jlen = meta.data.length; j < jlen; ++j) {
 			var element = meta.data[j];
 			if (!element._view.skip) {
+				element.datasetlength = meta.data.length;
 				handler(element);
 			}
 		}
@@ -277,10 +278,23 @@ module.exports = {
 			var position = getRelativePosition(e, chart);
 			var items = [];
 			var intersectsItem = false;
+			var j;
 
 			parseVisibleItems(chart, function(element) {
-				if (element.inXRange(position.x)) {
-					items.push(element);
+				if (element.datasetlength < 40) {
+					if (element.inXRange(position.x)) {
+						items.push(element);
+					}
+				} else if (element.datasetlength >= 40) {
+					if (element.inXRangeSmall(position.x)) {
+						items.push(element);
+						// Cleanup extra elements
+						if (items.length > 1) {
+							for (j = 1; j <= items.length; j++) {
+								items.splice(j, 1);
+							}
+						}
+					}
 				}
 
 				if (element.inRange(position.x, position.y)) {
@@ -293,6 +307,7 @@ module.exports = {
 			if (options.intersect && !intersectsItem) {
 				items = [];
 			}
+
 			return items;
 		},
 

--- a/src/core/core.interaction.js
+++ b/src/core/core.interaction.js
@@ -278,7 +278,6 @@ module.exports = {
 			var position = getRelativePosition(e, chart);
 			var items = [];
 			var intersectsItem = false;
-			var j;
 
 			parseVisibleItems(chart, function(element) {
 				if (element.datasetlength < 40) {
@@ -290,13 +289,10 @@ module.exports = {
 						items.push(element);
 						// Cleanup extra elements
 						if (items.length > 1) {
-							for (j = 1; j <= items.length; j++) {
-								items.splice(j, 1);
-							}
+							items.splice(1, items.length);
 						}
 					}
 				}
-
 				if (element.inRange(position.x, position.y)) {
 					intersectsItem = true;
 				}
@@ -307,7 +303,6 @@ module.exports = {
 			if (options.intersect && !intersectsItem) {
 				items = [];
 			}
-
 			return items;
 		},
 

--- a/src/core/core.interaction.js
+++ b/src/core/core.interaction.js
@@ -280,17 +280,11 @@ module.exports = {
 			var intersectsItem = false;
 
 			parseVisibleItems(chart, function(element) {
-				if (element.datasetlength < 40) {
-					if (element.inXRange(position.x)) {
-						items.push(element);
-					}
-				} else if (element.datasetlength >= 40) {
-					if (element.inXRangeSmall(position.x)) {
-						items.push(element);
-						// Cleanup extra elements
-						if (items.length > 1) {
-							items.splice(1, items.length);
-						}
+				if (element.inXRange(position.x)) {
+					items.push(element);
+					// Cleanup extra elements
+					if (items.length > 1) {
+						items.splice(1, items.length);
 					}
 				}
 				if (element.inRange(position.x, position.y)) {

--- a/src/elements/element.point.js
+++ b/src/elements/element.point.js
@@ -27,6 +27,11 @@ function xRange(mouseX) {
 	return vm ? (Math.abs(mouseX - vm.x) < vm.radius + vm.hitRadius) : false;
 }
 
+function xRangeSmall(mouseX) {
+	var vm = this._view;
+	return vm ? (Math.abs(mouseX - vm.x) < 2) : false;
+}
+
 function yRange(mouseY) {
 	var vm = this._view;
 	return vm ? (Math.abs(mouseY - vm.y) < vm.radius + vm.hitRadius) : false;
@@ -40,6 +45,7 @@ module.exports = Element.extend({
 
 	inLabelRange: xRange,
 	inXRange: xRange,
+	inXRangeSmall: xRangeSmall,
 	inYRange: yRange,
 
 	getCenterPoint: function() {

--- a/src/elements/element.point.js
+++ b/src/elements/element.point.js
@@ -24,11 +24,6 @@ defaults._set('global', {
 
 function xRange(mouseX) {
 	var vm = this._view;
-	return vm ? (Math.abs(mouseX - vm.x) < vm.radius + vm.hitRadius) : false;
-}
-
-function xRangeSmall(mouseX) {
-	var vm = this._view;
 	return vm ? (Math.abs(mouseX - vm.x) < 2) : false;
 }
 
@@ -45,7 +40,6 @@ module.exports = Element.extend({
 
 	inLabelRange: xRange,
 	inXRange: xRange,
-	inXRangeSmall: xRangeSmall,
 	inYRange: yRange,
 
 	getCenterPoint: function() {


### PR DESCRIPTION
Fixes #5231 

While investigating `core.interaction.js` I noticed the culprit of this problem is `xRange(mouseX)`. The reasoning behind this is when there are an excessive amount of data points more than one falls into the range of `x` causing there to be multiple datapoints hovered because they are so close together. Of course, when there are fewer data points (around 40 or less) this doesn't occur.

To fix this I made a separate function called `xRangeSmall` that narrows down the range of which a data point will be retrieved. In my testing, it only occurred when there was more than 40 data points on the graph so I added an `else if` to `x: function(chart, e, options)` that accounts for this problem when there are more than 40 data points. Feedback is welcome!

## Result 

![chart tooltip fix](https://user-images.githubusercontent.com/27080760/37264047-abe1e8d0-2581-11e8-8e0c-2cb0a755b402.gif)



[JSFiddle](https://jsfiddle.net/yebuh6jq/1/)