### PR TITLE
Add plugin hooks descriptions

### DIFF
--- a/docs/developers/plugins.md
+++ b/docs/developers/plugins.md
@@ -108,25 +108,27 @@ var chart = new Chart(ctx, {
 
 Available hooks (as of version 2.6):
 
-* beforeInit
-* afterInit
-* beforeUpdate *(cancellable)*
-* afterUpdate
-* beforeLayout *(cancellable)*
-* afterLayout
-* beforeDatasetsUpdate *(cancellable)*
-* afterDatasetsUpdate
-* beforeDatasetUpdate *(cancellable)*
-* afterDatasetUpdate
-* beforeRender *(cancellable)*
-* afterRender
-* beforeDraw *(cancellable)*
-* afterDraw
-* beforeDatasetsDraw *(cancellable)*
-* afterDatasetsDraw
-* beforeDatasetDraw *(cancellable)*
-* afterDatasetDraw
-* beforeEvent *(cancellable)*
-* afterEvent
-* resize
-* destroy
+| Hook | Description
+| ---- | -----------
+| `beforeInit` | Called before initializing `chart`.
+| `afterInit` | Called after `chart` has been initialized and before the first update.
+| `beforeUpdate` *(cancellable)* | Called before updating `chart`. If any plugin returns `false`, the update is cancelled (and thus subsequent render(s)) until another `update` is triggered
+| `afterUpdate` | Called after `chart` has been updated and before rendering. Note that this hook will not be called if the chart update has been previously cancelled.
+| `beforeLayout` *(cancellable)* | Called before laying out `chart`. If any plugin returns `false`, the layout update is cancelled until another `update` is triggered.
+| `afterLayout` | Called after the `chart` has been layed out. Note that this hook will not be called if the layout update has been previously cancelled.
+| `beforeDatasetsUpdate` *(cancellable)* | Called before updating the `chart` datasets. If any plugin returns `false`, the datasets update is cancelled until another `update` is triggered.
+| `afterDatasetsUpdate` | Called after the `chart` datasets have been updated. Note that this hook will not be called if the datasets update has been previously cancelled.
+| `beforeDatasetUpdate` *(cancellable)* | Called before updating the `chart` dataset at the given `args.index`. If any plugin returns `false`, the datasets update is cancelled until another `update` is triggered.
+| `afterDatasetUpdate` | Called after the `chart` datasets at the given `args.index` has been updated. Note that this hook will not be called if the datasets update has been previously cancelled.
+| `beforeRender` *(cancellable)* | Called before rendering `chart`. If any plugin returns `false`, the rendering is cancelled until another `render` is triggered.
+| `afterRender` | Called after the `chart` has been fully rendered (and animation completed). Note that this hook will not be called if the rendering has been previously cancelled.
+| `beforeDraw` *(cancellable)* | Called before drawing `chart` at every animation frame specified by the given easing value. If any plugin returns `false`, the frame drawing is cancelled until another `render` is triggered.
+| `afterDraw` | Called after the `chart` has been drawn for the specific easing value. Note that this hook will not be called if the drawing has been previously cancelled.
+| `beforeDatasetsDraw` *(cancellable)* | Called before drawing the `chart` datasets. If any plugin returns `false`, the datasets drawing is cancelled until another `render` is triggered.
+| `afterDatasetsDraw` | Called after the `chart` datasets have been drawn. Note that this hook will not be called if the datasets drawing has been previously cancelled.
+| `beforeDatasetDraw` *(cancellable)* | Called before drawing the `chart` dataset at the given `args.index` (datasets are drawn in the reverse order). If any plugin returns `false`, the datasets drawing is cancelled until another `render` is triggered.
+| `afterDatasetDraw` | Called after the `chart` datasets at the given `args.index` have been drawn (datasets are drawn in the reverse order). Note that this hook will not be called if the datasets drawing has been previously cancelled.
+| `beforeEvent` *(cancellable)* | Called before processing the specified `event`. If any plugin returns `false`, the event will be discarded.
+| `afterEvent` | Called after the `event` has been consumed. Note that this hook will not be called if the `event` has been previously discarded.
+| `resize` | Called after the chart as been resized.
+| `destroy` | Called after the chart as been destroyed.


### PR DESCRIPTION
I think it would be useful to have the hook descriptions in the docs. They can be found in the source code of course, but would not hurt to have them here as well :)