### PR TITLE
Scales are measuring the longest text for all ticks including skipped…

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -333,7 +333,7 @@ module.exports = Element.extend({
 		var me = this;
 		var context = me.ctx;
 		var tickOpts = me.options.ticks;
-		var labels = labelsFromTicks(me._ticks);
+		var labels = tickOpts.autoSkip ? me._autoSkip(me.getTicks()) : me.getTicks();
 
 		// Get the width of each grid by calculating the difference
 		// between x offsets between 0 and 1.

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -333,7 +333,7 @@ module.exports = Element.extend({
 		var me = this;
 		var context = me.ctx;
 		var tickOpts = me.options.ticks;
-		var labels = tickOpts.autoSkip ? me._autoSkip(me.getTicks()) : me.getTicks();
+		var labels = tickOpts.autoSkip ? labelsFromTicks(me._autoSkip(me.getTicks())) : labelsFromTicks(me.getTicks());
 
 		// Get the width of each grid by calculating the difference
 		// between x offsets between 0 and 1.


### PR DESCRIPTION
… ticks

This causes a decrease in performance.

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- http://jsbin.com/
- http://jsfiddle.net/
- http://codepen.io/pen/
- Premade template: http://codepen.io/pen?template=JXVYzq
-->
