### PR TITLE
Improve tick generation for linear scales

### DIFF
--- a/src/scales/scale.linear.js
+++ b/src/scales/scale.linear.js
@@ -132,26 +132,16 @@ module.exports = function(Chart) {
 			// Common base implementation to handle ticks.min, ticks.max, ticks.beginAtZero
 			this.handleTickRangeOptions();
 		},
-		getTickLimit: function() {
+		// Returns the maximum number of ticks based on the scale dimension
+		_computeTickLimit: function() {
 			var me = this;
-			var tickOpts = me.options.ticks;
-			var stepSize = tickOpts.stepSize;
-			var maxTicksLimit = tickOpts.maxTicksLimit;
-			var maxTicks, tickFont;
+			var tickFont;
 
-			if (stepSize > 0) {
-				maxTicks = Math.ceil(me.max / stepSize) - Math.floor(me.min / stepSize) + 1;
-			} else if (me.isHorizontal()) {
-				maxTicks = Math.ceil(me.width / 40);
-			} else {
-				tickFont = helpers.options._parseFont(tickOpts);
-				maxTicks = Math.ceil(me.height / tickFont.lineHeight);
+			if (me.isHorizontal()) {
+				return Math.ceil(me.width / 40);
 			}
-			if (maxTicksLimit || !(stepSize > 0)) {
-				maxTicks = Math.min(maxTicksLimit || 11, maxTicks);
-			}
-
-			return maxTicks;
+			tickFont = helpers.options._parseFont(me.options.ticks);
+			return Math.ceil(me.height / tickFont.lineHeight);
 		},
 		// Called after the ticks are built. We need
 		handleDirectionalChanges: function() {

--- a/src/scales/scale.linear.js
+++ b/src/scales/scale.linear.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var defaults = require('../core/core.defaults');
 var helpers = require('../helpers/index');
 var scaleService = require('../core/core.scaleService');
 var Ticks = require('../core/core.ticks');
@@ -134,16 +133,22 @@ module.exports = function(Chart) {
 			this.handleTickRangeOptions();
 		},
 		getTickLimit: function() {
-			var maxTicks;
 			var me = this;
 			var tickOpts = me.options.ticks;
+			var stepSize = tickOpts.stepSize;
+			var maxTicksLimit = tickOpts.maxTicksLimit;
+			var maxTicks, tickFont;
 
-			if (me.isHorizontal()) {
-				maxTicks = Math.min(tickOpts.maxTicksLimit ? tickOpts.maxTicksLimit : 11, Math.ceil(me.width / 40));
+			if (stepSize > 0) {
+				maxTicks = Math.ceil(me.max / stepSize) - Math.floor(me.min / stepSize) + 1;
+			} else if (me.isHorizontal()) {
+				maxTicks = Math.ceil(me.width / 40);
 			} else {
-				// The factor of 2 used to scale the font size has been experimentally determined.
-				var tickFontSize = helpers.valueOrDefault(tickOpts.fontSize, defaults.global.defaultFontSize);
-				maxTicks = Math.min(tickOpts.maxTicksLimit ? tickOpts.maxTicksLimit : 11, Math.ceil(me.height / (1.5 * tickFontSize)));
+				tickFont = helpers.options._parseFont(tickOpts);
+				maxTicks = Math.ceil(me.height / tickFont.lineHeight);
+			}
+			if (maxTicksLimit || !(stepSize > 0)) {
+				maxTicks = Math.min(maxTicksLimit || 11, maxTicks);
 			}
 
 			return maxTicks;

--- a/src/scales/scale.linear.js
+++ b/src/scales/scale.linear.js
@@ -139,11 +139,11 @@ module.exports = function(Chart) {
 			var tickOpts = me.options.ticks;
 
 			if (me.isHorizontal()) {
-				maxTicks = Math.min(tickOpts.maxTicksLimit ? tickOpts.maxTicksLimit : 11, Math.ceil(me.width / 50));
+				maxTicks = Math.min(tickOpts.maxTicksLimit ? tickOpts.maxTicksLimit : 11, Math.ceil(me.width / 40));
 			} else {
 				// The factor of 2 used to scale the font size has been experimentally determined.
 				var tickFontSize = helpers.valueOrDefault(tickOpts.fontSize, defaults.global.defaultFontSize);
-				maxTicks = Math.min(tickOpts.maxTicksLimit ? tickOpts.maxTicksLimit : 11, Math.ceil(me.height / (2 * tickFontSize)));
+				maxTicks = Math.min(tickOpts.maxTicksLimit ? tickOpts.maxTicksLimit : 11, Math.ceil(me.height / (1.5 * tickFontSize)));
 			}
 
 			return maxTicks;

--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -15,10 +15,6 @@ function generateTicks(generationOptions, dataRange) {
 	var ticks = [];
 	var valueOrDefault = helpers.valueOrDefault;
 
-	// Figure out what the max number of ticks we can support it is based on the size of
-	// the axis area. For now, we say that the minimum tick spacing in pixels must be 50
-	// We also limit the maximum number of ticks to 11 which gives a nice 10 squares on
-	// the graph
 	var tickVal = valueOrDefault(generationOptions.min, Math.pow(10, Math.floor(helpers.log10(dataRange.min))));
 
 	var endExp = Math.floor(helpers.log10(dataRange.max));

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -358,10 +358,23 @@ module.exports = function(Chart) {
 			me.handleTickRangeOptions();
 		},
 		getTickLimit: function() {
-			var opts = this.options;
+			var me = this;
+			var opts = me.options;
 			var tickOpts = opts.ticks;
-			var tickBackdropHeight = getTickBackdropHeight(opts);
-			return Math.min(tickOpts.maxTicksLimit ? tickOpts.maxTicksLimit : 11, Math.ceil(this.drawingArea / tickBackdropHeight));
+			var stepSize = tickOpts.stepSize;
+			var maxTicksLimit = tickOpts.maxTicksLimit;
+			var maxTicks;
+
+			if (stepSize > 0) {
+				maxTicks = Math.ceil(me.max / stepSize) - Math.floor(me.min / stepSize) + 1;
+			} else {
+				maxTicks = Math.ceil(me.drawingArea / getTickBackdropHeight(opts));
+			}
+			if (maxTicksLimit || !(stepSize > 0)) {
+				maxTicks = Math.min(maxTicksLimit || 11, maxTicks);
+			}
+
+			return maxTicks;
 		},
 		convertTicksToLabels: function() {
 			var me = this;

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -357,24 +357,9 @@ module.exports = function(Chart) {
 			// Common base implementation to handle ticks.min, ticks.max, ticks.beginAtZero
 			me.handleTickRangeOptions();
 		},
-		getTickLimit: function() {
-			var me = this;
-			var opts = me.options;
-			var tickOpts = opts.ticks;
-			var stepSize = tickOpts.stepSize;
-			var maxTicksLimit = tickOpts.maxTicksLimit;
-			var maxTicks;
-
-			if (stepSize > 0) {
-				maxTicks = Math.ceil(me.max / stepSize) - Math.floor(me.min / stepSize) + 1;
-			} else {
-				maxTicks = Math.ceil(me.drawingArea / getTickBackdropHeight(opts));
-			}
-			if (maxTicksLimit || !(stepSize > 0)) {
-				maxTicks = Math.min(maxTicksLimit || 11, maxTicks);
-			}
-
-			return maxTicks;
+		// Returns the maximum number of ticks based on the scale dimension
+		_computeTickLimit: function() {
+			return Math.ceil(this.drawingArea / getTickBackdropHeight(this.options));
 		},
 		convertTicksToLabels: function() {
 			var me = this;

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -570,7 +570,7 @@ describe('Linear Scale', function() {
 		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
 		expect(chart.scales.yScale0.min).toBe(1);
 		expect(chart.scales.yScale0.max).toBe(11);
-		expect(chart.scales.yScale0.ticks).toEqual(['11', '9', '7', '5', '3', '1']);
+		expect(chart.scales.yScale0.ticks).toEqual(['11', '10', '8', '6', '4', '2', '1']);
 	});
 
 	it('Should create decimal steps if stepSize is a decimal number', function() {
@@ -788,6 +788,12 @@ describe('Linear Scale', function() {
 		chart.update();
 
 		expect(chart.scales.yScale.ticks).toEqual(['2.5', '2.0', '1.5', '1.0', '0.5']);
+
+		chart.options.scales.yAxes[0].ticks.min = 0.3;
+		chart.options.scales.yAxes[0].ticks.max = 2.8;
+		chart.update();
+
+		expect(chart.scales.yScale.ticks).toEqual(['2.8', '2.5', '2.0', '1.5', '1.0', '0.5', '0.3']);
 	});
 
 	it('Should build labels using the user supplied callback', function() {

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -749,6 +749,47 @@ describe('Linear Scale', function() {
 		expect(chart.scales.yScale0.ticks).toEqual(['0.06', '0.05', '0.04', '0.03', '0.02', '0.01', '0']);
 	});
 
+	it('Should correctly limit the maximum number of ticks', function() {
+		var chart = window.acquireChart({
+			type: 'bar',
+			data: {
+				labels: ['a', 'b'],
+				datasets: [{
+					data: [0.5, 2.5]
+				}]
+			},
+			options: {
+				scales: {
+					yAxes: [{
+						id: 'yScale'
+					}]
+				}
+			}
+		});
+
+		expect(chart.scales.yScale.ticks).toEqual(['2.5', '2.0', '1.5', '1.0', '0.5']);
+
+		chart.options.scales.yAxes[0].ticks.maxTicksLimit = 11;
+		chart.update();
+
+		expect(chart.scales.yScale.ticks).toEqual(['2.5', '2.0', '1.5', '1.0', '0.5']);
+
+		chart.options.scales.yAxes[0].ticks.maxTicksLimit = 21;
+		chart.update();
+
+		expect(chart.scales.yScale.ticks).toEqual([
+			'2.5', '2.4', '2.3', '2.2', '2.1', '2.0', '1.9', '1.8', '1.7', '1.6',
+			'1.5', '1.4', '1.3', '1.2', '1.1', '1.0', '0.9', '0.8', '0.7', '0.6',
+			'0.5'
+		]);
+
+		chart.options.scales.yAxes[0].ticks.maxTicksLimit = 11;
+		chart.options.scales.yAxes[0].ticks.stepSize = 0.01;
+		chart.update();
+
+		expect(chart.scales.yScale.ticks).toEqual(['2.5', '2.0', '1.5', '1.0', '0.5']);
+	});
+
 	it('Should build labels using the user supplied callback', function() {
 		var chart = window.acquireChart({
 			type: 'bar',

--- a/test/specs/scale.radialLinear.tests.js
+++ b/test/specs/scale.radialLinear.tests.js
@@ -282,6 +282,37 @@ describe('Test the radial linear scale', function() {
 		expect(chart.scale.end).toBe(0);
 	});
 
+	it('Should correctly limit the maximum number of ticks', function() {
+		var chart = window.acquireChart({
+			type: 'radar',
+			data: {
+				labels: ['label1', 'label2', 'label3'],
+				datasets: [{
+					data: [0.5, 1.5, 2.5]
+				}]
+			},
+			options: {
+				scale: {
+					pointLabels: {
+						display: false
+					}
+				}
+			}
+		});
+
+		expect(chart.scale.ticks).toEqual(['0.5', '1.0', '1.5', '2.0', '2.5']);
+
+		chart.options.scale.ticks.maxTicksLimit = 11;
+		chart.update();
+
+		expect(chart.scale.ticks).toEqual(['0.5', '1.0', '1.5', '2.0', '2.5']);
+
+		chart.options.scale.ticks.stepSize = 0.01;
+		chart.update();
+
+		expect(chart.scale.ticks).toEqual(['0.5', '1.0', '1.5', '2.0', '2.5']);
+	});
+
 	it('Should build labels using the user supplied callback', function() {
 		var chart = window.acquireChart({
 			type: 'radar',

--- a/test/specs/scale.radialLinear.tests.js
+++ b/test/specs/scale.radialLinear.tests.js
@@ -311,6 +311,12 @@ describe('Test the radial linear scale', function() {
 		chart.update();
 
 		expect(chart.scale.ticks).toEqual(['0.5', '1.0', '1.5', '2.0', '2.5']);
+
+		chart.options.scale.ticks.min = 0.3;
+		chart.options.scale.ticks.max = 2.8;
+		chart.update();
+
+		expect(chart.scale.ticks).toEqual(['0.3', '0.5', '1.0', '1.5', '2.0', '2.5', '2.8']);
 	});
 
 	it('Should build labels using the user supplied callback', function() {


### PR DESCRIPTION
There are a few problems in tick generation for linear scales:
1. When `maxTicksLimit` is not set, the number of ticks can exceed `11` which is the default value of `maxTicksLimit` (see **a** and **b** in the example below).
2. #5922 fixed an issue in `_autoSkip` so that the number of ticks stay within `maxTicksLimit`, however tick values are not aligned to a nice number and the tick at the min value is missing (see **c** and **d**).
3. When both `stepSize` and `maxTicksLimit` are set, `maxTicksLimit` doesn’t limit the number of ticks as reported in #2539. In this case, `stepSize` should work as the minimum unit of `stepSize` for ticks, and it should be multiplied by a nice number (see **d**).
4. Auto-generated ticks differ depending on `maxTicksLimit` despite it doesn’t actually limit the number of ticks (see **e** and **f**).
5. Ticks in a radar chart overlaps each other as mentioned in #5914. #5922 didn’t fix this as the maximum number of ticks based on the scale size is not used in `_autoSkip` but in `generateTicks` (see **g**).

**Version 2.7.3: https://jsfiddle.net/nagix/eygnmo5b/**

<img width="902" alt="screen shot 2018-12-27 at 1 28 11 am" src="https://user-images.githubusercontent.com/723188/50452716-c658a580-0976-11e9-861a-d590ecfda68b.png">


**Master: https://jsfiddle.net/nagix/jds1c98z/**

<img width="903" alt="screen shot 2018-12-27 at 1 28 24 am" src="https://user-images.githubusercontent.com/723188/50452722-cbb5f000-0976-11e9-90df-73abe8ddfc25.png">

This PR improves tick generation for linear scales by adding the following logic:
1. In the `getTickLimit` method, `maxTicks` is calculated based not only on `maxTicksLimit`, the default limit (`11`), the default spacing (40 pixels) or the tick font size but also on `stepSize`.
2. In the `generateTicks` function,
    1. Find a nice number of the dataRange divided by `maxNumSpaces` for `spacing`. `stepSize` is used as a minimum unit if it is specified.
    2. Find the number of spaces (`numSpaces`) such that both `dataRange.min` and  `dataRange.max` are contained in the range.
    3. If `numSpaces` exceeds `maxNumSpaces`,  `spacing` is set to a nice number of `numSpaces * spacing / maxNumSpaces`, which guarantees that `dataRange.min ` and  `dataRange.max ` are contained in the range. `stepSize` is used as a minimum unit if it is specified.
    4. `niceMin` and `niceMax` are adjusted separately based on `min`, `max` and `stepSize`.

**Master + This PR: https://jsfiddle.net/nagix/7jxefc94/**

<img width="904" alt="screen shot 2018-12-27 at 1 28 39 am" src="https://user-images.githubusercontent.com/723188/50452725-d2446780-0976-11e9-91c3-49ae6e8e44c0.png">


Fixes #2539