### PR TITLE
Update tooltip custom label example

### DIFF
--- a/docs/configuration/tooltip.md
+++ b/docs/configuration/tooltip.md
@@ -261,7 +261,8 @@ var myPieChart = new Chart(ctx, {
                 tooltipEl.style.fontFamily = tooltipModel._bodyFontFamily;
                 tooltipEl.style.fontSize = tooltipModel.bodyFontSize + 'px';
                 tooltipEl.style.fontStyle = tooltipModel._bodyFontStyle;
-                tooltipEl.style.padding = tooltipModel.yPadding + 'px ' + tooltipModel.xPadding + 'px';
+                tooltipEl.style.padding = tooltipModel.yPadding + 'px ' + tooltipModel.xPadding + 'px
+				tooltipEl.style.pointerEvents = 'none';
             }
         }
     }

--- a/docs/configuration/tooltip.md
+++ b/docs/configuration/tooltip.md
@@ -261,7 +261,7 @@ var myPieChart = new Chart(ctx, {
                 tooltipEl.style.fontFamily = tooltipModel._bodyFontFamily;
                 tooltipEl.style.fontSize = tooltipModel.bodyFontSize + 'px';
                 tooltipEl.style.fontStyle = tooltipModel._bodyFontStyle;
-                tooltipEl.style.padding = tooltipModel.yPadding + 'px ' + tooltipModel.xPadding + 'px
+                tooltipEl.style.padding = tooltipModel.yPadding + 'px ' + tooltipModel.xPadding + 'px';
 				tooltipEl.style.pointerEvents = 'none';
             }
         }

--- a/docs/configuration/tooltip.md
+++ b/docs/configuration/tooltip.md
@@ -255,9 +255,9 @@ var myPieChart = new Chart(ctx, {
 
                 // Display, position, and set styles for font
                 tooltipEl.style.opacity = 1;
-                tooltipEl.style.position = 'fixed';
-                tooltipEl.style.left = position.left + tooltipModel.caretX + 'px';
-                tooltipEl.style.top = position.top + tooltipModel.caretY + 'px';
+                tooltipEl.style.position = 'absolute';
+                tooltipEl.style.left = position.left + window.pageXOffset + tooltipModel.caretX + 'px';
+                tooltipEl.style.top = position.top + window.pageYOffset + tooltipModel.caretY + 'px';
                 tooltipEl.style.fontFamily = tooltipModel._bodyFontFamily;
                 tooltipEl.style.fontSize = tooltipModel.bodyFontSize + 'px';
                 tooltipEl.style.fontStyle = tooltipModel._bodyFontStyle;

--- a/docs/configuration/tooltip.md
+++ b/docs/configuration/tooltip.md
@@ -262,7 +262,7 @@ var myPieChart = new Chart(ctx, {
                 tooltipEl.style.fontSize = tooltipModel.bodyFontSize + 'px';
                 tooltipEl.style.fontStyle = tooltipModel._bodyFontStyle;
                 tooltipEl.style.padding = tooltipModel.yPadding + 'px ' + tooltipModel.xPadding + 'px';
-				tooltipEl.style.pointerEvents = 'none';
+                tooltipEl.style.pointerEvents = 'none';
             }
         }
     }

--- a/docs/configuration/tooltip.md
+++ b/docs/configuration/tooltip.md
@@ -255,7 +255,7 @@ var myPieChart = new Chart(ctx, {
 
                 // Display, position, and set styles for font
                 tooltipEl.style.opacity = 1;
-                tooltipEl.style.position = 'absolute';
+                tooltipEl.style.position = 'fixed';
                 tooltipEl.style.left = position.left + tooltipModel.caretX + 'px';
                 tooltipEl.style.top = position.top + tooltipModel.caretY + 'px';
                 tooltipEl.style.fontFamily = tooltipModel._bodyFontFamily;


### PR DESCRIPTION
The [`canvas.getBoundingClientRect()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect)
> returns the size of an element and its position relative to the viewport

So the tooltip should also reflect that as fixed positioning and not absolute