### PR TITLE
Better for-loop code size optimization

### DIFF
--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -102,13 +102,13 @@ defaults._set('horizontalBar', {
 function computeMinSampleSize(scale, pixels) {
 	var min = scale.isHorizontal() ? scale.width : scale.height;
 	var ticks = scale.getTicks();
-	var prev, curr, i, ilen;
+	var prev, curr;
 
-	for (i = 1, ilen = pixels.length; i < ilen; ++i) {
+	for (var i = 1; i < pixels.length; ++i) {
 		min = Math.min(min, pixels[i] - pixels[i - 1]);
 	}
 
-	for (i = 0, ilen = ticks.length; i < ilen; ++i) {
+	for (var i = 0; i < ticks.length; ++i) {
 		curr = scale.getPixelForTick(i);
 		min = i > 0 ? Math.min(min, curr - prev) : min;
 		prev = curr;
@@ -202,11 +202,10 @@ module.exports = function(Chart) {
 		update: function(reset) {
 			var me = this;
 			var rects = me.getMeta().data;
-			var i, ilen;
 
 			me._ruler = me.getRuler();
 
-			for (i = 0, ilen = rects.length; i < ilen; ++i) {
+			for (var i = 0; i < rects.length; ++i) {
 				me.updateElement(rects[i], i, reset);
 			}
 		},
@@ -300,9 +299,9 @@ module.exports = function(Chart) {
 			var stacked = scale.options.stacked;
 			var ilen = last === undefined ? chart.data.datasets.length : last + 1;
 			var stacks = [];
-			var i, meta;
+			var meta;
 
-			for (i = 0; i < ilen; ++i) {
+			for (var i = 0; i < ilen; ++i) {
 				meta = chart.getDatasetMeta(i);
 				if (meta.bar && chart.isDatasetVisible(i) &&
 					(stacked === false ||
@@ -459,12 +458,10 @@ module.exports = function(Chart) {
 			var scale = me.getValueScale();
 			var rects = me.getMeta().data;
 			var dataset = me.getDataset();
-			var ilen = rects.length;
-			var i = 0;
 
 			helpers.canvas.clipArea(chart.ctx, chart.chartArea);
 
-			for (; i < ilen; ++i) {
+			for (var i = 0; i < rects.length; ++i) {
 				if (!isNaN(scale.getRightValue(dataset.data[i]))) {
 					rects[i].draw();
 				}

--- a/src/controllers/controller.bubble.js
+++ b/src/controllers/controller.bubble.js
@@ -128,7 +128,7 @@ module.exports = function(Chart) {
 			var resolve = helpers.options.resolve;
 			var data = dataset.data[index];
 			var values = {};
-			var i, ilen, key;
+			var key;
 
 			// Scriptable options
 			var context = {
@@ -151,7 +151,7 @@ module.exports = function(Chart) {
 				'rotation'
 			];
 
-			for (i = 0, ilen = keys.length; i < ilen; ++i) {
+			for (var i = 0; i < keys.length; ++i) {
 				key = keys[i];
 				values[key] = resolve([
 					custom[key],

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -44,7 +44,7 @@ module.exports = function(Chart) {
 			var options = me.chart.options;
 			var lineElementOptions = options.elements.line;
 			var scale = me.getScaleForId(meta.yAxisID);
-			var i, ilen, custom;
+			var custom;
 			var dataset = me.getDataset();
 			var showLine = lineEnabled(dataset, options);
 
@@ -86,7 +86,7 @@ module.exports = function(Chart) {
 			}
 
 			// Update Points
-			for (i = 0, ilen = points.length; i < ilen; ++i) {
+			for (var i = 0; i < points.length; ++i) {
 				me.updateElement(points[i], i, reset);
 			}
 
@@ -95,7 +95,7 @@ module.exports = function(Chart) {
 			}
 
 			// Now pivot the point for animation
-			for (i = 0, ilen = points.length; i < ilen; ++i) {
+			for (var i = 0; i < points.length; ++i) {
 				points[i].pivot();
 			}
 		},
@@ -247,7 +247,7 @@ module.exports = function(Chart) {
 			var meta = me.getMeta();
 			var area = me.chart.chartArea;
 			var points = (meta.data || []);
-			var i, ilen, point, model, controlPoints;
+			var point, model, controlPoints;
 
 			// Only consider points that are drawn in case the spanGaps option is used
 			if (meta.dataset._model.spanGaps) {
@@ -263,7 +263,7 @@ module.exports = function(Chart) {
 			if (meta.dataset._model.cubicInterpolationMode === 'monotone') {
 				helpers.splineCurveMonotone(points);
 			} else {
-				for (i = 0, ilen = points.length; i < ilen; ++i) {
+				for (var i = 0; i < points.length; ++i) {
 					point = points[i];
 					model = point._model;
 					controlPoints = helpers.splineCurve(
@@ -280,7 +280,7 @@ module.exports = function(Chart) {
 			}
 
 			if (me.chart.options.elements.line.capBezierPoints) {
-				for (i = 0, ilen = points.length; i < ilen; ++i) {
+				for (var i = 0; i < points.length; ++i) {
 					model = points[i]._model;
 					model.controlPointPreviousX = capControlPoint(model.controlPointPreviousX, area.left, area.right);
 					model.controlPointPreviousY = capControlPoint(model.controlPointPreviousY, area.top, area.bottom);
@@ -296,9 +296,7 @@ module.exports = function(Chart) {
 			var meta = me.getMeta();
 			var points = meta.data || [];
 			var area = chart.chartArea;
-			var ilen = points.length;
 			var halfBorderWidth;
-			var i = 0;
 
 			if (lineEnabled(me.getDataset(), chart.options)) {
 				halfBorderWidth = (meta.dataset._model.borderWidth || 0) / 2;
@@ -316,7 +314,7 @@ module.exports = function(Chart) {
 			}
 
 			// Draw the points
-			for (; i < ilen; ++i) {
+			for (var i = 0; i < points.length; ++i) {
 				points[i].draw(area);
 			}
 		},

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -34,7 +34,6 @@ module.exports = function(Chart) {
 			var dataset = me.getDataset();
 			var lineElementOptions = me.chart.options.elements.line;
 			var scale = me.chart.scale;
-			var i, ilen;
 
 			// Compatibility: If the properties are defined with only the old name, use those values
 			if ((dataset.tension !== undefined) && (dataset.lineTension === undefined)) {
@@ -66,7 +65,7 @@ module.exports = function(Chart) {
 			meta.dataset.pivot();
 
 			// Update Points
-			for (i = 0, ilen = points.length; i < ilen; i++) {
+			for (var i = 0; i < points.length; i++) {
 				me.updateElement(points[i], i, reset);
 			}
 
@@ -74,7 +73,7 @@ module.exports = function(Chart) {
 			me.updateBezierControlPoints();
 
 			// Now pivot the point for animation
-			for (i = 0, ilen = points.length; i < ilen; i++) {
+			for (var i = 0; i < points.length; i++) {
 				points[i].pivot();
 			}
 		},
@@ -126,13 +125,13 @@ module.exports = function(Chart) {
 			var meta = me.getMeta();
 			var area = me.chart.chartArea;
 			var points = meta.data || [];
-			var i, ilen, model, controlPoints;
+			var model, controlPoints;
 
 			function capControlPoint(pt, min, max) {
 				return Math.max(Math.min(pt, max), min);
 			}
 
-			for (i = 0, ilen = points.length; i < ilen; i++) {
+			for (var i = 0; i < points.length; i++) {
 				model = points[i]._model;
 				controlPoints = helpers.splineCurve(
 					helpers.previousItem(points, i, true)._model,

--- a/src/core/core.animations.js
+++ b/src/core/core.animations.js
@@ -27,7 +27,6 @@ module.exports = {
 	 */
 	addAnimation: function(chart, animation, duration, lazy) {
 		var animations = this.animations;
-		var i, ilen;
 
 		animation.chart = chart;
 
@@ -35,7 +34,7 @@ module.exports = {
 			chart.animating = true;
 		}
 
-		for (i = 0, ilen = animations.length; i < ilen; ++i) {
+		for (var i = 0; i < animations.length; ++i) {
 			if (animations[i].chart === chart) {
 				animations[i] = animation;
 				return;

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -168,9 +168,8 @@ module.exports = function(Chart) {
 			var meta = me.getMeta();
 			var data = me.getDataset().data || [];
 			var metaData = meta.data;
-			var i, ilen;
 
-			for (i = 0, ilen = data.length; i < ilen; ++i) {
+			for (var i = 0; i < data.length; ++i) {
 				metaData[i] = metaData[i] || me.createMetaData(i);
 			}
 
@@ -211,10 +210,8 @@ module.exports = function(Chart) {
 		transition: function(easingValue) {
 			var meta = this.getMeta();
 			var elements = meta.data || [];
-			var ilen = elements.length;
-			var i = 0;
 
-			for (; i < ilen; ++i) {
+			for (var i = 0; i < elements.length; ++i) {
 				elements[i].transition(easingValue);
 			}
 
@@ -226,14 +223,12 @@ module.exports = function(Chart) {
 		draw: function() {
 			var meta = this.getMeta();
 			var elements = meta.data || [];
-			var ilen = elements.length;
-			var i = 0;
 
 			if (meta.dataset) {
 				meta.dataset.draw();
 			}
 
-			for (; i < ilen; ++i) {
+			for (var i = 0; i < elements.length; ++i) {
 				elements[i].draw();
 			}
 		},

--- a/src/core/core.element.js
+++ b/src/core/core.element.js
@@ -5,9 +5,9 @@ var helpers = require('../helpers/index');
 
 function interpolate(start, view, model, ease) {
 	var keys = Object.keys(model);
-	var i, ilen, key, actual, origin, target, type, c0, c1;
+	var key, actual, origin, target, type, c0, c1;
 
-	for (i = 0, ilen = keys.length; i < ilen; ++i) {
+	for (var i = 0; i < keys.length; ++i) {
 		key = keys[i];
 
 		target = model[key];

--- a/src/core/core.interaction.js
+++ b/src/core/core.interaction.js
@@ -26,15 +26,15 @@ function getRelativePosition(e, chart) {
  */
 function parseVisibleItems(chart, handler) {
 	var datasets = chart.data.datasets;
-	var meta, i, j, ilen, jlen;
+	var meta;
 
-	for (i = 0, ilen = datasets.length; i < ilen; ++i) {
+	for (var i = 0; i < datasets.length; ++i) {
 		if (!chart.isDatasetVisible(i)) {
 			continue;
 		}
 
 		meta = chart.getDatasetMeta(i);
-		for (j = 0, jlen = meta.data.length; j < jlen; ++j) {
+		for (var j = 0; j < meta.data.length; ++j) {
 			var element = meta.data[j];
 			if (!element._view.skip) {
 				handler(element);

--- a/src/core/core.layouts.js
+++ b/src/core/core.layouts.js
@@ -87,11 +87,9 @@ module.exports = {
 	 */
 	configure: function(chart, item, options) {
 		var props = ['fullWidth', 'position', 'weight'];
-		var ilen = props.length;
-		var i = 0;
 		var prop;
 
-		for (; i < ilen; ++i) {
+		for (var i = 0; i < props.length; ++i) {
 			prop = props[i];
 			if (options.hasOwnProperty(prop)) {
 				item[prop] = options[prop];

--- a/src/core/core.plugins.js
+++ b/src/core/core.plugins.js
@@ -96,10 +96,9 @@ module.exports = {
 	 */
 	notify: function(chart, hook, args) {
 		var descriptors = this.descriptors(chart);
-		var ilen = descriptors.length;
-		var i, descriptor, plugin, params, method;
+		var descriptor, plugin, params, method;
 
-		for (i = 0; i < ilen; ++i) {
+		for (var i = 0; i < descriptors.length; ++i) {
 			descriptor = descriptors[i];
 			plugin = descriptor.plugin;
 			method = plugin[hook];

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -67,9 +67,8 @@ defaults._set('scale', {
 
 function labelsFromTicks(ticks) {
 	var labels = [];
-	var i, ilen;
 
-	for (i = 0, ilen = ticks.length; i < ilen; ++i) {
+	for (var i = 0; i < ticks.length; ++i) {
 		labels.push(ticks[i].label);
 	}
 
@@ -174,7 +173,7 @@ module.exports = Element.extend({
 
 	update: function(maxWidth, maxHeight, margins) {
 		var me = this;
-		var i, ilen, labels, label, ticks, tick;
+		var labels, label, ticks, tick;
 
 		// Update Lifecycle - Probably don't want to ever extend or overwrite this function ;)
 		me.beforeUpdate();
@@ -229,7 +228,7 @@ module.exports = Element.extend({
 		// IMPORTANT: from this point, we consider that `this.ticks` will NEVER change!
 
 		// BACKWARD COMPAT: synchronize `_ticks` with labels (so potentially `this.ticks`)
-		for (i = 0, ilen = labels.length; i < ilen; ++i) {
+		for (var i = 0; i < labels.length; ++i) {
 			label = labels[i];
 			tick = ticks[i];
 			if (!tick) {

--- a/src/helpers/helpers.core.js
+++ b/src/helpers/helpers.core.js
@@ -134,13 +134,13 @@ var helpers = {
 	 * @returns {Boolean}
 	 */
 	arrayEquals: function(a0, a1) {
-		var i, ilen, v0, v1;
+		var v0, v1;
 
 		if (!a0 || !a1 || a0.length !== a1.length) {
 			return false;
 		}
 
-		for (i = 0, ilen = a0.length; i < ilen; ++i) {
+		for (var i = 0; i < a0.length; ++i) {
 			v0 = a0[i];
 			v1 = a1[i];
 
@@ -225,8 +225,7 @@ var helpers = {
 	 */
 	merge: function(target, source, options) {
 		var sources = helpers.isArray(source) ? source : [source];
-		var ilen = sources.length;
-		var merge, i, keys, klen, k;
+		var merge, keys;
 
 		if (!helpers.isObject(target)) {
 			return target;
@@ -235,14 +234,14 @@ var helpers = {
 		options = options || {};
 		merge = options.merger || helpers._merger;
 
-		for (i = 0; i < ilen; ++i) {
+		for (var i = 0; i < sources.length; ++i) {
 			source = sources[i];
 			if (!helpers.isObject(source)) {
 				continue;
 			}
 
 			keys = Object.keys(source);
-			for (k = 0, klen = keys.length; k < klen; ++k) {
+			for (var k = 0; k < keys.length; ++k) {
 				merge(keys[k], target, source, options);
 			}
 		}
@@ -272,7 +271,7 @@ var helpers = {
 		var setFn = function(value, key) {
 			target[key] = value;
 		};
-		for (var i = 1, ilen = arguments.length; i < ilen; ++i) {
+		for (var i = 1; i < arguments.length; ++i) {
 			helpers.each(arguments[i], setFn);
 		}
 		return target;

--- a/src/helpers/helpers.options.js
+++ b/src/helpers/helpers.options.js
@@ -75,10 +75,8 @@ module.exports = {
 	 * @since 2.7.0
 	 */
 	resolve: function(inputs, context, index) {
-		var i, ilen, value;
-
-		for (i = 0, ilen = inputs.length; i < ilen; ++i) {
-			value = inputs[i];
+		for (var i = 0; i < inputs.length; ++i) {
+			var value = inputs[i];
 			if (value === undefined) {
 				continue;
 			}

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -69,9 +69,8 @@ function sorter(a, b) {
 function arrayUnique(items) {
 	var hash = {};
 	var out = [];
-	var i, ilen, item;
 
-	for (i = 0, ilen = items.length; i < ilen; ++i) {
+	for (var i = 0; i < items.length; ++i) {
 		item = items[i];
 		if (!hash[item]) {
 			hash[item] = true;
@@ -107,9 +106,9 @@ function buildLookupTable(timestamps, min, max, distribution) {
 
 	var table = [];
 	var items = [min];
-	var i, ilen, prev, curr, next;
+	var ilen, prev, curr, next;
 
-	for (i = 0, ilen = timestamps.length; i < ilen; ++i) {
+	for (var i = 0; i < timestamps.length; ++i) {
 		curr = timestamps[i];
 		if (curr > min && curr < max) {
 			items.push(curr);
@@ -118,7 +117,7 @@ function buildLookupTable(timestamps, min, max, distribution) {
 
 	items.push(max);
 
-	for (i = 0, ilen = items.length; i < ilen; ++i) {
+	for (var i = 0, ilen = items.length; i < ilen; ++i) {
 		next = items[i + 1];
 		prev = items[i - 1];
 		curr = items[i];
@@ -239,13 +238,13 @@ function determineStepSize(min, max, unit, capacity) {
 	var interval = INTERVALS[unit];
 	var milliseconds = interval.size;
 	var steps = interval.steps;
-	var i, ilen, factor;
+	var factor;
 
 	if (!steps) {
 		return Math.ceil(range / (capacity * milliseconds));
 	}
 
-	for (i = 0, ilen = steps.length; i < ilen; ++i) {
+	for (var i = 0; i < steps.length; ++i) {
 		factor = steps[i];
 		if (Math.ceil(range / (milliseconds * factor)) <= capacity) {
 			break;
@@ -260,9 +259,9 @@ function determineStepSize(min, max, unit, capacity) {
  */
 function determineUnitForAutoTicks(minUnit, min, max, capacity) {
 	var ilen = UNITS.length;
-	var i, interval, factor;
+	var interval, factor, ilen;
 
-	for (i = UNITS.indexOf(minUnit); i < ilen - 1; ++i) {
+	for (var i = UNITS.indexOf(minUnit); i < ilen - 1; ++i) {
 		interval = INTERVALS[UNITS[i]];
 		factor = interval.steps ? interval.steps[interval.steps.length - 1] : MAX_INTEGER;
 
@@ -293,7 +292,7 @@ function determineUnitForFormatting(ticks, minUnit, min, max) {
 }
 
 function determineMajorUnit(unit) {
-	for (var i = UNITS.indexOf(unit) + 1, ilen = UNITS.length; i < ilen; ++i) {
+	for (var i = UNITS.indexOf(unit) + 1; i < UNITS.length; ++i) {
 		if (INTERVALS[UNITS[i]].common) {
 			return UNITS[i];
 		}
@@ -390,9 +389,9 @@ function computeOffsets(table, ticks, min, max, options) {
 
 function ticksFromTimestamps(values, majorUnit) {
 	var ticks = [];
-	var i, ilen, value, major;
+	var value, major;
 
-	for (i = 0, ilen = values.length; i < ilen; ++i) {
+	for (var i = 0; i < values.length; ++i) {
 		value = values[i];
 		major = majorUnit ? value === +moment(value).startOf(majorUnit) : false;
 
@@ -406,12 +405,11 @@ function ticksFromTimestamps(values, majorUnit) {
 }
 
 function determineLabelFormat(data, timeOpts) {
-	var i, momentDate, hasTime;
-	var ilen = data.length;
+	var momentDate, hasTime;
 
 	// find the label with the most parts (milliseconds, minutes, etc.)
 	// format all labels with the same level of detail as the most specific label
-	for (i = 0; i < ilen; i++) {
+	for (var i = 0; i < data.length; i++) {
 		momentDate = momentify(data[i], timeOpts);
 		if (momentDate.millisecond() !== 0) {
 			return 'MMM D, YYYY h:mm:ss.SSS a';
@@ -533,7 +531,7 @@ module.exports = function() {
 			var timestamps = [];
 			var datasets = [];
 			var labels = [];
-			var i, j, ilen, jlen, data, timestamp;
+			var i, ilen, data, timestamp;
 			var dataLabels = chart.data.labels || [];
 
 			// Convert labels to timestamps
@@ -550,7 +548,7 @@ module.exports = function() {
 					if (helpers.isObject(data[0])) {
 						datasets[i] = [];
 
-						for (j = 0, jlen = data.length; j < jlen; ++j) {
+						for (var j = 0; j < data.length; ++j) {
 							timestamp = parse(data[j], me);
 							timestamps.push(timestamp);
 							datasets[i][j] = timestamp;
@@ -606,7 +604,7 @@ module.exports = function() {
 			var timeOpts = options.time;
 			var timestamps = [];
 			var ticks = [];
-			var i, ilen, timestamp;
+			var timestamp;
 
 			switch (options.ticks.source) {
 			case 'data':
@@ -630,7 +628,7 @@ module.exports = function() {
 			max = parse(timeOpts.max, me) || max;
 
 			// Remove ticks outside the min/max range
-			for (i = 0, ilen = timestamps.length; i < ilen; ++i) {
+			for (var i = 0; i < timestamps.length; ++i) {
 				timestamp = timestamps[i];
 				if (timestamp >= min && timestamp <= max) {
 					ticks.push(timestamp);
@@ -694,9 +692,8 @@ module.exports = function() {
 
 		convertTicksToLabels: function(ticks) {
 			var labels = [];
-			var i, ilen;
 
-			for (i = 0, ilen = ticks.length; i < ilen; ++i) {
+			for (var i = 0; i < ticks.length; ++i) {
 				labels.push(this.tickFormatFunction(moment(ticks[i].value), i, ticks));
 			}
 


### PR DESCRIPTION
Write for-loops normally instead of trying to manually optimize code size

This results in smaller files. It's easier to write and makes the project more approachable to newcomers who would not be familiar with the idiosyncratic coding style. It's a better use of expensive developer time to let contributors to the project focus on core issues and let the uglifyJS authors deal with the problem of minifying code

**Before**
```
$ ls -l dist/
550346 Oct 23 20:22 Chart.bundle.js
210688 Oct 23 20:22 Chart.bundle.min.js
403486 Oct 23 20:22 Chart.js
397024 Sep  9  2017 Chart.js.zip
159001 Oct 23 20:22 Chart.min.js
159001 Oct 23 20:03 Chart.orig.min.js

$ gulp size
[20:22:52] all files 56.43 kB (gzipped)
```

**After**
```
$ ls -l dist/
549420 Oct 23 20:24 Chart.bundle.js
210470 Oct 23 20:24 Chart.bundle.min.js
402560 Oct 23 20:24 Chart.js
397024 Sep  9  2017 Chart.js.zip
158772 Oct 23 20:24 Chart.min.js
159001 Oct 23 20:03 Chart.orig.min.js

$ gulp size
[20:24:56] all files 56.28 kB (gzipped)
```