### PR TITLE
Make legend layouting respect padding at the start of columns

### DIFF
--- a/test/specs/plugin.legend.tests.js
+++ b/test/specs/plugin.legend.tests.js
@@ -525,6 +525,43 @@ describe('Legend block tests', function() {
 		});
 	});
 
+	it('should not draw legend items outside of the chart bounds', function() {
+		var chart = window.acquireChart(
+			{
+				type: 'line',
+				data: {
+					datasets: [1, 2, 3].map(function(n) {
+						return {
+							label: 'dataset' + n,
+							data: []
+						};
+					}),
+					labels: []
+				},
+				options: {
+					legend: {
+						position: 'right'
+					}
+				}
+			},
+			{
+				canvas: {
+					width: 512,
+					height: 105
+				}
+			}
+		);
+
+		// Check some basic assertions about the test setup
+		expect(chart.width).toBe(512);
+		expect(chart.legend.legendHitBoxes.length).toBe(3);
+
+		// Check whether any legend items reach outside the established bounds
+		chart.legend.legendHitBoxes.forEach(function(item) {
+			expect(item.left + item.width).toBeLessThanOrEqual(chart.width);
+		});
+	});
+
 	describe('config update', function() {
 		it ('should update the options', function() {
 			var chart = acquireChart({


### PR DESCRIPTION
The `draw` function of chart legends introduces a vertical padding at the very beginning of each column:

https://github.com/chartjs/Chart.js/blob/5816770e459284847be10d1d0c00e5a4ee2b8434/src/plugins/plugin.legend.js#L420-L424

Before individual items of a legend are being drawn, the `fit` function performs some layouting. This includes the calculation of how many columns of items will be needed to fit all items into a vertical legend. However, this calculation does not consider the aforementioned initial column padding. Instead, all new columns are assigned a height of `0`:

https://github.com/chartjs/Chart.js/blob/5816770e459284847be10d1d0c00e5a4ee2b8434/src/plugins/plugin.legend.js#L272-L303

In some edge cases with specific amounts of legend items and chart heights, this lead to overflow bugs as seen in #5491. This pull request fixes this issue.

Fixes #5491