### PR TITLE
Float-bar support. Duplicate of 5262. The logic is to use array values [start, end]

### DIFF
--- a/docs/charts/bar.md
+++ b/docs/charts/bar.md
@@ -16,7 +16,7 @@ A bar chart provides a way of showing data values represented as vertical bars. 
         ],
         "datasets": [{
             "label": "My First Dataset",
-            "data": [65, 59, 80, 81, 56, 55, 40],
+            "data": [65, 59, 80, 81, 56, 55, 40, [10, 20]],
             "fill": false,
             "backgroundColor": [
                 "rgba(255, 99, 132, 0.2)",
@@ -86,6 +86,7 @@ Options are:
 * 'left'
 * 'top'
 * 'right'
+* false - in the case of floating bar chart we need to have all borders, so you can set var to false to draw all borders
 
 ## Configuration Options
 
@@ -146,10 +147,10 @@ Sample:     |==============|
 
 ## Data Structure
 
-The `data` property of a dataset for a bar chart is specified as a an array of numbers. Each point in the data array corresponds to the label at the same index on the x axis.
-
+The `data` property of a dataset for a bar chart is specified as a an array of numbers or arrays. Each point in the data array corresponds to the label at the same index on the x axis.
+For floating bar chart you can use array for a specific Y value passing two numbers. First one will be used as min value and second one as max value for a bar.
 ```javascript
-data: [20, 10]
+data: [20, 10, [10, 20]]
 ```
 
 You can also specify the dataset as x/y coordinates when using the [time scale](../axes/cartesian/time.md#time-cartesian-axis).
@@ -196,7 +197,7 @@ A horizontal bar chart is a variation on a vertical bar chart. It is sometimes u
         "labels": ["January", "February", "March", "April", "May", "June", "July"],
         "datasets": [{
             "label": "My First Dataset",
-            "data": [65, 59, 80, 81, 56, 55, 40],
+            "data": [65, 59, 80, 81, 56, 55, 40, [10, 20]],
             "fill": false,
             "backgroundColor": [
                 "rgba(255, 99, 132, 0.2)",

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -514,6 +514,14 @@ module.exports = Element.extend({
 
 	// Get the correct value. NaN bad inputs, If the value type is object get the x or y based on whether we are horizontal or not
 	getRightValue: function(rawValue) {
+		// Float-bar support. Check if array so be aware of min/max Y values. Return min for stacked chars and max for general char
+		if (helpers.isArray(rawValue)) {
+			if ((this.chart.options.scales.yAxes[0].stacked || this.chart.options.scales.xAxes[0].stacked) && !isNaN(rawValue[0])) {
+				rawValue = rawValue[0];
+			} else if (!isNaN(rawValue[1])) {
+				rawValue = rawValue[1];
+			}
+		}
 		// Null and undefined values first
 		if (helpers.isNullOrUndef(rawValue)) {
 			return NaN;

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -68,7 +68,13 @@ defaults._set('global', {
 				if (label) {
 					label += ': ';
 				}
-				label += tooltipItem.yLabel;
+				//	float-bar support, if y arguments are array tooltip will show bottom and up values
+				var Yvalue = data.datasets[tooltipItem.datasetIndex].data[tooltipItem.index];
+				if (helpers.isArray(Yvalue)) {
+					label += Yvalue[0] + ' - ' + Yvalue[1];
+				} else {
+					label += tooltipItem.yLabel;
+				}
 				return label;
 			},
 			labelColor: function(tooltipItem, chart) {

--- a/src/elements/element.rectangle.js
+++ b/src/elements/element.rectangle.js
@@ -67,7 +67,12 @@ module.exports = Element.extend({
 			bottom = vm.base;
 			signX = 1;
 			signY = bottom > top ? 1 : -1;
-			borderSkipped = vm.borderSkipped || 'bottom';
+			// no border support
+			if (vm.borderSkipped === null) {
+				borderSkipped = null;
+			} else {
+				borderSkipped = vm.borderSkipped || 'bottom';
+			}
 		} else {
 			// horizontal bar
 			left = vm.base;
@@ -76,7 +81,12 @@ module.exports = Element.extend({
 			bottom = vm.y + vm.height / 2;
 			signX = right > left ? 1 : -1;
 			signY = 1;
-			borderSkipped = vm.borderSkipped || 'left';
+			// no border support
+			if (vm.borderSkipped === null) {
+				borderSkipped = null;
+			} else {
+				borderSkipped = vm.borderSkipped || 'left';
+			}
 		}
 
 		// Canvas doesn't allow us to stroke inside the width so we can
@@ -132,8 +142,14 @@ module.exports = Element.extend({
 		// Draw rectangle from 'startCorner'
 		var corner = cornerAt(0);
 		ctx.moveTo(corner[0], corner[1]);
+		//	float-bar support, let's rectangle allow to have all borders, assign corners_count to 5 instead of 4, so we are allowing to fill all sides.
+		var cornersCount = 4;
 
-		for (var i = 1; i < 4; i++) {
+		if (borderSkipped === null) {
+			cornersCount = 5;
+		}
+
+		for (var i = 1; i < cornersCount; i++) {
 			corner = cornerAt(i);
 			ctx.lineTo(corner[0], corner[1]);
 		}

--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -161,7 +161,6 @@ module.exports = function(Chart) {
 							} else if (value > me.max) {
 								me.max = value;
 							}
-
 							if (value !== 0 && (me.minNotZero === null || value < me.minNotZero)) {
 								me.minNotZero = value;
 							}


### PR DESCRIPTION
The logic is to use array values [start, end]  
Duplicate of https://github.com/chartjs/Chart.js/pull/5262  
Fixed conflict in src/core/core.scale.js (just a formatting)  
  
Tested horizontal Bar charts (integer and time types). Looks ok!  