### PR TITLE
Remove unused eslint directive

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -1,4 +1,3 @@
-/* global window: false */
 'use strict';
 
 var adapter = require('../core/core.adapters')._date;


### PR DESCRIPTION
`gulp lint` has started failing with the latest version because of this unused directive. This fixes the build on master