### PR TITLE
Adding watch task for docs

### DIFF
--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -37,6 +37,7 @@ The following commands are now available from the repository root:
 > gulp lint                 // perform code linting (ESLint)
 > gulp test                 // perform code linting and run unit tests
 > gulp docs                 // build the documentation in ./dist/docs
+> gulp docs --watch         // starts the gitbook live reloaded server
 ```
 
 More information can be found in [gulpfile.js](https://github.com/chartjs/Chart.js/blob/master/gulpfile.js).

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -190,7 +190,7 @@ function docsTask(done) {
   const cmd = process.execPath;
 
   exec([cmd, script, 'install', './'].join(' ')).then(() => {
-    return exec([cmd, script, 'build', './', './dist/docs'].join(' '));
+    return exec([cmd, script, argv.watch ? 'serve' : 'build', './', './dist/docs'].join(' '));
   }).catch((err) => {
     console.error(err.stdout);
   }).then(() => {


### PR DESCRIPTION
closes: #5718 

added: `gulp docs --watch`