### PR TITLE
Provide a rectangle getArea implementation for horizontal bars

### DIFF
--- a/src/elements/element.rectangle.js
+++ b/src/elements/element.rectangle.js
@@ -206,7 +206,15 @@ module.exports = Element.extend({
 
 	getArea: function() {
 		var vm = this._view;
-		return vm.width * Math.abs(vm.y - vm.base);
+		var area;
+
+		if (isVertical(this)) {
+			area = vm.width * Math.abs(vm.y - vm.base);
+		} else {
+			area = vm.height * Math.abs(vm.x - vm.base);
+		}
+
+		return area;
 	},
 
 	tooltipPosition: function() {

--- a/src/elements/element.rectangle.js
+++ b/src/elements/element.rectangle.js
@@ -206,15 +206,10 @@ module.exports = Element.extend({
 
 	getArea: function() {
 		var vm = this._view;
-		var area;
 
-		if (isVertical(this)) {
-			area = vm.width * Math.abs(vm.y - vm.base);
-		} else {
-			area = vm.height * Math.abs(vm.x - vm.base);
-		}
-
-		return area;
+		return isVertical(this)
+			? vm.width * Math.abs(vm.y - vm.base)
+			: vm.height * Math.abs(vm.x - vm.base);
 	},
 
 	tooltipPosition: function() {

--- a/test/specs/element.rectangle.tests.js
+++ b/test/specs/element.rectangle.tests.js
@@ -132,7 +132,7 @@ describe('Rectangle element tests', function() {
 		});
 	});
 
-	it ('should get the correct area', function() {
+	it ('should get the correct vertical area', function() {
 		var rectangle = new Chart.elements.Rectangle({
 			_datasetIndex: 2,
 			_index: 1
@@ -147,6 +147,23 @@ describe('Rectangle element tests', function() {
 		};
 
 		expect(rectangle.getArea()).toEqual(60);
+	});
+
+	it ('should get the correct horizontal area', function() {
+		var rectangle = new Chart.elements.Rectangle({
+			_datasetIndex: 2,
+			_index: 1
+		});
+
+		// Attach a view object as if we were the controller
+		rectangle._view = {
+			base: 0,
+			height: 4,
+			x: 10,
+			y: 15
+		};
+
+		expect(rectangle.getArea()).toEqual(40);
 	});
 
 	it ('should get the center', function() {


### PR DESCRIPTION
Resolves #4480

It should be noted that since #5857 `getArea()` is not used anywhere in the code.

```
~/D/o/chartjs ❯❯❯ grep getArea -rni src/*
src/elements/element.arc.js:68:	getArea: function() {
src/elements/element.point.js:55:	getArea: function() {
src/elements/element.rectangle.js:207:	getArea: function() {
~/D/o/chartjs ❯❯❯ 
```

I considered removing the method from the different elements but that would be a breaking change. I don't think anyone is using it, but we can't guarantee it.