### PR TITLE
Fix xAlign calculation when yAlign = center

### DIFF
--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -354,9 +354,11 @@ function determineAlignment(tooltip, size) {
 	var xAlign = 'center';
 	var yAlign = 'center';
 
-	if (model.y < size.height) {
+	// If the tooltip is vertically centered then the bounds of the tooltip move up by half the height of the tooltip
+	var yPos = (tooltip._options.yAlign === 'center') ? (model.y - size.height / 2) : model.y;
+	if (yPos < size.height) {
 		yAlign = 'top';
-	} else if (model.y > (chart.height - size.height)) {
+	} else if (yPos > (chart.height - size.height)) {
 		yAlign = 'bottom';
 	}
 


### PR DESCRIPTION
Fix for #5693

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- http://jsbin.com/
- http://jsfiddle.net/
- http://codepen.io/pen/
- Premade template: http://codepen.io/pen?template=JXVYzq
-->
