### PR TITLE
Fix For Adding And Removing Datasets For Bar Samples

### DIFF
--- a/samples/charts/bar/horizontal.html
+++ b/samples/charts/bar/horizontal.html
@@ -102,7 +102,7 @@
 			var colorName = colorNames[horizontalBarChartData.datasets.length % colorNames.length];
 			var dsColor = window.chartColors[colorName];
 			var newDataset = {
-				label: 'Dataset ' + horizontalBarChartData.datasets.length,
+				label: 'Dataset ' + (horizontalBarChartData.datasets.length + 1),
 				backgroundColor: color(dsColor).alpha(0.5).rgbString(),
 				borderColor: dsColor,
 				data: []
@@ -130,7 +130,7 @@
 		});
 
 		document.getElementById('removeDataset').addEventListener('click', function() {
-			horizontalBarChartData.datasets.splice(0, 1);
+			horizontalBarChartData.datasets.pop();
 			window.myHorizontalBar.update();
 		});
 

--- a/samples/charts/bar/vertical.html
+++ b/samples/charts/bar/vertical.html
@@ -95,7 +95,7 @@
 			var colorName = colorNames[barChartData.datasets.length % colorNames.length];
 			var dsColor = window.chartColors[colorName];
 			var newDataset = {
-				label: 'Dataset ' + barChartData.datasets.length,
+				label: 'Dataset ' + (barChartData.datasets.length + 1),
 				backgroundColor: color(dsColor).alpha(0.5).rgbString(),
 				borderColor: dsColor,
 				borderWidth: 1,
@@ -125,7 +125,7 @@
 		});
 
 		document.getElementById('removeDataset').addEventListener('click', function() {
-			barChartData.datasets.splice(0, 1);
+			barChartData.datasets.pop();
 			window.myBar.update();
 		});
 


### PR DESCRIPTION
Fix for #5662

Now accounts for zero indexing of arrays when creating a name for an added dataset.
Now removes the last dataset in the array when removing a dataset rather than removing the first.