### PR TITLE
Fix padding of horizontal axes when labels are rotated

### DIFF
--- a/src/core/core.layouts.js
+++ b/src/core/core.layouts.js
@@ -221,7 +221,7 @@ module.exports = {
 
 		// Step 3
 		// TODO re-limit horizontal axis height (this limit has affected only padding calculation since PR 1837)
-		// var horizontalBoxHeight = (height - chartAreaHeight) / (topBoxes.length + bottomBoxes.length);
+		// var horizontalBoxHeight = (height - chartAreaHeight) / horizontalBoxes.length;
 
 		// Step 4
 		var maxChartAreaWidth = chartWidth;

--- a/src/core/core.layouts.js
+++ b/src/core/core.layouts.js
@@ -26,6 +26,33 @@ function sortByWeight(array, reverse) {
 	});
 }
 
+function findMaxPadding(boxes) {
+	var maxPadding = {top: 0, left: 0, bottom: 0, right: 0};
+	helpers.each(boxes, function(box) {
+		if (box.getPadding) {
+			var boxPadding = box.getPadding();
+			maxPadding.left = Math.max(maxPadding.left, boxPadding.left);
+			maxPadding.right = Math.max(maxPadding.right, boxPadding.right);
+			maxPadding.top = Math.max(maxPadding.top, boxPadding.top);
+			maxPadding.bottom = Math.max(maxPadding.bottom, boxPadding.bottom);
+		}
+	});
+	return maxPadding;
+}
+
+function addHeightByPosition(boxes, size) {
+	helpers.each(boxes, function(box) {
+		size[box.position] += box.height;
+	});
+}
+
+function addWidthByPosition(boxes, size) {
+	helpers.each(boxes, function(box) {
+		size[box.position] += box.width;
+	});
+}
+
+
 defaults._set('global', {
 	layout: {
 		padding: {
@@ -142,6 +169,10 @@ module.exports = {
 		sortByWeight(topBoxes, true);
 		sortByWeight(bottomBoxes, false);
 
+		var verticalBoxes = leftBoxes.concat(rightBoxes);
+		var horizontalBoxes = topBoxes.concat(bottomBoxes);
+		var outerBoxes = verticalBoxes.concat(horizontalBoxes);
+
 		// Essentially we now have any number of boxes on each of the 4 sides.
 		// Our canvas looks like the following.
 		// The areas L1 and L2 are the left axes. R1 is the right axis, T1 is the top axis and
@@ -184,7 +215,7 @@ module.exports = {
 		var chartAreaWidth = chartWidth / 2; // min 50%
 
 		// Step 2
-		var verticalBoxWidth = (width - chartAreaWidth) / (leftBoxes.length + rightBoxes.length);
+		var verticalBoxWidth = (width - chartAreaWidth) / verticalBoxes.length;
 
 
 		// Step 4
@@ -211,37 +242,15 @@ module.exports = {
 			});
 		}
 
-		helpers.each(leftBoxes.concat(rightBoxes, topBoxes, bottomBoxes), getMinimumBoxSize);
+		helpers.each(outerBoxes, getMinimumBoxSize);
 
 		// If a horizontal box has padding, we move the left boxes over to avoid ugly charts (see issue #2478)
-		var maxHorizontalLeftPadding = 0;
-		var maxHorizontalRightPadding = 0;
-		var maxVerticalTopPadding = 0;
-		var maxVerticalBottomPadding = 0;
-
-		helpers.each(topBoxes.concat(bottomBoxes), function(horizontalBox) {
-			if (horizontalBox.getPadding) {
-				var boxPadding = horizontalBox.getPadding();
-				maxHorizontalLeftPadding = Math.max(maxHorizontalLeftPadding, boxPadding.left);
-				maxHorizontalRightPadding = Math.max(maxHorizontalRightPadding, boxPadding.right);
-			}
-		});
-
-		helpers.each(leftBoxes.concat(rightBoxes), function(verticalBox) {
-			if (verticalBox.getPadding) {
-				var boxPadding = verticalBox.getPadding();
-				maxVerticalTopPadding = Math.max(maxVerticalTopPadding, boxPadding.top);
-				maxVerticalBottomPadding = Math.max(maxVerticalBottomPadding, boxPadding.bottom);
-			}
-		});
+		var maxPadding = findMaxPadding(outerBoxes);
 
 		// At this point, maxChartAreaHeight and maxChartAreaWidth are the size the chart area could
 		// be if the axes are drawn at their minimum sizes.
 		// Steps 5 & 6
-		var totalLeftBoxesWidth = leftPadding;
-		var totalRightBoxesWidth = rightPadding;
-		var totalTopBoxesHeight = topPadding;
-		var totalBottomBoxesHeight = bottomPadding;
+		var outerBoxSizes = {top: topPadding, left: leftPadding, bottom: bottomPadding, right: rightPadding};
 
 		// Function to fit a box
 		function fitBox(box) {
@@ -250,10 +259,10 @@ module.exports = {
 			});
 
 			if (minBoxSize) {
-				if (box.isHorizontal()) {
+				if (minBoxSize.horizontal) {
 					var scaleMargin = {
-						left: Math.max(totalLeftBoxesWidth, maxHorizontalLeftPadding),
-						right: Math.max(totalRightBoxesWidth, maxHorizontalRightPadding),
+						left: Math.max(outerBoxSizes.left, maxPadding.left),
+						right: Math.max(outerBoxSizes.right, maxPadding.right),
 						top: 0,
 						bottom: 0
 					};
@@ -268,27 +277,12 @@ module.exports = {
 		}
 
 		// Update, and calculate the left and right margins for the horizontal boxes
-		helpers.each(leftBoxes.concat(rightBoxes), fitBox);
-
-		helpers.each(leftBoxes, function(box) {
-			totalLeftBoxesWidth += box.width;
-		});
-
-		helpers.each(rightBoxes, function(box) {
-			totalRightBoxesWidth += box.width;
-		});
+		helpers.each(verticalBoxes, fitBox);
+		addWidthByPosition(verticalBoxes, outerBoxSizes);
 
 		// Set the Left and Right margins for the horizontal boxes
-		helpers.each(topBoxes.concat(bottomBoxes), fitBox);
-
-		// Figure out how much margin is on the top and bottom of the vertical boxes
-		helpers.each(topBoxes, function(box) {
-			totalTopBoxesHeight += box.height;
-		});
-
-		helpers.each(bottomBoxes, function(box) {
-			totalBottomBoxesHeight += box.height;
-		});
+		helpers.each(horizontalBoxes, fitBox);
+		addHeightByPosition(horizontalBoxes, outerBoxSizes);
 
 		function finalFitVerticalBox(box) {
 			var minBoxSize = helpers.findNextWhere(minBoxSizes, function(minSize) {
@@ -298,8 +292,8 @@ module.exports = {
 			var scaleMargin = {
 				left: 0,
 				right: 0,
-				top: totalTopBoxesHeight,
-				bottom: totalBottomBoxesHeight
+				top: outerBoxSizes.top,
+				bottom: outerBoxSizes.bottom
 			};
 
 			if (minBoxSize) {
@@ -308,60 +302,34 @@ module.exports = {
 		}
 
 		// Let the left layout know the final margin
-		helpers.each(leftBoxes.concat(rightBoxes), finalFitVerticalBox);
+		helpers.each(verticalBoxes, finalFitVerticalBox);
 
 		// Recalculate because the size of each layout might have changed slightly due to the margins (label rotation for instance)
-		totalLeftBoxesWidth = leftPadding;
-		totalRightBoxesWidth = rightPadding;
-		totalTopBoxesHeight = topPadding;
-		totalBottomBoxesHeight = bottomPadding;
-
-		helpers.each(leftBoxes, function(box) {
-			totalLeftBoxesWidth += box.width;
-		});
-
-		helpers.each(rightBoxes, function(box) {
-			totalRightBoxesWidth += box.width;
-		});
-
-		helpers.each(topBoxes, function(box) {
-			totalTopBoxesHeight += box.height;
-		});
-		helpers.each(bottomBoxes, function(box) {
-			totalBottomBoxesHeight += box.height;
-		});
+		outerBoxSizes = {top: topPadding, left: leftPadding, bottom: bottomPadding, right: rightPadding};
+		addWidthByPosition(verticalBoxes, outerBoxSizes);
+		addHeightByPosition(horizontalBoxes, outerBoxSizes);
 
 		// We may be adding some padding to account for rotated x axis labels
-		var leftPaddingAddition = Math.max(maxHorizontalLeftPadding - totalLeftBoxesWidth, 0);
-		totalLeftBoxesWidth += leftPaddingAddition;
-		totalRightBoxesWidth += Math.max(maxHorizontalRightPadding - totalRightBoxesWidth, 0);
+		var leftPaddingAddition = Math.max(maxPadding.left - outerBoxSizes.left, 0);
+		outerBoxSizes.left += leftPaddingAddition;
+		outerBoxSizes.right += Math.max(maxPadding.right - outerBoxSizes.right, 0);
 
-		var topPaddingAddition = Math.max(maxVerticalTopPadding - totalTopBoxesHeight, 0);
-		totalTopBoxesHeight += topPaddingAddition;
-		totalBottomBoxesHeight += Math.max(maxVerticalBottomPadding - totalBottomBoxesHeight, 0);
+		var topPaddingAddition = Math.max(maxPadding.top - outerBoxSizes.top, 0);
+		outerBoxSizes.top += topPaddingAddition;
+		outerBoxSizes.bottom += Math.max(maxPadding.bottom - outerBoxSizes.bottom, 0);
 
 		// Figure out if our chart area changed. This would occur if the dataset layout label rotation
 		// changed due to the application of the margins in step 6. Since we can only get bigger, this is safe to do
 		// without calling `fit` again
-		var newMaxChartAreaHeight = height - totalTopBoxesHeight - totalBottomBoxesHeight;
-		var newMaxChartAreaWidth = width - totalLeftBoxesWidth - totalRightBoxesWidth;
+		var newMaxChartAreaHeight = height - outerBoxSizes.top - outerBoxSizes.bottom;
+		var newMaxChartAreaWidth = width - outerBoxSizes.left - outerBoxSizes.right;
 
 		if (newMaxChartAreaWidth !== maxChartAreaWidth || newMaxChartAreaHeight !== maxChartAreaHeight) {
-			helpers.each(leftBoxes, function(box) {
+			helpers.each(verticalBoxes, function(box) {
 				box.height = newMaxChartAreaHeight;
 			});
 
-			helpers.each(rightBoxes, function(box) {
-				box.height = newMaxChartAreaHeight;
-			});
-
-			helpers.each(topBoxes, function(box) {
-				if (!box.fullWidth) {
-					box.width = newMaxChartAreaWidth;
-				}
-			});
-
-			helpers.each(bottomBoxes, function(box) {
+			helpers.each(horizontalBoxes, function(box) {
 				if (!box.fullWidth) {
 					box.width = newMaxChartAreaWidth;
 				}
@@ -377,8 +345,8 @@ module.exports = {
 
 		function placeBox(box) {
 			if (box.isHorizontal()) {
-				box.left = box.fullWidth ? leftPadding : totalLeftBoxesWidth;
-				box.right = box.fullWidth ? width - rightPadding : totalLeftBoxesWidth + maxChartAreaWidth;
+				box.left = box.fullWidth ? leftPadding : outerBoxSizes.left;
+				box.right = box.fullWidth ? width - rightPadding : outerBoxSizes.left + maxChartAreaWidth;
 				box.top = top;
 				box.bottom = top + box.height;
 
@@ -389,8 +357,8 @@ module.exports = {
 
 				box.left = left;
 				box.right = left + box.width;
-				box.top = totalTopBoxesHeight;
-				box.bottom = totalTopBoxesHeight + maxChartAreaHeight;
+				box.top = outerBoxSizes.top;
+				box.bottom = outerBoxSizes.top + maxChartAreaHeight;
 
 				// Move to next point
 				left = box.right;
@@ -408,10 +376,10 @@ module.exports = {
 
 		// Step 8
 		chart.chartArea = {
-			left: totalLeftBoxesWidth,
-			top: totalTopBoxesHeight,
-			right: totalLeftBoxesWidth + maxChartAreaWidth,
-			bottom: totalTopBoxesHeight + maxChartAreaHeight
+			left: outerBoxSizes.left,
+			top: outerBoxSizes.top,
+			right: outerBoxSizes.left + maxChartAreaWidth,
+			bottom: outerBoxSizes.top + maxChartAreaHeight
 		};
 
 		// Step 9

--- a/src/core/core.layouts.js
+++ b/src/core/core.layouts.js
@@ -27,17 +27,25 @@ function sortByWeight(array, reverse) {
 }
 
 function findMaxPadding(boxes) {
-	var maxPadding = {top: 0, left: 0, bottom: 0, right: 0};
+	var top = 0;
+	var left = 0;
+	var bottom = 0;
+	var right = 0;
 	helpers.each(boxes, function(box) {
 		if (box.getPadding) {
 			var boxPadding = box.getPadding();
-			maxPadding.left = Math.max(maxPadding.left, boxPadding.left);
-			maxPadding.right = Math.max(maxPadding.right, boxPadding.right);
-			maxPadding.top = Math.max(maxPadding.top, boxPadding.top);
-			maxPadding.bottom = Math.max(maxPadding.bottom, boxPadding.bottom);
+			top = Math.max(top, boxPadding.top);
+			left = Math.max(left, boxPadding.left);
+			bottom = Math.max(bottom, boxPadding.bottom);
+			right = Math.max(right, boxPadding.right);
 		}
 	});
-	return maxPadding;
+	return {
+		top: top,
+		left: left,
+		bottom: bottom,
+		right: right
+	};
 }
 
 function addSizeByPosition(boxes, size) {

--- a/src/core/core.layouts.js
+++ b/src/core/core.layouts.js
@@ -171,7 +171,6 @@ module.exports = {
 		// What we do to find the best sizing, we do the following
 		// 1. Determine the minimum size of the chart area.
 		// 2. Split the remaining width equally between each vertical axis
-		// 3. Split the remaining height equally between each horizontal axis
 		// 4. Give each layout the maximum size it can be. The layout will return it's minimum size
 		// 5. Adjust the sizes of each axis based on it's minimum reported size.
 		// 6. Refit each axis
@@ -183,13 +182,10 @@ module.exports = {
 		var chartWidth = width - leftPadding - rightPadding;
 		var chartHeight = height - topPadding - bottomPadding;
 		var chartAreaWidth = chartWidth / 2; // min 50%
-		var chartAreaHeight = chartHeight / 2; // min 50%
 
 		// Step 2
 		var verticalBoxWidth = (width - chartAreaWidth) / (leftBoxes.length + rightBoxes.length);
 
-		// Step 3
-		var horizontalBoxHeight = (height - chartAreaHeight) / (topBoxes.length + bottomBoxes.length);
 
 		// Step 4
 		var maxChartAreaWidth = chartWidth;
@@ -201,7 +197,7 @@ module.exports = {
 			var isHorizontal = box.isHorizontal();
 
 			if (isHorizontal) {
-				minSize = box.update(box.fullWidth ? chartWidth : maxChartAreaWidth, horizontalBoxHeight);
+				minSize = box.update(box.fullWidth ? chartWidth : maxChartAreaWidth, chartHeight / 2);
 				maxChartAreaHeight -= minSize.height;
 			} else {
 				minSize = box.update(verticalBoxWidth, maxChartAreaHeight);

--- a/src/core/core.layouts.js
+++ b/src/core/core.layouts.js
@@ -203,12 +203,13 @@ module.exports = {
 		// What we do to find the best sizing, we do the following
 		// 1. Determine the minimum size of the chart area.
 		// 2. Split the remaining width equally between each vertical axis
-		// 3. Give each layout the maximum size it can be. The layout will return it's minimum size
-		// 4. Adjust the sizes of each axis based on it's minimum reported size.
-		// 5. Refit each axis
-		// 6. Position each axis in the final location
-		// 7. Tell the chart the final location of the chart area
-		// 8. Tell any axes that overlay the chart area the positions of the chart area
+		// 3. Split the remaining height equally between each horizontal axis
+		// 4. Give each layout the maximum size it can be. The layout will return it's minimum size
+		// 5. Adjust the sizes of each axis based on it's minimum reported size.
+		// 6. Refit each axis
+		// 7. Position each axis in the final location
+		// 8. Tell the chart the final location of the chart area
+		// 9. Tell any axes that overlay the chart area the positions of the chart area
 
 		// Step 1
 		var chartWidth = width - leftPadding - rightPadding;
@@ -219,6 +220,10 @@ module.exports = {
 		var verticalBoxWidth = (width - chartAreaWidth) / verticalBoxes.length;
 
 		// Step 3
+		// TODO re-limit horizontal axis height (this limit has affected only padding calculation since PR 1837)
+		// var horizontalBoxHeight = (height - chartAreaHeight) / (topBoxes.length + bottomBoxes.length);
+
+		// Step 4
 		var maxChartAreaWidth = chartWidth;
 		var maxChartAreaHeight = chartHeight;
 		var outerBoxSizes = {top: topPadding, left: leftPadding, bottom: bottomPadding, right: rightPadding};
@@ -251,7 +256,7 @@ module.exports = {
 
 		// At this point, maxChartAreaHeight and maxChartAreaWidth are the size the chart area could
 		// be if the axes are drawn at their minimum sizes.
-		// Steps 4 & 5
+		// Steps 5 & 6
 
 		// Function to fit a box
 		function fitBox(box) {
@@ -339,7 +344,7 @@ module.exports = {
 			maxChartAreaWidth = newMaxChartAreaWidth;
 		}
 
-		// Step 6 - Position the boxes
+		// Step 7 - Position the boxes
 		var left = leftPadding + leftPaddingAddition;
 		var top = topPadding + topPaddingAddition;
 
@@ -374,7 +379,7 @@ module.exports = {
 		helpers.each(rightBoxes, placeBox);
 		helpers.each(bottomBoxes, placeBox);
 
-		// Step 7
+		// Step 8
 		chart.chartArea = {
 			left: outerBoxSizes.left,
 			top: outerBoxSizes.top,
@@ -382,7 +387,7 @@ module.exports = {
 			bottom: outerBoxSizes.top + maxChartAreaHeight
 		};
 
-		// Step 8
+		// Step 9
 		helpers.each(chartAreaBoxes, function(box) {
 			box.left = chart.chartArea.left;
 			box.top = chart.chartArea.top;


### PR DESCRIPTION
I noticed a issue with layout when working with label rotations.
The left/right padding for all horizontal scales are calculated in a "minimum height" phase. That causes excess padding if long labels are present (rotation would be zero or close to it).

Side effects of this same issue has been worked by @nagix in #5961 / `calculateTickRotation` [comment](https://github.com/chartjs/Chart.js/pull/5961/files#r246709795)

**Master**:
![master](https://user-images.githubusercontent.com/27971921/51832913-ad893a00-22fe-11e9-9de2-5c622dbb6887.png)

**This PR**:
![pr](https://user-images.githubusercontent.com/27971921/51832918-b0842a80-22fe-11e9-850c-21c21422af4f.png)

The actual change is using `chartHeight / 2` instead of `horizontalBoxHeight` in `getMinimumBoxSize`. Other changes are refactoring to make this function simpler.
