### PR TITLE
Time scale performance improvement

### DIFF
--- a/src/adapters/adapter.moment.js
+++ b/src/adapters/adapter.moment.js
@@ -7,6 +7,7 @@ var adapter = require('../core/core.adapters')._date;
 var helpers = require('../helpers/helpers.core');
 
 var FORMATS = {
+	datetime: 'MMM D, YYYY, h:mm:ss a',
 	millisecond: 'h:mm:ss.SSS a',
 	second: 'h:mm:ss a',
 	minute: 'h:mm a',
@@ -18,21 +19,11 @@ var FORMATS = {
 	year: 'YYYY'
 };
 
-var PRESETS = {
-	full: 'MMM D, YYYY h:mm:ss.SSS a',
-	time: 'MMM D, YYYY h:mm:ss a',
-	date: 'MMM D, YYYY'
-};
-
 helpers.merge(adapter, moment ? {
 	_id: 'moment', // DEBUG ONLY
 
 	formats: function() {
 		return FORMATS;
-	},
-
-	presets: function() {
-		return PRESETS;
 	},
 
 	parse: function(value, format) {

--- a/src/core/core.adapters.js
+++ b/src/core/core.adapters.js
@@ -30,7 +30,8 @@ function abstract() {
 /** @lends Chart._adapters._date */
 module.exports._date = {
 	/**
-	 * Returns a map of time formats for the supported units.
+	 * Returns a map of time formats for the supported formatting units.
+	 * This includes all scale tick units defined in Unit as well as 'datetime' used in the tooltip.
 	 * @returns {{string: string}}
 	 */
 	formats: abstract,

--- a/src/core/core.adapters.js
+++ b/src/core/core.adapters.js
@@ -30,8 +30,8 @@ function abstract() {
 /** @lends Chart._adapters._date */
 module.exports._date = {
 	/**
-	 * Returns a map of time formats for the supported formatting units.
-	 * This includes all scale tick units defined in Unit as well as 'datetime' used in the tooltip.
+	 * Returns a map of time formats for the supported formatting units defined
+	 * in Unit as well as 'datetime' representing a detailed date/time string.
 	 * @returns {{string: string}}
 	 */
 	formats: abstract,

--- a/src/core/core.adapters.js
+++ b/src/core/core.adapters.js
@@ -36,15 +36,6 @@ module.exports._date = {
 	formats: abstract,
 
 	/**
-	 * Returns a map of date/time formats for the following presets:
-	 * 'full': date + time + millisecond
-	 * 'time': date + time
-	 * 'date': date
-	 * @returns {{string: string}}
-	 */
-	presets: abstract,
-
-	/**
 	 * Parses the given `value` and return the associated timestamp.
 	 * @param {any} value - the value to parse (usually comes from the data)
 	 * @param {string} [format] - the expected data format

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -638,7 +638,7 @@ module.exports = Scale.extend({
 		if (typeof label === 'string') {
 			return label;
 		}
-		return adapter.format(toTimestamp(label, timeOpts), timeOpts.displayFormats[me._unit]);
+		return adapter.format(toTimestamp(label, timeOpts), timeOpts.displayFormats.datetime);
 	},
 
 	/**

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -408,21 +408,12 @@ function ticksFromTimestamps(values, majorUnit) {
 /**
  * Return the time format for the label with the most parts (milliseconds, second, etc.)
  */
-function determineLabelFormat(timestamps) {
+function determineLabelFormat(timestamp) {
 	var presets = adapter.presets();
-	var ilen = timestamps.length;
-	var i, ts, hasTime;
-
-	for (i = 0; i < ilen; i++) {
-		ts = timestamps[i];
-		if (ts % INTERVALS.second.size !== 0) {
-			return presets.full;
-		}
-		if (!hasTime && adapter.startOf(ts, 'day') !== ts) {
-			hasTime = true;
-		}
+	if (timestamp % INTERVALS.second.size !== 0) {
+		return presets.full;
 	}
-	if (hasTime) {
+	if (adapter.startOf(timestamp, 'day') !== timestamp) {
 		return presets.time;
 	}
 	return presets.date;
@@ -637,7 +628,6 @@ module.exports = Scale.extend({
 		me._majorUnit = determineMajorUnit(me._unit);
 		me._table = buildLookupTable(me._timestamps.data, min, max, options.distribution);
 		me._offsets = computeOffsets(me._table, ticks, min, max, options);
-		me._labelFormat = determineLabelFormat(me._timestamps.data);
 
 		if (options.ticks.reverse) {
 			ticks.reverse();
@@ -652,6 +642,7 @@ module.exports = Scale.extend({
 		var timeOpts = me.options.time;
 		var label = data.labels && index < data.labels.length ? data.labels[index] : '';
 		var value = data.datasets[datasetIndex].data[index];
+		var ts;
 
 		if (helpers.isObject(value)) {
 			label = me.getRightValue(value);
@@ -663,7 +654,8 @@ module.exports = Scale.extend({
 			return label;
 		}
 
-		return adapter.format(toTimestamp(label, timeOpts), me._labelFormat);
+		ts = toTimestamp(label, timeOpts);
+		return adapter.format(ts, determineLabelFormat(ts));
 	},
 
 	/**

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -405,20 +405,6 @@ function ticksFromTimestamps(values, majorUnit) {
 	return ticks;
 }
 
-/**
- * Return the time format for the label with the most parts (milliseconds, second, etc.)
- */
-function determineLabelFormat(timestamp) {
-	var presets = adapter.presets();
-	if (timestamp % INTERVALS.second.size !== 0) {
-		return presets.full;
-	}
-	if (adapter.startOf(timestamp, 'day') !== timestamp) {
-		return presets.time;
-	}
-	return presets.date;
-}
-
 var defaultConfig = {
 	position: 'bottom',
 
@@ -642,7 +628,6 @@ module.exports = Scale.extend({
 		var timeOpts = me.options.time;
 		var label = data.labels && index < data.labels.length ? data.labels[index] : '';
 		var value = data.datasets[datasetIndex].data[index];
-		var ts;
 
 		if (helpers.isObject(value)) {
 			label = me.getRightValue(value);
@@ -653,9 +638,7 @@ module.exports = Scale.extend({
 		if (typeof label === 'string') {
 			return label;
 		}
-
-		ts = toTimestamp(label, timeOpts);
-		return adapter.format(ts, determineLabelFormat(ts));
+		return adapter.format(toTimestamp(label, timeOpts), timeOpts.displayFormats[me._unit]);
 	},
 
 	/**

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -624,7 +624,7 @@ describe('Time scale tests', function() {
 
 		var xScale = chart.scales.xScale0;
 		var label = xScale.getLabelForIndex(0, 0);
-		expect(label).toEqual('Jan 8, 2018 5:14:23.234 am');
+		expect(label).toEqual('5AM');
 	});
 
 	it('should get the correct label for a timestamp with time', function() {
@@ -652,7 +652,7 @@ describe('Time scale tests', function() {
 
 		var xScale = chart.scales.xScale0;
 		var label = xScale.getLabelForIndex(0, 0);
-		expect(label).toEqual('Jan 8, 2018 5:14:23 am');
+		expect(label).toEqual('5AM');
 	});
 
 	it('should get the correct label for a timestamp representing a date', function() {
@@ -680,7 +680,7 @@ describe('Time scale tests', function() {
 
 		var xScale = chart.scales.xScale0;
 		var label = xScale.getLabelForIndex(0, 0);
-		expect(label).toEqual('Jan 8, 2018');
+		expect(label).toEqual('12AM');
 	});
 
 	it('should get the correct pixel for only one data in the dataset', function() {

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -599,7 +599,7 @@ describe('Time scale tests', function() {
 		expect(xScale.getLabelForIndex(0, 0)).toBe('2015-01-01T20:00:00');
 	});
 
-	it('should get the correct label for a timestamp with milliseconds', function() {
+	it('should get the correct label for a timestamp', function() {
 		var chart = window.acquireChart({
 			type: 'line',
 			data: {
@@ -624,63 +624,7 @@ describe('Time scale tests', function() {
 
 		var xScale = chart.scales.xScale0;
 		var label = xScale.getLabelForIndex(0, 0);
-		expect(label).toEqual('5AM');
-	});
-
-	it('should get the correct label for a timestamp with time', function() {
-		var chart = window.acquireChart({
-			type: 'line',
-			data: {
-				datasets: [{
-					xAxisID: 'xScale0',
-					data: [
-						{t: +new Date('2018-01-08 05:14:23'), y: 10},
-						{t: +new Date('2018-01-09 06:17:43'), y: 3}
-					]
-				}],
-			},
-			options: {
-				scales: {
-					xAxes: [{
-						id: 'xScale0',
-						type: 'time',
-						position: 'bottom'
-					}],
-				}
-			}
-		});
-
-		var xScale = chart.scales.xScale0;
-		var label = xScale.getLabelForIndex(0, 0);
-		expect(label).toEqual('5AM');
-	});
-
-	it('should get the correct label for a timestamp representing a date', function() {
-		var chart = window.acquireChart({
-			type: 'line',
-			data: {
-				datasets: [{
-					xAxisID: 'xScale0',
-					data: [
-						{t: +new Date('2018-01-08 00:00:00'), y: 10},
-						{t: +new Date('2018-01-09 00:00:00'), y: 3}
-					]
-				}],
-			},
-			options: {
-				scales: {
-					xAxes: [{
-						id: 'xScale0',
-						type: 'time',
-						position: 'bottom'
-					}],
-				}
-			}
-		});
-
-		var xScale = chart.scales.xScale0;
-		var label = xScale.getLabelForIndex(0, 0);
-		expect(label).toEqual('12AM');
+		expect(label).toEqual('Jan 8, 2018, 5:14:23 am');
 	});
 
 	it('should get the correct pixel for only one data in the dataset', function() {
@@ -1532,6 +1476,7 @@ describe('Time scale tests', function() {
 
 				// NOTE: built-in adapter uses moment
 				var expected = {
+					datetime: 'MMM D, YYYY, h:mm:ss a',
 					millisecond: 'h:mm:ss.SSS a',
 					second: 'h:mm:ss a',
 					minute: 'h:mm a',
@@ -1570,6 +1515,7 @@ describe('Time scale tests', function() {
 
 				// NOTE: built-in adapter uses moment
 				var expected = {
+					datetime: 'MMM D, YYYY, h:mm:ss a',
 					millisecond: 'foo',
 					second: 'h:mm:ss a',
 					minute: 'h:mm a',


### PR DESCRIPTION
`determineLabelFormat` was looping through every data point on chart creation and creating a new moment object for each one. This was a major part of the time to render a time chart and was unnecessary. Since it's only used to format the tooltip we can just do it for the corresponding data point when the tooltip is displayed