### PR TITLE
Introduce formatter -options for tooltips and tick labels

### DIFF
--- a/samples/scales/logarithmic/scatter.html
+++ b/samples/scales/logarithmic/scatter.html
@@ -136,7 +136,7 @@
 						type: 'logarithmic',
 						position: 'bottom',
 						ticks: {
-							userCallback: function(tick) {
+							callback: function(tick) {
 								var remain = tick / (Math.pow(10, Math.floor(Chart.helpers.log10(tick))));
 								if (remain === 1 || remain === 2 || remain === 5) {
 									return tick.toString() + 'Hz';
@@ -152,7 +152,7 @@
 					yAxes: [{
 						type: 'linear',
 						ticks: {
-							userCallback: function(tick) {
+							callback: function(tick) {
 								return tick.toString() + 'dB';
 							}
 						},

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -580,6 +580,9 @@ module.exports = Element.extend({
 		return rawValue;
 	},
 
+	/**
+	 * @private
+	 */
 	_formatTick: function(tick, index) {
 		var me = this;
 		var context = {
@@ -589,6 +592,7 @@ module.exports = Element.extend({
 		};
 		return valueOrDefault(callback(me._config.tickFormatter, [tick, context]), tick.label);
 	},
+
 	/**
 	 * @private
 	 */

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -217,8 +217,8 @@ function createTooltipItem(element) {
 	return {
 		xLabel: xScale ? xScale.getLabelForIndex(index, datasetIndex) : '',
 		yLabel: yScale ? yScale.getLabelForIndex(index, datasetIndex) : '',
-		label: indexScale ? '' + indexScale.getLabelForIndex(index, datasetIndex) : '',
-		value: valueScale ? '' + valueScale.getLabelForIndex(index, datasetIndex) : '',
+		label: indexScale ? indexScale._formatTooltip(index, datasetIndex) : '',
+		value: valueScale ? valueScale._formatTooltip(index, datasetIndex) : '',
 		index: index,
 		datasetIndex: datasetIndex,
 		x: element._model.x,

--- a/src/scales/scale.linearbase.js
+++ b/src/scales/scale.linearbase.js
@@ -230,6 +230,6 @@ module.exports = Scale.extend({
 		me.ticksAsNumbers = me.ticks.slice();
 		me.zeroLineIndex = me.ticks.indexOf(0);
 
-		Scale.prototype.convertTicksToLabels.call(me);
+		return Scale.prototype.convertTicksToLabels.call(me);
 	}
 });

--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -237,7 +237,7 @@ module.exports = Scale.extend({
 	convertTicksToLabels: function() {
 		this.tickValues = this.ticks.slice();
 
-		Scale.prototype.convertTicksToLabels.call(this);
+		return Scale.prototype.convertTicksToLabels.call(this);
 	},
 
 	// Get the correct tooltip label

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -368,10 +368,12 @@ module.exports = LinearScaleBase.extend({
 	convertTicksToLabels: function() {
 		var me = this;
 
-		LinearScaleBase.prototype.convertTicksToLabels.call(me);
+		var labels = LinearScaleBase.prototype.convertTicksToLabels.call(me);
 
 		// Point labels
 		me.pointLabels = me.chart.data.labels.map(me.options.pointLabels.callback, me);
+
+		return labels;
 	},
 
 	getLabelForIndex: function(index, datasetIndex) {

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -643,7 +643,7 @@ module.exports = Scale.extend({
 			ticks.reverse();
 		}
 
-		return ticksFromTimestamps(ticks, options.ticks.major.enabled ? me._majorUnit : false);
+		return ticksFromTimestamps(ticks, me._majorUnit);
 	},
 
 	getLabelForIndex: function(index, datasetIndex) {
@@ -674,9 +674,11 @@ module.exports = Scale.extend({
 		var me = this;
 		var options = me.options;
 		var formats = options.time.displayFormats;
-		var tickOpts = tick.major ? options.ticks.major : options.ticks.minor;
+		var major = options.ticks.major;
+		var isMajor = major.enabled && tick.major;
+		var tickOpts = isMajor ? major : options.ticks.minor;
 		var formatter = valueOrDefault(tickOpts.callback, tickOpts.userCallback);
-		var timeFormat = format || (tick.major ? formats[me._majorUnit] : formats[me._unit]);
+		var timeFormat = format || (isMajor ? formats[me._majorUnit] : formats[me._unit]);
 		var label = adapter.format(tick.value, timeFormat);
 		tick.label = formatter ? formatter(label, index, ticks) : label;
 		return me._formatTick(tick, index);

--- a/test/specs/core.scale.tests.js
+++ b/test/specs/core.scale.tests.js
@@ -74,7 +74,7 @@ describe('Core.scale', function() {
 			expect(lastTick(chart).label).toBeUndefined();
 		});
 
-		it('should display multiline-labels correctly', function() {
+		it('should display multiline labels correctly', function() {
 			var chart = getChart({
 				labels: [
 					['January', '2018'], 'February 2018', 'March 2018', 'April 2018',
@@ -87,7 +87,6 @@ describe('Core.scale', function() {
 			});
 
 			expect(lastTick(chart).label).toEqual(['September', '2018']);
-
 		});
 	});
 

--- a/test/specs/core.scale.tests.js
+++ b/test/specs/core.scale.tests.js
@@ -73,6 +73,22 @@ describe('Core.scale', function() {
 
 			expect(lastTick(chart).label).toBeUndefined();
 		});
+
+		it('should display multiline-labels correctly', function() {
+			var chart = getChart({
+				labels: [
+					['January', '2018'], 'February 2018', 'March 2018', 'April 2018',
+					'May 2018', 'June 2018', 'July 2018', 'August 2018',
+					['September', '2018']
+				],
+				datasets: [{
+					data: [12, 19, 3, 5, 2, 3, 7, 8, 9]
+				}]
+			});
+
+			expect(lastTick(chart).label).toEqual(['September', '2018']);
+
+		});
 	});
 
 	var gridLineTests = [{


### PR DESCRIPTION
#### Couple of things going on here:

* Fix scatter sample to use `callback` instead of legacy `userCallback`
* Alias helpers.callback for minimization
* Propose a `_configure` step to scale for resolving options
* Propose a fallback path for `formatter` options in `_configure`
* Propose `_formatTick` and `_formatTooltip` method names
* Format tick labels if a callback is provided
* Format `value`/`label` in `TooltipItem`
* Add a test for multiline labels (I broke it and nothing failed)

#### Todo if merging is plausible:
- [ ] Tests for `formatter`'s
- [ ] Docs

#### For testing: [CodePen](https://codepen.io/kurkle/pen/Rvpagg)
