### PR TITLE
Prevent infinite resize when vertical scrollbar appears

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -189,10 +189,6 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 		var canvas = me.canvas;
 		var aspectRatio = (options.maintainAspectRatio && me.aspectRatio) || null;
 
-		if (!canvas) {
-			return;
-		}
-
 		// the canvas render width and height will be casted to integers so make sure that
 		// the canvas display style uses the same integer values to avoid blurring effect.
 
@@ -217,13 +213,13 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 			plugins.notify(me, 'resize', [newSize]);
 
 			// Notify of resize
-			if (me.options.onResize) {
-				me.options.onResize(me, newSize);
+			if (options.onResize) {
+				options.onResize(me, newSize);
 			}
 
 			me.stop();
 			me.update({
-				duration: me.options.responsiveAnimationDuration
+				duration: options.responsiveAnimationDuration
 			});
 		}
 	},

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -189,6 +189,10 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 		var canvas = me.canvas;
 		var aspectRatio = (options.maintainAspectRatio && me.aspectRatio) || null;
 
+		if (!canvas) {
+			return;
+		}
+
 		// the canvas render width and height will be casted to integers so make sure that
 		// the canvas display style uses the same integer values to avoid blurring effect.
 

--- a/src/platforms/platform.dom.js
+++ b/src/platforms/platform.dom.js
@@ -276,9 +276,14 @@ function addResizeListener(node, listener, chart) {
 			var container = chart.options.maintainAspectRatio && node.parentNode;
 			var w = container ? container.clientWidth : 0;
 			listener(createEvent('resize', chart));
-			if (container && container.clientWidth !== w && chart.canvas) {
-				// If the container size changed during chart resize, we can assume scrollbar appeared.
-				// So let's resize again, with the scrollbar visible
+			if (container && container.clientWidth < w && chart.canvas) {
+				// If the container size shrank during chart resize, let's assume
+				// scrollbar appeared. So we resize again with the scrollbar visible -
+				// effectively making chart smaller and the scrollbar hidden again.
+				// Because we are inside `throttled`, and currently `ticking`, scroll
+				// events are ignored during this whole 2 resize process.
+				// If we assumed wrong and something else happened, we are resizing
+				// twice in a frame (potential performance issue)
 				listener(createEvent('resize', chart));
 			}
 		}

--- a/src/platforms/platform.dom.js
+++ b/src/platforms/platform.dom.js
@@ -277,13 +277,10 @@ function addResizeListener(node, listener, chart) {
 			var container = aspectRatio && node.parentNode;
 			var w = container ? container.clientWidth : 0;
 			var ret = listener(createEvent('resize', chart));
-			if (container) {
-				expando._width = container.clientWidth;
-				if (expando._width !== w && chart.canvas) {
-					// If the container size changed during chart resize, we can assume scrollbar appeared.
-					// So let's resize again, with the scrollbar visible
-					ret = listener(createEvent('resize', chart));
-				}
+			if (container && container.clientWidth !== w && chart.canvas) {
+				// If the container size changed during chart resize, we can assume scrollbar appeared.
+				// So let's resize again, with the scrollbar visible
+				ret = listener(createEvent('resize', chart));
 			}
 			return ret;
 		}

--- a/src/platforms/platform.dom.js
+++ b/src/platforms/platform.dom.js
@@ -273,7 +273,30 @@ function addResizeListener(node, listener, chart) {
 	// Let's keep track of this added resizer and thus avoid DOM query when removing it.
 	var resizer = expando.resizer = createResizer(throttled(function() {
 		if (expando.resizer) {
-			return listener(createEvent('resize', chart));
+			var aspectRatio = chart.options.maintainAspectRatio && chart.aspectRatio || null;
+			var ret = false;
+			var w, container;
+			if (!aspectRatio) {
+				ret = listener(createEvent('resize', chart));
+			} else {
+				container = node.parentNode;
+				if (container) {
+					w = container.clientWidth;
+					if (expando._width !== w) {
+						ret = listener(createEvent('resize', chart));
+						// Store new size **after** the resize
+						expando._width = container.clientWidth;
+						if (expando._width !== w) {
+							// If the size changed during resize, we can assume scrollbar appeared.
+							// So let's resize again, with the scrollbar visible (and keep that size stored)
+							ret = listener(createEvent('resize', chart));
+						} else {
+							expando._width = 0;
+						}
+					}
+				}
+			}
+			return ret;
 		}
 	}));
 

--- a/src/platforms/platform.dom.js
+++ b/src/platforms/platform.dom.js
@@ -268,21 +268,19 @@ function unwatchForRender(node) {
 }
 
 function addResizeListener(node, listener, chart) {
-	var expando = node[EXPANDO_KEY] = node[EXPANDO_KEY] || {};
+	var expando = node[EXPANDO_KEY] || (node[EXPANDO_KEY] = {});
 
 	// Let's keep track of this added resizer and thus avoid DOM query when removing it.
 	var resizer = expando.resizer = createResizer(throttled(function() {
 		if (expando.resizer) {
-			var aspectRatio = chart.options.maintainAspectRatio && chart.aspectRatio || null;
-			var container = aspectRatio && node.parentNode;
+			var container = chart.options.maintainAspectRatio && node.parentNode;
 			var w = container ? container.clientWidth : 0;
-			var ret = listener(createEvent('resize', chart));
+			listener(createEvent('resize', chart));
 			if (container && container.clientWidth !== w && chart.canvas) {
 				// If the container size changed during chart resize, we can assume scrollbar appeared.
 				// So let's resize again, with the scrollbar visible
-				ret = listener(createEvent('resize', chart));
+				listener(createEvent('resize', chart));
 			}
-			return ret;
 		}
 	}));
 


### PR DESCRIPTION
A workaround to the _infinte resize_ problem.

Pens to demonstrate:  
[master](https://codepen.io/kurkle/pen/YBXpxW)
[master - 3 columns](https://codepen.io/kurkle/pen/YBwBjK)

THIS PR:(https://github.com/chartjs/Chart.js/pull/6011/commits/840d11a8d32260849f9ff3ad0b4f775eda99e9c2)
[single](https://codepen.io/kurkle/pen/XObNgQ) 
[3 rows](https://codepen.io/kurkle/pen/QYyNRQ)
[3 columns](https://codepen.io/kurkle/pen/qgbNbd)
[collapse rows](https://codepen.io/kurkle/pen/xMZOrw)
[collapse columns](https://codepen.io/kurkle/pen/qgbNvr)

You get the effect (in master) by resizing window so that scrollbar just appears.

Fixes: #2127 