### PR TITLE
Add 'parser' instead of deprecated 'format'

### DIFF
--- a/samples/scales/time/line.html
+++ b/samples/scales/time/line.html
@@ -106,7 +106,7 @@
 					xAxes: [{
 						type: 'time',
 						time: {
-							format: timeFormat,
+							parser: timeFormat,
 							// round: 'day'
 							tooltipFormat: 'll HH:mm'
 						},


### PR DESCRIPTION
Fixes #5456 

update line chart demo to replace deprecated 'format' property with the 'parser' property under the 'scales' option of chart.js configuration(as per moment.js documentation). This update removes the below warning while running the example -
`options.time.format is deprecated and replaced by options.time.parser`.

jsfiddle sample after using 'parser' :  [Demo](http://jsfiddle.net/xwrnh2c6/2/)

