### PR TITLE
Updated controller.scatter.test.js to test default tooltip callbacks

### DIFF
--- a/test/specs/controller.scatter.test.js
+++ b/test/specs/controller.scatter.test.js
@@ -3,6 +3,28 @@ describe('Chart.controllers.scatter', function() {
 		expect(typeof Chart.controllers.scatter).toBe('function');
 	});
 
+	it('should test default tooltip callbacks', function() {
+		var chart = window.acquireChart({
+			type: 'scatter',
+			data: {
+				datasets: [{
+					data: [{
+						x: 10,
+						y: 15
+					}],
+					label: 'dataset1'
+				}],
+			},
+			options: {}
+		});
+		var point = chart.getDatasetMeta(0).data[0];
+		jasmine.triggerMouseEvent(chart, 'mousemove', point);
+
+		// Title should be empty
+		expect(chart.tooltip._view.title.length).toBe(0);
+		expect(chart.tooltip._view.body[0].lines).toEqual(['(10, 15)']);
+	});
+
 	describe('showLines option', function() {
 		it('should not draw a line if undefined', function() {
 			var chart = window.acquireChart({


### PR DESCRIPTION
### What changed
- This moves the mouse over the drawn point and verifies that there is
  no title in the tooltip and that the body contains expected.

### Reason for change
- Initially implemented because I saw lacking code coverage for the default tooltip callbacks.

### Testing
- Ran gulp test which passed both lint and unittests.
- Ran gulp unittest --coverage to verify that the associated lines for the controller.scatter.js are now covered.
