### PR TITLE
Remove gulp-connect and add jsdelivr/unpkg paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "6"
+  - lts/*
 
 before_install:
   - "export CHROME_BIN=/usr/bin/google-chrome"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,5 @@
 var gulp = require('gulp');
 var concat = require('gulp-concat');
-var connect = require('gulp-connect');
 var eslint = require('gulp-eslint');
 var file = require('gulp-file');
 var insert = require('gulp-insert');
@@ -26,7 +25,7 @@ var argv = yargs
   .option('force-output', {default: false})
   .option('silent-errors', {default: false})
   .option('verbose', {default: false})
-  .argv
+  .argv;
 
 var srcDir = './src/';
 var outDir = './dist/';
@@ -53,15 +52,12 @@ gulp.task('lint-html', lintHtmlTask);
 gulp.task('lint-js', lintJsTask);
 gulp.task('lint', gulp.parallel('lint-html', 'lint-js'));
 gulp.task('docs', docsTask);
-gulp.task('server', serverTask);
 gulp.task('unittest', unittestTask);
 gulp.task('test', gulp.parallel('lint', 'unittest'));
 gulp.task('library-size', librarySizeTask);
 gulp.task('module-sizes', moduleSizesTask);
 gulp.task('size', gulp.parallel('library-size', 'module-sizes'));
-gulp.task('_open', _openTask);
 gulp.task('default', gulp.parallel('build', 'watch'));
-gulp.task('dev', gulp.parallel('server', 'default'));
 
 /**
  * Generates the bower.json manifest file which will be pushed along release tags.
@@ -136,7 +132,6 @@ function buildTask() {
     .pipe(gulp.dest(outDir));
 
   return merge(bundled, nonBundled);
-
 }
 
 function packageTask() {
@@ -234,17 +229,4 @@ function moduleSizesTask() {
 
 function watchTask() {
   return gulp.watch('./src/**', gulp.parallel('build'));
-}
-
-function serverTask() {
-  connect.server({
-    port: 8000
-  });
-}
-
-// Convenience task for opening the project straight from the command line
-
-function _openTask() {
-  exec('open http://localhost:8000');
-  exec('subl .');
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,26 @@
 {
   "name": "chart.js",
-  "homepage": "http://www.chartjs.org",
+  "homepage": "https://www.chartjs.org",
   "description": "Simple HTML5 charts using the canvas element.",
   "version": "2.7.3",
   "license": "MIT",
+  "jsdelivr": "dist/Chart.min.js",
+  "unpkg": "dist/Chart.min.js",
   "main": "src/chart.js",
+  "keywords": [
+    "canvas",
+    "charts",
+    "data",
+    "graphs",
+    "html5",
+    "responsive"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/chartjs/Chart.js.git"
+  },
+  "bugs": {
+    "url": "https://github.com/chartjs/Chart.js/issues"
   },
   "devDependencies": {
     "browserify": "^16.2.3",
@@ -21,7 +34,6 @@
     "gitbook-cli": "^2.3.2",
     "gulp": "^4.0.0",
     "gulp-concat": "^2.6.0",
-    "gulp-connect": "^5.6.1",
     "gulp-eslint": "^5.0.0",
     "gulp-file": "^0.4.0",
     "gulp-htmllint": "^0.0.16",
@@ -39,16 +51,13 @@
     "karma-chrome-launcher": "^2.2.0",
     "karma-coverage": "^1.1.1",
     "karma-firefox-launcher": "^1.0.1",
-    "karma-jasmine": "^2.0.0",
+    "karma-jasmine": "^2.0.1",
     "karma-jasmine-html-reporter": "^1.4.0",
     "merge-stream": "^1.0.1",
     "pixelmatch": "^4.0.2",
     "vinyl-source-stream": "^2.0.0",
     "watchify": "^3.9.0",
-    "yargs": "^12.0.2"
-  },
-  "spm": {
-    "main": "Chart.js"
+    "yargs": "^12.0.5"
   },
   "dependencies": {
     "chartjs-color": "^2.1.0",


### PR DESCRIPTION
Remove the useless `gulp server` (no need for a web server) and the platform specific `gulp _open` tasks, and in the same time, get rid of the compromised `flatmap-stream` package. Make Travis to use [the latest LTS Node.js release](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions) but also added the `jsdelivr` and `unpkg` fields to `package.json` as requested by #5779. Finally, removed the [spm](https://github.com/spmjs/spm) entry point since this package manager seems deprecated(spmjs/spm#1416).

Fixes #5779
Fixes #5863
