### PR TITLE
Correct spelling mistake.

### DIFF
--- a/docs/general/fonts.md
+++ b/docs/general/fonts.md
@@ -27,6 +27,6 @@ let chart = new Chart(ctx, {
 | `defaultFontSize` | `Number` | `12` | Default font size (in px) for text. Does not apply to radialLinear scale point labels.
 | `defaultFontStyle` | `String` | `'normal'` | Default font style. Does not apply to tooltip title or footer. Does not apply to chart title.
 
-## Non-Existant Fonts
+## Nonexistent Fonts
 
 If a font is specified for a chart that does exist on the system, the browser will not apply the font when it is set. If you notice odd fonts appearing in your charts, check that the font you are applying exists on your system. See [issue 3318](https://github.com/chartjs/Chart.js/issues/3318) for more details.

--- a/docs/general/fonts.md
+++ b/docs/general/fonts.md
@@ -27,6 +27,6 @@ let chart = new Chart(ctx, {
 | `defaultFontSize` | `Number` | `12` | Default font size (in px) for text. Does not apply to radialLinear scale point labels.
 | `defaultFontStyle` | `String` | `'normal'` | Default font style. Does not apply to tooltip title or footer. Does not apply to chart title.
 
-## Nonexistent Fonts
+## Missing Fonts
 
 If a font is specified for a chart that does exist on the system, the browser will not apply the font when it is set. If you notice odd fonts appearing in your charts, check that the font you are applying exists on your system. See [issue 3318](https://github.com/chartjs/Chart.js/issues/3318) for more details.


### PR DESCRIPTION
Very simple fix of typo in fonts.md.

It's "Non-existent" not "Non-existant".

"Nonexistent" (no hyphen) is also the most common current usage so switched to that form.
