### PR TITLE
Add x-axis spacing options to make them more even

### DIFF
--- a/docs/axes/cartesian/linear.md
+++ b/docs/axes/cartesian/linear.md
@@ -12,6 +12,7 @@ The following options are provided by the linear scale. They are all located in 
 | `min` | `Number` | | User defined minimum number for the scale, overrides minimum value from data. [more...](#axis-range-settings)
 | `max` | `Number` | | User defined maximum number for the scale, overrides maximum value from data. [more...](#axis-range-settings)
 | `maxTicksLimit` | `Number` | `11` | Maximum number of ticks and gridlines to show.
+| `evenLabelSpacing` | `Boolean` |  | To be used with `maxTicksLimit`. If true, forces ticks to be evenly spaced, which is different to the default behaviour of unevenly spacing and forcing the display of the final point. 
 | `precision` | `Number` | | if defined and `stepSize` is not specified, the step size will be rounded to this many decimal places.
 | `stepSize` | `Number` | | User defined fixed step size for the scale. [more...](#step-size)
 | `suggestedMax` | `Number` | | Adjustment used when calculating the maximum data value. [more...](#axis-range-settings)

--- a/docs/axes/cartesian/linear.md
+++ b/docs/axes/cartesian/linear.md
@@ -13,6 +13,7 @@ The following options are provided by the linear scale. They are all located in 
 | `max` | `Number` | | User defined maximum number for the scale, overrides maximum value from data. [more...](#axis-range-settings)
 | `maxTicksLimit` | `Number` | `11` | Maximum number of ticks and gridlines to show.
 | `evenLabelSpacing` | `Boolean` |  | To be used with `maxTicksLimit`. If true, forces ticks to be evenly spaced, which is different to the default behaviour of unevenly spacing and forcing the display of the final point. 
+| `labelSpacing` | `Number` |  | This setting determines the spacing between labels on the x-axis.
 | `precision` | `Number` | | if defined and `stepSize` is not specified, the step size will be rounded to this many decimal places.
 | `stepSize` | `Number` | | User defined fixed step size for the scale. [more...](#step-size)
 | `suggestedMax` | `Number` | | Adjustment used when calculating the maximum data value. [more...](#axis-range-settings)

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -683,11 +683,10 @@ module.exports = Element.extend({
 					delete tick.label;
 				}
 			} else if ((i !== tickCount - 1) && ( // Always show last tick
-				(skipRatio > 1 && i % skipRatio > 0) ||
-				(i % skipRatio === 0 && i + skipRatio >= tickCount))) { // Since we always show the last tick,we need may need to hide the last shown one before
-					// leave tick in place but make sure it's not displayed (#4635)
-					delete tick.label;
-				}
+					(skipRatio > 1 && i % skipRatio > 0) ||
+					(i % skipRatio === 0 && i + skipRatio >= tickCount))) { // Since we always show the last tick,we need may need to hide the last shown one before
+				// leave tick in place but make sure it's not displayed (#4635)
+				delete tick.label;
 			}
 			result.push(tick);
 		}

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -634,7 +634,7 @@ module.exports = Element.extend({
 		var cosRotation = Math.cos(labelRotationRadians);
 		var longestRotatedLabel = me.longestLabelWidth * cosRotation;
 		var result = [];
-		var i, tick, shouldSkip;
+		var i, tick;
 
 		// figure out the maximum number of gridlines to show
 		var maxTicks;
@@ -642,31 +642,44 @@ module.exports = Element.extend({
 			maxTicks = optionTicks.maxTicksLimit;
 		}
 
-		if (isHorizontal) {
-			skipRatio = false;
+		var evenLabelSpacing;
+    if (optionTicks.evenLabelSpacing) {
+      evenLabelSpacing = optionTicks.evenLabelSpacing;
+    }
 
-			if ((longestRotatedLabel + optionTicks.autoSkipPadding) * tickCount > (me.width - (me.paddingLeft + me.paddingRight))) {
-				skipRatio = 1 + Math.floor(((longestRotatedLabel + optionTicks.autoSkipPadding) * tickCount) / (me.width - (me.paddingLeft + me.paddingRight)));
-			}
+    if (isHorizontal) {
+      skipRatio = false;
 
-			// if they defined a max number of optionTicks,
-			// increase skipRatio until that number is met
-			if (maxTicks && tickCount > maxTicks) {
-				skipRatio = Math.max(skipRatio, Math.floor(tickCount / maxTicks));
-			}
-		}
+      if ((longestRotatedLabel + optionTicks.autoSkipPadding) * tickCount > (me.width - (me.paddingLeft + me.paddingRight))) {
+        skipRatio = 1 + Math.floor(((longestRotatedLabel + optionTicks.autoSkipPadding) * tickCount) / (me.width - (me.paddingLeft + me.paddingRight)));
+      }
 
-		for (i = 0; i < tickCount; i++) {
-			tick = ticks[i];
+      // if they defined a max number of optionTicks,
+      // increase skipRatio until that number is met
+      if (maxTicks && tickCount > maxTicks) {
+        skipRatio = Math.max(skipRatio, Math.floor(tickCount / maxTicks));
+      }
+    }
 
-			// Since we always show the last tick,we need may need to hide the last shown one before
-			shouldSkip = (skipRatio > 1 && i % skipRatio > 0) || (i % skipRatio === 0 && i + skipRatio >= tickCount);
-			if (shouldSkip && i !== tickCount - 1) {
-				// leave tick in place but make sure it's not displayed (#4635)
-				delete tick.label;
-			}
-			result.push(tick);
-		}
+    for (i = 0; i < tickCount; i++) {
+      tick = ticks[i];
+
+      
+      if (evenLabelSpacing) {
+        if (skipRatio > 1 && i % skipRatio > 0) {
+          // leave tick in place but make sure it's not displayed (#4635)
+          delete tick.label;
+        }
+      } else {
+        if ((i !== tickCount - 1) && ( // Always show last tick
+            (skipRatio > 1 && i % skipRatio > 0) ||
+            (i % skipRatio === 0 && i + skipRatio >= tickCount))) { // Since we always show the last tick,we need may need to hide the last shown one before
+          // leave tick in place but make sure it's not displayed (#4635)
+          delete tick.label;
+        }
+      }
+      result.push(tick);
+    }
 		return result;
 	},
 

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -683,8 +683,8 @@ module.exports = Element.extend({
 					delete tick.label;
 				}
 			} else if ((i !== tickCount - 1) && ( // Always show last tick
-					(skipRatio > 1 && i % skipRatio > 0) ||
-					(i % skipRatio === 0 && i + skipRatio >= tickCount))) { // Since we always show the last tick,we need may need to hide the last shown one before
+				(skipRatio > 1 && i % skipRatio > 0) ||
+				(i % skipRatio === 0 && i + skipRatio >= tickCount))) { // Since we always show the last tick,we need may need to hide the last shown one before
 				// leave tick in place but make sure it's not displayed (#4635)
 				delete tick.label;
 			}

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -636,7 +636,7 @@ module.exports = Element.extend({
 		var result = [];
 		var i, tick;
 
-		// Specifiy the label spacing
+		// Specify the label spacing
 		var labelSpacing;
 		if (optionTicks.labelSpacing) {
 			labelSpacing = optionTicks.labelSpacing;

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -640,7 +640,7 @@ module.exports = Element.extend({
 		var labelSpacing;
 		if (optionTicks.labelSpacing) {
 			labelSpacing = optionTicks.labelSpacing;
-			// If not an even number, reject
+			// If not an integer, reject
 			if (labelSpacing !== Math.floor(labelSpacing)) {
 				labelSpacing = undefined;
 			}

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -659,18 +659,18 @@ module.exports = Element.extend({
 			skipRatio = false;
 
 			if ((longestRotatedLabel + optionTicks.autoSkipPadding) * tickCount > (me.width - (me.paddingLeft + me.paddingRight))) {
-			skipRatio = 1 + Math.floor(((longestRotatedLabel + optionTicks.autoSkipPadding) * tickCount) / (me.width - (me.paddingLeft + me.paddingRight)));
+				skipRatio = 1 + Math.floor(((longestRotatedLabel + optionTicks.autoSkipPadding) * tickCount) / (me.width - (me.paddingLeft + me.paddingRight)));
 			}
 
 			// if they defined a max number of optionTicks,
 			// increase skipRatio until that number is met
 			if (maxTicks && tickCount > maxTicks) {
-			skipRatio = Math.max(skipRatio, Math.floor(tickCount / maxTicks));
+				skipRatio = Math.max(skipRatio, Math.floor(tickCount / maxTicks));
 			}
 
 			// Requesting a label spacing cancels other settings established by maxTicks
 			if (labelSpacing) {
-			skipRatio = labelSpacing;
+				skipRatio = labelSpacing;
 			}
 		}
 
@@ -682,8 +682,7 @@ module.exports = Element.extend({
 					// leave tick in place but make sure it's not displayed (#4635)
 					delete tick.label;
 				}
-			} else {
-				if ((i !== tickCount - 1) && ( // Always show last tick
+			} else if ((i !== tickCount - 1) && ( // Always show last tick
 				(skipRatio > 1 && i % skipRatio > 0) ||
 				(i % skipRatio === 0 && i + skipRatio >= tickCount))) { // Since we always show the last tick,we need may need to hide the last shown one before
 					// leave tick in place but make sure it's not displayed (#4635)

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -636,12 +636,20 @@ module.exports = Element.extend({
 		var result = [];
 		var i, tick;
 
+    // Specifiy the label spacing
+		var labelSpacing;
+		if (optionTicks.labelSpacing) {
+      labelSpacing = optionTicks.labelSpacing;
+      // If not an even number, reject
+      if (labelSpacing !== Math.floor(labelSpacing)) {
+        labelSpacing = undefined;
+      }
+		}
 		// figure out the maximum number of gridlines to show
 		var maxTicks;
 		if (optionTicks.maxTicksLimit) {
 			maxTicks = optionTicks.maxTicksLimit;
 		}
-
 		var evenLabelSpacing;
     if (optionTicks.evenLabelSpacing) {
       evenLabelSpacing = optionTicks.evenLabelSpacing;
@@ -659,13 +667,17 @@ module.exports = Element.extend({
       if (maxTicks && tickCount > maxTicks) {
         skipRatio = Math.max(skipRatio, Math.floor(tickCount / maxTicks));
       }
+
+      // Requesting a label spacing cancels other settings established by maxTicks
+      if (labelSpacing) {
+        skipRatio = labelSpacing;
+      }
     }
 
     for (i = 0; i < tickCount; i++) {
       tick = ticks[i];
 
-      
-      if (evenLabelSpacing) {
+      if (evenLabelSpacing || labelSpacing) {
         if (skipRatio > 1 && i % skipRatio > 0) {
           // leave tick in place but make sure it's not displayed (#4635)
           delete tick.label;

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -636,14 +636,14 @@ module.exports = Element.extend({
 		var result = [];
 		var i, tick;
 
-    // Specifiy the label spacing
+		// Specifiy the label spacing
 		var labelSpacing;
 		if (optionTicks.labelSpacing) {
-      labelSpacing = optionTicks.labelSpacing;
-      // If not an even number, reject
-      if (labelSpacing !== Math.floor(labelSpacing)) {
-        labelSpacing = undefined;
-      }
+			labelSpacing = optionTicks.labelSpacing;
+			// If not an even number, reject
+			if (labelSpacing !== Math.floor(labelSpacing)) {
+				labelSpacing = undefined;
+			}
 		}
 		// figure out the maximum number of gridlines to show
 		var maxTicks;
@@ -651,47 +651,47 @@ module.exports = Element.extend({
 			maxTicks = optionTicks.maxTicksLimit;
 		}
 		var evenLabelSpacing;
-    if (optionTicks.evenLabelSpacing) {
-      evenLabelSpacing = optionTicks.evenLabelSpacing;
-    }
+		if (optionTicks.evenLabelSpacing) {
+			evenLabelSpacing = optionTicks.evenLabelSpacing;
+		}
 
-    if (isHorizontal) {
-      skipRatio = false;
+		if (isHorizontal) {
+			skipRatio = false;
 
-      if ((longestRotatedLabel + optionTicks.autoSkipPadding) * tickCount > (me.width - (me.paddingLeft + me.paddingRight))) {
-        skipRatio = 1 + Math.floor(((longestRotatedLabel + optionTicks.autoSkipPadding) * tickCount) / (me.width - (me.paddingLeft + me.paddingRight)));
-      }
+			if ((longestRotatedLabel + optionTicks.autoSkipPadding) * tickCount > (me.width - (me.paddingLeft + me.paddingRight))) {
+			skipRatio = 1 + Math.floor(((longestRotatedLabel + optionTicks.autoSkipPadding) * tickCount) / (me.width - (me.paddingLeft + me.paddingRight)));
+			}
 
-      // if they defined a max number of optionTicks,
-      // increase skipRatio until that number is met
-      if (maxTicks && tickCount > maxTicks) {
-        skipRatio = Math.max(skipRatio, Math.floor(tickCount / maxTicks));
-      }
+			// if they defined a max number of optionTicks,
+			// increase skipRatio until that number is met
+			if (maxTicks && tickCount > maxTicks) {
+			skipRatio = Math.max(skipRatio, Math.floor(tickCount / maxTicks));
+			}
 
-      // Requesting a label spacing cancels other settings established by maxTicks
-      if (labelSpacing) {
-        skipRatio = labelSpacing;
-      }
-    }
+			// Requesting a label spacing cancels other settings established by maxTicks
+			if (labelSpacing) {
+			skipRatio = labelSpacing;
+			}
+		}
 
-    for (i = 0; i < tickCount; i++) {
-      tick = ticks[i];
+		for (i = 0; i < tickCount; i++) {
+			tick = ticks[i];
 
-      if (evenLabelSpacing || labelSpacing) {
-        if (skipRatio > 1 && i % skipRatio > 0) {
-          // leave tick in place but make sure it's not displayed (#4635)
-          delete tick.label;
-        }
-      } else {
-        if ((i !== tickCount - 1) && ( // Always show last tick
-            (skipRatio > 1 && i % skipRatio > 0) ||
-            (i % skipRatio === 0 && i + skipRatio >= tickCount))) { // Since we always show the last tick,we need may need to hide the last shown one before
-          // leave tick in place but make sure it's not displayed (#4635)
-          delete tick.label;
-        }
-      }
-      result.push(tick);
-    }
+			if (evenLabelSpacing || labelSpacing) {
+				if (skipRatio > 1 && i % skipRatio > 0) {
+					// leave tick in place but make sure it's not displayed (#4635)
+					delete tick.label;
+				}
+			} else {
+				if ((i !== tickCount - 1) && ( // Always show last tick
+				(skipRatio > 1 && i % skipRatio > 0) ||
+				(i % skipRatio === 0 && i + skipRatio >= tickCount))) { // Since we always show the last tick,we need may need to hide the last shown one before
+					// leave tick in place but make sure it's not displayed (#4635)
+					delete tick.label;
+				}
+			}
+			result.push(tick);
+		}
 		return result;
 	},
 


### PR DESCRIPTION
Currently, spacing on the x-axis is uneven to allow for the final point to be displayed. This change gives two new options:
evenLabelSpacing - ensures even spaces between the labels (possibly ignoring the final point)
labelSpacing - allows the user to choose the space between the labels