### PR TITLE
supply correct start parameter to insertElements

### DIFF
--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -319,7 +319,9 @@ helpers.extend(DatasetController.prototype, {
 	 * @private
 	 */
 	onDataPush: function() {
-		this.insertElements(this.getDataset().data.length - 1, arguments.length);
+		var me = this;
+		var count = arguments.length;
+		me.insertElements(me.getDataset().data.length - count, count);
 	},
 
 	/**


### PR DESCRIPTION
in onDataPush, data is already in the data array.

So say the data was [1,2,3] before push and [4,5,6] was pushed.
Because data is already in place here, data.length would be 6 so start parameter would have been 5 to insertElement.

`splice` is executed on meta.data there, with given the index relative to start.
In 
[MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice) its said about start: "If greater than the length of the array, actual starting index will be set to the length of the array."
So the wrong `start` is fixed by splice.

However, when used for something else (I did), then things would go wrong. So this might as well be fixed for possible future changes.
