### PR TITLE
Update contributors guide and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,42 +1,14 @@
 <!--
-Please consider the following before submitting an issue:
+  Need help or support? Don't open an issue!
+  Head to https://stackoverflow.com/questions/tagged/chart.js
 
-- Ask questions and get support on StackOverflow: https://stackoverflow.com/questions/tagged/chart.js
-- DO NOT create issues for questions or support requests.
-- Issues are reserved for BUG reports and FEATURE requests.
-- Most features should start as plugins outside of Chart.js (https://www.chartjs.org/docs/#advanced-usage-creating-plugins).
-- Bug reports MUST be submitted with an interactive example (https://codepen.io/pen?template=JXVYzq).
-- Chart.js 1.x is NOT supported anymore, new issues will be disregarded.
+  Ahoy!
+
+  You're seeing this because you felt none of the other options fit the type of
+  issue you'd like to create. Please use this opportunity to tell us about the
+  type of issue you were looking for, so we can try to accommodate similar
+  issues in the future.
+
+  If you're using this template to report an issue covered by an existing issue
+  type, we'll close it as invalid faster than you can spell 'Mississippi'.
 -->
-
-<!--- Provide a general summary of the issue in the Title above prefixed by [BUG] or [FEATURE] -->
-
-## Expected Behavior
-<!--- If you're describing a bug, tell us what should happen -->
-<!--- If you're suggesting a change/improvement, tell us how it should work -->
-
-## Current Behavior
-<!--- If describing a bug, tell us what happens instead of the expected behavior -->
-<!--- If suggesting a change/improvement, explain the difference from current behavior -->
-
-## Possible Solution
-<!--- Not obligatory, but suggest a fix/reason for the bug, -->
-<!--- or ideas how to implement the addition or change -->
-
-## Steps to Reproduce (for bugs)
-<!--- Provide a link to a live example, or an unambiguous set of steps to -->
-<!--- reproduce this bug. Include code to reproduce, if relevant -->
-1.
-2.
-3.
-4.
-
-## Context
-<!--- How has this issue affected you? What are you trying to accomplish? -->
-<!--- Providing context helps us come up with a solution that is most useful in the real world -->
-
-## Environment
-<!--- Include as many relevant details about the environment you experienced the bug in -->
-* Chart.js version:
-* Browser name and version:
-* Link to your project:

--- a/.github/ISSUE_TEMPLATE/BUG.md
+++ b/.github/ISSUE_TEMPLATE/BUG.md
@@ -1,0 +1,43 @@
+---
+name: Bug Report
+about: Something went awry
+labels: 'type: bug'
+---
+
+<!--
+  Need help or support? Please don't open an issue!
+  Head to https://stackoverflow.com/questions/tagged/chart.js
+
+  Bug reports MUST be submitted with an interactive example:
+  https://codepen.io/pen?template=JXVYzq
+
+  Chart.js 1.x is NOT supported anymore, new issues will be disregarded.
+-->
+
+## Expected Behavior
+<!-- Tell us what should happen -->
+
+## Current Behavior
+<!-- Tell us what happens instead of the expected behavior -->
+
+## Possible Solution
+<!-- Not obligatory, but suggest a fix/reason for the bug, -->
+<!-- or ideas how to implement the addition or change -->
+
+## Steps to Reproduce (for bugs)
+<!--
+  Provide a link to a live example. Bug reports MUST be submitted with an
+  interactive example (https://codepen.io/pen?template=JXVYzq).
+-->
+
+## Context
+<!--
+  How has this issue affected you? What are you trying to accomplish? Providing
+  context helps us come up with a solution that is most useful in the real world
+-->
+
+## Environment
+<!-- Include as many relevant details about the environment you experienced the bug in -->
+* Chart.js version:
+* Browser name and version:
+* Link to your project:

--- a/.github/ISSUE_TEMPLATE/DOCS.md
+++ b/.github/ISSUE_TEMPLATE/DOCS.md
@@ -1,0 +1,25 @@
+---
+name: Documentation
+about: Are the docs lacking or missing something?
+labels: 'type: documentation'
+---
+
+Documentation Is:
+
+<!-- Please place an x (no spaces!) in all [ ] that apply -->
+
+- [ ] Missing or needed
+- [ ] Confusing
+- [ ] Not Sure?
+
+### Please Explain in Detail...
+
+
+### Your Proposal for Changes
+
+
+### Example
+<!--
+  Provide a link to a live example demonstrating the issue or feature to be documented:
+  https://codepen.io/pen?template=JXVYzq
+-->

--- a/.github/ISSUE_TEMPLATE/FEATURE.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE.md
@@ -1,0 +1,25 @@
+---
+name: Feature Request
+about: Suggest an idea
+labels: 'type: enhancement'
+---
+
+<!--
+  Most features should start as plugins outside of Chart.js
+  (https://www.chartjs.org/docs/#advanced-usage-creating-plugins).
+  Please consider whether your changes are useful for all users, or if this is
+  specific to your usecase and a Chart.js plugin would be more appropriate.
+
+  Need help or tech support? Please don't open an issue!
+  Head to https://stackoverflow.com/questions/tagged/chart.js
+-->
+
+### Feature Proposal
+<!-- Tell us how it should work -->
+
+### Feature Use Case
+<!-- What are you trying to accomplish? -->
+<!-- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Possible Implementation
+<!-- Not obligatory, but suggest ideas for how to implement the addition or change -->

--- a/.github/ISSUE_TEMPLATE/SUPPORT.md
+++ b/.github/ISSUE_TEMPLATE/SUPPORT.md
@@ -1,0 +1,27 @@
+---
+name: Support, Help, and Advice
+about: Need help or support? Head to https://stackoverflow.com/questions/tagged/chart.js
+labels: 'type: support'
+---
+
+<!--
+Hey there! 
+
+If you need help or tech support then this is not the place to ask. Please post
+a question to https://stackoverflow.com/questions/tagged/chart.js or head over
+to our Slack workspace at https://chartjs-slack.herokuapp.com/.
+
+You maximize your chances of having your question answered if you follow
+StackOverflow's guidelines: https://stackoverflow.com/help/how-to-ask.
+If your question was not answered on StackOverflow, that does not mean you 
+should post it here. If you do, it will be immediately closed.
+
+Chart.js users vastly outnumber our small number of volunteer maintainers and 
+we try to help as many users as we can, but we may not get to every question. 
+Chart.js is a community project. You can contribute towards the goal of helping
+every user by asking good questions, answering questions on StackOverflow
+or Slack, creating an issue or pull request for the documentation, or otherwise
+contributing to the project:
+
+https://www.chartjs.org/docs/latest/developers/contributing.html
+-->

--- a/.github/ISSUE_TEMPLATE/SUPPORT.md
+++ b/.github/ISSUE_TEMPLATE/SUPPORT.md
@@ -5,23 +5,23 @@ labels: 'type: support'
 ---
 
 <!--
-Hey there! 
+  Hey there! 
 
-If you need help or tech support then this is not the place to ask. Please post
-a question to https://stackoverflow.com/questions/tagged/chart.js or head over
-to our Slack workspace at https://chartjs-slack.herokuapp.com/.
+  If you need help or tech support then this is not the place to ask. Please post
+  a question to https://stackoverflow.com/questions/tagged/chart.js or head over
+  to our Slack workspace at https://chartjs-slack.herokuapp.com/.
 
-You maximize your chances of having your question answered if you follow
-StackOverflow's guidelines: https://stackoverflow.com/help/how-to-ask.
-If your question was not answered on StackOverflow, that does not mean you 
-should post it here. If you do, it will be immediately closed.
+  You maximize your chances of having your question answered if you follow
+  StackOverflow's guidelines: https://stackoverflow.com/help/how-to-ask.
+  If your question was not answered on StackOverflow, that does not mean you 
+  should post it here. If you do, it will be immediately closed.
 
-Chart.js users vastly outnumber our small number of volunteer maintainers and 
-we try to help as many users as we can, but we may not get to every question. 
-Chart.js is a community project. You can contribute towards the goal of helping
-every user by asking good questions, answering questions on StackOverflow
-or Slack, creating an issue or pull request for the documentation, or otherwise
-contributing to the project:
+  Chart.js users vastly outnumber our small number of volunteer maintainers and 
+  we try to help as many users as we can, but we may not get to every question. 
+  Chart.js is a community project. You can contribute towards the goal of helping
+  every user by asking good questions, answering questions on StackOverflow
+  or Slack, creating an issue or pull request for the documentation, or otherwise
+  contributing to the project:
 
-https://www.chartjs.org/docs/latest/developers/contributing.html
+  https://www.chartjs.org/docs/latest/developers/contributing.html
 -->

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -2,13 +2,12 @@
 
 New contributions to the library are welcome, but we ask that you please follow these guidelines:
 
-- Use tabs for indentation, not spaces.
-- Only change the individual files in `/src`.
-- Check that your code will pass `eslint` code standards, `gulp lint` will run this for you.
-- Check that your code will pass tests, `gulp test` will run tests for you.
-- Keep pull requests concise, and document new functionality in the relevant `.md` file.
+- Before opening a PR for major additions or changes, please discuss the expected API and/or implementation by [filing an issue](https://github.com/chartjs/Chart.js/issues) or asking about it in the [Chart.js Slack](https://chartjs-slack.herokuapp.com/) #dev channel. This will save you development time by getting feedback upfront and make review faster by giving the maintainers more context and details.
 - Consider whether your changes are useful for all users, or if creating a Chart.js [plugin](plugins.md) would be more appropriate.
-- Avoid breaking changes unless there is an upcoming major release, which are infrequent. We encourage people to write plugins for most new advanced features, so care a lot about backwards compatibility.
+- Check that your code will pass tests and `eslint` code standards. `gulp test` will run both the linter and tests for you.
+- Add unit tests and document new functionality (in the `test/` and `docs/` directories respectively).
+- Avoid breaking changes unless there is an upcoming major release, which are infrequent. We encourage people to write plugins for most new advanced features, and care a lot about backwards compatibility.
+- We strongly prefer new methods to be added as private whenever possible. A method can be made private either by making a top-level `function` outside of a class or by prefixing it with `_` and adding `@private` JSDoc if inside a class. Public APIs take considerable time to review and become locked once implemented as we have limited ability to change them without breaking backwards compatibility. Private APIs allow the flexibility to address unforeseen cases.
 
 # Joining the project
 


### PR DESCRIPTION
This adds the following:
- Suggest to ask maintainers about changes ahead of time
- Suggest that new methods be made private
- Suggest to add unit tests

Since a lot was added, I also wanted to try to keep it concise enough that everyone will read it, and so removed some information that was unnecessary or covered in another way:
- Remove the note to "Only change the individual files in `/src`". I'm not quite sure what this means. I believe it means don't check in the built files. We used to have these checked in prior to v2.2. E.g. https://github.com/chartjs/Chart.js/tree/v2.1.6/dist. We also want people to change tests, docs, and samples when appropriate, so I think it's clearer to remove this
- Combined the notes about running the linter and tests into a single line since `gulp test` covers both of these cases. There's a table down below that explains `gulp lint`, `gulp unittest`, etc. if users want to run only a subset of the checks
- Remove note about tabs vs spaces. This is covered by the line saying to run the linter