### PR TITLE
Change the .editorconfig file to include final newlines

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ indent_size = 4
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
-insert_final_newline = false
+insert_final_newline = true
 
 [gulpfile.js]
 indent_style = space


### PR DESCRIPTION
All source files end with a final newline, as is ensured by the linter. This was inconsistent with the `.editorconfig` file, which instructed editors not to include a final newline.

Fixes #5823