### PR TITLE
Fixes Tooltips Showing Outside Minimum Time Bounds [redo]

### DIFF
--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -915,11 +915,12 @@ var exports = module.exports = Element.extend({
 		var me = this;
 		var options = me._options;
 		var changed = false;
+		var area = me._chart.chartArea;
 
 		me._lastActive = me._lastActive || [];
 
 		// Find Active Elements for tooltips
-		if (e.type === 'mouseout') {
+		if (e.type === 'mouseout' || e.x < area.left || e.x > area.right || e.y < area.top || e.y > area.bottom) {
 			me._active = [];
 		} else {
 			me._active = me._chart.getElementsAtEventForMode(e, options.mode, options);

--- a/test/specs/core.tooltip.tests.js
+++ b/test/specs/core.tooltip.tests.js
@@ -68,7 +68,7 @@ describe('Core.Tooltip', function() {
 				bubbles: true,
 				cancelable: true,
 				clientX: rect.left + point._model.x,
-				clientY: 0
+				clientY: rect.left + point._model.y
 			});
 
 			// Manually trigger rather than having an async test


### PR DESCRIPTION
A redo of PR #5287 to add updates from master. This fixes #5228 by checking if x is outside the minimum border of the graph then allowing no tooltips to be created if so.