### PR TITLE
Enhance the rounded rectangle implementation

### DIFF
--- a/test/jasmine.context.js
+++ b/test/jasmine.context.js
@@ -75,6 +75,7 @@ Context.prototype._initMethods = function() {
 	var me = this;
 	var methods = {
 		arc: function() {},
+		arcTo: function() {},
 		beginPath: function() {},
 		bezierCurveTo: function() {},
 		clearRect: function() {},

--- a/test/specs/element.point.tests.js
+++ b/test/specs/element.point.tests.js
@@ -222,7 +222,7 @@ describe('Point element tests', function() {
 			15 - offset,
 			Math.SQRT2 * 2,
 			Math.SQRT2 * 2,
-			2 / 2
+			2 * 0.425
 		);
 		expect(mockContext.getCalls()).toContain(
 			jasmine.objectContaining({

--- a/test/specs/helpers.canvas.tests.js
+++ b/test/specs/helpers.canvas.tests.js
@@ -30,13 +30,13 @@ describe('Chart.helpers.canvas', function() {
 			expect(context.getCalls()).toEqual([
 				{name: 'moveTo', args: [15, 20]},
 				{name: 'lineTo', args: [35, 20]},
-				{name: 'quadraticCurveTo', args: [40, 20, 40, 25]},
+				{name: 'arcTo', args: [40, 20, 40, 25, 5]},
 				{name: 'lineTo', args: [40, 55]},
-				{name: 'quadraticCurveTo', args: [40, 60, 35, 60]},
+				{name: 'arcTo', args: [40, 60, 35, 60, 5]},
 				{name: 'lineTo', args: [15, 60]},
-				{name: 'quadraticCurveTo', args: [10, 60, 10, 55]},
+				{name: 'arcTo', args: [10, 60, 10, 55, 5]},
 				{name: 'lineTo', args: [10, 25]},
-				{name: 'quadraticCurveTo', args: [10, 20, 15, 20]}
+				{name: 'arcTo', args: [10, 20, 15, 20, 5]}
 			]);
 		});
 		it('should optimize path if radius is 0', function() {


### PR DESCRIPTION
Use `arcTo` instead of `quadraticCurveTo` (both methods have the same compatibility level) because it generates better results when the final rect is a circle but also when it's actually a rectangle and not a square. This change is needed by the datalabels plugin where the user can configure the `borderRadius` and thus generate circle from a rounded rectangle.

![image](https://user-images.githubusercontent.com/3874900/41896231-51873326-7924-11e8-915c-759258c55172.png)
![image](https://user-images.githubusercontent.com/3874900/41896289-750c1654-7924-11e8-86d1-80b1f1b05e8e.png)