### PR TITLE
Remove autoSkip logic to always display last tick

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -644,7 +644,7 @@ module.exports = Element.extend({
 		var cosRotation = Math.cos(labelRotationRadians);
 		var longestRotatedLabel = me.longestLabelWidth * cosRotation;
 		var result = [];
-		var i, tick, shouldSkip;
+		var i, tick;
 
 		// figure out the maximum number of gridlines to show
 		var maxTicks;
@@ -669,9 +669,7 @@ module.exports = Element.extend({
 		for (i = 0; i < tickCount; i++) {
 			tick = ticks[i];
 
-			// Since we always show the last tick,we need may need to hide the last shown one before
-			shouldSkip = (skipRatio > 1 && i % skipRatio > 0) || (i % skipRatio === 0 && i + skipRatio >= tickCount);
-			if (shouldSkip && i !== tickCount - 1) {
+			if (skipRatio > 1 && i % skipRatio > 0) {
 				// leave tick in place but make sure it's not displayed (#4635)
 				delete tick.label;
 			}

--- a/test/specs/core.scale.tests.js
+++ b/test/specs/core.scale.tests.js
@@ -20,6 +20,60 @@ describe('Core.scale', function() {
 		});
 	});
 
+	describe('displaying xAxis ticks with autoSkip=true', function() {
+		function getChart(data) {
+			return window.acquireChart({
+				type: 'line',
+				data: data,
+				options: {
+					scales: {
+						xAxes: [{
+							ticks: {
+								autoSkip: true
+							}
+						}]
+					}
+				}
+			});
+		}
+
+		function lastTick(chart) {
+			var xAxis = chart.scales['x-axis-0'];
+			var ticks = xAxis.getTicks();
+			return ticks[ticks.length - 1];
+		}
+
+		it('should display the last tick if it fits evenly with other ticks', function() {
+			var chart = getChart({
+				labels: [
+					'January 2018', 'February 2018', 'March 2018', 'April 2018',
+					'May 2018', 'June 2018', 'July 2018', 'August 2018',
+					'September 2018'
+				],
+				datasets: [{
+					data: [12, 19, 3, 5, 2, 3, 7, 8, 9]
+				}]
+			});
+
+			expect(lastTick(chart).label).toEqual('September 2018');
+		});
+
+		it('should not display the last tick if it does not fit evenly', function() {
+			var chart = getChart({
+				labels: [
+					'January 2018', 'February 2018', 'March 2018', 'April 2018',
+					'May 2018', 'June 2018', 'July 2018', 'August 2018',
+					'September 2018', 'October 2018', 'November 2018', 'December 2018'
+				],
+				datasets: [{
+					data: [12, 19, 3, 5, 2, 3, 7, 8, 9, 10, 11, 12]
+				}]
+			});
+
+			expect(lastTick(chart).label).toBeUndefined();
+		});
+	});
+
 	var gridLineTests = [{
 		labels: ['tick1', 'tick2', 'tick3', 'tick4', 'tick5'],
 		offsetGridLines: false,


### PR DESCRIPTION
This changes the behavior of `autoSkip` so that it does not force the display of the last tick. If the last tick can be displayed with equal spacing to the rest of the ticks, it will be. Otherwise, it is not.

Fixes https://github.com/chartjs/Chart.js/issues/5707
Fixes https://github.com/chartjs/Chart.js/issues/3277

JSFiddle with v2.7.3: http://jsfiddle.net/61thywor/
JSFiddle with this change: http://jsfiddle.net/9t7bs01j/
