### PR TITLE
Update gulpfile.js to use in strict mode

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,7 @@ var yargs = require('yargs');
 var path = require('path');
 var fs = require('fs');
 var htmllint = require('gulp-htmllint');
-var package = require('./package.json');
+var pkg = require('./package.json');
 
 var argv = yargs
   .option('force-output', {default: false})
@@ -69,11 +69,11 @@ gulp.task('default', ['build', 'watch']);
  */
 function bowerTask() {
   var json = JSON.stringify({
-      name: package.name,
-      description: package.description,
-      homepage: package.homepage,
-      license: package.license,
-      version: package.version,
+      name: pkg.name,
+      description: pkg.description,
+      homepage: pkg.homepage,
+      license: pkg.license,
+      version: pkg.version,
       main: outDir + "Chart.js",
       ignore: [
         '.github',
@@ -112,11 +112,11 @@ function buildTask() {
     .on('error', errorHandler)
     .pipe(source('Chart.bundle.js'))
     .pipe(insert.prepend(header))
-    .pipe(streamify(replace('{{ version }}', package.version)))
+    .pipe(streamify(replace('{{ version }}', pkg.version)))
     .pipe(gulp.dest(outDir))
     .pipe(streamify(uglify()))
     .pipe(insert.prepend(header))
-    .pipe(streamify(replace('{{ version }}', package.version)))
+    .pipe(streamify(replace('{{ version }}', pkg.version)))
     .pipe(streamify(concat('Chart.bundle.min.js')))
     .pipe(gulp.dest(outDir));
 
@@ -127,11 +127,11 @@ function buildTask() {
     .on('error', errorHandler)
     .pipe(source('Chart.js'))
     .pipe(insert.prepend(header))
-    .pipe(streamify(replace('{{ version }}', package.version)))
+    .pipe(streamify(replace('{{ version }}', pkg.version)))
     .pipe(gulp.dest(outDir))
     .pipe(streamify(uglify()))
     .pipe(insert.prepend(header))
-    .pipe(streamify(replace('{{ version }}', package.version)))
+    .pipe(streamify(replace('{{ version }}', pkg.version)))
     .pipe(streamify(concat('Chart.min.js')))
     .pipe(gulp.dest(outDir));
 


### PR DESCRIPTION
During build a project by gulp there is an error

>  Error: Error in parsing: "bower_components\chart.js\gulpfile.js", Line 23: Use of future reserved word in strict mode

"package" is a reserved word and cannot be used in strict mode

https://www.w3schools.com/js/js_reserved.asp

