### PR TITLE
Enhance helper.decimalPlaces

### DIFF
--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -126,7 +126,7 @@ module.exports = function() {
 	};
 	helpers.almostWhole = function(x, epsilon) {
 		var rounded = Math.round(x);
-		return (((rounded - epsilon) < x) && ((rounded + epsilon) > x));
+		return (((rounded - epsilon) <= x) && ((rounded + epsilon) >= x));
 	};
 	helpers.max = function(array) {
 		return array.reduce(function(max, value) {
@@ -185,11 +185,13 @@ module.exports = function() {
 		if (!helpers.isFinite(x)) {
 			return;
 		}
-		var e = 1;
+		x = Math.abs(x);
 		var p = 0;
-		while (Math.round(x * e) / e !== x) {
-			e *= 10;
-			p++;
+		if (x > 0) {
+			while (x < 0.99 || !helpers.almostWhole(x, 1e-6)) {
+				x *= 10;
+				p++;
+			}
 		}
 		return p;
 	};

--- a/test/specs/core.helpers.tests.js
+++ b/test/specs/core.helpers.tests.js
@@ -212,6 +212,8 @@ describe('Core helper tests', function() {
 	it('should correctly determine if a numbers are essentially whole', function() {
 		expect(helpers.almostWhole(0.99999, 0.0001)).toBe(true);
 		expect(helpers.almostWhole(0.9, 0.0001)).toBe(false);
+		expect(helpers.almostWhole(1234567890123, 0.0001)).toBe(true);
+		expect(helpers.almostWhole(1234567890123.001, 0.0001)).toBe(false);
 	});
 
 	it('should generate integer ids', function() {
@@ -244,6 +246,9 @@ describe('Core helper tests', function() {
 		expect(helpers.decimalPlaces(0)).toBe(0);
 		expect(helpers.decimalPlaces(0.01)).toBe(2);
 		expect(helpers.decimalPlaces(-0.01)).toBe(2);
+		expect(helpers.decimalPlaces(0.2 + 0.1)).toBe(1);
+		expect(helpers.decimalPlaces(0.12 + 0.02)).toBe(2);
+		expect(helpers.decimalPlaces(3.1415e-34)).toBe(38);
 		expect(helpers.decimalPlaces('1')).toBe(undefined);
 		expect(helpers.decimalPlaces('')).toBe(undefined);
 		expect(helpers.decimalPlaces(undefined)).toBe(undefined);


### PR DESCRIPTION
I think the new helper.decimalPlaces() function introduced in #5786 will be very helpful for generating ticks of fixed decimal places or scientific notation. Unfortunately, there were some tricky floating point issues which could fool it into returning too many decimals.

I've added some of those difficult cases to the tests and proposed an alternative calculation method which returns better results.
