### PR TITLE
Add error margin for detecting if a point or line is in the chartArea

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -710,6 +710,8 @@ module.exports = Element.extend({
 		var yTickStart = options.position === 'bottom' ? me.top + axisWidth : me.bottom - tl - axisWidth;
 		var yTickEnd = options.position === 'bottom' ? me.top + axisWidth + tl : me.bottom + axisWidth;
 
+		var epsilon = 0.0000001; // 0.0000001 is margin in pixels for Accumulated error.
+
 		helpers.each(ticks, function(tick, index) {
 			// autoskipper skipped this tick (#4635)
 			if (helpers.isNullOrUndef(tick.label)) {
@@ -753,7 +755,7 @@ module.exports = Element.extend({
 				}
 
 				var xLineValue = getLineValue(me, index, gridLines.offsetGridLines && ticks.length > 1);
-				if (xLineValue < me.left) {
+				if (xLineValue < me.left - epsilon) {
 					lineColor = 'rgba(0,0,0,0)';
 				}
 				xLineValue += helpers.aliasPixel(lineWidth);
@@ -780,7 +782,7 @@ module.exports = Element.extend({
 				labelX = isLeft ? me.right - labelXOffset : me.left + labelXOffset;
 
 				var yLineValue = getLineValue(me, index, gridLines.offsetGridLines && ticks.length > 1);
-				if (yLineValue < me.top) {
+				if (yLineValue < me.top - epsilon) {
 					lineColor = 'rgba(0,0,0,0)';
 				}
 				yLineValue += helpers.aliasPixel(lineWidth);

--- a/src/elements/element.point.js
+++ b/src/elements/element.point.js
@@ -72,14 +72,14 @@ module.exports = Element.extend({
 		var radius = vm.radius;
 		var x = vm.x;
 		var y = vm.y;
-		var errMargin = 1.01; // 1.01 is margin for Accumulated error. (Especially Edge, IE.)
+		var epsilon = 0.0000001; // 0.0000001 is margin in pixels for Accumulated error.
 
 		if (vm.skip) {
 			return;
 		}
 
 		// Clipping for Points.
-		if (chartArea === undefined || (model.x >= chartArea.left && chartArea.right * errMargin >= model.x && model.y >= chartArea.top && chartArea.bottom * errMargin >= model.y)) {
+		if (chartArea === undefined || (model.x > chartArea.left - epsilon && chartArea.right + epsilon > model.x && model.y > chartArea.top - epsilon && chartArea.bottom + epsilon > model.y)) {
 			ctx.strokeStyle = vm.borderColor || defaultColor;
 			ctx.lineWidth = helpers.valueOrDefault(vm.borderWidth, defaults.global.elements.point.borderWidth);
 			ctx.fillStyle = vm.backgroundColor || defaultColor;


### PR DESCRIPTION
Many issues about points/gridline at the top edge of the chart area being cut have been reported. The issue is caused by a decimal round-off error when detecting if a point or line is in the chartArea. This PR adds an err margin, which is already implemented for point clipping at the right and bottom edges.

v2.7.3: https://jsfiddle.net/nagix/z1bx459c/ (To reproduce the problem, you may need to resize the container as this is caused by decimal rounding)
<img width="416" alt="screenshot 2018-10-25 at 2 16 57 am" src="https://user-images.githubusercontent.com/723188/47452162-1cd12880-d7fc-11e8-87ba-84ec0bb0516e.png">

v2.7.3 + This PR: https://jsfiddle.net/nagix/yv6emrcf/
<img width="416" alt="screenshot 2018-10-25 at 2 17 11 am" src="https://user-images.githubusercontent.com/723188/47452165-1f338280-d7fc-11e8-8727-9056700742d4.png">

Fixes #4579
Fixes #4790
Fixes #5493