### PR TITLE
Event handling to use target instead currentTarget

### DIFF
--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -383,7 +383,7 @@ module.exports = function() {
 	helpers.getRelativePosition = function(evt, chart) {
 		var mouseX, mouseY;
 		var e = evt.originalEvent || evt;
-		var canvas = evt.currentTarget || evt.srcElement;
+		var canvas = evt.target || evt.srcElement;
 		var boundingRect = canvas.getBoundingClientRect();
 
 		var touches = e.touches;


### PR DESCRIPTION
If you attach event handlers to a container rather than directly to the canvas then the currentTarget is the container, event.target is the canvas that triggers the event.
It's useful to do this if you have many charts or are creating them dynamically.