### PR TITLE
Support CanvasGradient for hover colors

### DIFF
--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -647,7 +647,7 @@ module.exports = function() {
 
 	helpers.getHoverColor = function(colorValue) {
 		/* global CanvasPattern */
-		return (colorValue instanceof CanvasPattern) ?
+		return (colorValue instanceof CanvasPattern || colorValue instanceof CanvasGradient) ?
 			colorValue :
 			helpers.color(colorValue).saturate(0.5).darken(0.1).rgbString();
 	};

--- a/test/specs/core.helpers.tests.js
+++ b/test/specs/core.helpers.tests.js
@@ -848,6 +848,13 @@ describe('Core helper tests', function() {
 			};
 		});
 
+		it('should return a CanvasGradient when called with a CanvasGradient', function() {
+			var context = document.createElement('canvas').getContext('2d');
+			var gradient = context.createLinearGradient(0, 1, 2, 3);
+
+			expect(helpers.getHoverColor(gradient) instanceof CanvasGradient).toBe(true);
+		});
+
 		it('should return a modified version of color when called with a color', function() {
 			var originalColorRGB = 'rgb(70, 191, 189)';
 


### PR DESCRIPTION
When hovering over the point that has CanvasGradient border/background colors, its colors turn into grey because `helpers.color` converts `CanvasGradient` to `defaults.global.defaultColor` and `helpers.getHoverColor` generates colors from it. This PR makes `getHoverColor` return the original value if it is CanvasGradient.

**Chart.js 2.7.3 + #5858: https://jsfiddle.net/nagix/6rnfspu3/**
![gradient1](https://user-images.githubusercontent.com/723188/49091851-a06ab300-f29b-11e8-96fa-e7d6fd659b0c.png)

**Chart.js 2.7.3 + #5858 + This PR: https://jsfiddle.net/nagix/2ao9yrbf/**
![gradient2](https://user-images.githubusercontent.com/723188/49091863-a52f6700-f29b-11e8-8898-fcf6db6a41f7.png)