### PR TITLE
Refactoring using helpers.options.resolve

### DIFF
--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -5,6 +5,8 @@ var defaults = require('../core/core.defaults');
 var elements = require('../elements/index');
 var helpers = require('../helpers/index');
 
+var resolve = helpers.options.resolve;
+
 defaults._set('bar', {
 	hover: {
 		mode: 'label'
@@ -410,7 +412,6 @@ module.exports = DatasetController.extend({
 		var dataset = datasets[me.index];
 		var custom = rectangle.custom || {};
 		var options = chart.options.elements.rectangle;
-		var resolve = helpers.options.resolve;
 		var values = {};
 		var i, ilen, key;
 

--- a/src/controllers/controller.bubble.js
+++ b/src/controllers/controller.bubble.js
@@ -5,6 +5,10 @@ var defaults = require('../core/core.defaults');
 var elements = require('../elements/index');
 var helpers = require('../helpers/index');
 
+var getHoverColor = helpers.getHoverColor;
+var valueOrDefault = helpers.valueOrDefault;
+var resolve = helpers.options.resolve;
+
 defaults._set('bubble', {
 	hover: {
 		mode: 'single'
@@ -101,8 +105,6 @@ module.exports = DatasetController.extend({
 	setHoverStyle: function(point) {
 		var model = point._model;
 		var options = point._options;
-		var valueOrDefault = helpers.valueOrDefault;
-		var getHoverColor = helpers.getHoverColor;
 
 		point.$previousStyle = {
 			backgroundColor: model.backgroundColor,
@@ -127,7 +129,6 @@ module.exports = DatasetController.extend({
 		var dataset = datasets[me.index];
 		var custom = point.custom || {};
 		var options = chart.options.elements.point;
-		var resolve = helpers.options.resolve;
 		var data = dataset.data[index];
 		var values = {};
 		var i, ilen, key;

--- a/src/controllers/controller.bubble.js
+++ b/src/controllers/controller.bubble.js
@@ -5,7 +5,6 @@ var defaults = require('../core/core.defaults');
 var elements = require('../elements/index');
 var helpers = require('../helpers/index');
 
-var getHoverColor = helpers.getHoverColor;
 var valueOrDefault = helpers.valueOrDefault;
 var resolve = helpers.options.resolve;
 
@@ -105,6 +104,7 @@ module.exports = DatasetController.extend({
 	setHoverStyle: function(point) {
 		var model = point._model;
 		var options = point._options;
+		var getHoverColor = helpers.getHoverColor;
 
 		point.$previousStyle = {
 			backgroundColor: model.backgroundColor,

--- a/src/controllers/controller.bubble.js
+++ b/src/controllers/controller.bubble.js
@@ -5,6 +5,8 @@ var defaults = require('../core/core.defaults');
 var elements = require('../elements/index');
 var helpers = require('../helpers/index');
 
+var valueOrDefault = helpers.valueOrDefault;
+
 defaults._set('bubble', {
 	hover: {
 		mode: 'single'
@@ -109,9 +111,9 @@ module.exports = DatasetController.extend({
 			radius: model.radius
 		};
 
-		model.backgroundColor = helpers.valueOrDefault(options.hoverBackgroundColor, helpers.getHoverColor(options.backgroundColor));
-		model.borderColor = helpers.valueOrDefault(options.hoverBorderColor, helpers.getHoverColor(options.borderColor));
-		model.borderWidth = helpers.valueOrDefault(options.hoverBorderWidth, options.borderWidth);
+		model.backgroundColor = valueOrDefault(options.hoverBackgroundColor, helpers.getHoverColor(options.backgroundColor));
+		model.borderColor = valueOrDefault(options.hoverBorderColor, helpers.getHoverColor(options.borderColor));
+		model.borderWidth = valueOrDefault(options.hoverBorderWidth, options.borderWidth);
 		model.radius = options.radius + options.hoverRadius;
 	},
 

--- a/src/controllers/controller.bubble.js
+++ b/src/controllers/controller.bubble.js
@@ -5,8 +5,6 @@ var defaults = require('../core/core.defaults');
 var elements = require('../elements/index');
 var helpers = require('../helpers/index');
 
-var valueOrDefault = helpers.valueOrDefault;
-
 defaults._set('bubble', {
 	hover: {
 		mode: 'single'
@@ -103,6 +101,8 @@ module.exports = DatasetController.extend({
 	setHoverStyle: function(point) {
 		var model = point._model;
 		var options = point._options;
+		var valueOrDefault = helpers.valueOrDefault;
+		var getHoverColor = helpers.getHoverColor;
 
 		point.$previousStyle = {
 			backgroundColor: model.backgroundColor,
@@ -111,8 +111,8 @@ module.exports = DatasetController.extend({
 			radius: model.radius
 		};
 
-		model.backgroundColor = valueOrDefault(options.hoverBackgroundColor, helpers.getHoverColor(options.backgroundColor));
-		model.borderColor = valueOrDefault(options.hoverBorderColor, helpers.getHoverColor(options.borderColor));
+		model.backgroundColor = valueOrDefault(options.hoverBackgroundColor, getHoverColor(options.backgroundColor));
+		model.borderColor = valueOrDefault(options.hoverBorderColor, getHoverColor(options.borderColor));
 		model.borderWidth = valueOrDefault(options.hoverBorderWidth, options.borderWidth);
 		model.radius = options.radius + options.hoverRadius;
 	},

--- a/src/controllers/controller.doughnut.js
+++ b/src/controllers/controller.doughnut.js
@@ -5,6 +5,8 @@ var defaults = require('../core/core.defaults');
 var elements = require('../elements/index');
 var helpers = require('../helpers/index');
 
+var valueAtIndexOrDefault = helpers.valueAtIndexOrDefault;
+
 defaults._set('doughnut', {
 	animation: {
 		// Boolean - Whether we animate the rotation of the Doughnut
@@ -46,11 +48,10 @@ defaults._set('doughnut', {
 						var ds = data.datasets[0];
 						var arc = meta.data[i];
 						var custom = arc && arc.custom || {};
-						var valueAtIndexOrDefault = helpers.valueAtIndexOrDefault;
 						var arcOpts = chart.options.elements.arc;
 						var fill = custom.backgroundColor ? custom.backgroundColor : valueAtIndexOrDefault(ds.backgroundColor, i, arcOpts.backgroundColor);
 						var stroke = custom.borderColor ? custom.borderColor : valueAtIndexOrDefault(ds.borderColor, i, arcOpts.borderColor);
-						var bw = custom.borderWidth ? custom.borderWidth : valueAtIndexOrDefault(ds.borderWidth, i, arcOpts.borderWidth);
+						var bw = !isNaN(custom.borderWidth) ? custom.borderWidth : valueAtIndexOrDefault(ds.borderWidth, i, arcOpts.borderWidth);
 
 						return {
 							text: label,
@@ -227,7 +228,7 @@ module.exports = DatasetController.extend({
 				circumference: circumference,
 				outerRadius: outerRadius,
 				innerRadius: innerRadius,
-				label: helpers.valueAtIndexOrDefault(dataset.label, index, chart.data.labels[index])
+				label: valueAtIndexOrDefault(dataset.label, index, chart.data.labels[index])
 			}
 		});
 
@@ -322,12 +323,11 @@ module.exports = DatasetController.extend({
 		var dataset = me.getDataset();
 		var custom = arc.custom || {};
 		var options = me.chart.options.elements.arc;
-		var valueAtIndexOrDefault = helpers.valueAtIndexOrDefault;
 
 		return {
 			backgroundColor: custom.backgroundColor ? custom.backgroundColor : valueAtIndexOrDefault(dataset.backgroundColor, index, options.backgroundColor),
 			borderColor: custom.borderColor ? custom.borderColor : valueAtIndexOrDefault(dataset.borderColor, index, options.borderColor),
-			borderWidth: custom.borderWidth ? custom.borderWidth : valueAtIndexOrDefault(dataset.borderWidth, index, options.borderWidth),
+			borderWidth: !isNaN(custom.borderWidth) ? custom.borderWidth : valueAtIndexOrDefault(dataset.borderWidth, index, options.borderWidth),
 			borderAlign: custom.borderAlign ? custom.borderAlign : valueAtIndexOrDefault(dataset.borderAlign, index, options.borderAlign)
 		};
 	}

--- a/src/controllers/controller.doughnut.js
+++ b/src/controllers/controller.doughnut.js
@@ -5,7 +5,7 @@ var defaults = require('../core/core.defaults');
 var elements = require('../elements/index');
 var helpers = require('../helpers/index');
 
-var valueAtIndexOrDefault = helpers.valueAtIndexOrDefault;
+var resolve = helpers.options.resolve;
 
 defaults._set('doughnut', {
 	animation: {
@@ -49,9 +49,9 @@ defaults._set('doughnut', {
 						var arc = meta.data[i];
 						var custom = arc && arc.custom || {};
 						var arcOpts = chart.options.elements.arc;
-						var fill = custom.backgroundColor ? custom.backgroundColor : valueAtIndexOrDefault(ds.backgroundColor, i, arcOpts.backgroundColor);
-						var stroke = custom.borderColor ? custom.borderColor : valueAtIndexOrDefault(ds.borderColor, i, arcOpts.borderColor);
-						var bw = !isNaN(custom.borderWidth) ? custom.borderWidth : valueAtIndexOrDefault(ds.borderWidth, i, arcOpts.borderWidth);
+						var fill = resolve([custom.backgroundColor, ds.backgroundColor, arcOpts.backgroundColor], undefined, i);
+						var stroke = resolve([custom.borderColor, ds.borderColor, arcOpts.borderColor], undefined, i);
+						var bw = resolve([custom.borderWidth, ds.borderWidth, arcOpts.borderWidth], undefined, i);
 
 						return {
 							text: label,
@@ -228,7 +228,7 @@ module.exports = DatasetController.extend({
 				circumference: circumference,
 				outerRadius: outerRadius,
 				innerRadius: innerRadius,
-				label: valueAtIndexOrDefault(dataset.label, index, chart.data.labels[index])
+				label: helpers.valueAtIndexOrDefault(dataset.label, index, chart.data.labels[index])
 			}
 		});
 
@@ -325,10 +325,10 @@ module.exports = DatasetController.extend({
 		var options = me.chart.options.elements.arc;
 
 		return {
-			backgroundColor: custom.backgroundColor ? custom.backgroundColor : valueAtIndexOrDefault(dataset.backgroundColor, index, options.backgroundColor),
-			borderColor: custom.borderColor ? custom.borderColor : valueAtIndexOrDefault(dataset.borderColor, index, options.borderColor),
-			borderWidth: !isNaN(custom.borderWidth) ? custom.borderWidth : valueAtIndexOrDefault(dataset.borderWidth, index, options.borderWidth),
-			borderAlign: custom.borderAlign ? custom.borderAlign : valueAtIndexOrDefault(dataset.borderAlign, index, options.borderAlign)
+			backgroundColor: resolve([custom.backgroundColor, dataset.backgroundColor, options.backgroundColor], undefined, index),
+			borderColor: resolve([custom.borderColor, dataset.borderColor, options.borderColor], undefined, index),
+			borderWidth: resolve([custom.borderWidth, dataset.borderWidth, options.borderWidth], undefined, index),
+			borderAlign: resolve([custom.borderAlign, dataset.borderAlign, options.borderAlign], undefined, index)
 		};
 	}
 });

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -5,7 +5,6 @@ var defaults = require('../core/core.defaults');
 var elements = require('../elements/index');
 var helpers = require('../helpers/index');
 
-var getHoverColor = helpers.getHoverColor;
 var valueOrDefault = helpers.valueOrDefault;
 var resolve = helpers.options.resolve;
 var isPointInArea = helpers.canvas._isPointInArea;
@@ -324,6 +323,7 @@ module.exports = DatasetController.extend({
 		var index = element._index;
 		var custom = element.custom || {};
 		var model = element._model;
+		var getHoverColor = helpers.getHoverColor;
 
 		element.$previousStyle = {
 			backgroundColor: model.backgroundColor,

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -5,7 +5,10 @@ var defaults = require('../core/core.defaults');
 var elements = require('../elements/index');
 var helpers = require('../helpers/index');
 
-var _isPointInArea = helpers.canvas._isPointInArea;
+var valueOrDefault = helpers.valueOrDefault;
+var valueAtIndexOrDefault = helpers.valueAtIndexOrDefault;
+var fallback = helpers.options._fallback;
+var isPointInArea = helpers.canvas._isPointInArea;
 
 defaults._set('line', {
 	showLines: true,
@@ -28,7 +31,7 @@ defaults._set('line', {
 });
 
 function lineEnabled(dataset, options) {
-	return helpers.valueOrDefault(dataset.showLine, options.showLines);
+	return valueOrDefault(dataset.showLine, options.showLines);
 }
 
 module.exports = DatasetController.extend({
@@ -69,18 +72,18 @@ module.exports = DatasetController.extend({
 				// The default behavior of lines is to break at null values, according
 				// to https://github.com/chartjs/Chart.js/issues/2435#issuecomment-216718158
 				// This option gives lines the ability to span gaps
-				spanGaps: dataset.spanGaps ? dataset.spanGaps : options.spanGaps,
-				tension: custom.tension ? custom.tension : helpers.valueOrDefault(dataset.lineTension, lineElementOptions.tension),
-				backgroundColor: custom.backgroundColor ? custom.backgroundColor : (dataset.backgroundColor || lineElementOptions.backgroundColor),
-				borderWidth: custom.borderWidth ? custom.borderWidth : (dataset.borderWidth || lineElementOptions.borderWidth),
-				borderColor: custom.borderColor ? custom.borderColor : (dataset.borderColor || lineElementOptions.borderColor),
-				borderCapStyle: custom.borderCapStyle ? custom.borderCapStyle : (dataset.borderCapStyle || lineElementOptions.borderCapStyle),
-				borderDash: custom.borderDash ? custom.borderDash : (dataset.borderDash || lineElementOptions.borderDash),
-				borderDashOffset: custom.borderDashOffset ? custom.borderDashOffset : (dataset.borderDashOffset || lineElementOptions.borderDashOffset),
-				borderJoinStyle: custom.borderJoinStyle ? custom.borderJoinStyle : (dataset.borderJoinStyle || lineElementOptions.borderJoinStyle),
-				fill: custom.fill ? custom.fill : (dataset.fill !== undefined ? dataset.fill : lineElementOptions.fill),
-				steppedLine: custom.steppedLine ? custom.steppedLine : helpers.valueOrDefault(dataset.steppedLine, lineElementOptions.stepped),
-				cubicInterpolationMode: custom.cubicInterpolationMode ? custom.cubicInterpolationMode : helpers.valueOrDefault(dataset.cubicInterpolationMode, lineElementOptions.cubicInterpolationMode),
+				spanGaps: valueOrDefault(dataset.spanGaps, options.spanGaps),
+				tension: fallback(custom.tension, dataset.lineTension, lineElementOptions.tension),
+				backgroundColor: fallback(custom.backgroundColor, dataset.backgroundColor, lineElementOptions.backgroundColor),
+				borderWidth: fallback(custom.borderWidth, dataset.borderWidth, lineElementOptions.borderWidth),
+				borderColor: fallback(custom.borderColor, dataset.borderColor, lineElementOptions.borderColor),
+				borderCapStyle: fallback(custom.borderCapStyle, dataset.borderCapStyle, lineElementOptions.borderCapStyle),
+				borderDash: fallback(custom.borderDash, dataset.borderDash, lineElementOptions.borderDash),
+				borderDashOffset: fallback(custom.borderDashOffset, dataset.borderDashOffset, lineElementOptions.borderDashOffset),
+				borderJoinStyle: fallback(custom.borderJoinStyle, dataset.borderJoinStyle, lineElementOptions.borderJoinStyle),
+				fill: fallback(custom.fill, dataset.fill, lineElementOptions.fill),
+				steppedLine: fallback(custom.steppedLine, dataset.steppedLine, lineElementOptions.stepped),
+				cubicInterpolationMode: fallback(custom.cubicInterpolationMode, dataset.cubicInterpolationMode, lineElementOptions.cubicInterpolationMode),
 			};
 
 			line.pivot();
@@ -109,7 +112,7 @@ module.exports = DatasetController.extend({
 		if (custom.backgroundColor) {
 			backgroundColor = custom.backgroundColor;
 		} else if (dataset.pointBackgroundColor) {
-			backgroundColor = helpers.valueAtIndexOrDefault(dataset.pointBackgroundColor, index, backgroundColor);
+			backgroundColor = valueAtIndexOrDefault(dataset.pointBackgroundColor, index, backgroundColor);
 		} else if (dataset.backgroundColor) {
 			backgroundColor = dataset.backgroundColor;
 		}
@@ -125,7 +128,7 @@ module.exports = DatasetController.extend({
 		if (custom.borderColor) {
 			borderColor = custom.borderColor;
 		} else if (dataset.pointBorderColor) {
-			borderColor = helpers.valueAtIndexOrDefault(dataset.pointBorderColor, index, borderColor);
+			borderColor = valueAtIndexOrDefault(dataset.pointBorderColor, index, borderColor);
 		} else if (dataset.borderColor) {
 			borderColor = dataset.borderColor;
 		}
@@ -141,7 +144,7 @@ module.exports = DatasetController.extend({
 		if (!isNaN(custom.borderWidth)) {
 			borderWidth = custom.borderWidth;
 		} else if (!isNaN(dataset.pointBorderWidth) || helpers.isArray(dataset.pointBorderWidth)) {
-			borderWidth = helpers.valueAtIndexOrDefault(dataset.pointBorderWidth, index, borderWidth);
+			borderWidth = valueAtIndexOrDefault(dataset.pointBorderWidth, index, borderWidth);
 		} else if (!isNaN(dataset.borderWidth)) {
 			borderWidth = dataset.borderWidth;
 		}
@@ -157,7 +160,7 @@ module.exports = DatasetController.extend({
 		if (!isNaN(custom.rotation)) {
 			pointRotation = custom.rotation;
 		} else if (!isNaN(dataset.pointRotation) || helpers.isArray(dataset.pointRotation)) {
-			pointRotation = helpers.valueAtIndexOrDefault(dataset.pointRotation, index, pointRotation);
+			pointRotation = valueAtIndexOrDefault(dataset.pointRotation, index, pointRotation);
 		}
 		return pointRotation;
 	},
@@ -197,8 +200,8 @@ module.exports = DatasetController.extend({
 			y: y,
 			skip: custom.skip || isNaN(x) || isNaN(y),
 			// Appearance
-			radius: custom.radius || helpers.valueAtIndexOrDefault(dataset.pointRadius, index, pointOptions.radius),
-			pointStyle: custom.pointStyle || helpers.valueAtIndexOrDefault(dataset.pointStyle, index, pointOptions.pointStyle),
+			radius: !isNaN(custom.radius) ? custom.radius : valueAtIndexOrDefault(dataset.pointRadius, index, pointOptions.radius),
+			pointStyle: custom.pointStyle || valueAtIndexOrDefault(dataset.pointStyle, index, pointOptions.pointStyle),
 			rotation: me.getPointRotation(point, index),
 			backgroundColor: me.getPointBackgroundColor(point, index),
 			borderColor: me.getPointBorderColor(point, index),
@@ -206,7 +209,7 @@ module.exports = DatasetController.extend({
 			tension: meta.dataset._model ? meta.dataset._model.tension : 0,
 			steppedLine: meta.dataset._model ? meta.dataset._model.steppedLine : false,
 			// Tooltip
-			hitRadius: custom.hitRadius || helpers.valueAtIndexOrDefault(dataset.pointHitRadius, index, pointOptions.hitRadius)
+			hitRadius: !isNaN(custom.hitRadius) ? custom.hitRadius : valueAtIndexOrDefault(dataset.pointHitRadius, index, pointOptions.hitRadius)
 		};
 	},
 
@@ -285,12 +288,12 @@ module.exports = DatasetController.extend({
 		if (chart.options.elements.line.capBezierPoints) {
 			for (i = 0, ilen = points.length; i < ilen; ++i) {
 				model = points[i]._model;
-				if (_isPointInArea(model, area)) {
-					if (i > 0 && _isPointInArea(points[i - 1]._model, area)) {
+				if (isPointInArea(model, area)) {
+					if (i > 0 && isPointInArea(points[i - 1]._model, area)) {
 						model.controlPointPreviousX = capControlPoint(model.controlPointPreviousX, area.left, area.right);
 						model.controlPointPreviousY = capControlPoint(model.controlPointPreviousY, area.top, area.bottom);
 					}
-					if (i < points.length - 1 && _isPointInArea(points[i + 1]._model, area)) {
+					if (i < points.length - 1 && isPointInArea(points[i + 1]._model, area)) {
 						model.controlPointNextX = capControlPoint(model.controlPointNextX, area.left, area.right);
 						model.controlPointNextY = capControlPoint(model.controlPointNextY, area.top, area.bottom);
 					}
@@ -344,9 +347,9 @@ module.exports = DatasetController.extend({
 			radius: model.radius
 		};
 
-		model.backgroundColor = custom.hoverBackgroundColor || helpers.valueAtIndexOrDefault(dataset.pointHoverBackgroundColor, index, helpers.getHoverColor(model.backgroundColor));
-		model.borderColor = custom.hoverBorderColor || helpers.valueAtIndexOrDefault(dataset.pointHoverBorderColor, index, helpers.getHoverColor(model.borderColor));
-		model.borderWidth = custom.hoverBorderWidth || helpers.valueAtIndexOrDefault(dataset.pointHoverBorderWidth, index, model.borderWidth);
-		model.radius = custom.hoverRadius || helpers.valueAtIndexOrDefault(dataset.pointHoverRadius, index, this.chart.options.elements.point.hoverRadius);
+		model.backgroundColor = custom.hoverBackgroundColor || valueAtIndexOrDefault(dataset.pointHoverBackgroundColor, index, helpers.getHoverColor(model.backgroundColor));
+		model.borderColor = custom.hoverBorderColor || valueAtIndexOrDefault(dataset.pointHoverBorderColor, index, helpers.getHoverColor(model.borderColor));
+		model.borderWidth = !isNaN(custom.hoverBorderWidth) ? custom.hoverBorderWidth : valueAtIndexOrDefault(dataset.pointHoverBorderWidth, index, model.borderWidth);
+		model.radius = !isNaN(custom.hoverRadius) ? custom.hoverRadius : valueAtIndexOrDefault(dataset.pointHoverRadius, index, this.chart.options.elements.point.hoverRadius);
 	}
 });

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -5,8 +5,10 @@ var defaults = require('../core/core.defaults');
 var elements = require('../elements/index');
 var helpers = require('../helpers/index');
 
+var getHoverColor = helpers.getHoverColor;
 var valueOrDefault = helpers.valueOrDefault;
 var resolve = helpers.options.resolve;
+var isPointInArea = helpers.canvas._isPointInArea;
 
 defaults._set('line', {
 	showLines: true,
@@ -236,7 +238,6 @@ module.exports = DatasetController.extend({
 		var lineModel = meta.dataset._model;
 		var area = chart.chartArea;
 		var points = meta.data || [];
-		var isPointInArea = helpers.canvas._isPointInArea;
 		var i, ilen, point, model, controlPoints;
 
 		// Only consider points that are drawn in case the spanGaps option is used
@@ -323,7 +324,6 @@ module.exports = DatasetController.extend({
 		var index = element._index;
 		var custom = element.custom || {};
 		var model = element._model;
-		var getHoverColor = helpers.getHoverColor;
 
 		element.$previousStyle = {
 			backgroundColor: model.backgroundColor,

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -245,7 +245,7 @@ module.exports = DatasetController.extend({
 			datasetIndex: me.index
 		};
 
-		return helpers.options.resolve([
+		return resolve([
 			me.chart.options.elements.arc.angle,
 			(2 * Math.PI) / count
 		], context, index);

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -5,6 +5,8 @@ var defaults = require('../core/core.defaults');
 var elements = require('../elements/index');
 var helpers = require('../helpers/index');
 
+var valueAtIndexOrDefault = helpers.valueAtIndexOrDefault;
+
 defaults._set('polarArea', {
 	scale: {
 		type: 'radialLinear',
@@ -60,11 +62,10 @@ defaults._set('polarArea', {
 						var ds = data.datasets[0];
 						var arc = meta.data[i];
 						var custom = arc.custom || {};
-						var valueAtIndexOrDefault = helpers.valueAtIndexOrDefault;
 						var arcOpts = chart.options.elements.arc;
-						var fill = custom.backgroundColor ? custom.backgroundColor : valueAtIndexOrDefault(ds.backgroundColor, i, arcOpts.backgroundColor);
-						var stroke = custom.borderColor ? custom.borderColor : valueAtIndexOrDefault(ds.borderColor, i, arcOpts.borderColor);
-						var bw = custom.borderWidth ? custom.borderWidth : valueAtIndexOrDefault(ds.borderWidth, i, arcOpts.borderWidth);
+						var fill = custom.backgroundColor || valueAtIndexOrDefault(ds.backgroundColor, i, arcOpts.backgroundColor);
+						var stroke = custom.borderColor || valueAtIndexOrDefault(ds.borderColor, i, arcOpts.borderColor);
+						var bw = !isNaN(custom.borderWidth) ? custom.borderWidth : valueAtIndexOrDefault(ds.borderWidth, i, arcOpts.borderWidth);
 
 						return {
 							text: label,
@@ -192,20 +193,19 @@ module.exports = DatasetController.extend({
 				outerRadius: reset ? resetRadius : distance,
 				startAngle: reset && animationOpts.animateRotate ? datasetStartAngle : startAngle,
 				endAngle: reset && animationOpts.animateRotate ? datasetStartAngle : endAngle,
-				label: helpers.valueAtIndexOrDefault(labels, index, labels[index])
+				label: valueAtIndexOrDefault(labels, index, labels[index])
 			}
 		});
 
 		// Apply border and fill style
 		var elementOpts = this.chart.options.elements.arc;
 		var custom = arc.custom || {};
-		var valueOrDefault = helpers.valueAtIndexOrDefault;
 		var model = arc._model;
 
-		model.backgroundColor = custom.backgroundColor ? custom.backgroundColor : valueOrDefault(dataset.backgroundColor, index, elementOpts.backgroundColor);
-		model.borderColor = custom.borderColor ? custom.borderColor : valueOrDefault(dataset.borderColor, index, elementOpts.borderColor);
-		model.borderWidth = custom.borderWidth ? custom.borderWidth : valueOrDefault(dataset.borderWidth, index, elementOpts.borderWidth);
-		model.borderAlign = custom.borderAlign ? custom.borderAlign : valueOrDefault(dataset.borderAlign, index, elementOpts.borderAlign);
+		model.backgroundColor = custom.backgroundColor || valueAtIndexOrDefault(dataset.backgroundColor, index, elementOpts.backgroundColor);
+		model.borderColor = custom.borderColor || valueAtIndexOrDefault(dataset.borderColor, index, elementOpts.borderColor);
+		model.borderWidth = !isNaN(custom.borderWidth) ? custom.borderWidth : valueAtIndexOrDefault(dataset.borderWidth, index, elementOpts.borderWidth);
+		model.borderAlign = custom.borderAlign || valueAtIndexOrDefault(dataset.borderAlign, index, elementOpts.borderAlign);
 
 		arc.pivot();
 	},

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -5,7 +5,7 @@ var defaults = require('../core/core.defaults');
 var elements = require('../elements/index');
 var helpers = require('../helpers/index');
 
-var valueAtIndexOrDefault = helpers.valueAtIndexOrDefault;
+var resolve = helpers.options.resolve;
 
 defaults._set('polarArea', {
 	scale: {
@@ -63,9 +63,9 @@ defaults._set('polarArea', {
 						var arc = meta.data[i];
 						var custom = arc.custom || {};
 						var arcOpts = chart.options.elements.arc;
-						var fill = custom.backgroundColor || valueAtIndexOrDefault(ds.backgroundColor, i, arcOpts.backgroundColor);
-						var stroke = custom.borderColor || valueAtIndexOrDefault(ds.borderColor, i, arcOpts.borderColor);
-						var bw = !isNaN(custom.borderWidth) ? custom.borderWidth : valueAtIndexOrDefault(ds.borderWidth, i, arcOpts.borderWidth);
+						var fill = resolve([custom.backgroundColor, ds.backgroundColor, arcOpts.backgroundColor], undefined, i);
+						var stroke = resolve([custom.borderColor, ds.borderColor, arcOpts.borderColor], undefined, i);
+						var bw = resolve([custom.borderWidth, ds.borderWidth, arcOpts.borderWidth], undefined, i);
 
 						return {
 							text: label,
@@ -193,7 +193,7 @@ module.exports = DatasetController.extend({
 				outerRadius: reset ? resetRadius : distance,
 				startAngle: reset && animationOpts.animateRotate ? datasetStartAngle : startAngle,
 				endAngle: reset && animationOpts.animateRotate ? datasetStartAngle : endAngle,
-				label: valueAtIndexOrDefault(labels, index, labels[index])
+				label: helpers.valueAtIndexOrDefault(labels, index, labels[index])
 			}
 		});
 
@@ -202,10 +202,10 @@ module.exports = DatasetController.extend({
 		var custom = arc.custom || {};
 		var model = arc._model;
 
-		model.backgroundColor = custom.backgroundColor || valueAtIndexOrDefault(dataset.backgroundColor, index, elementOpts.backgroundColor);
-		model.borderColor = custom.borderColor || valueAtIndexOrDefault(dataset.borderColor, index, elementOpts.borderColor);
-		model.borderWidth = !isNaN(custom.borderWidth) ? custom.borderWidth : valueAtIndexOrDefault(dataset.borderWidth, index, elementOpts.borderWidth);
-		model.borderAlign = custom.borderAlign || valueAtIndexOrDefault(dataset.borderAlign, index, elementOpts.borderAlign);
+		model.backgroundColor = resolve([custom.backgroundColor, dataset.backgroundColor, elementOpts.backgroundColor], undefined, index);
+		model.borderColor = resolve([custom.borderColor, dataset.borderColor, elementOpts.borderColor], undefined, index);
+		model.borderWidth = resolve([custom.borderWidth, dataset.borderWidth, elementOpts.borderWidth], undefined, index);
+		model.borderAlign = resolve([custom.borderAlign, dataset.borderAlign, elementOpts.borderAlign], undefined, index);
 
 		arc.pivot();
 	},

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -5,7 +5,6 @@ var defaults = require('../core/core.defaults');
 var elements = require('../elements/index');
 var helpers = require('../helpers/index');
 
-var getHoverColor = helpers.getHoverColor;
 var resolve = helpers.options.resolve;
 
 defaults._set('radar', {
@@ -159,6 +158,7 @@ module.exports = DatasetController.extend({
 		var custom = point.custom || {};
 		var index = point._index;
 		var model = point._model;
+		var getHoverColor = helpers.getHoverColor;
 
 		point.$previousStyle = {
 			backgroundColor: model.backgroundColor,

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -5,6 +5,7 @@ var defaults = require('../core/core.defaults');
 var elements = require('../elements/index');
 var helpers = require('../helpers/index');
 
+var getHoverColor = helpers.getHoverColor;
 var resolve = helpers.options.resolve;
 
 defaults._set('radar', {
@@ -158,7 +159,6 @@ module.exports = DatasetController.extend({
 		var custom = point.custom || {};
 		var index = point._index;
 		var model = point._model;
-		var getHoverColor = helpers.getHoverColor;
 
 		point.$previousStyle = {
 			backgroundColor: model.backgroundColor,

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -5,6 +5,9 @@ var defaults = require('../core/core.defaults');
 var elements = require('../elements/index');
 var helpers = require('../helpers/index');
 
+var valueAtIndexOrDefault = helpers.valueAtIndexOrDefault;
+var fallback = helpers.options._fallback;
+
 defaults._set('radar', {
 	scale: {
 		type: 'radialLinear'
@@ -50,15 +53,15 @@ module.exports = DatasetController.extend({
 			// Model
 			_model: {
 				// Appearance
-				tension: custom.tension ? custom.tension : helpers.valueOrDefault(dataset.lineTension, lineElementOptions.tension),
-				backgroundColor: custom.backgroundColor ? custom.backgroundColor : (dataset.backgroundColor || lineElementOptions.backgroundColor),
-				borderWidth: custom.borderWidth ? custom.borderWidth : (dataset.borderWidth || lineElementOptions.borderWidth),
-				borderColor: custom.borderColor ? custom.borderColor : (dataset.borderColor || lineElementOptions.borderColor),
-				fill: custom.fill ? custom.fill : (dataset.fill !== undefined ? dataset.fill : lineElementOptions.fill),
-				borderCapStyle: custom.borderCapStyle ? custom.borderCapStyle : (dataset.borderCapStyle || lineElementOptions.borderCapStyle),
-				borderDash: custom.borderDash ? custom.borderDash : (dataset.borderDash || lineElementOptions.borderDash),
-				borderDashOffset: custom.borderDashOffset ? custom.borderDashOffset : (dataset.borderDashOffset || lineElementOptions.borderDashOffset),
-				borderJoinStyle: custom.borderJoinStyle ? custom.borderJoinStyle : (dataset.borderJoinStyle || lineElementOptions.borderJoinStyle),
+				tension: fallback(custom.tension, dataset.lineTension, lineElementOptions.tension),
+				backgroundColor: fallback(custom.backgroundColor, dataset.backgroundColor, lineElementOptions.backgroundColor),
+				borderWidth: fallback(custom.borderWidth, dataset.borderWidth, lineElementOptions.borderWidth),
+				borderColor: fallback(custom.borderColor, dataset.borderColor, lineElementOptions.borderColor),
+				fill: fallback(custom.fill, dataset.fill, lineElementOptions.fill),
+				borderCapStyle: fallback(custom.borderCapStyle, dataset.borderCapStyle, lineElementOptions.borderCapStyle),
+				borderDash: fallback(custom.borderDash, dataset.borderDash, lineElementOptions.borderDash),
+				borderDashOffset: fallback(custom.borderDashOffset, dataset.borderDashOffset, lineElementOptions.borderDashOffset),
+				borderJoinStyle: fallback(custom.borderJoinStyle, dataset.borderJoinStyle, lineElementOptions.borderJoinStyle),
 			}
 		});
 
@@ -106,20 +109,20 @@ module.exports = DatasetController.extend({
 				y: reset ? scale.yCenter : pointPosition.y,
 
 				// Appearance
-				tension: custom.tension ? custom.tension : helpers.valueOrDefault(dataset.lineTension, me.chart.options.elements.line.tension),
-				radius: custom.radius ? custom.radius : helpers.valueAtIndexOrDefault(dataset.pointRadius, index, pointElementOptions.radius),
-				backgroundColor: custom.backgroundColor ? custom.backgroundColor : helpers.valueAtIndexOrDefault(dataset.pointBackgroundColor, index, pointElementOptions.backgroundColor),
-				borderColor: custom.borderColor ? custom.borderColor : helpers.valueAtIndexOrDefault(dataset.pointBorderColor, index, pointElementOptions.borderColor),
-				borderWidth: custom.borderWidth ? custom.borderWidth : helpers.valueAtIndexOrDefault(dataset.pointBorderWidth, index, pointElementOptions.borderWidth),
-				pointStyle: custom.pointStyle ? custom.pointStyle : helpers.valueAtIndexOrDefault(dataset.pointStyle, index, pointElementOptions.pointStyle),
-				rotation: custom.rotation ? custom.rotation : helpers.valueAtIndexOrDefault(dataset.pointRotation, index, pointElementOptions.rotation),
+				tension: fallback(custom.tension, dataset.lineTension, me.chart.options.elements.line.tension),
+				radius: !isNaN(custom.radius) ? custom.radius : valueAtIndexOrDefault(dataset.pointRadius, index, pointElementOptions.radius),
+				backgroundColor: custom.backgroundColor || valueAtIndexOrDefault(dataset.pointBackgroundColor, index, pointElementOptions.backgroundColor),
+				borderColor: custom.borderColor || valueAtIndexOrDefault(dataset.pointBorderColor, index, pointElementOptions.borderColor),
+				borderWidth: !isNaN(custom.borderWidth) ? custom.borderWidth : valueAtIndexOrDefault(dataset.pointBorderWidth, index, pointElementOptions.borderWidth),
+				pointStyle: custom.pointStyle || valueAtIndexOrDefault(dataset.pointStyle, index, pointElementOptions.pointStyle),
+				rotation: !isNaN(custom.rotation) ? custom.rotation : valueAtIndexOrDefault(dataset.pointRotation, index, pointElementOptions.rotation),
 
 				// Tooltip
-				hitRadius: custom.hitRadius ? custom.hitRadius : helpers.valueAtIndexOrDefault(dataset.pointHitRadius, index, pointElementOptions.hitRadius)
+				hitRadius: !isNaN(custom.hitRadius) ? custom.hitRadius : valueAtIndexOrDefault(dataset.pointHitRadius, index, pointElementOptions.hitRadius)
 			}
 		});
 
-		point._model.skip = custom.skip ? custom.skip : (isNaN(point._model.x) || isNaN(point._model.y));
+		point._model.skip = custom.skip || isNaN(point._model.x) || isNaN(point._model.y);
 	},
 
 	updateBezierControlPoints: function() {
@@ -164,9 +167,9 @@ module.exports = DatasetController.extend({
 			radius: model.radius
 		};
 
-		model.radius = custom.hoverRadius ? custom.hoverRadius : helpers.valueAtIndexOrDefault(dataset.pointHoverRadius, index, this.chart.options.elements.point.hoverRadius);
-		model.backgroundColor = custom.hoverBackgroundColor ? custom.hoverBackgroundColor : helpers.valueAtIndexOrDefault(dataset.pointHoverBackgroundColor, index, helpers.getHoverColor(model.backgroundColor));
-		model.borderColor = custom.hoverBorderColor ? custom.hoverBorderColor : helpers.valueAtIndexOrDefault(dataset.pointHoverBorderColor, index, helpers.getHoverColor(model.borderColor));
-		model.borderWidth = custom.hoverBorderWidth ? custom.hoverBorderWidth : helpers.valueAtIndexOrDefault(dataset.pointHoverBorderWidth, index, model.borderWidth);
+		model.radius = !isNaN(custom.hoverRadius) ? custom.hoverRadius : valueAtIndexOrDefault(dataset.pointHoverRadius, index, this.chart.options.elements.point.hoverRadius);
+		model.backgroundColor = custom.hoverBackgroundColor || valueAtIndexOrDefault(dataset.pointHoverBackgroundColor, index, helpers.getHoverColor(model.backgroundColor));
+		model.borderColor = custom.hoverBorderColor || valueAtIndexOrDefault(dataset.pointHoverBorderColor, index, helpers.getHoverColor(model.borderColor));
+		model.borderWidth = !isNaN(custom.hoverBorderWidth) ? custom.hoverBorderWidth : valueAtIndexOrDefault(dataset.pointHoverBorderWidth, index, model.borderWidth);
 	}
 });

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -5,8 +5,7 @@ var defaults = require('../core/core.defaults');
 var elements = require('../elements/index');
 var helpers = require('../helpers/index');
 
-var valueAtIndexOrDefault = helpers.valueAtIndexOrDefault;
-var fallback = helpers.options._fallback;
+var resolve = helpers.options.resolve;
 
 defaults._set('radar', {
 	scale: {
@@ -53,15 +52,15 @@ module.exports = DatasetController.extend({
 			// Model
 			_model: {
 				// Appearance
-				tension: fallback(custom.tension, dataset.lineTension, lineElementOptions.tension),
-				backgroundColor: fallback(custom.backgroundColor, dataset.backgroundColor, lineElementOptions.backgroundColor),
-				borderWidth: fallback(custom.borderWidth, dataset.borderWidth, lineElementOptions.borderWidth),
-				borderColor: fallback(custom.borderColor, dataset.borderColor, lineElementOptions.borderColor),
-				fill: fallback(custom.fill, dataset.fill, lineElementOptions.fill),
-				borderCapStyle: fallback(custom.borderCapStyle, dataset.borderCapStyle, lineElementOptions.borderCapStyle),
-				borderDash: fallback(custom.borderDash, dataset.borderDash, lineElementOptions.borderDash),
-				borderDashOffset: fallback(custom.borderDashOffset, dataset.borderDashOffset, lineElementOptions.borderDashOffset),
-				borderJoinStyle: fallback(custom.borderJoinStyle, dataset.borderJoinStyle, lineElementOptions.borderJoinStyle),
+				tension: resolve([custom.tension, dataset.lineTension, lineElementOptions.tension]),
+				backgroundColor: resolve([custom.backgroundColor, dataset.backgroundColor, lineElementOptions.backgroundColor]),
+				borderWidth: resolve([custom.borderWidth, dataset.borderWidth, lineElementOptions.borderWidth]),
+				borderColor: resolve([custom.borderColor, dataset.borderColor, lineElementOptions.borderColor]),
+				fill: resolve([custom.fill, dataset.fill, lineElementOptions.fill]),
+				borderCapStyle: resolve([custom.borderCapStyle, dataset.borderCapStyle, lineElementOptions.borderCapStyle]),
+				borderDash: resolve([custom.borderDash, dataset.borderDash, lineElementOptions.borderDash]),
+				borderDashOffset: resolve([custom.borderDashOffset, dataset.borderDashOffset, lineElementOptions.borderDashOffset]),
+				borderJoinStyle: resolve([custom.borderJoinStyle, dataset.borderJoinStyle, lineElementOptions.borderJoinStyle]),
 			}
 		});
 
@@ -109,16 +108,16 @@ module.exports = DatasetController.extend({
 				y: reset ? scale.yCenter : pointPosition.y,
 
 				// Appearance
-				tension: fallback(custom.tension, dataset.lineTension, me.chart.options.elements.line.tension),
-				radius: !isNaN(custom.radius) ? custom.radius : valueAtIndexOrDefault(dataset.pointRadius, index, pointElementOptions.radius),
-				backgroundColor: custom.backgroundColor || valueAtIndexOrDefault(dataset.pointBackgroundColor, index, pointElementOptions.backgroundColor),
-				borderColor: custom.borderColor || valueAtIndexOrDefault(dataset.pointBorderColor, index, pointElementOptions.borderColor),
-				borderWidth: !isNaN(custom.borderWidth) ? custom.borderWidth : valueAtIndexOrDefault(dataset.pointBorderWidth, index, pointElementOptions.borderWidth),
-				pointStyle: custom.pointStyle || valueAtIndexOrDefault(dataset.pointStyle, index, pointElementOptions.pointStyle),
-				rotation: !isNaN(custom.rotation) ? custom.rotation : valueAtIndexOrDefault(dataset.pointRotation, index, pointElementOptions.rotation),
+				tension: resolve([custom.tension, dataset.lineTension, me.chart.options.elements.line.tension]),
+				radius: resolve([custom.radius, dataset.pointRadius, pointElementOptions.radius], undefined, index),
+				backgroundColor: resolve([custom.backgroundColor, dataset.pointBackgroundColor, pointElementOptions.backgroundColor], undefined, index),
+				borderColor: resolve([custom.borderColor, dataset.pointBorderColor, pointElementOptions.borderColor], undefined, index),
+				borderWidth: resolve([custom.borderWidth, dataset.pointBorderWidth, pointElementOptions.borderWidth], undefined, index),
+				pointStyle: resolve([custom.pointStyle, dataset.pointStyle, pointElementOptions.pointStyle], undefined, index),
+				rotation: resolve([custom.rotation, dataset.pointRotation, pointElementOptions.rotation], undefined, index),
 
 				// Tooltip
-				hitRadius: !isNaN(custom.hitRadius) ? custom.hitRadius : valueAtIndexOrDefault(dataset.pointHitRadius, index, pointElementOptions.hitRadius)
+				hitRadius: resolve([custom.hitRadius, dataset.pointHitRadius, pointElementOptions.hitRadius], undefined, index)
 			}
 		});
 
@@ -159,6 +158,7 @@ module.exports = DatasetController.extend({
 		var custom = point.custom || {};
 		var index = point._index;
 		var model = point._model;
+		var getHoverColor = helpers.getHoverColor;
 
 		point.$previousStyle = {
 			backgroundColor: model.backgroundColor,
@@ -167,9 +167,9 @@ module.exports = DatasetController.extend({
 			radius: model.radius
 		};
 
-		model.radius = !isNaN(custom.hoverRadius) ? custom.hoverRadius : valueAtIndexOrDefault(dataset.pointHoverRadius, index, this.chart.options.elements.point.hoverRadius);
-		model.backgroundColor = custom.hoverBackgroundColor || valueAtIndexOrDefault(dataset.pointHoverBackgroundColor, index, helpers.getHoverColor(model.backgroundColor));
-		model.borderColor = custom.hoverBorderColor || valueAtIndexOrDefault(dataset.pointHoverBorderColor, index, helpers.getHoverColor(model.borderColor));
-		model.borderWidth = !isNaN(custom.hoverBorderWidth) ? custom.hoverBorderWidth : valueAtIndexOrDefault(dataset.pointHoverBorderWidth, index, model.borderWidth);
+		model.radius = resolve([custom.hoverRadius, dataset.pointHoverRadius, this.chart.options.elements.point.hoverRadius], undefined, index);
+		model.backgroundColor = resolve([custom.hoverBackgroundColor, dataset.pointHoverBackgroundColor, getHoverColor(model.backgroundColor)], undefined, index);
+		model.borderColor = resolve([custom.hoverBorderColor, dataset.pointHoverBorderColor, getHoverColor(model.borderColor)], undefined, index);
+		model.borderWidth = resolve([custom.hoverBorderWidth, dataset.pointHoverBorderWidth, model.borderWidth], undefined, index);
 	}
 });

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -510,9 +510,7 @@ module.exports = function(Chart) {
 			}
 
 			var animationOptions = me.options.animation;
-			var duration = typeof config.duration !== 'undefined'
-				? config.duration
-				: animationOptions && animationOptions.duration;
+			var duration = helpers.valueOrDefault(config.duration, animationOptions && animationOptions.duration);
 			var lazy = config.lazy;
 
 			if (plugins.notify(me, 'beforeRender') === false) {

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -12,6 +12,8 @@ var plugins = require('./core.plugins');
 var scaleService = require('../core/core.scaleService');
 var Tooltip = require('./core.tooltip');
 
+var valueOrDefault = helpers.valueOrDefault;
+
 module.exports = function(Chart) {
 
 	// Create a dictionary of chart types, to allow for extension of existing types
@@ -265,7 +267,7 @@ module.exports = function(Chart) {
 			helpers.each(items, function(item) {
 				var scaleOptions = item.options;
 				var id = scaleOptions.id;
-				var scaleType = helpers.valueOrDefault(scaleOptions.type, item.dtype);
+				var scaleType = valueOrDefault(scaleOptions.type, item.dtype);
 
 				if (positionIsHorizontal(scaleOptions.position) !== positionIsHorizontal(item.dposition)) {
 					scaleOptions.position = item.dposition;
@@ -510,7 +512,7 @@ module.exports = function(Chart) {
 			}
 
 			var animationOptions = me.options.animation;
-			var duration = helpers.valueOrDefault(config.duration, animationOptions && animationOptions.duration);
+			var duration = valueOrDefault(config.duration, animationOptions && animationOptions.duration);
 			var lazy = config.lazy;
 
 			if (plugins.notify(me, 'beforeRender') === false) {

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -2,7 +2,6 @@
 
 var helpers = require('../helpers/index');
 
-var getHoverColor = helpers.getHoverColor;
 var resolve = helpers.options.resolve;
 
 var arrayEvents = ['push', 'pop', 'shift', 'splice', 'unshift'];
@@ -249,6 +248,7 @@ helpers.extend(DatasetController.prototype, {
 		var index = element._index;
 		var custom = element.custom || {};
 		var model = element._model;
+		var getHoverColor = helpers.getHoverColor;
 
 		element.$previousStyle = {
 			backgroundColor: model.backgroundColor,

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -2,6 +2,7 @@
 
 var helpers = require('../helpers/index');
 
+var getHoverColor = helpers.getHoverColor;
 var resolve = helpers.options.resolve;
 
 var arrayEvents = ['push', 'pop', 'shift', 'splice', 'unshift'];
@@ -247,7 +248,6 @@ helpers.extend(DatasetController.prototype, {
 		var dataset = this.chart.data.datasets[element._datasetIndex];
 		var index = element._index;
 		var custom = element.custom || {};
-		var getHoverColor = helpers.getHoverColor;
 		var model = element._model;
 
 		element.$previousStyle = {

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -2,6 +2,8 @@
 
 var helpers = require('../helpers/index');
 
+var valueAtIndexOrDefault = helpers.valueAtIndexOrDefault;
+
 var arrayEvents = ['push', 'pop', 'shift', 'splice', 'unshift'];
 
 /**
@@ -245,7 +247,6 @@ helpers.extend(DatasetController.prototype, {
 		var dataset = this.chart.data.datasets[element._datasetIndex];
 		var index = element._index;
 		var custom = element.custom || {};
-		var valueOrDefault = helpers.valueAtIndexOrDefault;
 		var getHoverColor = helpers.getHoverColor;
 		var model = element._model;
 
@@ -255,9 +256,9 @@ helpers.extend(DatasetController.prototype, {
 			borderWidth: model.borderWidth
 		};
 
-		model.backgroundColor = custom.hoverBackgroundColor ? custom.hoverBackgroundColor : valueOrDefault(dataset.hoverBackgroundColor, index, getHoverColor(model.backgroundColor));
-		model.borderColor = custom.hoverBorderColor ? custom.hoverBorderColor : valueOrDefault(dataset.hoverBorderColor, index, getHoverColor(model.borderColor));
-		model.borderWidth = custom.hoverBorderWidth ? custom.hoverBorderWidth : valueOrDefault(dataset.hoverBorderWidth, index, model.borderWidth);
+		model.backgroundColor = custom.hoverBackgroundColor || valueAtIndexOrDefault(dataset.hoverBackgroundColor, index, getHoverColor(model.backgroundColor));
+		model.borderColor = custom.hoverBorderColor || valueAtIndexOrDefault(dataset.hoverBorderColor, index, getHoverColor(model.borderColor));
+		model.borderWidth = !isNaN(custom.hoverBorderWidth) ? custom.hoverBorderWidth : valueAtIndexOrDefault(dataset.hoverBorderWidth, index, model.borderWidth);
 	},
 
 	/**

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -2,7 +2,7 @@
 
 var helpers = require('../helpers/index');
 
-var valueAtIndexOrDefault = helpers.valueAtIndexOrDefault;
+var resolve = helpers.options.resolve;
 
 var arrayEvents = ['push', 'pop', 'shift', 'splice', 'unshift'];
 
@@ -256,9 +256,9 @@ helpers.extend(DatasetController.prototype, {
 			borderWidth: model.borderWidth
 		};
 
-		model.backgroundColor = custom.hoverBackgroundColor || valueAtIndexOrDefault(dataset.hoverBackgroundColor, index, getHoverColor(model.backgroundColor));
-		model.borderColor = custom.hoverBorderColor || valueAtIndexOrDefault(dataset.hoverBorderColor, index, getHoverColor(model.borderColor));
-		model.borderWidth = !isNaN(custom.hoverBorderWidth) ? custom.hoverBorderWidth : valueAtIndexOrDefault(dataset.hoverBorderWidth, index, model.borderWidth);
+		model.backgroundColor = resolve([custom.hoverBackgroundColor, dataset.hoverBackgroundColor, getHoverColor(model.backgroundColor)], undefined, index);
+		model.borderColor = resolve([custom.hoverBorderColor, dataset.hoverBorderColor, getHoverColor(model.borderColor)], undefined, index);
+		model.borderWidth = resolve([custom.hoverBorderWidth, dataset.hoverBorderWidth, model.borderWidth], undefined, index);
 	},
 
 	/**

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -5,6 +5,9 @@ var Element = require('./core.element');
 var helpers = require('../helpers/index');
 var Ticks = require('./core.ticks');
 
+var valueOrDefault = helpers.valueOrDefault;
+var valueAtIndexOrDefault = helpers.valueAtIndexOrDefault;
+
 defaults._set('scale', {
 	display: true,
 	position: 'left',
@@ -730,24 +733,24 @@ module.exports = Element.extend({
 
 		var parseFont = helpers.options._parseFont;
 		var ticks = optionTicks.autoSkip ? me._autoSkip(me.getTicks()) : me.getTicks();
-		var tickFontColor = helpers.valueOrDefault(optionTicks.fontColor, defaultFontColor);
+		var tickFontColor = valueOrDefault(optionTicks.fontColor, defaultFontColor);
 		var tickFont = parseFont(optionTicks);
 		var lineHeight = tickFont.lineHeight;
-		var majorTickFontColor = helpers.valueOrDefault(optionMajorTicks.fontColor, defaultFontColor);
+		var majorTickFontColor = valueOrDefault(optionMajorTicks.fontColor, defaultFontColor);
 		var majorTickFont = parseFont(optionMajorTicks);
 		var tickPadding = optionTicks.padding;
 		var labelOffset = optionTicks.labelOffset;
 
 		var tl = gridLines.drawTicks ? gridLines.tickMarkLength : 0;
 
-		var scaleLabelFontColor = helpers.valueOrDefault(scaleLabel.fontColor, defaultFontColor);
+		var scaleLabelFontColor = valueOrDefault(scaleLabel.fontColor, defaultFontColor);
 		var scaleLabelFont = parseFont(scaleLabel);
 		var scaleLabelPadding = helpers.options.toPadding(scaleLabel.padding);
 		var labelRotationRadians = helpers.toRadians(me.labelRotation);
 
 		var itemsToDraw = [];
 
-		var axisWidth = gridLines.drawBorder ? helpers.valueAtIndexOrDefault(gridLines.lineWidth, 0, 0) : 0;
+		var axisWidth = gridLines.drawBorder ? valueAtIndexOrDefault(gridLines.lineWidth, 0, 0) : 0;
 		var alignPixel = helpers._alignPixel;
 		var borderValue, tickStart, tickEnd;
 
@@ -786,8 +789,8 @@ module.exports = Element.extend({
 				borderDash = gridLines.zeroLineBorderDash || [];
 				borderDashOffset = gridLines.zeroLineBorderDashOffset || 0.0;
 			} else {
-				lineWidth = helpers.valueAtIndexOrDefault(gridLines.lineWidth, index);
-				lineColor = helpers.valueAtIndexOrDefault(gridLines.color, index);
+				lineWidth = valueAtIndexOrDefault(gridLines.lineWidth, index);
+				lineColor = valueAtIndexOrDefault(gridLines.color, index);
 				borderDash = gridLines.borderDash || [];
 				borderDashOffset = gridLines.borderDashOffset || 0.0;
 			}
@@ -961,7 +964,7 @@ module.exports = Element.extend({
 		if (axisWidth) {
 			// Draw the line at the edge of the axis
 			var firstLineWidth = axisWidth;
-			var lastLineWidth = helpers.valueAtIndexOrDefault(gridLines.lineWidth, ticks.length - 1, 0);
+			var lastLineWidth = valueAtIndexOrDefault(gridLines.lineWidth, ticks.length - 1, 0);
 			var x1, x2, y1, y2;
 
 			if (isHorizontal) {
@@ -975,7 +978,7 @@ module.exports = Element.extend({
 			}
 
 			context.lineWidth = axisWidth;
-			context.strokeStyle = helpers.valueAtIndexOrDefault(gridLines.color, 0);
+			context.strokeStyle = valueAtIndexOrDefault(gridLines.color, 0);
 			context.beginPath();
 			context.moveTo(x1, y1);
 			context.lineTo(x2, y2);

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -5,6 +5,9 @@ var Element = require('./core.element');
 var helpers = require('../helpers/index');
 var Ticks = require('./core.ticks');
 
+var valueOrDefault = helpers.valueOrDefault;
+var valueAtIndexOrDefault = helpers.valueAtIndexOrDefault;
+
 defaults._set('scale', {
 	display: true,
 	position: 'left',
@@ -728,8 +731,6 @@ module.exports = Element.extend({
 		var isMirrored = optionTicks.mirror;
 		var isHorizontal = me.isHorizontal();
 
-		var valueOrDefault = helpers.valueOrDefault;
-		var valueAtIndexOrDefault = helpers.valueAtIndexOrDefault;
 		var parseFont = helpers.options._parseFont;
 		var ticks = optionTicks.autoSkip ? me._autoSkip(me.getTicks()) : me.getTicks();
 		var tickFontColor = valueOrDefault(optionTicks.fontColor, defaultFontColor);

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -5,9 +5,6 @@ var Element = require('./core.element');
 var helpers = require('../helpers/index');
 var Ticks = require('./core.ticks');
 
-var valueOrDefault = helpers.valueOrDefault;
-var valueAtIndexOrDefault = helpers.valueAtIndexOrDefault;
-
 defaults._set('scale', {
 	display: true,
 	position: 'left',
@@ -731,6 +728,8 @@ module.exports = Element.extend({
 		var isMirrored = optionTicks.mirror;
 		var isHorizontal = me.isHorizontal();
 
+		var valueOrDefault = helpers.valueOrDefault;
+		var valueAtIndexOrDefault = helpers.valueAtIndexOrDefault;
 		var parseFont = helpers.options._parseFont;
 		var ticks = optionTicks.autoSkip ? me._autoSkip(me.getTicks()) : me.getTicks();
 		var tickFontColor = valueOrDefault(optionTicks.fontColor, defaultFontColor);

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -4,6 +4,8 @@ var defaults = require('./core.defaults');
 var Element = require('./core.element');
 var helpers = require('../helpers/index');
 
+var valueOrDefault = helpers.valueOrDefault;
+
 defaults._set('global', {
 	tooltips: {
 		enabled: true,
@@ -221,7 +223,6 @@ function createTooltipItem(element) {
  */
 function getBaseModel(tooltipOpts) {
 	var globalDefaults = defaults.global;
-	var valueOrDefault = helpers.valueOrDefault;
 
 	return {
 		// Positioning

--- a/src/elements/element.line.js
+++ b/src/elements/element.line.js
@@ -50,9 +50,9 @@ module.exports = Element.extend({
 			ctx.setLineDash(vm.borderDash || globalOptionLineElements.borderDash);
 		}
 
-		ctx.lineDashOffset = vm.borderDashOffset || globalOptionLineElements.borderDashOffset;
+		ctx.lineDashOffset = helpers.valueOrDefault(vm.borderDashOffset, globalOptionLineElements.borderDashOffset);
 		ctx.lineJoin = vm.borderJoinStyle || globalOptionLineElements.borderJoinStyle;
-		ctx.lineWidth = vm.borderWidth || globalOptionLineElements.borderWidth;
+		ctx.lineWidth = helpers.valueOrDefault(vm.borderWidth, globalOptionLineElements.borderWidth);
 		ctx.strokeStyle = vm.borderColor || globalDefaults.defaultColor;
 
 		// Stroke Line

--- a/src/elements/element.line.js
+++ b/src/elements/element.line.js
@@ -30,6 +30,7 @@ module.exports = Element.extend({
 		var ctx = me._chart.ctx;
 		var spanGaps = vm.spanGaps;
 		var points = me._children.slice(); // clone array
+		var valueOrDefault = helpers.valueOrDefault;
 		var globalDefaults = defaults.global;
 		var globalOptionLineElements = globalDefaults.elements.line;
 		var lastDrawnIndex = -1;
@@ -50,9 +51,9 @@ module.exports = Element.extend({
 			ctx.setLineDash(vm.borderDash || globalOptionLineElements.borderDash);
 		}
 
-		ctx.lineDashOffset = helpers.valueOrDefault(vm.borderDashOffset, globalOptionLineElements.borderDashOffset);
+		ctx.lineDashOffset = valueOrDefault(vm.borderDashOffset, globalOptionLineElements.borderDashOffset);
 		ctx.lineJoin = vm.borderJoinStyle || globalOptionLineElements.borderJoinStyle;
-		ctx.lineWidth = helpers.valueOrDefault(vm.borderWidth, globalOptionLineElements.borderWidth);
+		ctx.lineWidth = valueOrDefault(vm.borderWidth, globalOptionLineElements.borderWidth);
 		ctx.strokeStyle = vm.borderColor || globalDefaults.defaultColor;
 
 		// Stroke Line

--- a/src/elements/element.line.js
+++ b/src/elements/element.line.js
@@ -4,6 +4,8 @@ var defaults = require('../core/core.defaults');
 var Element = require('../core/core.element');
 var helpers = require('../helpers/index');
 
+var valueOrDefault = helpers.valueOrDefault;
+
 var defaultColor = defaults.global.defaultColor;
 
 defaults._set('global', {
@@ -30,7 +32,6 @@ module.exports = Element.extend({
 		var ctx = me._chart.ctx;
 		var spanGaps = vm.spanGaps;
 		var points = me._children.slice(); // clone array
-		var valueOrDefault = helpers.valueOrDefault;
 		var globalDefaults = defaults.global;
 		var globalOptionLineElements = globalDefaults.elements.line;
 		var lastDrawnIndex = -1;

--- a/src/elements/element.point.js
+++ b/src/elements/element.point.js
@@ -4,6 +4,8 @@ var defaults = require('../core/core.defaults');
 var Element = require('../core/core.element');
 var helpers = require('../helpers/index');
 
+var valueOrDefault = helpers.valueOrDefault;
+
 var defaultColor = defaults.global.defaultColor;
 
 defaults._set('global', {
@@ -81,7 +83,7 @@ module.exports = Element.extend({
 		// Clipping for Points.
 		if (chartArea === undefined || helpers.canvas._isPointInArea(vm, chartArea)) {
 			ctx.strokeStyle = vm.borderColor || defaultColor;
-			ctx.lineWidth = helpers.valueOrDefault(vm.borderWidth, globalDefaults.elements.point.borderWidth);
+			ctx.lineWidth = valueOrDefault(vm.borderWidth, globalDefaults.elements.point.borderWidth);
 			ctx.fillStyle = vm.backgroundColor || defaultColor;
 			helpers.canvas.drawPoint(ctx, pointStyle, radius, x, y, rotation);
 		}

--- a/src/helpers/helpers.options.js
+++ b/src/helpers/helpers.options.js
@@ -134,22 +134,5 @@ module.exports = {
 				return value;
 			}
 		}
-	},
-
-	/**
-	 * Returns the first defined value from the given `args`.
-	 * @param {*} args - The arguments from which the first defined value is to be returned.
-	 * @returns {*}
-	 */
-	_fallback: function() {
-		var i, ilen, value;
-
-		for (i = 0, ilen = arguments.length - 1; i < ilen; ++i) {
-			value = arguments[i];
-			if (typeof value !== 'undefined') {
-				return value;
-			}
-		}
-		return arguments[i];
 	}
 };

--- a/src/helpers/helpers.options.js
+++ b/src/helpers/helpers.options.js
@@ -3,6 +3,8 @@
 var defaults = require('../core/core.defaults');
 var helpers = require('./helpers.core');
 
+var valueOrDefault = helpers.valueOrDefault;
+
 /**
  * Converts the given font object into a CSS font string.
  * @param {Object} font - A font object.
@@ -91,7 +93,6 @@ module.exports = {
 	 * @private
 	 */
 	_parseFont: function(options) {
-		var valueOrDefault = helpers.valueOrDefault;
 		var globalDefaults = defaults.global;
 		var size = valueOrDefault(options.fontSize, globalDefaults.defaultFontSize);
 		var font = {

--- a/src/helpers/helpers.options.js
+++ b/src/helpers/helpers.options.js
@@ -134,5 +134,22 @@ module.exports = {
 				return value;
 			}
 		}
+	},
+
+	/**
+	 * Returns the first defined value from the given `args`.
+	 * @param {*} args - The arguments from which the first defined value is to be returned.
+	 * @returns {*}
+	 */
+	_fallback: function() {
+		var i, ilen, value;
+
+		for (i = 0, ilen = arguments.length - 1; i < ilen; ++i) {
+			value = arguments[i];
+			if (typeof value !== 'undefined') {
+				return value;
+			}
+		}
+		return arguments[i];
 	}
 };

--- a/src/helpers/helpers.options.js
+++ b/src/helpers/helpers.options.js
@@ -8,7 +8,7 @@ var valueOrDefault = helpers.valueOrDefault;
 /**
  * Converts the given font object into a CSS font string.
  * @param {Object} font - A font object.
- * @return {Stringg} The CSS font string. See https://developer.mozilla.org/en-US/docs/Web/CSS/font
+ * @return {String} The CSS font string. See https://developer.mozilla.org/en-US/docs/Web/CSS/font
  * @private
  */
 function toFontString(font) {
@@ -87,7 +87,7 @@ module.exports = {
 
 	/**
 	 * Parses font options and returns the font object.
-	 * @param {Object} options - A object that contains font opttons to be parsed.
+	 * @param {Object} options - A object that contains font options to be parsed.
 	 * @return {Object} The font object.
 	 * @todo Support font.* options and renamed to toFont().
 	 * @private

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -6,6 +6,7 @@ var helpers = require('../helpers/index');
 var layouts = require('../core/core.layouts');
 
 var noop = helpers.noop;
+var valueOrDefault = helpers.valueOrDefault;
 
 defaults._set('global', {
 	legend: {
@@ -327,7 +328,6 @@ var Legend = Element.extend({
 
 		if (opts.display) {
 			var ctx = me.ctx;
-			var valueOrDefault = helpers.valueOrDefault;
 			var fontColor = valueOrDefault(labelOpts.fontColor, globalDefaults.defaultFontColor);
 			var labelFont = helpers.options._parseFont(labelOpts);
 			var fontSize = labelFont.size;

--- a/src/plugins/plugin.title.js
+++ b/src/plugins/plugin.title.js
@@ -141,7 +141,6 @@ var Title = Element.extend({
 	draw: function() {
 		var me = this;
 		var ctx = me.ctx;
-		var valueOrDefault = helpers.valueOrDefault;
 		var opts = me.options;
 
 		if (opts.display) {
@@ -155,7 +154,7 @@ var Title = Element.extend({
 			var right = me.right;
 			var maxWidth, titleX, titleY;
 
-			ctx.fillStyle = valueOrDefault(opts.fontColor, defaults.global.defaultFontColor); // render in correct colour
+			ctx.fillStyle = helpers.valueOrDefault(opts.fontColor, defaults.global.defaultFontColor); // render in correct colour
 			ctx.font = fontOpts.string;
 
 			// Horizontal

--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -170,8 +170,7 @@ module.exports = Scale.extend({
 
 	handleTickRangeOptions: function() {
 		var me = this;
-		var opts = me.options;
-		var tickOpts = opts.ticks;
+		var tickOpts = me.options.ticks;
 		var DEFAULT_MIN = 1;
 		var DEFAULT_MAX = 10;
 
@@ -208,8 +207,7 @@ module.exports = Scale.extend({
 
 	buildTicks: function() {
 		var me = this;
-		var opts = me.options;
-		var tickOpts = opts.ticks;
+		var tickOpts = me.options.ticks;
 		var reverse = !me.isHorizontal();
 
 		var generationOptions = {
@@ -266,7 +264,8 @@ module.exports = Scale.extend({
 
 	getPixelForValue: function(value) {
 		var me = this;
-		var reverse = me.options.ticks.reverse;
+		var tickOpts = me.options.ticks;
+		var reverse = tickOpts.reverse;
 		var log10 = helpers.log10;
 		var firstTickValue = me._getFirstTickValue(me.minNotZero);
 		var offset = 0;
@@ -292,10 +291,7 @@ module.exports = Scale.extend({
 		}
 		if (value !== start) {
 			if (start === 0) { // include zero tick
-				offset = helpers.getValueOrDefault(
-					me.options.ticks.fontSize,
-					defaults.global.defaultFontSize
-				);
+				offset = valueOrDefault(tickOpts.fontSize, defaults.global.defaultFontSize);
 				innerDimension -= offset;
 				start = firstTickValue;
 			}
@@ -309,7 +305,8 @@ module.exports = Scale.extend({
 
 	getValueForPixel: function(pixel) {
 		var me = this;
-		var reverse = me.options.ticks.reverse;
+		var tickOpts = me.options.ticks;
+		var reverse = tickOpts.reverse;
 		var log10 = helpers.log10;
 		var firstTickValue = me._getFirstTickValue(me.minNotZero);
 		var innerDimension, start, end, value;
@@ -330,10 +327,7 @@ module.exports = Scale.extend({
 		}
 		if (value !== start) {
 			if (start === 0) { // include zero tick
-				var offset = helpers.getValueOrDefault(
-					me.options.ticks.fontSize,
-					defaults.global.defaultFontSize
-				);
+				var offset = valueOrDefault(tickOpts.fontSize, defaults.global.defaultFontSize);
 				value -= offset;
 				innerDimension -= offset;
 				start = firstTickValue;

--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -5,6 +5,8 @@ var helpers = require('../helpers/index');
 var Scale = require('../core/core.scale');
 var Ticks = require('../core/core.ticks');
 
+var valueOrDefault = helpers.valueOrDefault;
+
 /**
  * Generate a set of logarithmic ticks
  * @param generationOptions the options used to generate the ticks
@@ -13,7 +15,6 @@ var Ticks = require('../core/core.ticks');
  */
 function generateTicks(generationOptions, dataRange) {
 	var ticks = [];
-	var valueOrDefault = helpers.valueOrDefault;
 
 	var tickVal = valueOrDefault(generationOptions.min, Math.pow(10, Math.floor(helpers.log10(dataRange.min))));
 
@@ -171,7 +172,6 @@ module.exports = Scale.extend({
 		var me = this;
 		var opts = me.options;
 		var tickOpts = opts.ticks;
-		var valueOrDefault = helpers.valueOrDefault;
 		var DEFAULT_MIN = 1;
 		var DEFAULT_MAX = 10;
 

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -7,7 +7,6 @@ var Ticks = require('../core/core.ticks');
 
 var valueOrDefault = helpers.valueOrDefault;
 var valueAtIndexOrDefault = helpers.valueAtIndexOrDefault;
-var fallback = helpers.options._fallback;
 
 var defaultConfig = {
 	display: true,
@@ -227,6 +226,7 @@ function drawPointLabels(scale) {
 	var angleLineOpts = opts.angleLines;
 	var gridLineOpts = opts.gridLines;
 	var pointLabelOpts = opts.pointLabels;
+	var resolve = helpers.options.resolve;
 	var lineWidth = valueOrDefault(angleLineOpts.lineWidth, gridLineOpts.lineWidth);
 	var lineColor = valueOrDefault(angleLineOpts.color, gridLineOpts.color);
 	var tickBackdropHeight = getTickBackdropHeight(opts);
@@ -235,8 +235,8 @@ function drawPointLabels(scale) {
 	ctx.lineWidth = lineWidth;
 	ctx.strokeStyle = lineColor;
 	if (ctx.setLineDash) {
-		ctx.setLineDash(fallback(angleLineOpts.borderDash, gridLineOpts.borderDash, []));
-		ctx.lineDashOffset = fallback(angleLineOpts.borderDashOffset, gridLineOpts.borderDashOffset, 0.0);
+		ctx.setLineDash(resolve([angleLineOpts.borderDash, gridLineOpts.borderDash, []]));
+		ctx.lineDashOffset = resolve([angleLineOpts.borderDashOffset, gridLineOpts.borderDashOffset, 0.0]);
 	}
 
 	var outerDistance = scale.getDistanceFromCenterForValue(opts.ticks.reverse ? scale.min : scale.max);

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -5,6 +5,10 @@ var helpers = require('../helpers/index');
 var LinearScaleBase = require('./scale.linearbase');
 var Ticks = require('../core/core.ticks');
 
+var valueOrDefault = helpers.valueOrDefault;
+var valueAtIndexOrDefault = helpers.valueAtIndexOrDefault;
+var fallback = helpers.options._fallback;
+
 var defaultConfig = {
 	display: true,
 
@@ -64,7 +68,7 @@ function getTickBackdropHeight(opts) {
 	var tickOpts = opts.ticks;
 
 	if (tickOpts.display && opts.display) {
-		return helpers.valueOrDefault(tickOpts.fontSize, defaults.global.defaultFontSize) + tickOpts.backdropPaddingY * 2;
+		return valueOrDefault(tickOpts.fontSize, defaults.global.defaultFontSize) + tickOpts.backdropPaddingY * 2;
 	}
 	return 0;
 }
@@ -223,16 +227,16 @@ function drawPointLabels(scale) {
 	var angleLineOpts = opts.angleLines;
 	var gridLineOpts = opts.gridLines;
 	var pointLabelOpts = opts.pointLabels;
-	var lineWidth = helpers.valueOrDefault(angleLineOpts.lineWidth, gridLineOpts.lineWidth);
-	var lineColor = helpers.valueOrDefault(angleLineOpts.color, gridLineOpts.color);
+	var lineWidth = valueOrDefault(angleLineOpts.lineWidth, gridLineOpts.lineWidth);
+	var lineColor = valueOrDefault(angleLineOpts.color, gridLineOpts.color);
 	var tickBackdropHeight = getTickBackdropHeight(opts);
 
 	ctx.save();
 	ctx.lineWidth = lineWidth;
 	ctx.strokeStyle = lineColor;
 	if (ctx.setLineDash) {
-		ctx.setLineDash(helpers.valueOrDefault(angleLineOpts.borderDash, gridLineOpts.borderDash) || []);
-		ctx.lineDashOffset = helpers.valueOrDefault(angleLineOpts.borderDashOffset, gridLineOpts.borderDashOffset) || 0.0;
+		ctx.setLineDash(fallback(angleLineOpts.borderDash, gridLineOpts.borderDash, []));
+		ctx.lineDashOffset = fallback(angleLineOpts.borderDashOffset, gridLineOpts.borderDashOffset, 0.0);
 	}
 
 	var outerDistance = scale.getDistanceFromCenterForValue(opts.ticks.reverse ? scale.min : scale.max);
@@ -258,7 +262,7 @@ function drawPointLabels(scale) {
 			var pointLabelPosition = scale.getPointPosition(i, outerDistance + extra + 5);
 
 			// Keep this in loop since we may support array properties here
-			var pointLabelFontColor = helpers.valueAtIndexOrDefault(pointLabelOpts.fontColor, i, defaults.global.defaultFontColor);
+			var pointLabelFontColor = valueAtIndexOrDefault(pointLabelOpts.fontColor, i, defaults.global.defaultFontColor);
 			ctx.fillStyle = pointLabelFontColor;
 
 			var angleRadians = scale.getIndexAngle(i);
@@ -275,8 +279,8 @@ function drawRadiusLine(scale, gridLineOpts, radius, index) {
 	var ctx = scale.ctx;
 	var circular = gridLineOpts.circular;
 	var valueCount = getValueCount(scale);
-	var lineColor = helpers.valueAtIndexOrDefault(gridLineOpts.color, index - 1);
-	var lineWidth = helpers.valueAtIndexOrDefault(gridLineOpts.lineWidth, index - 1);
+	var lineColor = valueAtIndexOrDefault(gridLineOpts.color, index - 1);
+	var lineWidth = valueAtIndexOrDefault(gridLineOpts.lineWidth, index - 1);
 	var pointPosition;
 
 	if ((!circular && !valueCount) || !lineColor || !lineWidth) {
@@ -475,7 +479,6 @@ module.exports = LinearScaleBase.extend({
 		var opts = me.options;
 		var gridLineOpts = opts.gridLines;
 		var tickOpts = opts.ticks;
-		var valueOrDefault = helpers.valueOrDefault;
 
 		if (opts.display) {
 			var ctx = me.ctx;

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -7,6 +7,7 @@ var Ticks = require('../core/core.ticks');
 
 var valueOrDefault = helpers.valueOrDefault;
 var valueAtIndexOrDefault = helpers.valueAtIndexOrDefault;
+var resolve = helpers.options.resolve;
 
 var defaultConfig = {
 	display: true,
@@ -226,7 +227,6 @@ function drawPointLabels(scale) {
 	var angleLineOpts = opts.angleLines;
 	var gridLineOpts = opts.gridLines;
 	var pointLabelOpts = opts.pointLabels;
-	var resolve = helpers.options.resolve;
 	var lineWidth = valueOrDefault(angleLineOpts.lineWidth, gridLineOpts.lineWidth);
 	var lineColor = valueOrDefault(angleLineOpts.color, gridLineOpts.color);
 	var tickBackdropHeight = getTickBackdropHeight(opts);

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -6,6 +6,8 @@ var defaults = require('../core/core.defaults');
 var helpers = require('../helpers/index');
 var Scale = require('../core/core.scale');
 
+var valueOrDefault = helpers.valueOrDefault;
+
 // Integer constants are from the ES6 spec.
 var MIN_INTEGER = Number.MIN_SAFE_INTEGER || -9007199254740991;
 var MAX_INTEGER = Number.MAX_SAFE_INTEGER || 9007199254740991;
@@ -307,7 +309,7 @@ function generate(min, max, capacity, options) {
 	var timeOpts = options.time;
 	var minor = timeOpts.unit || determineUnitForAutoTicks(timeOpts.minUnit, min, max, capacity);
 	var major = determineMajorUnit(minor);
-	var stepSize = helpers.valueOrDefault(timeOpts.stepSize, timeOpts.unitStepSize);
+	var stepSize = valueOrDefault(timeOpts.stepSize, timeOpts.unitStepSize);
 	var weekday = minor === 'week' ? timeOpts.isoWeekday : false;
 	var majorTicksEnabled = options.ticks.major.enabled;
 	var interval = INTERVALS[minor];
@@ -690,7 +692,7 @@ module.exports = Scale.extend({
 		var major = majorTickOpts.enabled && majorUnit && majorFormat && time === majorTime;
 		var label = tick.format(formatOverride ? formatOverride : major ? majorFormat : minorFormat);
 		var tickOpts = major ? majorTickOpts : options.ticks.minor;
-		var formatter = helpers.valueOrDefault(tickOpts.callback, tickOpts.userCallback);
+		var formatter = valueOrDefault(tickOpts.callback, tickOpts.userCallback);
 
 		return formatter ? formatter(label, index, ticks) : label;
 	},
@@ -765,7 +767,7 @@ module.exports = Scale.extend({
 		var angle = helpers.toRadians(ticksOpts.maxRotation);
 		var cosRotation = Math.cos(angle);
 		var sinRotation = Math.sin(angle);
-		var tickFontSize = helpers.valueOrDefault(ticksOpts.fontSize, defaults.global.defaultFontSize);
+		var tickFontSize = valueOrDefault(ticksOpts.fontSize, defaults.global.defaultFontSize);
 
 		return (tickLabelWidth * cosRotation) + (tickFontSize * sinRotation);
 	},

--- a/test/specs/helpers.options.tests.js
+++ b/test/specs/helpers.options.tests.js
@@ -197,4 +197,29 @@ describe('Chart.helpers.options', function() {
 			expect(resolve([input, ['foo', 'bar']], {v: 42}, 1)).toBe('bar');
 		});
 	});
+
+	describe('_fallback', function() {
+		var fallback = options._fallback;
+
+		it('should return the first value if defined', function() {
+			var object = {};
+			var array = [];
+
+			expect(fallback(null, 21, 42)).toBe(null);
+			expect(fallback(false, 21, 42)).toBe(false);
+			expect(fallback(object, 21, 42)).toBe(object);
+			expect(fallback(array, 21, 42)).toBe(array);
+			expect(fallback('', 21, 42)).toBe('');
+			expect(fallback(0, 21, 42)).toBe(0);
+		});
+		it('should return the second value if the first value is undefined', function() {
+			expect(fallback(undefined, 21, 42)).toBe(21);
+			expect(fallback({}.foo, 21, 42)).toBe(21);
+		});
+		it('should return the last value if others are undefined', function() {
+			expect(fallback(undefined, 42)).toBe(42);
+			expect(fallback(undefined, undefined, 42)).toBe(42);
+			expect(fallback(undefined, undefined, undefined, 42)).toBe(42);
+		});
+	});
 });

--- a/test/specs/helpers.options.tests.js
+++ b/test/specs/helpers.options.tests.js
@@ -197,29 +197,4 @@ describe('Chart.helpers.options', function() {
 			expect(resolve([input, ['foo', 'bar']], {v: 42}, 1)).toBe('bar');
 		});
 	});
-
-	describe('_fallback', function() {
-		var fallback = options._fallback;
-
-		it('should return the first value if defined', function() {
-			var object = {};
-			var array = [];
-
-			expect(fallback(null, 21, 42)).toBe(null);
-			expect(fallback(false, 21, 42)).toBe(false);
-			expect(fallback(object, 21, 42)).toBe(object);
-			expect(fallback(array, 21, 42)).toBe(array);
-			expect(fallback('', 21, 42)).toBe('');
-			expect(fallback(0, 21, 42)).toBe(0);
-		});
-		it('should return the second value if the first value is undefined', function() {
-			expect(fallback(undefined, 21, 42)).toBe(21);
-			expect(fallback({}.foo, 21, 42)).toBe(21);
-		});
-		it('should return the last value if others are undefined', function() {
-			expect(fallback(undefined, 42)).toBe(42);
-			expect(fallback(undefined, undefined, 42)).toBe(42);
-			expect(fallback(undefined, undefined, undefined, 42)).toBe(42);
-		});
-	});
 });


### PR DESCRIPTION
This PR adds `helpers.options._fallback` method that takes an arbitrary number of arguments and returns the first defined value as discussed in #5961.

In controller code, options such as `custom.radius` and `custom.borderWidth` don't fallback correctly when they are defined but falsy values, so this has been fixed.

Several helper methods are aliased globally, and the size of min.js is reduced by 922 bytes. Also, the variable `_isPointInArea` is renamed to `isPointInArea` as per https://github.com/chartjs/Chart.js/pull/5937#discussion_r245504850.

**Edit:** After some discussion, we decide to use `helpers.options.resolve` instead of introducing a new helper method.