### PR TITLE
Generate jsdocs

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -44,6 +44,7 @@
   * [Styling](axes/styling.md)
 * [Developers](developers/README.md)
   * [Chart.js API](developers/api.md)
+  * [JSDoc](jsdoc/index.html)
   * [Updating Charts](developers/updates.md)
   * [Plugins](developers/plugins.md)
   * [New Charts](developers/charts.md)

--- a/docs/developers/plugins.md
+++ b/docs/developers/plugins.md
@@ -104,29 +104,6 @@ var chart = new Chart(ctx, {
 });
 ```
 
-## Plugin Core API
+ ## Plugin Core API
 
-Available hooks (as of version 2.7):
-
-* `beforeInit`
-* `afterInit`
-* `beforeUpdate` *(cancellable)*
-* `afterUpdate`
-* `beforeLayout` *(cancellable)*
-* `afterLayout`
-* `beforeDatasetsUpdate` *(cancellable)*
-* `afterDatasetsUpdate`
-* `beforeDatasetUpdate` *(cancellable)*
-* `afterDatasetUpdate`
-* `beforeRender` *(cancellable)*
-* `afterRender`
-* `beforeDraw` *(cancellable)*
-* `afterDraw`
-* `beforeDatasetsDraw` *(cancellable)*
-* `afterDatasetsDraw`
-* `beforeDatasetDraw` *(cancellable)*
-* `afterDatasetDraw`
-* `beforeEvent` *(cancellable)*
-* `afterEvent`
-* `resize`
-* `destroy`
+Read more about the [existing plugin extension hooks](../jsdoc/IPlugin.html).

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,7 @@
 var gulp = require('gulp');
 var eslint = require('gulp-eslint');
 var file = require('gulp-file');
+var jsdoc = require('gulp-jsdoc3');
 var replace = require('gulp-replace');
 var size = require('gulp-size');
 var streamify = require('gulp-streamify');
@@ -129,12 +130,24 @@ function lintHtmlTask() {
     }));
 }
 
-function docsTask() {
-  var bin = 'gitbook-cli/bin/gitbook.js';
+function docsTask(done) {
+  var bin = require.resolve('gitbook-cli/bin/gitbook.js');
   var cmd = argv.watch ? 'serve' : 'build';
 
   return run(bin, ['install', './'])
-    .then(() => run(bin, [cmd, './', './dist/docs']));
+    .then(() => run(bin, [cmd, './', './dist/docs']))
+    .then(() => {
+      var config = {
+        opts: {
+          destination: './dist/docs/jsdoc'
+        },
+        recurse: true
+      };
+      gulp.src(['./src/**/*.js'], {read: false})
+        .pipe(jsdoc(config, done));
+    }).catch((err) => {
+      done(new Error(err.stdout || err));
+    });
 }
 
 function unittestTask(done) {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "gulp-eslint": "^5.0.0",
     "gulp-file": "^0.4.0",
     "gulp-htmllint": "^0.0.16",
+    "gulp-jsdoc3": "^2.0.0",
     "gulp-replace": "^1.0.0",
     "gulp-size": "^3.0.0",
     "gulp-streamify": "^1.0.2",


### PR DESCRIPTION
Closes https://github.com/chartjs/Chart.js/pull/5821

This PR generates jsdocs that we can link to from the docs to add missing docs as suggested by @jukra 