### PR TITLE
Remove dead and broken code from gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -233,9 +233,6 @@ function moduleSizesTask() {
 }
 
 function watchTask() {
-  if (util.env.test) {
-    return gulp.watch('./src/**', ['build', 'unittest', 'unittestWatch']);
-  }
   return gulp.watch('./src/**', ['build']);
 }
 


### PR DESCRIPTION
In commit c216c0af76, the task unittestWatch was removed. However, as of now, the watch task links to it, when executed with the test flag. As watching the unittest is possible with `gulp unittest --watch`, this code is not needed anymore and thus removed.

