### PR TITLE
Ignore invalid log scale min and max

### DIFF
--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -62,7 +62,7 @@ var defaultConfig = {
 	}
 };
 
-// TODO(v3): change this to isPositiveOrDefault
+// TODO(v3): change this to positiveOrDefault
 function nonNegativeOrDefault(value, defaultValue) {
 	return helpers.isFinite(value) && value >= 0 ? value : defaultValue;
 }

--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -62,6 +62,10 @@ var defaultConfig = {
 	}
 };
 
+function isNonNegative(value) {
+	return typeof(value) === 'number' && value >= 0;
+}
+
 module.exports = Scale.extend({
 	determineDataLimits: function() {
 		var me = this;
@@ -174,8 +178,8 @@ module.exports = Scale.extend({
 		var DEFAULT_MIN = 1;
 		var DEFAULT_MAX = 10;
 
-		me.min = tickOpts.min >= 0 ? tickOpts.min : me.min;
-		me.max = tickOpts.max >= 0 ? tickOpts.max : me.max;
+		me.min = isNonNegative(tickOpts.min) ? tickOpts.min : me.min;
+		me.max = isNonNegative(tickOpts.max) ? tickOpts.max : me.max;
 
 		if (me.min === me.max) {
 			if (me.min !== 0 && me.min !== null) {
@@ -211,8 +215,8 @@ module.exports = Scale.extend({
 		var reverse = !me.isHorizontal();
 
 		var generationOptions = {
-			min: tickOpts.min >= 0 ? tickOpts.min : undefined,
-			max: tickOpts.max >= 0 ? tickOpts.max : undefined
+			min: isNonNegative(tickOpts.min) ? tickOpts.min : undefined,
+			max: isNonNegative(tickOpts.max) ? tickOpts.max : undefined
 		};
 		var ticks = me.ticks = generateTicks(generationOptions, me);
 

--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -62,6 +62,7 @@ var defaultConfig = {
 	}
 };
 
+// TODO(v3): change this to isPositive
 function isNonNegative(value) {
 	return typeof value === 'number' && value >= 0;
 }

--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -63,7 +63,7 @@ var defaultConfig = {
 };
 
 function isNonNegative(value) {
-	return typeof(value) === 'number' && value >= 0;
+	return typeof value === 'number' && value >= 0;
 }
 
 module.exports = Scale.extend({

--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -64,7 +64,7 @@ var defaultConfig = {
 
 // TODO(v3): change this to isPositive
 function isNonNegative(value) {
-	return typeof value === 'number' && value >= 0;
+	return helpers.isFinite(value) && value >= 0;
 }
 
 module.exports = Scale.extend({

--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -62,9 +62,9 @@ var defaultConfig = {
 	}
 };
 
-// TODO(v3): change this to isPositive
-function isNonNegative(value) {
-	return helpers.isFinite(value) && value >= 0;
+// TODO(v3): change this to isPositiveOrDefault
+function nonNegativeOrDefault(value, defaultValue) {
+	return helpers.isFinite(value) && value >= 0 ? value : defaultValue;
 }
 
 module.exports = Scale.extend({
@@ -179,8 +179,8 @@ module.exports = Scale.extend({
 		var DEFAULT_MIN = 1;
 		var DEFAULT_MAX = 10;
 
-		me.min = isNonNegative(tickOpts.min) ? tickOpts.min : me.min;
-		me.max = isNonNegative(tickOpts.max) ? tickOpts.max : me.max;
+		me.min = nonNegativeOrDefault(tickOpts.min, me.min);
+		me.max = nonNegativeOrDefault(tickOpts.max, me.max);
 
 		if (me.min === me.max) {
 			if (me.min !== 0 && me.min !== null) {
@@ -216,8 +216,8 @@ module.exports = Scale.extend({
 		var reverse = !me.isHorizontal();
 
 		var generationOptions = {
-			min: isNonNegative(tickOpts.min) ? tickOpts.min : undefined,
-			max: isNonNegative(tickOpts.max) ? tickOpts.max : undefined
+			min: nonNegativeOrDefault(tickOpts.min),
+			max: nonNegativeOrDefault(tickOpts.max)
 		};
 		var ticks = me.ticks = generateTicks(generationOptions, me);
 

--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -174,8 +174,8 @@ module.exports = Scale.extend({
 		var DEFAULT_MIN = 1;
 		var DEFAULT_MAX = 10;
 
-		me.min = valueOrDefault(tickOpts.min, me.min);
-		me.max = valueOrDefault(tickOpts.max, me.max);
+		me.min = tickOpts.min >= 0 ? tickOpts.min : me.min;
+		me.max = tickOpts.max >= 0 ? tickOpts.max : me.max;
 
 		if (me.min === me.max) {
 			if (me.min !== 0 && me.min !== null) {
@@ -211,8 +211,8 @@ module.exports = Scale.extend({
 		var reverse = !me.isHorizontal();
 
 		var generationOptions = {
-			min: tickOpts.min,
-			max: tickOpts.max
+			min: tickOpts.min >= 0 ? tickOpts.min : undefined,
+			max: tickOpts.max >= 0 ? tickOpts.max : undefined
 		};
 		var ticks = me.ticks = generateTicks(generationOptions, me);
 

--- a/test/specs/scale.logarithmic.tests.js
+++ b/test/specs/scale.logarithmic.tests.js
@@ -477,7 +477,7 @@ describe('Logarithmic Scale tests', function() {
 		expect(yScale.ticks[tickCount - 1]).toBe(10);
 	});
 
-	it('should ignore invalid min and max options', function() {
+	it('should ignore negative min and max options', function() {
 		var chart = window.acquireChart({
 			type: 'bar',
 			data: {
@@ -494,6 +494,37 @@ describe('Logarithmic Scale tests', function() {
 						ticks: {
 							min: -10,
 							max: -1010,
+							callback: function(value) {
+								return value;
+							}
+						}
+					}]
+				}
+			}
+		});
+
+		var yScale = chart.scales.yScale;
+		expect(yScale.min).toBe(0);
+		expect(yScale.max).toBe(2);
+	});
+
+	it('should ignore invalid min and max options', function() {
+		var chart = window.acquireChart({
+			type: 'bar',
+			data: {
+				datasets: [{
+					data: [1, 1, 1, 2, 1, 0]
+				}],
+				labels: []
+			},
+			options: {
+				scales: {
+					yAxes: [{
+						id: 'yScale',
+						type: 'logarithmic',
+						ticks: {
+							min: '',
+							max: false,
 							callback: function(value) {
 								return value;
 							}

--- a/test/specs/scale.logarithmic.tests.js
+++ b/test/specs/scale.logarithmic.tests.js
@@ -477,6 +477,37 @@ describe('Logarithmic Scale tests', function() {
 		expect(yScale.ticks[tickCount - 1]).toBe(10);
 	});
 
+	it('should ignore invalid min and max options', function() {
+		var chart = window.acquireChart({
+			type: 'bar',
+			data: {
+				datasets: [{
+					data: [1, 1, 1, 2, 1, 0]
+				}],
+				labels: []
+			},
+			options: {
+				scales: {
+					yAxes: [{
+						id: 'yScale',
+						type: 'logarithmic',
+						ticks: {
+							min: -10,
+							max: -1010,
+							callback: function(value) {
+								return value;
+							}
+						}
+					}]
+				}
+			}
+		});
+
+		var yScale = chart.scales.yScale;
+		expect(yScale.min).toBe(0);
+		expect(yScale.max).toBe(2);
+	});
+
 	it('should generate tick marks', function() {
 		var chart = window.acquireChart({
 			type: 'bar',


### PR DESCRIPTION
Currently the log scale fails to render if a negative value is passed to it. This changes it to ignore the invalid value instead