### PR TITLE
Display tooltip for only one item per dataset at a time

### DIFF
--- a/src/core/core.interaction.js
+++ b/src/core/core.interaction.js
@@ -294,8 +294,8 @@ module.exports = {
 				items = [];
 			}
 			if (options.onlyOne) {
-				const byIndex = {};
-				items.forEach(element => {
+				var byIndex = {};
+				items.forEach(function(element) {
 					if (!byIndex[element._datasetIndex]) {
 						byIndex[element._datasetIndex] = element;
 					}

--- a/src/core/core.interaction.js
+++ b/src/core/core.interaction.js
@@ -275,6 +275,7 @@ module.exports = {
 		 */
 		x: function(chart, e, options) {
 			var position = getRelativePosition(e, chart);
+			var distanceMetric = getDistanceMetricForAxis('x');
 			var items = [];
 			var intersectsItem = false;
 
@@ -312,10 +313,14 @@ module.exports = {
 					var distanceA = distanceMetric(position, centerA);
 					var distanceB = distanceMetric(position, centerB);
 					return distanceA - distanceB;
-				})
+				});
 			});
 
-			return Object.values(byIndex).map(els => els[0]);
+			return Object.values(byIndex).map(
+				function(els) {
+					return els[0];
+				}
+			);
 		},
 
 		/**

--- a/src/core/core.interaction.js
+++ b/src/core/core.interaction.js
@@ -293,7 +293,7 @@ module.exports = {
 			if (options.intersect && !intersectsItem) {
 				items = [];
 			}
-			if (options.onlyOne) {
+			if (options.onePerDataset) {
 				var byIndex = {};
 				items.forEach(function(element) {
 					if (!byIndex[element._datasetIndex]) {

--- a/src/core/core.interaction.js
+++ b/src/core/core.interaction.js
@@ -293,16 +293,29 @@ module.exports = {
 			if (options.intersect && !intersectsItem) {
 				items = [];
 			}
-			if (options.onePerDataset) {
-				var byIndex = {};
-				items.forEach(function(element) {
-					if (!byIndex[element._datasetIndex]) {
-						byIndex[element._datasetIndex] = element;
-					}
-				});
-				return Object.values(byIndex);
-			}
-			return items;
+
+			// group by dataset
+			var byIndex = items.reduce(function(res, element) {
+				if (!res[element._datasetIndex]) {
+					res[element._datasetIndex] = [element];
+				} else {
+					res[element._datasetIndex].push(element);
+				}
+				return res;
+			}, {});
+
+			// sort by distance
+			Object.values(byIndex).forEach(function(elements) {
+				elements.sort(function(a, b) {
+					var centerA = a.getCenterPoint();
+					var centerB = b.getCenterPoint();
+					var distanceA = distanceMetric(position, centerA);
+					var distanceB = distanceMetric(position, centerB);
+					return distanceA - distanceB;
+				})
+			});
+
+			return Object.values(byIndex).map(els => els[0]);
 		},
 
 		/**

--- a/src/core/core.interaction.js
+++ b/src/core/core.interaction.js
@@ -308,11 +308,7 @@ module.exports = {
 			// sort by distance
 			Object.keys(byIndex).forEach(function(key) {
 				byIndex[key].sort(function(a, b) {
-					var centerA = a.getCenterPoint();
-					var centerB = b.getCenterPoint();
-					var distanceA = distanceMetric(position, centerA);
-					var distanceB = distanceMetric(position, centerB);
-					return distanceA - distanceB;
+					return distanceMetric(position, a.getCenterPoint()) - distanceMetric(position, b.getCenterPoint());
 				});
 			});
 

--- a/src/core/core.interaction.js
+++ b/src/core/core.interaction.js
@@ -293,6 +293,15 @@ module.exports = {
 			if (options.intersect && !intersectsItem) {
 				items = [];
 			}
+			if (options.onlyOne) {
+				const byIndex = {};
+				items.forEach(element => {
+					if (!byIndex[element._datasetIndex]) {
+						byIndex[element._datasetIndex] = element;
+					}
+				});
+				return Object.values(byIndex);
+			}
 			return items;
 		},
 

--- a/src/core/core.interaction.js
+++ b/src/core/core.interaction.js
@@ -297,7 +297,7 @@ module.exports = {
 
 			// group by dataset
 			var byIndex = items.reduce(function(res, element) {
-				if (!res[element._datasetIndex]) {
+				if (res[element._datasetIndex] === undefined) {
 					res[element._datasetIndex] = [element];
 				} else {
 					res[element._datasetIndex].push(element);
@@ -306,8 +306,8 @@ module.exports = {
 			}, {});
 
 			// sort by distance
-			Object.values(byIndex).forEach(function(elements) {
-				elements.sort(function(a, b) {
+			Object.keys(byIndex).forEach(function(key) {
+				byIndex[key].sort(function(a, b) {
 					var centerA = a.getCenterPoint();
 					var centerB = b.getCenterPoint();
 					var distanceA = distanceMetric(position, centerA);

--- a/src/core/core.interaction.js
+++ b/src/core/core.interaction.js
@@ -316,9 +316,9 @@ module.exports = {
 				});
 			});
 
-			return Object.values(byIndex).map(
-				function(els) {
-					return els[0];
+			return Object.keys(byIndex).map(
+				function(key) {
+					return byIndex[key][0];
 				}
 			);
 		},

--- a/test/specs/core.interaction.tests.js
+++ b/test/specs/core.interaction.tests.js
@@ -556,22 +556,53 @@ describe('Core.Interaction', function() {
 	describe('x mode', function() {
 		beforeEach(function() {
 			this.chart = window.acquireChart({
-				type: 'line',
+				type: 'scatter',
 				data: {
 					datasets: [{
 						label: 'Dataset 1',
-						data: [10, 40, 30],
-						pointRadius: [5, 10, 5],
+						data: [
+							{
+								x: 1,
+								y: 10
+							},
+							{
+								x: 2,
+								y: 40
+							},
+							{
+								x: 2,
+								y: 40
+							},
+							{
+								x: 3,
+								y: 30
+							}],
+						pointRadius: [10, 5, 10, 5],
 						pointHoverBorderColor: 'rgb(255, 0, 0)',
 						pointHoverBackgroundColor: 'rgb(0, 255, 0)'
 					}, {
 						label: 'Dataset 2',
-						data: [40, 40, 40],
-						pointRadius: [10, 10, 10],
+						data: [
+							{
+								x: 1,
+								y: 40
+							},
+							{
+								x: 2,
+								y: 40
+							},
+							{
+								x: 2,
+								y: 40
+							},
+							{
+								x: 3,
+								y: 40
+							}],
+						pointRadius: [10, 5, 10, 5],
 						pointHoverBorderColor: 'rgb(0, 0, 255)',
 						pointHoverBackgroundColor: 'rgb(0, 255, 255)'
-					}],
-					labels: ['Point 1', 'Point 2', 'Point 3']
+					}]
 				}
 			});
 		});
@@ -610,7 +641,7 @@ describe('Core.Interaction', function() {
 			expect(elements).toEqual([]);
 		});
 
-		it('should return items at the same x value when intersect is true', function() {
+		it('should return one item per dataset at the same x value when intersect is true', function() {
 			var chart = this.chart;
 			var meta0 = chart.getDatasetMeta(0);
 			var meta1 = chart.getDatasetMeta(1);


### PR DESCRIPTION
I have a problem with the tooltips.

Sometimes when using mode x tooltip option, you want there to be only one item per dataset. Currently you can set pointHitRadius low. While this would work most of the time, sometimes it will not return anything because of the different distances between data points. With an option like the one in this PR, you can have a larger pointHitRadius but always get only one tooltip item returned per dataset. 