### PR TITLE
Handle axis lineWidth as an array

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -704,7 +704,7 @@ module.exports = Element.extend({
 
 		var itemsToDraw = [];
 
-		var axisWidth = me.options.gridLines.lineWidth;
+		var axisWidth = helpers.valueAtIndexOrDefault(me.options.gridLines.lineWidth, 0);
 		var xTickStart = options.position === 'right' ? me.left : me.right - axisWidth - tl;
 		var xTickEnd = options.position === 'right' ? me.left + tl : me.right;
 		var yTickStart = options.position === 'bottom' ? me.top + axisWidth : me.bottom - tl - axisWidth;


### PR DESCRIPTION
When the axis lineWidth setting is set to an array, use the first item when determining the size of the axis area.

Resolves #5668 