### PR TITLE
skip clipped points with zero opacity

### DIFF
--- a/src/elements/element.point.js
+++ b/src/elements/element.point.js
@@ -83,7 +83,7 @@ module.exports = Element.extend({
 		ctx.lineWidth = helpers.valueOrDefault(vm.borderWidth, defaults.global.elements.point.borderWidth);
 		ctx.fillStyle = vm.backgroundColor || defaultColor;
 
-		// Cliping for Points.
+		// Clipping for Points.
 		// going out from inner charArea?
 		if ((chartArea !== undefined) && ((model.x < chartArea.left) || (chartArea.right * errMargin < model.x) || (model.y < chartArea.top) || (chartArea.bottom * errMargin < model.y))) {
 			// Point fade out
@@ -97,10 +97,13 @@ module.exports = Element.extend({
 				ratio = (model.y - y) / (model.y - chartArea.bottom);
 			}
 			ratio = Math.round(ratio * 100) / 100;
-			ctx.strokeStyle = color(ctx.strokeStyle).alpha(ratio).rgbString();
-			ctx.fillStyle = color(ctx.fillStyle).alpha(ratio).rgbString();
+			if (ratio >= 0.01) {
+				ctx.strokeStyle = color(ctx.strokeStyle).alpha(ratio).rgbString();
+				ctx.fillStyle = color(ctx.fillStyle).alpha(ratio).rgbString();
+				helpers.canvas.drawPoint(ctx, pointStyle, radius, x, y);
+			}
+		} else {
+			helpers.canvas.drawPoint(ctx, pointStyle, radius, x, y);
 		}
-
-		helpers.canvas.drawPoint(ctx, pointStyle, radius, x, y);
 	}
 });

--- a/src/elements/element.point.js
+++ b/src/elements/element.point.js
@@ -71,38 +71,17 @@ module.exports = Element.extend({
 		var radius = vm.radius;
 		var x = vm.x;
 		var y = vm.y;
-		var color = helpers.color;
 		var errMargin = 1.01; // 1.01 is margin for Accumulated error. (Especially Edge, IE.)
-		var ratio = 0;
 
 		if (vm.skip) {
 			return;
 		}
 
-		ctx.strokeStyle = vm.borderColor || defaultColor;
-		ctx.lineWidth = helpers.valueOrDefault(vm.borderWidth, defaults.global.elements.point.borderWidth);
-		ctx.fillStyle = vm.backgroundColor || defaultColor;
-
 		// Clipping for Points.
-		// going out from inner charArea?
-		if ((chartArea !== undefined) && ((model.x < chartArea.left) || (chartArea.right * errMargin < model.x) || (model.y < chartArea.top) || (chartArea.bottom * errMargin < model.y))) {
-			// Point fade out
-			if (model.x < chartArea.left) {
-				ratio = (x - model.x) / (chartArea.left - model.x);
-			} else if (chartArea.right * errMargin < model.x) {
-				ratio = (model.x - x) / (model.x - chartArea.right);
-			} else if (model.y < chartArea.top) {
-				ratio = (y - model.y) / (chartArea.top - model.y);
-			} else if (chartArea.bottom * errMargin < model.y) {
-				ratio = (model.y - y) / (model.y - chartArea.bottom);
-			}
-			ratio = Math.round(ratio * 100) / 100;
-			if (ratio >= 0.01) {
-				ctx.strokeStyle = color(ctx.strokeStyle).alpha(ratio).rgbString();
-				ctx.fillStyle = color(ctx.fillStyle).alpha(ratio).rgbString();
-				helpers.canvas.drawPoint(ctx, pointStyle, radius, x, y);
-			}
-		} else {
+		if (chartArea === undefined || (model.x >= chartArea.left && chartArea.right * errMargin >= model.x && model.y >= chartArea.top && chartArea.bottom * errMargin >= model.y)) {
+			ctx.strokeStyle = vm.borderColor || defaultColor;
+			ctx.lineWidth = helpers.valueOrDefault(vm.borderWidth, defaults.global.elements.point.borderWidth);
+			ctx.fillStyle = vm.backgroundColor || defaultColor;
 			helpers.canvas.drawPoint(ctx, pointStyle, radius, x, y);
 		}
 	}


### PR DESCRIPTION
Currently, there is an issue with rendering performance when setting the axis range to a subrange of the data range (i.e. some data points lie outside of the chart area, and should therefore not be rendered).  This is a common situation when zooming in on a graph, and has been referenced in the chartjs-plugin-zoom repo: https://github.com/chartjs/chartjs-plugin-zoom/issues/75

The problem arises from the approach taken when drawing points outside the chart area. Data points outside the chart area are assigned an opacity based on how far they are outside the chart. The opacity is rounded to the nearest percent. This is an expensive process, as, for each data point outside of the chart area, the following must occur: 

- ratio needs to be calculated
- a new style string needs to be generated and applied for both stroke and fill
- the point needs to be rendered with transparency

This PR improves performance in the common situation where the assigned opacity is zero. In this case, it skips the last two steps above. 

[This](https://codepen.io/veggiesaurus/pen/EoGdGG) is a codepen demonstrating the current behaviour. The CPU usage increases significantly when selecting a higher minimum range (by pressing the buttons below the graph). From my tests, CPU usage increased from 50% (and an average rendering time of 6 ms) to 95% (and an average rendering time of 29 ms) when selecting the "90%" minimum. 

[Here](https://codepen.io/veggiesaurus/pen/eMRqKE) is another codepen with the issue fixed. In this case CPU usage decreases when fewer points are rendered, which is what one would intuitively expect. 