### PR TITLE
_resolveElementPoint utility for triggerMouseEvent

### DIFF
--- a/test/specs/controller.polarArea.tests.js
+++ b/test/specs/controller.polarArea.tests.js
@@ -281,12 +281,12 @@ describe('Chart.controllers.polarArea', function() {
 			var chart = this.chart;
 			var arc = chart.getDatasetMeta(0).data[0];
 
-			jasmine.triggerMouseEvent(chart, 'mousemove', {_model: arc.getCenterPoint()});
+			jasmine.triggerMouseEvent(chart, 'mousemove', arc);
 			expect(arc._model.backgroundColor).toBe('rgb(49, 135, 221)');
 			expect(arc._model.borderColor).toBe('rgb(22, 89, 156)');
 			expect(arc._model.borderWidth).toBe(2);
 
-			jasmine.triggerMouseEvent(chart, 'mouseout', {_model: arc.getCenterPoint()});
+			jasmine.triggerMouseEvent(chart, 'mouseout', arc);
 			expect(arc._model.backgroundColor).toBe('rgb(100, 150, 200)');
 			expect(arc._model.borderColor).toBe('rgb(50, 100, 150)');
 			expect(arc._model.borderWidth).toBe(2);
@@ -304,12 +304,12 @@ describe('Chart.controllers.polarArea', function() {
 
 			chart.update();
 
-			jasmine.triggerMouseEvent(chart, 'mousemove', {_model: arc.getCenterPoint()});
+			jasmine.triggerMouseEvent(chart, 'mousemove', arc);
 			expect(arc._model.backgroundColor).toBe('rgb(200, 100, 150)');
 			expect(arc._model.borderColor).toBe('rgb(150, 50, 100)');
 			expect(arc._model.borderWidth).toBe(8.4);
 
-			jasmine.triggerMouseEvent(chart, 'mouseout', {_model: arc.getCenterPoint()});
+			jasmine.triggerMouseEvent(chart, 'mouseout', arc);
 			expect(arc._model.backgroundColor).toBe('rgb(100, 150, 200)');
 			expect(arc._model.borderColor).toBe('rgb(50, 100, 150)');
 			expect(arc._model.borderWidth).toBe(2);
@@ -327,12 +327,12 @@ describe('Chart.controllers.polarArea', function() {
 
 			chart.update();
 
-			jasmine.triggerMouseEvent(chart, 'mousemove', {_model: arc.getCenterPoint()});
+			jasmine.triggerMouseEvent(chart, 'mousemove', arc);
 			expect(arc._model.backgroundColor).toBe('rgb(200, 100, 150)');
 			expect(arc._model.borderColor).toBe('rgb(150, 50, 100)');
 			expect(arc._model.borderWidth).toBe(8.4);
 
-			jasmine.triggerMouseEvent(chart, 'mouseout', {_model: arc.getCenterPoint()});
+			jasmine.triggerMouseEvent(chart, 'mouseout', arc);
 			expect(arc._model.backgroundColor).toBe('rgb(100, 150, 200)');
 			expect(arc._model.borderColor).toBe('rgb(50, 100, 150)');
 			expect(arc._model.borderWidth).toBe(2);
@@ -350,12 +350,12 @@ describe('Chart.controllers.polarArea', function() {
 
 			chart.update();
 
-			jasmine.triggerMouseEvent(chart, 'mousemove', {_model: arc.getCenterPoint()});
+			jasmine.triggerMouseEvent(chart, 'mousemove', arc);
 			expect(arc._model.backgroundColor).toBe('rgb(200, 100, 150)');
 			expect(arc._model.borderColor).toBe('rgb(150, 50, 100)');
 			expect(arc._model.borderWidth).toBe(8.4);
 
-			jasmine.triggerMouseEvent(chart, 'mouseout', {_model: arc.getCenterPoint()});
+			jasmine.triggerMouseEvent(chart, 'mouseout', arc);
 			expect(arc._model.backgroundColor).toBe('rgb(100, 150, 200)');
 			expect(arc._model.borderColor).toBe('rgb(50, 100, 150)');
 			expect(arc._model.borderWidth).toBe(2);

--- a/test/utils.js
+++ b/test/utils.js
@@ -106,12 +106,27 @@ function waitForResize(chart, callback) {
 	};
 }
 
+function _resolveElementPoint(el) {
+	var point = {x: 0, y: 0};
+	if (el) {
+		if (typeof el.getCenterPoint === 'function') {
+			point = el.getCenterPoint();
+		} else if (el.x !== undefined && el.y !== undefined) {
+			point = el;
+		} else if (el._model && el._model.x !== undefined && el._model.y !== undefined) {
+			point = el._model;
+		}
+	}
+	return point;
+}
+
 function triggerMouseEvent(chart, type, el) {
 	var node = chart.canvas;
 	var rect = node.getBoundingClientRect();
+	var point = _resolveElementPoint(el);
 	var event = new MouseEvent(type, {
-		clientX: rect.left + el._model.x,
-		clientY: rect.top + el._model.y,
+		clientX: rect.left + point.x,
+		clientY: rect.top + point.y,
 		cancelable: true,
 		bubbles: true,
 		view: window


### PR DESCRIPTION
* Default to `getCenterPoint` for element when triggering events in tests. Plain {x,y} also supported.
* Revert `Trigger mouse events at the center of arc` commit