### PR TITLE
Added Wicked-Charts to the Popular Extensions Page

### DIFF
--- a/docs/notes/extensions.md
+++ b/docs/notes/extensions.md
@@ -57,6 +57,7 @@ In addition, many plugins can be found on the [npm registry](https://www.npmjs.c
 
 ### Java
  - <a href="https://github.com/mdewilde/chart/" target="_blank">Chart.java</a>
+ - <a href="https://github.com/adessoAG/wicked-charts" target="_blank">Wicked-Charts</a>
 
 ### GWT (Google Web toolkit)
  - <a href="https://github.com/pepstock-org/Charba" target="_blank">Charba</a>


### PR DESCRIPTION
Wicked-Charts is a Java wrapper around Chart.js and allows users to create charts in Java using the Wicket framework.
The latest version of Wicked-Charts (3.1.0) supports Chartjs and Wicket 8.