### PR TITLE
Use https in documentation links where possible

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -58,8 +58,8 @@ var myChart = new Chart(ctx, {
 
 Before submitting an issue or a pull request to the project, please take a moment to look over the [contributing guidelines](https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md) first.
 
-For support using Chart.js, please post questions with the [`chartjs` tag on Stack Overflow](http://stackoverflow.com/questions/tagged/chartjs).
+For support using Chart.js, please post questions with the [`chartjs` tag on Stack Overflow](https://stackoverflow.com/questions/tagged/chartjs).
 
 ## License
 
-Chart.js is available under the [MIT license](http://opensource.org/licenses/MIT).
+Chart.js is available under the [MIT license](https://opensource.org/licenses/MIT).

--- a/docs/axes/cartesian/time.md
+++ b/docs/axes/cartesian/time.md
@@ -19,7 +19,7 @@ The x-axis data points may additionally be specified via the `t` or `x` attribut
 
 ### Date Formats
 
-When providing data for the time scale, Chart.js supports all of the formats that Moment.js accepts. See [Moment.js docs](http://momentjs.com/docs/#/parsing/) for details.
+When providing data for the time scale, Chart.js supports all of the formats that Moment.js accepts. See [Moment.js docs](https://momentjs.com/docs/#/parsing/) for details.
 
 ## Configuration Options
 
@@ -75,7 +75,7 @@ var chart = new Chart(ctx, {
 ```
 
 ### Display Formats
-The following display formats are used to configure how different time units are formed into strings for the axis tick marks. See [moment.js](http://momentjs.com/docs/#/displaying/format/) for the allowable format strings.
+The following display formats are used to configure how different time units are formed into strings for the axis tick marks. See [moment.js](https://momentjs.com/docs/#/displaying/format/) for the allowable format strings.
 
 Name | Default | Example
 --- | --- | ---

--- a/docs/charts/line.md
+++ b/docs/charts/line.md
@@ -162,7 +162,7 @@ When charting a lot of data, the chart render time may start to get quite large.
 
 Decimating your data will achieve the best results. When there is a lot of data to display on the graph, it doesn't make sense to show tens of thousands of data points on a graph that is only a few hundred pixels wide.
 
-There are many approaches to data decimation and selection of an algorithm will depend on your data and the results you want to achieve. For instance, [min/max](http://digital.ni.com/public.nsf/allkb/F694FFEEA0ACF282862576020075F784) decimation will preserve peaks in your data but could require up to 4 points for each pixel. This type of decimation would work well for a very noisy signal where you need to see data peaks.
+There are many approaches to data decimation and selection of an algorithm will depend on your data and the results you want to achieve. For instance, [min/max](https://digital.ni.com/public.nsf/allkb/F694FFEEA0ACF282862576020075F784) decimation will preserve peaks in your data but could require up to 4 points for each pixel. This type of decimation would work well for a very noisy signal where you need to see data peaks.
 
 ## Disable Bezier Curves
 

--- a/docs/configuration/tooltip.md
+++ b/docs/configuration/tooltip.md
@@ -269,7 +269,7 @@ var myPieChart = new Chart(ctx, {
 });
 ```
 
-See [samples](http://www.chartjs.org/samples/) for examples on how to get started with custom tooltips.
+See [samples](https://www.chartjs.org/samples/) for examples on how to get started with custom tooltips.
 
 ## Tooltip Model
 The tooltip model contains parameters that can be used to render the tooltip.

--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -6,15 +6,15 @@ Developer features allow extending and enhancing Chart.js in many different ways
 
 Latest documentation and samples, including unreleased features, are available at:
 
- - http://www.chartjs.org/docs/master/
- - http://www.chartjs.org/samples/master/
+ - https://www.chartjs.org/docs/master/
+ - https://www.chartjs.org/samples/master/
 
 # Development releases
 
 Latest builds are available for testing at:
 
- - http://www.chartjs.org/dist/master/Chart.min.js
- - http://www.chartjs.org/dist/master/Chart.bundle.min.js
+ - https://www.chartjs.org/dist/master/Chart.min.js
+ - https://www.chartjs.org/dist/master/Chart.bundle.min.js
 
 > Note: Development builds are currently only available via HTTP, so in order to include them in [JSFiddle](http://jsfiddle.net) or [CodePen](http://codepen.io), you need to access these tools via HTTP as well.
 
@@ -29,7 +29,7 @@ Chart.js offers support for the following browsers:
 * Edge 14+
 * Safari 9+
 
-Browser support for the canvas element is available in all modern & major mobile browsers. [CanIUse](http://caniuse.com/#feat=canvas)
+Browser support for the canvas element is available in all modern & major mobile browsers. [CanIUse](https://caniuse.com/#feat=canvas)
 
 Thanks to [BrowserStack](https://browserstack.com) for allowing our team to test on thousands of browsers.
 
@@ -39,7 +39,7 @@ Version 2 has a completely different API than earlier versions.
 
 Most earlier version options have current equivalents or are the same.
 
-Please use the documentation that is available on [chartjs.org](http://www.chartjs.org/docs/) for the current version of Chart.js.
+Please use the documentation that is available on [chartjs.org](https://www.chartjs.org/docs/) for the current version of Chart.js.
 
 Please note - documentation for previous versions are available on the GitHub repo.
 

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -16,7 +16,7 @@ New contributions to the library are welcome, but we ask that you please follow 
 
 # Building and Testing
 
-Chart.js uses <a href="http://gulpjs.com/" target="_blank">gulp</a> to build the library into a single JavaScript file.
+Chart.js uses <a href="https://gulpjs.com/" target="_blank">gulp</a> to build the library into a single JavaScript file.
 
 Firstly, we need to ensure development dependencies are installed. With node and npm installed, after cloning the Chart.js repo to a local directory, and navigating to that directory in the command line, we can run the following:
 
@@ -25,7 +25,7 @@ Firstly, we need to ensure development dependencies are installed. With node and
 > npm install -g gulp
 ```
 
-This will install the local development dependencies for Chart.js, along with a CLI for the JavaScript task runner <a href="http://gulpjs.com/" target="_blank">gulp</a>.
+This will install the local development dependencies for Chart.js, along with a CLI for the JavaScript task runner <a href="https://gulpjs.com/" target="_blank">gulp</a>.
 
 The following commands are now available from the repository root:
 
@@ -45,7 +45,7 @@ More information can be found in [gulpfile.js](https://github.com/chartjs/Chart.
 
 # Bugs and Issues
 
-Please report these on the GitHub page - at <a href="https://github.com/chartjs/Chart.js" target="_blank">github.com/chartjs/Chart.js</a>. Please do not use issues for support requests. For help using Chart.js, please take a look at the [`chartjs`](http://stackoverflow.com/questions/tagged/chartjs) tag on Stack Overflow.
+Please report these on the GitHub page - at <a href="https://github.com/chartjs/Chart.js" target="_blank">github.com/chartjs/Chart.js</a>. Please do not use issues for support requests. For help using Chart.js, please take a look at the [`chartjs`](https://stackoverflow.com/questions/tagged/chartjs) tag on Stack Overflow.
 
 Well structured, detailed bug reports are hugely valuable for the project.
 
@@ -53,6 +53,6 @@ Guidelines for reporting bugs:
 
  - Check the issue search to see if it has already been reported
  - Isolate the problem to a simple test case
- - Please include a demonstration of the bug on a website such as [JS Bin](http://jsbin.com/), [JS Fiddle](http://jsfiddle.net/), or [Codepen](http://codepen.io/pen/). ([Template](http://codepen.io/pen?template=JXVYzq))
+ - Please include a demonstration of the bug on a website such as [JS Bin](https://jsbin.com/), [JS Fiddle](https://jsfiddle.net/), or [Codepen](https://codepen.io/pen/). ([Template](https://codepen.io/pen?template=JXVYzq))
 
 Please provide any additional details associated with the bug, if it's browser or screen density specific, or only happens with a certain configuration or data.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ https://cdnjs.com/libraries/Chart.js
 ### jsDelivr
 [![jsdelivr](https://img.shields.io/npm/v/chart.js.svg?label=jsdelivr&style=flat-square&maxAge=600)](https://cdn.jsdelivr.net/npm/chart.js@latest/dist/) [![jsdelivr hits](https://data.jsdelivr.com/v1/package/npm/chart.js/badge)](https://www.jsdelivr.com/package/npm/chart.js)
 
-Chart.js built files are also available through [jsDelivr](http://www.jsdelivr.com/):
+Chart.js built files are also available through [jsDelivr](https://www.jsdelivr.com/):
 
 https://www.jsdelivr.com/package/npm/chart.js?path=dist
 
@@ -47,7 +47,7 @@ Files:
 * `dist/Chart.js`
 * `dist/Chart.min.js`
 
-The stand-alone build includes Chart.js as well as the color parsing library. If this version is used, you are required to include [Moment.js](http://momentjs.com/) before Chart.js for the functionality of the time axis.
+The stand-alone build includes Chart.js as well as the color parsing library. If this version is used, you are required to include [Moment.js](https://momentjs.com/) before Chart.js for the functionality of the time axis.
 
 ## Bundled Build
 Files:

--- a/docs/notes/license.md
+++ b/docs/notes/license.md
@@ -1,3 +1,3 @@
 # License
 
-Chart.js is <a href="https://github.com/chartjs/Chart.js" target="_blank">open source</a> and available under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>.
+Chart.js is <a href="https://github.com/chartjs/Chart.js" target="_blank">open source</a> and available under the <a href="https://opensource.org/licenses/MIT" target="_blank">MIT license</a>.


### PR DESCRIPTION
Per @simonbrunel 's request here: https://github.com/chartjs/Chart.js/pull/5883#pullrequestreview-181862942