### PR TITLE
Fix "RangeError: Maximum call stack size exceeded" exception when labels are big (>125000) - #5935 

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -554,7 +554,7 @@ module.exports = function() {
 							datasets[i][j] = timestamp;
 						}
 					} else {
-						for (j = 0; j < labels.length; ++j) {
+						for (j = 0, jlen = labels.length; j < jlen; ++j) {
 							timestamps.push(labels[j]);
 						}
 						datasets[i] = labels.slice(0);

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -531,7 +531,7 @@ module.exports = function() {
 			var timestamps = [];
 			var datasets = [];
 			var labels = [];
-			var i, j, ilen, jlen, data, timestamp;
+			var i, j, k, ilen, jlen, data, timestamp;
 			var dataLabels = chart.data.labels || [];
 
 			// Convert labels to timestamps
@@ -554,7 +554,9 @@ module.exports = function() {
 							datasets[i][j] = timestamp;
 						}
 					} else {
-						timestamps.push.apply(timestamps, labels);
+						for (k = 0; k < labels.length; ++k) {
+							timestamps.push(labels[k]);
+						}
 						datasets[i] = labels.slice(0);
 					}
 				} else {

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -531,7 +531,7 @@ module.exports = function() {
 			var timestamps = [];
 			var datasets = [];
 			var labels = [];
-			var i, j, k, ilen, jlen, data, timestamp;
+			var i, j, ilen, jlen, data, timestamp;
 			var dataLabels = chart.data.labels || [];
 
 			// Convert labels to timestamps
@@ -554,8 +554,8 @@ module.exports = function() {
 							datasets[i][j] = timestamp;
 						}
 					} else {
-						for (k = 0; k < labels.length; ++k) {
-							timestamps.push(labels[k]);
+						for (j = 0; j < labels.length; ++j) {
+							timestamps.push(labels[j]);
 						}
 						datasets[i] = labels.slice(0);
 					}


### PR DESCRIPTION
Below is copied from MDN [Function.prototype.apply](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply#Using_apply_and_built-in_functions):

But beware: in using apply this way, you run the risk of exceeding the JavaScript engine's argument length limit. 

Fixes #5935