### PR TITLE
opt-in caching of data limits

### DIFF
--- a/src/core/core.layouts.js
+++ b/src/core/core.layouts.js
@@ -189,10 +189,10 @@ module.exports = {
 			var isHorizontal = box.isHorizontal();
 
 			if (isHorizontal) {
-				minSize = box.update(box.fullWidth ? chartWidth : maxChartAreaWidth, horizontalBoxHeight);
+				minSize = box.update(box.fullWidth ? chartWidth : maxChartAreaWidth, horizontalBoxHeight, false);
 				maxChartAreaHeight -= minSize.height;
 			} else {
-				minSize = box.update(verticalBoxWidth, maxChartAreaHeight);
+				minSize = box.update(verticalBoxWidth, maxChartAreaHeight, false);
 				maxChartAreaWidth -= minSize.width;
 			}
 
@@ -252,9 +252,9 @@ module.exports = {
 
 					// Don't use min size here because of label rotation. When the labels are rotated, their rotation highly depends
 					// on the margin. Sometimes they need to increase in size slightly
-					box.update(box.fullWidth ? chartWidth : maxChartAreaWidth, chartHeight / 2, scaleMargin);
+					box.update(box.fullWidth ? chartWidth : maxChartAreaWidth, chartHeight / 2, true, scaleMargin);
 				} else {
-					box.update(minBoxSize.minSize.width, maxChartAreaHeight);
+					box.update(minBoxSize.minSize.width, maxChartAreaHeight, true);
 				}
 			}
 		}
@@ -295,7 +295,7 @@ module.exports = {
 			};
 
 			if (minBoxSize) {
-				box.update(minBoxSize.minSize.width, maxChartAreaHeight, scaleMargin);
+				box.update(minBoxSize.minSize.width, maxChartAreaHeight, true, scaleMargin);
 			}
 		}
 

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -172,7 +172,7 @@ module.exports = Element.extend({
 		helpers.callback(this.options.beforeUpdate, [this]);
 	},
 
-	update: function(maxWidth, maxHeight, margins) {
+	update: function(maxWidth, maxHeight, useCachedLimits, margins) {
 		var me = this;
 		var i, ilen, labels, label, ticks, tick;
 
@@ -196,9 +196,11 @@ module.exports = Element.extend({
 		me.afterSetDimensions();
 
 		// Data min/max
-		me.beforeDataLimits();
-		me.determineDataLimits();
-		me.afterDataLimits();
+		if (!useCachedLimits || !this.options.dataLimitCaching) {
+			me.beforeDataLimits();
+			me.determineDataLimits();
+			me.afterDataLimits();
+		}
 
 		// Ticks - `this.ticks` is now DEPRECATED!
 		// Internal ticks are now stored as objects in the PRIVATE `this._ticks` member


### PR DESCRIPTION
This PR allows for opt-in caching of the `min` and `max` values calculated by `determineDataLimits` during an update. See  #5389 for details.

Caching is opt-in, so it should not change the default behaviour. When updating a large (100 000 data points) chart, it shaves 10 ms off the update time. 