### PR TITLE
Move CSS in a separate file to be CSP-compliant

### DIFF
--- a/docs/getting-started/integration.md
+++ b/docs/getting-started/integration.md
@@ -87,7 +87,7 @@ require(['moment'], function() {
 
 ## Content Security Policy
 
-By default, Chart.js injects CSS directly into the DOM. For webpages secured using [`Content-Security-Policy` (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy), this requires to allow `style-src 'unsafe-inline'`. For stricter CSP environments, where only `style-src 'self'` is allowed, the following CSS file needs to be manually added to your webpage:
+By default, Chart.js injects CSS directly into the DOM. For webpages secured using [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP), this requires to allow `style-src 'unsafe-inline'`. For stricter CSP environments, where only `style-src 'self'` is allowed, the following CSS file needs to be manually added to your webpage:
 
 ```html
 <link rel="stylesheet" type="text/css" href="path/to/chartjs/dist/Chart.min.css">
@@ -97,5 +97,5 @@ And the style injection must be turned off **before creating the first chart**:
 
 ```javascript
 // Disable automatic style injection
-Chart.platform.useExternalStylesheet = true;
+Chart.platform.disableCSSInjection = true;
 ```

--- a/docs/getting-started/integration.md
+++ b/docs/getting-started/integration.md
@@ -84,3 +84,18 @@ require(['moment'], function() {
     });
 });
 ```
+
+## Content-Security-Policy
+
+By default, Chart.js injects CSS directly into the DOM. For webpages secured using [Content-Security-Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy), this requires to allow `style-src 'unsafe-inline'`. For stricter CSP environments, where only `style-src 'self'` is allowed, the following CSS file needs to be manually added to your webpage:
+
+```html
+<link rel="stylesheet" type="text/css" href="path/to/chartjs/dist/Chart.min.css">
+```
+
+And the style injection must be turned off **before creating the first chart**:
+
+```javascript
+// Disable automatic style injection
+Chart.platform.useExternalStylesheet = true;
+```

--- a/docs/getting-started/integration.md
+++ b/docs/getting-started/integration.md
@@ -85,9 +85,9 @@ require(['moment'], function() {
 });
 ```
 
-## Content-Security-Policy
+## Content Security Policy
 
-By default, Chart.js injects CSS directly into the DOM. For webpages secured using [Content-Security-Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy), this requires to allow `style-src 'unsafe-inline'`. For stricter CSP environments, where only `style-src 'self'` is allowed, the following CSS file needs to be manually added to your webpage:
+By default, Chart.js injects CSS directly into the DOM. For webpages secured using [`Content-Security-Policy` (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy), this requires to allow `style-src 'unsafe-inline'`. For stricter CSP environments, where only `style-src 'self'` is allowed, the following CSS file needs to be manually added to your webpage:
 
 ```html
 <link rel="stylesheet" type="text/css" href="path/to/chartjs/dist/Chart.min.css">

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -86,7 +86,7 @@ function buildTask() {
 function packageTask() {
   return merge(
       // gather "regular" files landing in the package root
-      gulp.src([outDir + '*.js', 'LICENSE.md']),
+      gulp.src([outDir + '*.js', outDir + '*.css', 'LICENSE.md']),
 
       // since we moved the dist files one folder up (package root), we need to rewrite
       // samples src="../dist/ to src="../ and then copy them in the /samples directory.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "url": "https://github.com/chartjs/Chart.js/issues"
   },
   "devDependencies": {
+    "clean-css": "^4.2.1",
     "coveralls": "^3.0.0",
     "eslint": "^5.9.0",
     "eslint-config-chartjs": "^0.1.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -29,7 +29,7 @@ module.exports = [
 			}),
 			optional({
 				include: ['moment']
-			}),
+			})
 		],
 		output: {
 			name: 'Chart',

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,7 @@ const commonjs = require('rollup-plugin-commonjs');
 const resolve = require('rollup-plugin-node-resolve');
 const terser = require('rollup-plugin-terser').terser;
 const optional = require('./rollup.plugins').optional;
+const stylesheet = require('./rollup.plugins').stylesheet;
 const pkg = require('./package.json');
 
 const input = 'src/chart.js';
@@ -23,9 +24,12 @@ module.exports = [
 		plugins: [
 			resolve(),
 			commonjs(),
+			stylesheet({
+				extract: true
+			}),
 			optional({
 				include: ['moment']
-			})
+			}),
 		],
 		output: {
 			name: 'Chart',
@@ -48,6 +52,10 @@ module.exports = [
 			commonjs(),
 			optional({
 				include: ['moment']
+			}),
+			stylesheet({
+				extract: true,
+				minify: true
 			}),
 			terser({
 				output: {
@@ -76,7 +84,8 @@ module.exports = [
 		input: input,
 		plugins: [
 			resolve(),
-			commonjs()
+			commonjs(),
+			stylesheet()
 		],
 		output: {
 			name: 'Chart',
@@ -91,6 +100,9 @@ module.exports = [
 		plugins: [
 			resolve(),
 			commonjs(),
+			stylesheet({
+				minify: true
+			}),
 			terser({
 				output: {
 					preamble: banner

--- a/samples/advanced/content-security-policy.css
+++ b/samples/advanced/content-security-policy.css
@@ -1,5 +1,20 @@
 .content {
 	max-width: 640px;
 	margin: auto;
-	padding: 16px 32px;
+	padding: 1rem;
+}
+
+.note {
+	font-family: sans-serif;
+	color: #5050a0;
+	line-height: 1.4;
+	margin-bottom: 1rem;
+	padding: 1rem;
+}
+
+code {
+	background-color: #f5f5ff;
+	border: 1px solid #d0d0fa;
+	border-radius: 4px;
+	padding: 0.05rem 0.25rem;
 }

--- a/samples/advanced/content-security-policy.css
+++ b/samples/advanced/content-security-policy.css
@@ -1,0 +1,5 @@
+.content {
+	max-width: 640px;
+	margin: auto;
+	padding: 16px 32px;
+}

--- a/samples/advanced/content-security-policy.html
+++ b/samples/advanced/content-security-policy.html
@@ -14,6 +14,11 @@
 </head>
 <body>
 	<div class="content">
+		<div class="note">
+			In order to support a strict content security policy (<code>default-src 'self'</code>),
+			this page manually loads <code>Chart.min.css</code> and turns off the automatic style
+			injection by setting <code>Chart.platform.useExternalStylesheet = true;</code>.
+		</div>
 		<div class="wrapper">
 			<canvas id="chart-0"></canvas>
 		</div>

--- a/samples/advanced/content-security-policy.html
+++ b/samples/advanced/content-security-policy.html
@@ -17,7 +17,7 @@
 		<div class="note">
 			In order to support a strict content security policy (<code>default-src 'self'</code>),
 			this page manually loads <code>Chart.min.css</code> and turns off the automatic style
-			injection by setting <code>Chart.platform.useExternalStylesheet = true;</code>.
+			injection by setting <code>Chart.platform.disableCSSInjection = true;</code>.
 		</div>
 		<div class="wrapper">
 			<canvas id="chart-0"></canvas>

--- a/samples/advanced/content-security-policy.html
+++ b/samples/advanced/content-security-policy.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=Edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta http-equiv="Content-Security-Policy" content="default-src 'self'">
+	<title>Scriptable > Bubble | Chart.js sample</title>
+	<link rel="stylesheet" type="text/css" href="../../dist/Chart.min.css">
+	<link rel="stylesheet" type="text/css" href="./content-security-policy.css">
+	<script src="../../dist/Chart.min.js"></script>
+	<script src="../utils.js"></script>
+	<script src="content-security-policy.js"></script>
+</head>
+<body>
+	<div class="content">
+		<div class="wrapper">
+			<canvas id="chart-0"></canvas>
+		</div>
+	</div>
+</body>
+</html>

--- a/samples/advanced/content-security-policy.js
+++ b/samples/advanced/content-security-policy.js
@@ -1,0 +1,54 @@
+var utils = Samples.utils;
+
+// CSP: disable automatic style injection
+Chart.platform.useExternalStylesheet = true;
+
+utils.srand(110);
+
+function generateData() {
+	var DATA_COUNT = 16;
+	var MIN_XY = -150;
+	var MAX_XY = 100;
+	var data = [];
+	var i;
+
+	for (i = 0; i < DATA_COUNT; ++i) {
+		data.push({
+			x: utils.rand(MIN_XY, MAX_XY),
+			y: utils.rand(MIN_XY, MAX_XY),
+			v: utils.rand(0, 1000)
+		});
+	}
+
+	return data;
+}
+
+window.addEventListener('load', function() {
+	new Chart('chart-0', {
+		type: 'bubble',
+		data: {
+			datasets: [{
+				backgroundColor: utils.color(0),
+				data: generateData()
+			}, {
+				backgroundColor: utils.color(1),
+				data: generateData()
+			}]
+		},
+		options: {
+			aspectRatio: 1,
+			legend: false,
+			tooltip: false,
+			elements: {
+				point: {
+					radius: function(context) {
+						var value = context.dataset.data[context.dataIndex];
+						var size = context.chart.width;
+						var base = Math.abs(value.v) / 1000;
+						return (size / 24) * base;
+					}
+				}
+			}
+		}
+	});
+});

--- a/samples/advanced/content-security-policy.js
+++ b/samples/advanced/content-security-policy.js
@@ -1,7 +1,7 @@
 var utils = Samples.utils;
 
 // CSP: disable automatic style injection
-Chart.platform.useExternalStylesheet = true;
+Chart.platform.disableCSSInjection = true;
 
 utils.srand(110);
 

--- a/samples/samples.js
+++ b/samples/samples.js
@@ -187,6 +187,9 @@
 		items: [{
 			title: 'Progress bar',
 			path: 'advanced/progress-bar.html'
+		}, {
+			title: 'Content-Security-Policy',
+			path: 'advanced/content-security-policy.html'
 		}]
 	}];
 

--- a/samples/samples.js
+++ b/samples/samples.js
@@ -188,7 +188,7 @@
 			title: 'Progress bar',
 			path: 'advanced/progress-bar.html'
 		}, {
-			title: 'Content-Security-Policy',
+			title: 'Content Security Policy',
 			path: 'advanced/content-security-policy.html'
 		}]
 	}];

--- a/samples/style.css
+++ b/samples/style.css
@@ -1,4 +1,3 @@
-
 @import url('https://fonts.googleapis.com/css?family=Lato:100,300,400,700,900');
 
 body, html {

--- a/samples/style.css
+++ b/samples/style.css
@@ -1,4 +1,4 @@
-@import url('https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css');
+
 @import url('https://fonts.googleapis.com/css?family=Lato:100,300,400,700,900');
 
 body, html {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -41,6 +41,7 @@ cd $TARGET_DIR
 git checkout $TARGET_BRANCH
 
 # Copy dist files
+deploy_files '../dist/*.css' './dist'
 deploy_files '../dist/*.js' './dist'
 
 # Copy generated documentation

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -21,7 +21,7 @@ git remote add auth-origin https://$GITHUB_AUTH_TOKEN@github.com/$TRAVIS_REPO_SL
 git config --global user.email "$GITHUB_AUTH_EMAIL"
 git config --global user.name "Chart.js"
 git checkout --detach --quiet
-git add -f dist/*.js bower.json
+git add -f dist/*.css dist/*.js bower.json
 git commit -m "Release $VERSION"
 git tag -a "v$VERSION" -m "Version $VERSION"
 git push -q auth-origin refs/tags/v$VERSION 2>/dev/null

--- a/src/platforms/platform.dom.css
+++ b/src/platforms/platform.dom.css
@@ -2,17 +2,12 @@
  * DOM element rendering detection
  * https://davidwalsh.name/detect-node-insertion
  */
-@-webkit-keyframes chartjs-render-animation {
-	from { opacity: 0.99; }
-	to { opacity: 1; }
-}
 @keyframes chartjs-render-animation {
 	from { opacity: 0.99; }
 	to { opacity: 1; }
 }
 
 .chartjs-render-monitor {
-	-webkit-animation: chartjs-render-animation 0.001s;
 	animation: chartjs-render-animation 0.001s;
 }
 

--- a/src/platforms/platform.dom.css
+++ b/src/platforms/platform.dom.css
@@ -1,0 +1,51 @@
+/*
+ * DOM element rendering detection
+ * https://davidwalsh.name/detect-node-insertion
+ */
+@-webkit-keyframes chartjs-render-animation {
+	from { opacity: 0.99; }
+	to { opacity: 1; }
+}
+@keyframes chartjs-render-animation {
+	from { opacity: 0.99; }
+	to { opacity: 1; }
+}
+
+.chartjs-render-monitor {
+	-webkit-animation: chartjs-render-animation 0.001s;
+	animation: chartjs-render-animation 0.001s;
+}
+
+/*
+ * DOM element resizing detection
+ * https://github.com/marcj/css-element-queries
+ */
+.chartjs-size-monitor,
+.chartjs-size-monitor-expand,
+.chartjs-size-monitor-shrink {
+	position: absolute;
+	left: 0;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	overflow: hidden;
+	pointer-events: none;
+	visibility: hidden;
+	z-index: -1;
+}
+
+.chartjs-size-monitor-expand > div {
+	position: absolute;
+	width: 1000000px;
+	height: 1000000px;
+	left: 0;
+	top: 0;
+}
+
+.chartjs-size-monitor-shrink > div {
+	position: absolute;
+	width: 200%;
+	height: 200%;
+	left: 0;
+	top: 0;
+}

--- a/src/platforms/platform.dom.js
+++ b/src/platforms/platform.dom.js
@@ -315,7 +315,7 @@ module.exports = {
 	 * to be manually imported to make this library compatible with any CSP.
 	 * See https://github.com/chartjs/Chart.js/issues/5208
 	 */
-	useExternalStylesheet: false,
+	disableCSSInjection: false,
 
 	/**
 	 * This property holds whether this platform is enabled for the current environment.
@@ -335,7 +335,7 @@ module.exports = {
 		this._loaded = true;
 
 		// https://github.com/chartjs/Chart.js/issues/5208
-		if (!this.useExternalStylesheet) {
+		if (!this.disableCSSInjection) {
 			injectCSS(this, stylesheet);
 		}
 	},
@@ -359,7 +359,7 @@ module.exports = {
 		var context = item && item.getContext && item.getContext('2d');
 
 		// Load platform resources on first chart creation, to make possible to change
-		// platform options after importing the library (e.g. `useExternalStylesheet`).
+		// platform options after importing the library (e.g. `disableCSSInjection`).
 		this._ensureLoaded();
 
 		// `instanceof HTMLCanvasElement/CanvasRenderingContext2D` fails when the item is

--- a/src/platforms/platform.dom.js
+++ b/src/platforms/platform.dom.js
@@ -5,9 +5,11 @@
 'use strict';
 
 var helpers = require('../helpers/index');
+var stylesheet = require('./platform.dom.css');
 
 var EXPANDO_KEY = '$chartjs';
 var CSS_PREFIX = 'chartjs-';
+var CSS_SIZE_MONITOR = CSS_PREFIX + 'size-monitor';
 var CSS_RENDER_MONITOR = CSS_PREFIX + 'render-monitor';
 var CSS_RENDER_ANIMATION = CSS_PREFIX + 'render-animation';
 var ANIMATION_START_EVENTS = ['animationstart', 'webkitAnimationStart'];
@@ -166,48 +168,24 @@ function throttled(fn, thisArg) {
 	};
 }
 
-function createDiv(cls, style) {
+function createDiv(cls) {
 	var el = document.createElement('div');
-	el.style.cssText = style || '';
 	el.className = cls || '';
 	return el;
 }
 
 // Implementation based on https://github.com/marcj/css-element-queries
 function createResizer(handler) {
-	var cls = CSS_PREFIX + 'size-monitor';
 	var maxSize = 1000000;
-	var style =
-		'position:absolute;' +
-		'left:0;' +
-		'top:0;' +
-		'right:0;' +
-		'bottom:0;' +
-		'overflow:hidden;' +
-		'pointer-events:none;' +
-		'visibility:hidden;' +
-		'z-index:-1;';
 
 	// NOTE(SB) Don't use innerHTML because it could be considered unsafe.
 	// https://github.com/chartjs/Chart.js/issues/5902
-	var resizer = createDiv(cls, style);
-	var expand = createDiv(cls + '-expand', style);
-	var shrink = createDiv(cls + '-shrink', style);
+	var resizer = createDiv(CSS_SIZE_MONITOR);
+	var expand = createDiv(CSS_SIZE_MONITOR + '-expand');
+	var shrink = createDiv(CSS_SIZE_MONITOR + '-shrink');
 
-	expand.appendChild(createDiv('',
-		'position:absolute;' +
-		'height:' + maxSize + 'px;' +
-		'width:' + maxSize + 'px;' +
-		'left:0;' +
-		'top:0;'
-	));
-	shrink.appendChild(createDiv('',
-		'position:absolute;' +
-		'height:200%;' +
-		'width:200%;' +
-		'left:0;' +
-		'top:0;'
-	));
+	expand.appendChild(createDiv());
+	shrink.appendChild(createDiv());
 
 	resizer.appendChild(expand);
 	resizer.appendChild(shrink);
@@ -331,25 +309,35 @@ function injectCSS(platform, css) {
 
 module.exports = {
 	/**
+	 * When `true`, prevents the automatic injection of the stylesheet required to
+	 * correctly detect when the chart is added to the DOM and then resized. This
+	 * switch has been added to allow external stylesheet (`dist/Chart(.min)?.js`)
+	 * to be manually imported to make this library compatible with any CSP.
+	 * See https://github.com/chartjs/Chart.js/issues/5208
+	 */
+	useExternalStylesheet: false,
+
+	/**
 	 * This property holds whether this platform is enabled for the current environment.
 	 * Currently used by platform.js to select the proper implementation.
 	 * @private
 	 */
 	_enabled: typeof window !== 'undefined' && typeof document !== 'undefined',
 
-	initialize: function() {
-		var keyframes = 'from{opacity:0.99}to{opacity:1}';
+	/**
+	 * @private
+	 */
+	_ensureLoaded: function() {
+		if (this._loaded) {
+			return;
+		}
 
-		injectCSS(this,
-			// DOM rendering detection
-			// https://davidwalsh.name/detect-node-insertion
-			'@-webkit-keyframes ' + CSS_RENDER_ANIMATION + '{' + keyframes + '}' +
-			'@keyframes ' + CSS_RENDER_ANIMATION + '{' + keyframes + '}' +
-			'.' + CSS_RENDER_MONITOR + '{' +
-				'-webkit-animation:' + CSS_RENDER_ANIMATION + ' 0.001s;' +
-				'animation:' + CSS_RENDER_ANIMATION + ' 0.001s;' +
-			'}'
-		);
+		this._loaded = true;
+
+		// https://github.com/chartjs/Chart.js/issues/5208
+		if (!this.useExternalStylesheet) {
+			injectCSS(this, stylesheet);
+		}
 	},
 
 	acquireContext: function(item, config) {
@@ -369,6 +357,10 @@ module.exports = {
 		// method, for example: https://github.com/kkapsner/CanvasBlocker
 		// https://github.com/chartjs/Chart.js/issues/2807
 		var context = item && item.getContext && item.getContext('2d');
+
+		// Load platform resources on first chart creation, to make possible to change
+		// platform options after importing the library (e.g. `useExternalStylesheet`).
+		this._ensureLoaded();
 
 		// `instanceof HTMLCanvasElement/CanvasRenderingContext2D` fails when the item is
 		// inside an iframe or when running in a protected environment. We could guess the


### PR DESCRIPTION
In order to be compatible with any CSP, we need to prevent the automatic creation of the DOM 'style' element and offer our CSS as a separate file that can be manually loaded (`Chart.js` or `Chart.min.js`). Users can now opt-out the style injection using `Chart.platform.disableCSSInjection = true` (note that the style sheet is now injected on the first chart creation).

To prevent duplicating and maintaining the same CSS code at different places, move all these rules in `platform.dom.css` and write a minimal rollup plugin to inject that style as string in `platform.dom.js`. Additionally, this plugin extract the imported style in `./dist/Chart.js` and `./dist/Chart.min.js`.

@jelhan @SebastianNiemann can you guys review and test that PR, then confirm it fixes CSP issues?

Closes #5952
Closes #6015
Fixes #5208
Fixes #5295
