### PR TITLE
Added note about maintainAspectRatio

### DIFF
--- a/docs/general/responsive.md
+++ b/docs/general/responsive.md
@@ -33,9 +33,10 @@ The chart can also be programmatically resized by modifying the container size:
 
 ```javascript
 chart.canvas.parentNode.style.height = '128px';
+chart.canvas.parentNode.style.width = '128px';
 ```
 
-Please note that in order for the above code to work properly, the maintainAspectRatio property (from [Configuration Options](#configuration-options)) must also be set to false, as shown in the full [example](https://codepen.io/chartjs/pen/YVWZbz).
+Note that in order for the above code to correctly resize the chart height, the [`maintainAspectRatio`](#configuration-options) option must also be set to `false`.
 
 ## Printing Resizeable Charts
 

--- a/docs/general/responsive.md
+++ b/docs/general/responsive.md
@@ -35,6 +35,8 @@ The chart can also be programmatically resized by modifying the container size:
 chart.canvas.parentNode.style.height = '128px';
 ```
 
+Please note that in order for the above code to work properly, the maintainAspectRatio property (from [Configuration Options](#configuration-options)) must also be set to false, as shown in the full [example](https://codepen.io/chartjs/pen/YVWZbz).
+
 ## Printing Resizeable Charts
 
 CSS media queries allow changing styles when printing a page. The CSS applied from these media queries may cause charts to need to resize. However, the resize won't happen automatically. To support resizing charts when printing, one needs to hook the [onbeforeprint](https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeprint) event and manually trigger resizing of each chart.


### PR DESCRIPTION
<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
Hi there, 
  This is rather a small documentation request, but do you think it might be worth it to explicitly say in the responsive.md file that in order for the given example to work, maintainAspectRatio property must be set to false? Here is a screenshot of the part I'm referring to: 
<img width="984" alt="chart_js_responsive_md_at_master_ _chartjs_chart_js" src="https://user-images.githubusercontent.com/26232823/50936233-3d953b80-1445-11e9-908c-c7686ec5a04a.png">
  I realize that in the example codepen you provide, the said property is set to false.  However, when I created my first chart, I just ran what I saw on the page above, then scratched my head for a while when it didn't work as I expected it to.  I ended up comparing my code with the codepen example and eventually figured it out. 
 
 I'm thinking that by making a small note about the property on the documentation page might cost someone less mental overhead and time in the future. 
<img width="732" alt="online_markdown_editor_-_dillinger__the_last_markdown_editor_ever_" src="https://user-images.githubusercontent.com/26232823/50974896-a40c6f00-14c2-11e9-92d4-42f0d8c90e0f.png">


Thanks for your consideration!
