### PR TITLE
Support decimal stepSize

### DIFF
--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -174,6 +174,26 @@ module.exports = function() {
 	helpers.toDegrees = function(radians) {
 		return radians * (180 / Math.PI);
 	};
+
+	/**
+	 * Returns the number of decimal places
+	 * i.e. the number of digits after the decimal point, of the value of this Number.
+	 * @param {Number} x - A number.
+	 * @returns {Number} The number of decimal places.
+	 */
+	helpers.decimalPlaces = function(x) {
+		if (!helpers.isFinite(x)) {
+			return;
+		}
+		var e = 1;
+		var p = 0;
+		while (Math.round(x * e) / e !== x) {
+			e *= 10;
+			p++;
+		}
+		return p;
+	};
+
 	// Gets the angle from vertical upright to the point about a centre.
 	helpers.getAngleFromPoint = function(centrePoint, anglePoint) {
 		var distanceFromXCenter = anglePoint.x - centrePoint.x;

--- a/test/specs/core.helpers.tests.js
+++ b/test/specs/core.helpers.tests.js
@@ -238,6 +238,17 @@ describe('Core helper tests', function() {
 		expect(helpers.toDegrees(Math.PI * 3 / 2)).toBe(270);
 	});
 
+	it('should get the correct number of decimal places', function() {
+		expect(helpers.decimalPlaces(100)).toBe(0);
+		expect(helpers.decimalPlaces(1)).toBe(0);
+		expect(helpers.decimalPlaces(0)).toBe(0);
+		expect(helpers.decimalPlaces(0.01)).toBe(2);
+		expect(helpers.decimalPlaces(-0.01)).toBe(2);
+		expect(helpers.decimalPlaces('1')).toBe(undefined);
+		expect(helpers.decimalPlaces('')).toBe(undefined);
+		expect(helpers.decimalPlaces(undefined)).toBe(undefined);
+	});
+
 	it('should get an angle from a point', function() {
 		var center = {
 			x: 0,

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -573,6 +573,35 @@ describe('Linear Scale', function() {
 		expect(chart.scales.yScale0.ticks).toEqual(['11', '9', '7', '5', '3', '1']);
 	});
 
+	it('Should create decimal steps if stepSize is a decimal number', function() {
+		var chart = window.acquireChart({
+			type: 'bar',
+			data: {
+				datasets: [{
+					yAxisID: 'yScale0',
+					data: [10, 3, 6, 8, 3, 1]
+				}],
+				labels: ['a', 'b', 'c', 'd', 'e', 'f']
+			},
+			options: {
+				scales: {
+					yAxes: [{
+						id: 'yScale0',
+						type: 'linear',
+						ticks: {
+							stepSize: 2.5
+						}
+					}]
+				}
+			}
+		});
+
+		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
+		expect(chart.scales.yScale0.min).toBe(0);
+		expect(chart.scales.yScale0.max).toBe(10);
+		expect(chart.scales.yScale0.ticks).toEqual(['10', '7.5', '5', '2.5', '0']);
+	});
+
 	describe('precision', function() {
 		it('Should create integer steps if precision is 0', function() {
 			var chart = window.acquireChart({


### PR DESCRIPTION
This PR adds support for decimal `stepSize` for linear scales. In the current code,
- if `stepSize` >= 1, ticks will be rounded to integers
- if `stepSize` < 1, ticks will have the appropriate decimal precision
- If `stepSize` is not specified, the tick interval will be set to a 'nice' number, so there is no rounding issue

In this PR, the decimal precision is calculated based on `stepSize` if specified, or a generated 'nice' number or `ticks.precision` (only if `stepSize` is not specified).

Fixes #5392
Fixes #5579