### PR TITLE
Fix tick label rotation and layout issues

### DIFF
--- a/test/specs/core.scale.tests.js
+++ b/test/specs/core.scale.tests.js
@@ -208,6 +208,43 @@ describe('Core.scale', function() {
 		});
 	});
 
+	it('should add the correct padding for long tick labels', function() {
+		var chart = window.acquireChart({
+			type: 'line',
+			data: {
+				labels: [
+					'This is a very long label',
+					'This is a very long label'
+				],
+				datasets: [{
+					data: [0, 1]
+				}]
+			},
+			options: {
+				scales: {
+					xAxes: [{
+						id: 'foo'
+					}],
+					yAxes: [{
+						display: false
+					}]
+				},
+				legend: {
+					display: false
+				}
+			}
+		}, {
+			canvas: {
+				height: 100,
+				width: 200
+			}
+		});
+
+		var scale = chart.scales.foo;
+		expect(scale.left).toBeGreaterThan(100);
+		expect(scale.right).toBeGreaterThan(190);
+	});
+
 	describe('given the axes display option is set to auto', function() {
 		describe('for the x axes', function() {
 			it('should draw the axes if at least one associated dataset is visible', function() {


### PR DESCRIPTION
There are a few problems `ticks.minor` and `ticks.major` configuration:

1. Can't update `scale.ticks.*` options at runtime because the scale class copies the minor and major ticks options from `ticks.*` on the initial chart creation, and it doesn’t update them on the following update calls as the values already exist (#4896).
2. `ticks.major.enabled` is set to `false` by default, but `ticks.major` options are effective. The behavior should be consistent with the `ticks.major.enabled` setting.
3. Only `ticks.minor` options are used for `calculateTickRotation`,  `fit`,  `draw` and `_autoSkip` calculations, so major tick labels can overlap or be cropped.
4. Tick labels on X axis overlap each other. This happens because  `calculateTickRotation` only considers the first tick interval before fitting, and doesn’t take into account margins for the tick labels on the left and right.

This PR fixes these problems as follows.

1. Deprecates `mergeTicksOptions` and adds `parseTickFontOptions` to parse minor and major tick font options. Omitted options are inherited from `ticks` at runtime.
2. Uses minor tick options when `ticks.major.enabled` is `false`.
3. Deprecates `computeTextSize` and adds `computeLabelSizes` to measure tick labels and find the widest, highest, first and last labels at a time.
4. Improve `calculateTickRotation` so that it takes into account margins for the tick labels on the left and right.

**Edit:** This PR fixes the following problems as well.

5. The proposed `calculateTickRotation` calculates the maximum scale height using the scale label size, the tick mark size and the tick padding to remove the overlap with scale label  (#5906).
6. `calculateTickRotation` has a loop to determine the label rotation and it can be repeated 90 times at most. The proposed version eliminate the loop to improve performance.

**Edit2:** Problem 1 and 2 are addressed in #6102.

**Master: https://jsfiddle.net/nagix/amtLsdfb/**
<img width="519" alt="screen shot 2019-01-10 at 4 45 06 pm" src="https://user-images.githubusercontent.com/723188/50956687-421a2c80-14f7-11e9-82ad-f5596b228900.png">

**This PR: https://jsfiddle.net/nagix/mas98q17/**
<img width="518" alt="screen shot 2019-01-10 at 4 45 38 pm" src="https://user-images.githubusercontent.com/723188/50956681-3fb7d280-14f7-11e9-8c06-c82b32cb3840.png">

Fixes #5906
Fixes #2106
