### PR TITLE
fixed contribution docs

### DIFF
--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -4,8 +4,8 @@ New contributions to the library are welcome, but we ask that you please follow 
 
 - Use tabs for indentation, not spaces.
 - Only change the individual files in `/src`.
-- Check that your code will pass `eslint` code standards, `gulp lint` will run this for you.
-- Check that your code will pass tests, `gulp test` will run tests for you.
+- Check that your code will pass `eslint` code standards, `npm run gulp lint` will run this for you.
+- Check that your code will pass tests, `npm run gulp test` will run tests for you.
 - Keep pull requests concise, and document new functionality in the relevant `.md` file.
 - Consider whether your changes are useful for all users, or if creating a Chart.js [plugin](plugins.md) would be more appropriate.
 - Avoid breaking changes unless there is an upcoming major release, which are infrequent. We encourage people to write plugins for most new advanced features, so care a lot about backwards compatibility.
@@ -22,23 +22,22 @@ Firstly, we need to ensure development dependencies are installed. With node and
 
 ```bash
 > npm install
-> npm install -g gulp
 ```
 
-This will install the local development dependencies for Chart.js, along with a CLI for the JavaScript task runner <a href="https://gulpjs.com/" target="_blank">gulp</a>.
+This will install the local development dependencies for Chart.js including a CLI for the JavaScript task runner <a href="https://gulpjs.com/" target="_blank">gulp</a>.
 
 The following commands are now available from the repository root:
 
 ```bash
-> gulp build                // build dist files in ./dist
-> gulp build --watch        // build and watch for changes
-> gulp unittest             // run tests from ./test/specs
-> gulp unittest --watch     // run tests and watch for source changes
-> gulp unittest --coverage  // run tests and generate coverage reports in ./coverage
-> gulp lint                 // perform code linting (ESLint)
-> gulp test                 // perform code linting and run unit tests
-> gulp docs                 // build the documentation in ./dist/docs
-> gulp docs --watch         // starts the gitbook live reloaded server
+> npm run gulp build                // build dist files in ./dist
+> npm run gulp build --watch        // build and watch for changes
+> npm run gulp unittest             // run tests from ./test/specs
+> npm run gulp unittest --watch     // run tests and watch for source changes
+> npm run gulp unittest --coverage  // run tests and generate coverage reports in ./coverage
+> npm run gulp lint                 // perform code linting (ESLint)
+> npm run gulp test                 // perform code linting and run unit tests
+> npm run gulp docs                 // build the documentation in ./dist/docs
+> npm run gulp docs --watch         // starts the gitbook live reloaded server
 ```
 
 More information can be found in [gulpfile.js](https://github.com/chartjs/Chart.js/blob/master/gulpfile.js).

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -4,8 +4,8 @@ New contributions to the library are welcome, but we ask that you please follow 
 
 - Use tabs for indentation, not spaces.
 - Only change the individual files in `/src`.
-- Check that your code will pass `eslint` code standards, `npm run gulp lint` will run this for you.
-- Check that your code will pass tests, `npm run gulp test` will run tests for you.
+- Check that your code will pass `eslint` code standards, `gulp lint` will run this for you.
+- Check that your code will pass tests, `gulp test` will run tests for you.
 - Keep pull requests concise, and document new functionality in the relevant `.md` file.
 - Consider whether your changes are useful for all users, or if creating a Chart.js [plugin](plugins.md) would be more appropriate.
 - Avoid breaking changes unless there is an upcoming major release, which are infrequent. We encourage people to write plugins for most new advanced features, so care a lot about backwards compatibility.
@@ -22,22 +22,23 @@ Firstly, we need to ensure development dependencies are installed. With node and
 
 ```bash
 > npm install
+> npm install -g gulp-cli
 ```
 
-This will install the local development dependencies for Chart.js including a CLI for the JavaScript task runner <a href="https://gulpjs.com/" target="_blank">gulp</a>.
+This will install the local development dependencies for Chart.js, along with a CLI for the JavaScript task runner <a href="https://gulpjs.com/" target="_blank">gulp</a>.
 
 The following commands are now available from the repository root:
 
 ```bash
-> npm run gulp build                // build dist files in ./dist
-> npm run gulp build --watch        // build and watch for changes
-> npm run gulp unittest             // run tests from ./test/specs
-> npm run gulp unittest --watch     // run tests and watch for source changes
-> npm run gulp unittest --coverage  // run tests and generate coverage reports in ./coverage
-> npm run gulp lint                 // perform code linting (ESLint)
-> npm run gulp test                 // perform code linting and run unit tests
-> npm run gulp docs                 // build the documentation in ./dist/docs
-> npm run gulp docs --watch         // starts the gitbook live reloaded server
+> gulp build                // build dist files in ./dist
+> gulp build --watch        // build and watch for changes
+> gulp unittest             // run tests from ./test/specs
+> gulp unittest --watch     // run tests and watch for source changes
+> gulp unittest --coverage  // run tests and generate coverage reports in ./coverage
+> gulp lint                 // perform code linting (ESLint)
+> gulp test                 // perform code linting and run unit tests
+> gulp docs                 // build the documentation in ./dist/docs
+> gulp docs --watch         // starts the gitbook live reloaded server
 ```
 
 More information can be found in [gulpfile.js](https://github.com/chartjs/Chart.js/blob/master/gulpfile.js).

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   "bugs": {
     "url": "https://github.com/chartjs/Chart.js/issues"
   },
+  "scripts": {
+    "gulp": "gulp"
+  },
   "devDependencies": {
     "coveralls": "^3.0.0",
     "eslint": "^5.9.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "url": "https://github.com/chartjs/Chart.js/issues"
   },
   "scripts": {
-    "gulp": "gulp"
+    "gulp": "gulp",
+    "start": "npm run gulp build --watch",
+    "test": "npm run gulp test"
   },
   "devDependencies": {
     "coveralls": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -22,11 +22,6 @@
   "bugs": {
     "url": "https://github.com/chartjs/Chart.js/issues"
   },
-  "scripts": {
-    "gulp": "gulp",
-    "start": "npm run gulp build --watch",
-    "test": "npm run gulp test"
-  },
   "devDependencies": {
     "coveralls": "^3.0.0",
     "eslint": "^5.9.0",


### PR DESCRIPTION
This makes it possible to use the local version of gulp (from `node_modeues/gulp`) to build the library.
The current builds e.g. `gulp build` of course still work if gulp is globally installed. If gulp is only installed locally via `npm install` than the user should use `npm run gulp` to do the same.
This way it is possible to use different versions of gulb for different projects.

I also added the common npm build scripts: `npm start` and `npm test`, because they are a common go-to for new developers.

*I hope you like these suggestions*
