### PR TITLE
Update integration docs: first method only works with Webpack

### DIFF
--- a/docs/getting-started/integration.md
+++ b/docs/getting-started/integration.md
@@ -2,13 +2,6 @@
 
 Chart.js can be integrated with plain JavaScript or with different module loaders. The examples below show how to load Chart.js in different systems.
 
-## Webpack
-
-```javascript
-import Chart from 'chart.js';
-var myChart = new Chart(ctx, {...});
-```
-
 ## Script Tag
 
 ```html
@@ -16,6 +9,13 @@ var myChart = new Chart(ctx, {...});
 <script>
     var myChart = new Chart(ctx, {...});
 </script>
+```
+
+## Webpack
+
+```javascript
+import Chart from 'chart.js';
+var myChart = new Chart(ctx, {...});
 ```
 
 ## Common JS

--- a/docs/getting-started/integration.md
+++ b/docs/getting-started/integration.md
@@ -2,7 +2,7 @@
 
 Chart.js can be integrated with plain JavaScript or with different module loaders. The examples below show how to load Chart.js in different systems.
 
-## ES6 Modules
+## Webpack
 
 ```javascript
 import Chart from 'chart.js';


### PR DESCRIPTION
This is broken, as mentioned in #5179.

It's really frustrating to advertise this as working while it's actually known to be broken.