### PR TITLE
Update plugin.legend.js with a new option: 'alignment'.  

### DIFF
--- a/docs/configuration/legend.md
+++ b/docs/configuration/legend.md
@@ -9,6 +9,7 @@ The legend configuration is passed into the `options.legend` namespace. The glob
 | -----| ---- | --------| -----------
 | `display` | `Boolean` | `true` | Is the legend shown?
 | `position` | `String` | `'top'` | Position of the legend. [more...](#position)
+| `align`    | `String` | `'center'` | The alignment of the legend. [more...](#align)
 | `fullWidth` | `Boolean` | `true` | Marks that this box should take the full width of the canvas (pushing down other boxes). This is unlikely to need to be changed in day-to-day use.
 | `onClick` | `Function` | | A callback that is called when a click event is registered on a label item.
 | `onHover` | `Function` | | A callback that is called when a 'mousemove' event is registered on top of a label item.
@@ -21,6 +22,14 @@ Position of the legend. Options are:
 * `'left'`
 * `'bottom'`
 * `'right'`
+
+## Align
+The alignment of the legend.  
+
+* `'start'`
+* `'center'` (default)
+* `'end'`
+
 
 ## Legend Label Configuration
 

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -11,6 +11,7 @@ defaults._set('global', {
 	legend: {
 		display: true,
 		position: 'top',
+		align: 'center',
 		fullWidth: true,
 		reverse: false,
 		weight: 1000,
@@ -407,24 +408,41 @@ var Legend = Element.extend({
 					ctx.stroke();
 				}
 			};
+			var itemHeight = fontSize + labelOpts.padding;
 
 			// Horizontal
 			var isHorizontal = me.isHorizontal();
 			if (isHorizontal) {
+				// default to center as this is the original behaviour of just position
+				var alignedX = me.left + ((legendWidth - lineWidths[0]) / 2);
+				if (opts.align === 'start') {
+					alignedX = me.left;
+				} else if (opts.align === 'end') {
+					alignedX = ((me.right - lineWidths[0]));
+				}
 				cursor = {
-					x: me.left + ((legendWidth - lineWidths[0]) / 2) + labelOpts.padding,
+					x: alignedX + labelOpts.padding,
 					y: me.top + labelOpts.padding,
 					line: 0
 				};
 			} else {
+				// default to top as this is the original behaviour of just position
+				var alignedY = me.top;
+				var maxItemsPerColumn = Math.floor((me.minSize.height - labelOpts.padding) / itemHeight);
+				var legendHeight = Math.min(me.legendItems.length, maxItemsPerColumn) * itemHeight + labelOpts.padding;
+				// var legendHeight = (fontSize + labelOpts.padding) * me.legendItems.length;
+				if (opts.align === 'end') {
+					alignedY = ((me.bottom - legendHeight));
+				} else if (opts.align === 'center') {
+					alignedY = (((me.bottom - legendHeight) / 2));
+				}
 				cursor = {
 					x: me.left + labelOpts.padding,
-					y: me.top + labelOpts.padding,
+					y: alignedY + labelOpts.padding,
 					line: 0
 				};
 			}
 
-			var itemHeight = fontSize + labelOpts.padding;
 			helpers.each(me.legendItems, function(legendItem, i) {
 				var textWidth = ctx.measureText(legendItem.text).width;
 				var width = boxWidth + (fontSize / 2) + textWidth;
@@ -438,11 +456,28 @@ var Legend = Element.extend({
 					if (i > 0 && x + width + labelOpts.padding > me.left + me.minSize.width) {
 						y = cursor.y += itemHeight;
 						cursor.line++;
-						x = cursor.x = me.left + ((legendWidth - lineWidths[cursor.line]) / 2) + labelOpts.padding;
+						// We must account for the align parameter when resetting the x position
+						alignedX = me.left + ((legendWidth - lineWidths[cursor.line]) / 2);
+						if (opts.align === 'start') {
+							alignedX = me.left;
+						} else if (opts.align === 'end') {
+							alignedX = ((me.right - lineWidths[cursor.line]));
+						}
+						x = cursor.x = alignedX + labelOpts.padding;
 					}
 				} else if (i > 0 && y + itemHeight > me.top + me.minSize.height) {
 					x = cursor.x = x + me.columnWidths[cursor.line] + labelOpts.padding;
-					y = cursor.y = me.top + labelOpts.padding;
+					// We must account for the align parameter when resetting the y position
+					alignedY = me.top;
+					maxItemsPerColumn = Math.floor((me.minSize.height - labelOpts.padding) / itemHeight);
+					legendHeight = Math.min(me.legendItems.length, maxItemsPerColumn) * itemHeight + labelOpts.padding;
+					// var legendHeight = (fontSize + labelOpts.padding) * me.legendItems.length;
+					if (opts.align === 'end') {
+						alignedY = ((me.bottom - legendHeight));
+					} else if (opts.align === 'center') {
+						alignedY = (((me.bottom - legendHeight) / 2));
+					}
+					y = cursor.y = alignedY + labelOpts.padding;
 					cursor.line++;
 				}
 

--- a/test/specs/plugin.legend.tests.js
+++ b/test/specs/plugin.legend.tests.js
@@ -4,6 +4,7 @@ describe('Legend block tests', function() {
 		expect(Chart.defaults.global.legend).toEqual({
 			display: true,
 			position: 'top',
+			align: 'center',
 			fullWidth: true, // marks that this box should take the full width of the canvas (pushing down other boxes)
 			reverse: false,
 			weight: 1000,
@@ -176,7 +177,7 @@ describe('Legend block tests', function() {
 		expect(makeChart).not.toThrow();
 	});
 
-	it('should draw correctly when the legend is positioned on the top', function() {
+	it('should draw correctly when the legend is positioned on the top and align start', function() {
 		var chart = window.acquireChart({
 			type: 'bar',
 			data: {
@@ -199,6 +200,58 @@ describe('Legend block tests', function() {
 					data: []
 				}],
 				labels: []
+			},
+			options: {
+				legend: {
+					position: 'top',
+					align: 'start'
+				}
+			}
+		});
+
+		expect(chart.legend.legendHitBoxes.length).toBe(3);
+
+		[
+			{h: 12, l: 10, t: 10, w: 93},
+			{h: 12, l: 113, t: 10, w: 93},
+			{h: 12, l: 216, t: 10, w: 93}
+		].forEach(function(expected, i) {
+			expect(chart.legend.legendHitBoxes[i].height).toBeCloseToPixel(expected.h);
+			expect(chart.legend.legendHitBoxes[i].left).toBeCloseToPixel(expected.l);
+			expect(chart.legend.legendHitBoxes[i].top).toBeCloseToPixel(expected.t);
+			expect(chart.legend.legendHitBoxes[i].width).toBeCloseToPixel(expected.w);
+		});
+	});
+
+	it('should draw correctly when the legend is positioned on the top and align center', function() {
+		var chart = window.acquireChart({
+			type: 'bar',
+			data: {
+				datasets: [{
+					label: 'dataset1',
+					backgroundColor: '#f31',
+					borderCapStyle: 'butt',
+					borderDash: [2, 2],
+					borderDashOffset: 5.5,
+					data: []
+				}, {
+					label: 'dataset2',
+					hidden: true,
+					borderJoinStyle: 'miter',
+					data: []
+				}, {
+					label: 'dataset3',
+					borderWidth: 10,
+					borderColor: 'green',
+					data: []
+				}],
+				labels: []
+			},
+			options: {
+				legend: {
+					position: 'top',
+					align: 'center'
+				}
 			}
 		});
 
@@ -389,7 +442,7 @@ describe('Legend block tests', function() {
 		}]);*/
 	});
 
-	it('should draw correctly when the legend is positioned on the left', function() {
+	it('should draw correctly when the legend is positioned on the top and align end', function() {
 		var chart = window.acquireChart({
 			type: 'bar',
 			data: {
@@ -415,7 +468,54 @@ describe('Legend block tests', function() {
 			},
 			options: {
 				legend: {
-					position: 'left'
+					position: 'top',
+					align: 'end'
+				}
+			}
+		});
+
+		expect(chart.legend.legendHitBoxes.length).toBe(3);
+
+		[
+			{h: 12, l: 203, t: 10, w: 93},
+			{h: 12, l: 306, t: 10, w: 93},
+			{h: 12, l: 409, t: 10, w: 93}
+		].forEach(function(expected, i) {
+			expect(chart.legend.legendHitBoxes[i].height).toBeCloseToPixel(expected.h);
+			expect(chart.legend.legendHitBoxes[i].left).toBeCloseToPixel(expected.l);
+			expect(chart.legend.legendHitBoxes[i].top).toBeCloseToPixel(expected.t);
+			expect(chart.legend.legendHitBoxes[i].width).toBeCloseToPixel(expected.w);
+		});
+	});
+
+	it('should draw correctly when the legend is positioned on the left and align start', function() {
+		var chart = window.acquireChart({
+			type: 'bar',
+			data: {
+				datasets: [{
+					label: 'dataset1',
+					backgroundColor: '#f31',
+					borderCapStyle: 'butt',
+					borderDash: [2, 2],
+					borderDashOffset: 5.5,
+					data: []
+				}, {
+					label: 'dataset2',
+					hidden: true,
+					borderJoinStyle: 'miter',
+					data: []
+				}, {
+					label: 'dataset3',
+					borderWidth: 10,
+					borderColor: 'green',
+					data: []
+				}],
+				labels: []
+			},
+			options: {
+				legend: {
+					position: 'left',
+					align: 'start'
 				}
 			}
 		});
@@ -434,7 +534,99 @@ describe('Legend block tests', function() {
 		});
 	});
 
-	it('should draw correctly when the legend is positioned on the top and has multiple rows', function() {
+	it('should draw correctly when the legend is positioned on the left and align center', function() {
+		var chart = window.acquireChart({
+			type: 'bar',
+			data: {
+				datasets: [{
+					label: 'dataset1',
+					backgroundColor: '#f31',
+					borderCapStyle: 'butt',
+					borderDash: [2, 2],
+					borderDashOffset: 5.5,
+					data: []
+				}, {
+					label: 'dataset2',
+					hidden: true,
+					borderJoinStyle: 'miter',
+					data: []
+				}, {
+					label: 'dataset3',
+					borderWidth: 10,
+					borderColor: 'green',
+					data: []
+				}],
+				labels: []
+			},
+			options: {
+				legend: {
+					position: 'left',
+					align: 'center'
+				}
+			}
+		});
+
+		expect(chart.legend.legendHitBoxes.length).toBe(3);
+
+		[
+			{h: 12, l: 10, t: 214, w: 93},
+			{h: 12, l: 10, t: 236, w: 93},
+			{h: 12, l: 10, t: 258, w: 93}
+		].forEach(function(expected, i) {
+			expect(chart.legend.legendHitBoxes[i].height).toBeCloseToPixel(expected.h);
+			expect(chart.legend.legendHitBoxes[i].left).toBeCloseToPixel(expected.l);
+			expect(chart.legend.legendHitBoxes[i].top).toBeCloseToPixel(expected.t);
+			expect(chart.legend.legendHitBoxes[i].width).toBeCloseToPixel(expected.w);
+		});
+	});
+
+	it('should draw correctly when the legend is positioned on the left and align end', function() {
+		var chart = window.acquireChart({
+			type: 'bar',
+			data: {
+				datasets: [{
+					label: 'dataset1',
+					backgroundColor: '#f31',
+					borderCapStyle: 'butt',
+					borderDash: [2, 2],
+					borderDashOffset: 5.5,
+					data: []
+				}, {
+					label: 'dataset2',
+					hidden: true,
+					borderJoinStyle: 'miter',
+					data: []
+				}, {
+					label: 'dataset3',
+					borderWidth: 10,
+					borderColor: 'green',
+					data: []
+				}],
+				labels: []
+			},
+			options: {
+				legend: {
+					position: 'left',
+					align: 'end'
+				}
+			}
+		});
+
+		expect(chart.legend.legendHitBoxes.length).toBe(3);
+
+		[
+			{h: 12, l: 10, t: 418, w: 93},
+			{h: 12, l: 10, t: 440, w: 93},
+			{h: 12, l: 10, t: 462, w: 93}
+		].forEach(function(expected, i) {
+			expect(chart.legend.legendHitBoxes[i].height).toBeCloseToPixel(expected.h);
+			expect(chart.legend.legendHitBoxes[i].left).toBeCloseToPixel(expected.l);
+			expect(chart.legend.legendHitBoxes[i].top).toBeCloseToPixel(expected.t);
+			expect(chart.legend.legendHitBoxes[i].width).toBeCloseToPixel(expected.w);
+		});
+	});
+
+	it('should draw correctly when the legend is positioned on the top, align start, and has multiple rows', function() {
 		var chart = window.acquireChart({
 			type: 'bar',
 			data: {
@@ -445,6 +637,56 @@ describe('Legend block tests', function() {
 					};
 				}),
 				labels: []
+			},
+			options: {
+				legend: {
+					position: 'top',
+					align: 'start'
+				}
+			}
+		});
+
+		expect(chart.legend.left).toBeCloseToPixel(0);
+		expect(chart.legend.top).toBeCloseToPixel(0);
+		expect(chart.legend.width).toBeCloseToPixel(512);
+		expect(chart.legend.height).toBeCloseToPixel(54);
+		expect(chart.legend.legendHitBoxes.length).toBe(9);
+
+		[
+			{h: 12, l: 10, t: 10, w: 49},
+			{h: 12, l: 69, t: 10, w: 49},
+			{h: 12, l: 128, t: 10, w: 49},
+			{h: 12, l: 187, t: 10, w: 49},
+			{h: 12, l: 247, t: 10, w: 49},
+			{h: 12, l: 306, t: 10, w: 49},
+			{h: 12, l: 365, t: 10, w: 49},
+			{h: 12, l: 424, t: 10, w: 49},
+			{h: 12, l: 10, t: 32, w: 49}
+		].forEach(function(expected, i) {
+			expect(chart.legend.legendHitBoxes[i].height).toBeCloseToPixel(expected.h);
+			expect(chart.legend.legendHitBoxes[i].left).toBeCloseToPixel(expected.l);
+			expect(chart.legend.legendHitBoxes[i].top).toBeCloseToPixel(expected.t);
+			expect(chart.legend.legendHitBoxes[i].width).toBeCloseToPixel(expected.w);
+		});
+	});
+
+	it('should draw correctly when the legend is positioned on the top, align center, and has multiple rows', function() {
+		var chart = window.acquireChart({
+			type: 'bar',
+			data: {
+				datasets: Array.apply(null, Array(9)).map(function() {
+					return {
+						label: ' ',
+						data: []
+					};
+				}),
+				labels: []
+			},
+			options: {
+				legend: {
+					position: 'top',
+					align: 'center'
+				}
 			}
 		});
 
@@ -472,7 +714,51 @@ describe('Legend block tests', function() {
 		});
 	});
 
-	it('should draw correctly when the legend is positioned on the left and has multiple columns', function() {
+	it('should draw correctly when the legend is positioned on the top, align end, and has multiple rows', function() {
+		var chart = window.acquireChart({
+			type: 'bar',
+			data: {
+				datasets: Array.apply(null, Array(9)).map(function() {
+					return {
+						label: ' ',
+						data: []
+					};
+				}),
+				labels: []
+			},
+			options: {
+				legend: {
+					position: 'top',
+					align: 'end'
+				}
+			}
+		});
+
+		expect(chart.legend.left).toBeCloseToPixel(0);
+		expect(chart.legend.top).toBeCloseToPixel(0);
+		expect(chart.legend.width).toBeCloseToPixel(512);
+		expect(chart.legend.height).toBeCloseToPixel(54);
+		expect(chart.legend.legendHitBoxes.length).toBe(9);
+
+		[
+			{h: 12, l: 38, t: 10, w: 49},
+			{h: 12, l: 97, t: 10, w: 49},
+			{h: 12, l: 156, t: 10, w: 49},
+			{h: 12, l: 215, t: 10, w: 49},
+			{h: 12, l: 274, t: 10, w: 49},
+			{h: 12, l: 333, t: 10, w: 49},
+			{h: 12, l: 392, t: 10, w: 49},
+			{h: 12, l: 452, t: 10, w: 49},
+			{h: 12, l: 452, t: 32, w: 49}
+		].forEach(function(expected, i) {
+			expect(chart.legend.legendHitBoxes[i].height).toBeCloseToPixel(expected.h);
+			expect(chart.legend.legendHitBoxes[i].left).toBeCloseToPixel(expected.l);
+			expect(chart.legend.legendHitBoxes[i].top).toBeCloseToPixel(expected.t);
+			expect(chart.legend.legendHitBoxes[i].width).toBeCloseToPixel(expected.w);
+		});
+	});
+
+	it('should draw correctly when the legend is positioned on the left, align start, and has multiple columns', function() {
 		var chart = window.acquireChart({
 			type: 'bar',
 			data: {
@@ -486,7 +772,8 @@ describe('Legend block tests', function() {
 			},
 			options: {
 				legend: {
-					position: 'left'
+					position: 'left',
+					align: 'start'
 				}
 			}
 		});


### PR DESCRIPTION
The position options for the legend only allow top, bottom, left, and right.  Then the legends are aligned in the center on the top and bottom and at the top in left and right.

This adds a new option to the legend: 'alignment' which allow the legend to be aligned within its layout box. 

In the case of position top or bottom, the legend can be aligned 'left', 'right', or 'center', with center being the default.  For position right or left the legend can be aligned 'top', 'center', or 'bottom', with top being default as the current behavior.

Updated the legend help page to reflect these changes.

Similar: [https://github.com/chartjs/Chart.js/issues/3706](https://github.com/chartjs/Chart.js/issues/3706)

See: [http://jsfiddle.net/pdht9ces/10/](http://jsfiddle.net/pdht9ces/10/)
