### PR TITLE
Remove date auto type conversions

### DIFF
--- a/src/adapters/adapter.moment.js
+++ b/src/adapters/adapter.moment.js
@@ -41,7 +41,7 @@ helpers.merge(adapter, moment ? {
 		} else if (!(value instanceof moment)) {
 			value = moment(value);
 		}
-		return value.isValid() ? +value : null;
+		return value.isValid() ? value.valueOf() : null;
 	},
 
 	format: function(time, format) {
@@ -49,7 +49,7 @@ helpers.merge(adapter, moment ? {
 	},
 
 	add: function(time, amount, unit) {
-		return +moment(time).add(amount, unit);
+		return moment(time).add(amount, unit).valueOf();
 	},
 
 	diff: function(max, min, unit) {
@@ -59,13 +59,13 @@ helpers.merge(adapter, moment ? {
 	startOf: function(time, unit, weekday) {
 		time = moment(time);
 		if (unit === 'isoWeek') {
-			return +time.isoWeekday(weekday);
+			return time.isoWeekday(weekday).valueOf();
 		}
-		return +time.startOf(unit);
+		return time.startOf(unit).valueOf();
 	},
 
 	endOf: function(time, unit) {
-		return +moment(time).endOf(unit);
+		return moment(time).endOf(unit).valueOf();
 	},
 
 	// DEPRECATIONS

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -574,8 +574,8 @@ module.exports = Scale.extend({
 		max = parse(timeOpts.max, me) || max;
 
 		// In case there is no valid min/max, set limits based on unit time option
-		min = min === MAX_INTEGER ? +adapter.startOf(+new Date(), unit) : min;
-		max = max === MIN_INTEGER ? +adapter.endOf(+new Date(), unit) + 1 : max;
+		min = min === MAX_INTEGER ? +adapter.startOf(Date.now(), unit) : min;
+		max = max === MIN_INTEGER ? +adapter.endOf(Date.now(), unit) + 1 : max;
 
 		// Make sure that max is strictly higher than min (required by the lookup table)
 		me.min = Math.min(min, max);


### PR DESCRIPTION
These were mostly no-ops now that we have timestamps

`new Date().getTime()` is more than twice as fast as `+new Date()` and `Date.now()` faster still. https://jsperf.com/new-date-timing

It also appears to be faster not to use `+moment` as well. https://jsperf.com/moment-getvalue