### PR TITLE
Add label for first dataset

### DIFF
--- a/samples/advanced/progress-bar.html
+++ b/samples/advanced/progress-bar.html
@@ -28,6 +28,7 @@
 			data: {
 				labels: ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
 				datasets: [{
+					label: 'My First dataset',
 					fill: false,
 					borderColor: window.chartColors.red,
 					backgroundColor: window.chartColors.red,


### PR DESCRIPTION
While the second dataset already has a label (My Second dataset) the first dataset showed "undefined" as a label.
Added a label to the first dataset object.

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- http://jsbin.com/
- http://jsfiddle.net/
- http://codepen.io/pen/
- Premade template: http://codepen.io/pen?template=JXVYzq
-->
