### PR TITLE
omit inconsistent note

### DIFF
--- a/docs/general/options.md
+++ b/docs/general/options.md
@@ -16,7 +16,6 @@ color: function(context) {
 }
 ```
 
-> **Note:** scriptable options are only supported by a few bubble chart options.
 
 ## Indexable Options
 


### PR DESCRIPTION
I noticed that recently there were a bunch PRs (#5780, #5973 #5976, #5966) adding scriptable options to different charts which would make the note below inconsistent (now that it looks like a lot of the charts support scriptable options): 

<img width="1430" alt="options_ _chart_js_documentation" src="https://user-images.githubusercontent.com/26232823/51948491-1a83f900-23ff-11e9-936c-6097e0a7ae84.png">

I just omitted it but I guess another option would be to make it more specific to alert the user which charts do/don't support scriptable options.  
