### PR TITLE
Fix fitWithPointLabels calculation in radialLinear scale

### DIFF
--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -141,7 +141,7 @@ function fitWithPointLabels(scale) {
 		l: 0,
 		r: scale.width,
 		t: 0,
-		b: scale.height
+		b: scale.height - scale.paddingTop
 	};
 	var furthestAngles = {};
 	var i, textSize, pointPosition;


### PR DESCRIPTION
This PR fix the issues that point labels are cut off at the bottom in a radar chart.

**Master: https://jsfiddle.net/nagix/ao4h0bd2/**
<img width="437" alt="screen shot 2019-01-07 at 5 21 10 pm" src="https://user-images.githubusercontent.com/723188/50759849-2ae20180-12a1-11e9-8912-61673fb1e2e2.png">

**This PR: https://jsfiddle.net/nagix/9vprhz84/**
<img width="437" alt="screen shot 2019-01-07 at 5 21 24 pm" src="https://user-images.githubusercontent.com/723188/50759857-2ddcf200-12a1-11e9-8aa6-1095c56d7166.png">

