### PR TITLE
Replace deprecated gulp-util and remove unused watchify

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,11 +1,11 @@
 var gulp = require('gulp');
 var eslint = require('gulp-eslint');
 var file = require('gulp-file');
+var log = require('fancy-log');
 var replace = require('gulp-replace');
 var size = require('gulp-size');
 var streamify = require('gulp-streamify');
 var terser = require('gulp-terser');
-var util = require('gulp-util');
 var zip = require('gulp-zip');
 var exec = require('child_process').exec;
 var karma = require('karma');
@@ -23,7 +23,7 @@ var srcDir = './src/';
 var outDir = './dist/';
 
 if (argv.verbose) {
-  util.log("Gulp running with options: " + JSON.stringify(argv, null, 2));
+  log("Gulp running with options: " + JSON.stringify(argv, null, 2));
 }
 
 gulp.task('bower', bowerTask);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,6 @@
 var gulp = require('gulp');
 var eslint = require('gulp-eslint');
 var file = require('gulp-file');
-var log = require('fancy-log');
 var replace = require('gulp-replace');
 var size = require('gulp-size');
 var streamify = require('gulp-streamify');
@@ -21,10 +20,6 @@ var argv = yargs
 
 var srcDir = './src/';
 var outDir = './dist/';
-
-if (argv.verbose) {
-  log("Gulp running with options: " + JSON.stringify(argv, null, 2));
-}
 
 gulp.task('bower', bowerTask);
 gulp.task('build', buildTask);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "eslint": "^5.9.0",
     "eslint-config-chartjs": "^0.1.0",
     "eslint-plugin-html": "^5.0.0",
-    "fancy-log": "^1.3.3",
     "gitbook-cli": "^2.3.2",
     "gulp": "^4.0.0",
     "gulp-eslint": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint": "^5.9.0",
     "eslint-config-chartjs": "^0.1.0",
     "eslint-plugin-html": "^5.0.0",
+    "fancy-log": "^1.3.3",
     "gitbook-cli": "^2.3.2",
     "gulp": "^4.0.0",
     "gulp-eslint": "^5.0.0",
@@ -36,11 +37,10 @@
     "gulp-size": "^3.0.0",
     "gulp-streamify": "^1.0.2",
     "gulp-terser": "^1.1.6",
-    "gulp-util": "^3.0.0",
     "gulp-zip": "^4.2.0",
     "jasmine": "^3.3.0",
     "jasmine-core": "^3.3.0",
-    "karma": "^3.1.1",
+    "karma": "^4.0.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-coverage": "^1.1.1",
     "karma-firefox-launcher": "^1.0.1",
@@ -54,7 +54,6 @@
     "rollup-plugin-istanbul": "^2.0.1",
     "rollup-plugin-node-resolve": "^3.4.0",
     "rollup-plugin-terser": "^3.0.0",
-    "watchify": "^3.9.0",
     "yargs": "^12.0.5"
   },
   "dependencies": {


### PR DESCRIPTION
<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
