### PR TITLE
Add aspectRatio property to responsive doc

### DIFF
--- a/docs/general/responsive.md
+++ b/docs/general/responsive.md
@@ -16,7 +16,7 @@ Chart.js provides a [few options](#configuration-options) to enable responsivene
 | `responsive` | `Boolean` | `true` | Resizes the chart canvas when its container does ([important note...](#important-note)).
 | `responsiveAnimationDuration` | `Number` | `0` | Duration in milliseconds it takes to animate to new size after a resize event.
 | `maintainAspectRatio` | `Boolean` | `true` | Maintain the original canvas aspect ratio `(width / height)` when resizing.
-| `aspectRatio` | `Number` | `width / height` | You can define your custom aspect ratio. If you want a 1:1 aspect ratio just set this property to 1. This doesn't work when you define a custom `width` and `height`.
+| `aspectRatio` | `Number` | `width / height` | You can define your custom aspect ratio. If you want a 1:1 aspect ratio just set this property to 1. This property doesn't take effect when you define a custom `height`.
 | `onResize` | `Function` | `null` | Called when a resize occurs. Gets passed two arguments: the chart instance and the new size.
 
 ## Important Note

--- a/docs/general/responsive.md
+++ b/docs/general/responsive.md
@@ -16,6 +16,7 @@ Chart.js provides a [few options](#configuration-options) to enable responsivene
 | `responsive` | `Boolean` | `true` | Resizes the chart canvas when its container does ([important note...](#important-note)).
 | `responsiveAnimationDuration` | `Number` | `0` | Duration in milliseconds it takes to animate to new size after a resize event.
 | `maintainAspectRatio` | `Boolean` | `true` | Maintain the original canvas aspect ratio `(width / height)` when resizing.
+| `aspectRatio` | `Integer` | `(width / height)` | You can define your custom aspect ratio. If you want a 1:1 aspect ratio just set this property to 1. This doesn't work when you define a custom `width` and `height`.
 | `onResize` | `Function` | `null` | Called when a resize occurs. Gets passed two arguments: the chart instance and the new size.
 
 ## Important Note

--- a/docs/general/responsive.md
+++ b/docs/general/responsive.md
@@ -16,7 +16,7 @@ Chart.js provides a [few options](#configuration-options) to enable responsivene
 | `responsive` | `Boolean` | `true` | Resizes the chart canvas when its container does ([important note...](#important-note)).
 | `responsiveAnimationDuration` | `Number` | `0` | Duration in milliseconds it takes to animate to new size after a resize event.
 | `maintainAspectRatio` | `Boolean` | `true` | Maintain the original canvas aspect ratio `(width / height)` when resizing.
-| `aspectRatio` | `Number` | `width / height` | You can define your custom aspect ratio. If you want a 1:1 aspect ratio just set this property to 1. This property doesn't take effect when you define a custom `height`.
+| `aspectRatio` | `Number` | `2` | Canvas aspect ratio (i.e. `width / height`, a value of 1 representing a square canvas). Note that this option is ignored if the height is explicitly defined either as attribute or via the style.
 | `onResize` | `Function` | `null` | Called when a resize occurs. Gets passed two arguments: the chart instance and the new size.
 
 ## Important Note

--- a/docs/general/responsive.md
+++ b/docs/general/responsive.md
@@ -16,7 +16,7 @@ Chart.js provides a [few options](#configuration-options) to enable responsivene
 | `responsive` | `Boolean` | `true` | Resizes the chart canvas when its container does ([important note...](#important-note)).
 | `responsiveAnimationDuration` | `Number` | `0` | Duration in milliseconds it takes to animate to new size after a resize event.
 | `maintainAspectRatio` | `Boolean` | `true` | Maintain the original canvas aspect ratio `(width / height)` when resizing.
-| `aspectRatio` | `Number` | `(width / height)` | You can define your custom aspect ratio. If you want a 1:1 aspect ratio just set this property to 1. This doesn't work when you define a custom `width` and `height`.
+| `aspectRatio` | `Number` | `width / height` | You can define your custom aspect ratio. If you want a 1:1 aspect ratio just set this property to 1. This doesn't work when you define a custom `width` and `height`.
 | `onResize` | `Function` | `null` | Called when a resize occurs. Gets passed two arguments: the chart instance and the new size.
 
 ## Important Note

--- a/docs/general/responsive.md
+++ b/docs/general/responsive.md
@@ -16,7 +16,7 @@ Chart.js provides a [few options](#configuration-options) to enable responsivene
 | `responsive` | `Boolean` | `true` | Resizes the chart canvas when its container does ([important note...](#important-note)).
 | `responsiveAnimationDuration` | `Number` | `0` | Duration in milliseconds it takes to animate to new size after a resize event.
 | `maintainAspectRatio` | `Boolean` | `true` | Maintain the original canvas aspect ratio `(width / height)` when resizing.
-| `aspectRatio` | `Integer` | `(width / height)` | You can define your custom aspect ratio. If you want a 1:1 aspect ratio just set this property to 1. This doesn't work when you define a custom `width` and `height`.
+| `aspectRatio` | `Number` | `(width / height)` | You can define your custom aspect ratio. If you want a 1:1 aspect ratio just set this property to 1. This doesn't work when you define a custom `width` and `height`.
 | `onResize` | `Function` | `null` | Called when a resize occurs. Gets passed two arguments: the chart instance and the new size.
 
 ## Important Note


### PR DESCRIPTION
Hi There!

This PR includes a single but really useful property documentation for custom aspect ratio charts. 

What was my motivation behind this PR?:

- The tons of time I spent looking into different issues, StackOverflow pages, and blogs about how to put a 1:1 aspect ratio to my chart. 
- A lot of comments on different issues where people ask to add this property to the docs
- The powerful feature that this property has. 

This property is currently fully supported and tested, you just forgot to add it into the docs.

Please review if you feel comfortable with the description I added. If you want to propose another one just comment and I'll gladly change it :).

I hope this change can help a lot of people.

You can find a preview of the MD file in the following screenshot: 
<img width="1572" alt="aspectratiopreview" src="https://user-images.githubusercontent.com/8260962/46447885-e0a12f80-c749-11e8-9d0d-305c44551112.png">


Thanks! 🚀 