### PR TITLE
Add onLeave callback to legend

### DIFF
--- a/samples/legend/callbacks.html
+++ b/samples/legend/callbacks.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<html>
+
+<head>
+	<title>Line Chart</title>
+	<script src="../../../dist/Chart.min.js"></script>
+	<script src="../utils.js"></script>
+	<style>
+		body, html {
+			height: 100%;
+			font-family: sans-serif;
+		}
+		canvas{
+			-moz-user-select: none;
+			-webkit-user-select: none;
+			-ms-user-select: none;
+		}
+
+		#log {
+			position: absolute;
+			right: 0;
+			top: 0;
+			bottom: 0;
+			background-color: #EEE;
+			float: right;
+			width: 20%;
+			padding: 8px;
+			overflow-y: auto;
+			white-space: pre;
+			line-height: 1.5em;
+		}
+	</style>
+</head>
+
+<body>
+	<div id="log"></div>
+	<div style="width:75%;">
+		<canvas id="canvas"></canvas>
+	</div>
+	<script>
+		var logEntry = 1;
+		var logElement = document.getElementById('log');
+
+		function log(text) {
+			logElement.innerText += logEntry + '. ' + text + '\n';
+			logElement.scrollTop = logElement.scrollHeight;
+			logEntry++;
+		}
+
+		var config = {
+			type: 'line',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
+				datasets: [{
+					label: 'My First dataset',
+					backgroundColor: window.chartColors.red,
+					borderColor: window.chartColors.red,
+					data: [
+						randomScalingFactor(),
+						randomScalingFactor(),
+						randomScalingFactor(),
+						randomScalingFactor(),
+						randomScalingFactor(),
+						randomScalingFactor(),
+						randomScalingFactor()
+					],
+					fill: false,
+				}, {
+					label: 'My Second dataset',
+					fill: false,
+					backgroundColor: window.chartColors.blue,
+					borderColor: window.chartColors.blue,
+					data: [
+						randomScalingFactor(),
+						randomScalingFactor(),
+						randomScalingFactor(),
+						randomScalingFactor(),
+						randomScalingFactor(),
+						randomScalingFactor(),
+						randomScalingFactor()
+					],
+				}]
+			},
+			options: {
+				legend: {
+					onHover: function(event, legendItem) {
+						log('onHover: ' + legendItem.text);
+					},
+					onLeave: function(event, legendItem) {
+						log('onLeave: ' + legendItem.text);
+					},
+					onClick: function(event, legendItem) {
+						log('onClick:' + legendItem.text);
+					}
+				},
+				responsive: true,
+				title: {
+					display: true,
+					text: 'Chart.js Line Chart'
+				},
+				hover: {
+					mode: 'nearest',
+					intersect: true
+				},
+				scales: {
+					xAxes: [{
+						display: true,
+						scaleLabel: {
+							display: true,
+							labelString: 'Month'
+						}
+					}],
+					yAxes: [{
+						display: true,
+						scaleLabel: {
+							display: true,
+							labelString: 'Value'
+						}
+					}]
+				}
+			}
+		};
+
+		window.onload = function() {
+			var ctx = document.getElementById('canvas').getContext('2d');
+			window.myLine = new Chart(ctx, config);
+		};
+	</script>
+</body>
+
+</html>

--- a/samples/legend/callbacks.html
+++ b/samples/legend/callbacks.html
@@ -2,8 +2,8 @@
 <html>
 
 <head>
-	<title>Line Chart</title>
-	<script src="../../../dist/Chart.min.js"></script>
+	<title>Legend Callbacks</title>
+	<script src="../../dist/Chart.min.js"></script>
 	<script src="../utils.js"></script>
 	<style>
 		body, html {

--- a/samples/legend/callbacks.html
+++ b/samples/legend/callbacks.html
@@ -1,6 +1,5 @@
 <!doctype html>
 <html>
-
 <head>
 	<title>Legend Callbacks</title>
 	<script src="../../dist/Chart.min.js"></script>
@@ -40,6 +39,15 @@
 	<script>
 		var logEntry = 1;
 		var logElement = document.getElementById('log');
+		var utils = Samples.utils;
+		var inputs = {
+			min: 20,
+			max: 80,
+			count: 8,
+			decimals: 2,
+			continuity: 1
+		};
+		var config;
 
 		function log(text) {
 			logElement.innerText += logEntry + '. ' + text + '\n';
@@ -47,38 +55,31 @@
 			logEntry++;
 		}
 
-		var config = {
+		function generateData() {
+			return utils.numbers(inputs);
+		}
+		function generateLabels() {
+			return utils.months({count: inputs.count});
+		}
+
+		utils.srand(42);
+
+		config = {
 			type: 'line',
 			data: {
-				labels: ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
+				labels: generateLabels(),
 				datasets: [{
 					label: 'My First dataset',
-					backgroundColor: window.chartColors.red,
-					borderColor: window.chartColors.red,
-					data: [
-						randomScalingFactor(),
-						randomScalingFactor(),
-						randomScalingFactor(),
-						randomScalingFactor(),
-						randomScalingFactor(),
-						randomScalingFactor(),
-						randomScalingFactor()
-					],
+					backgroundColor: utils.color(0),
+					borderColor: utils.color(0),
+					data: generateData(),
 					fill: false,
 				}, {
 					label: 'My Second dataset',
 					fill: false,
-					backgroundColor: window.chartColors.blue,
-					borderColor: window.chartColors.blue,
-					data: [
-						randomScalingFactor(),
-						randomScalingFactor(),
-						randomScalingFactor(),
-						randomScalingFactor(),
-						randomScalingFactor(),
-						randomScalingFactor(),
-						randomScalingFactor()
-					],
+					backgroundColor: utils.color(1),
+					borderColor: utils.color(1),
+					data: generateData(),
 				}]
 			},
 			options: {
@@ -93,14 +94,9 @@
 						log('onClick:' + legendItem.text);
 					}
 				},
-				responsive: true,
 				title: {
 					display: true,
 					text: 'Chart.js Line Chart'
-				},
-				hover: {
-					mode: 'nearest',
-					intersect: true
 				},
 				scales: {
 					xAxes: [{
@@ -121,10 +117,7 @@
 			}
 		};
 
-		window.onload = function() {
-			var ctx = document.getElementById('canvas').getContext('2d');
-			window.myLine = new Chart(ctx, config);
-		};
+		new Chart(document.getElementById('canvas'), config);
 	</script>
 </body>
 

--- a/samples/samples.js
+++ b/samples/samples.js
@@ -148,6 +148,9 @@
 		}, {
 			title: 'Point style',
 			path: 'legend/point-style.html'
+		}, {
+			title: 'Callbacks',
+			path: 'legend/callbacks.html'
 		}]
 	}, {
 		title: 'Tooltip',

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -108,7 +108,10 @@ var Legend = Element.extend({
 		this.legendHitBoxes = [];
 
 		// Contains the currently hovered legend item
-		this.hoveredItem = null;
+		/**
+ 		* @private
+ 		*/
+		this._hoveredItem = null;
 
 		// Are we in doughnut mode which has a different data type
 		this.doughnutMode = false;
@@ -518,12 +521,12 @@ var Legend = Element.extend({
 			}
 		}
 
-		if (type === 'mousemove' && me.hoveredItem !== hoveredItem) {
-			if (me.hoveredItem) {
-				opts.onLeave.call(me, e.native, me.hoveredItem);
+		if (opts.onLeave && type === 'mousemove' && me._hoveredItem !== hoveredItem) {
+			if (me._hoveredItem) {
+				opts.onLeave.call(me, e.native, me._hoveredItem);
 				changed = true;
 			}
-			me.hoveredItem = hoveredItem;
+			me._hoveredItem = hoveredItem;
 		}
 
 		return changed;

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -108,8 +108,8 @@ var Legend = Element.extend({
 		this.legendHitBoxes = [];
 
 		/**
- 		* @private
- 		*/
+ 		 * @private
+ 		 */
 		this._hoveredItem = null;
 
 		// Are we in doughnut mode which has a different data type

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -507,7 +507,7 @@ var Legend = Element.extend({
 				return;
 			}
 		} else {
-      return;
+			return;
 		}
 
 		// Chart event already has relative position in it

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -469,6 +469,7 @@ var Legend = Element.extend({
 	 * @private
 	 * @param {number} x - The x coordinate to check
 	 * @param {number} y - The y coordindate to check
+	 * @return {?Object} - The legend item found
 	 */
 	getLegendItemAt: function(x, y) {
 		var me = this;
@@ -485,6 +486,8 @@ var Legend = Element.extend({
 				}
 			}
 		}
+
+		return null;
 	},
 
 	/**

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -465,20 +465,17 @@ var Legend = Element.extend({
 	},
 
 	/**
-	 * Gets the legend item, if any, at a given x,y position.
 	 * @private
-	 * @param {number} x - The x coordinate to check
-	 * @param {number} y - The y coordindate to check
-	 * @return {?Object} - The legend item found
 	 */
-	getLegendItemAt: function(x, y) {
+	_getLegendItemAt: function(x, y) {
 		var me = this;
+		var i, hitBox, lh;
 
 		if (x >= me.left && x <= me.right && y >= me.top && y <= me.bottom) {
 			// See if we are touching one of the dataset boxes
-			var lh = me.legendHitBoxes;
-			for (var i = 0; i < lh.length; ++i) {
-				var hitBox = lh[i];
+			lh = me.legendHitBoxes;
+			for (i = 0; i < lh.length; ++i) {
+				hitBox = lh[i];
 
 				if (x >= hitBox.left && x <= hitBox.left + hitBox.width && y >= hitBox.top && y <= hitBox.top + hitBox.height) {
 					// Touching an element
@@ -499,6 +496,7 @@ var Legend = Element.extend({
 		var me = this;
 		var opts = me.options;
 		var type = e.type === 'mouseup' ? 'click' : e.type;
+		var hoveredItem;
 
 		if (type === 'mousemove') {
 			if (!opts.onHover && !opts.onLeave) {
@@ -508,12 +506,12 @@ var Legend = Element.extend({
 			if (!opts.onClick) {
 				return;
 			}
-		}	else {
-			return;
+		} else {
+      return;
 		}
 
 		// Chart event already has relative position in it
-		var hoveredItem = me.getLegendItemAt(e.x, e.y);
+		hoveredItem = me._getLegendItemAt(e.x, e.y);
 
 		if (type === 'click') {
 			if (hoveredItem && opts.onClick) {

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -107,7 +107,6 @@ var Legend = Element.extend({
 		// Contains hit boxes for each dataset (in dataset order)
 		this.legendHitBoxes = [];
 
-		// Contains the currently hovered legend item
 		/**
  		* @private
  		*/

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -465,33 +465,13 @@ var Legend = Element.extend({
 	},
 
 	/**
-	 * Handle an event
+	 * Gets the legend item, if any, at a given x,y position.
 	 * @private
-	 * @param {IEvent} event - The event to handle
-	 * @return {boolean} true if a change occured
+	 * @param {number} x - The x coordinate to check
+	 * @param {number} y - The y coordindate to check
 	 */
-	handleEvent: function(e) {
+	getLegendItemAt: function(x, y) {
 		var me = this;
-		var opts = me.options;
-		var type = e.type === 'mouseup' ? 'click' : e.type;
-		var changed = false;
-
-		if (type === 'mousemove') {
-			if (!opts.onHover && !opts.onLeave) {
-				return;
-			}
-		} else if (type === 'click') {
-			if (!opts.onClick) {
-				return;
-			}
-		} else {
-			return;
-		}
-
-		// Chart event already has relative position in it
-		var x = e.x;
-		var y = e.y;
-		var hoveredItem = null;
 
 		if (x >= me.left && x <= me.right && y >= me.top && y <= me.bottom) {
 			// See if we are touching one of the dataset boxes
@@ -501,34 +481,55 @@ var Legend = Element.extend({
 
 				if (x >= hitBox.left && x <= hitBox.left + hitBox.width && y >= hitBox.top && y <= hitBox.top + hitBox.height) {
 					// Touching an element
-					hoveredItem = me.legendItems[i];
-
-					if (type === 'click') {
-						// use e.native for backwards compatibility
-						opts.onClick.call(me, e.native, me.legendItems[i]);
-						changed = true;
-						break;
-					} else if (type === 'mousemove') {
-						if (opts.onHover) {
-							// use e.native for backwards compatibility
-							opts.onHover.call(me, e.native, me.legendItems[i]);
-							changed = true;
-						}
-						break;
-					}
+					return me.legendItems[i];
 				}
 			}
 		}
+	},
 
-		if (opts.onLeave && type === 'mousemove' && me._hoveredItem !== hoveredItem) {
-			if (me._hoveredItem) {
-				opts.onLeave.call(me, e.native, me._hoveredItem);
-				changed = true;
+	/**
+	 * Handle an event
+	 * @private
+	 * @param {IEvent} event - The event to handle
+	 */
+	handleEvent: function(e) {
+		var me = this;
+		var opts = me.options;
+		var type = e.type === 'mouseup' ? 'click' : e.type;
+
+		if (type === 'mousemove') {
+			if (!opts.onHover && !opts.onLeave) {
+				return;
 			}
-			me._hoveredItem = hoveredItem;
+		} else if (type === 'click') {
+			if (!opts.onClick) {
+				return;
+			}
+		}	else {
+			return;
 		}
 
-		return changed;
+		// Chart event already has relative position in it
+		var hoveredItem = me.getLegendItemAt(e.x, e.y);
+
+		if (type === 'click') {
+			if (hoveredItem && opts.onClick) {
+				// use e.native for backwards compatibility
+				opts.onClick.call(me, e.native, hoveredItem);
+			}
+		} else {
+			if (opts.onLeave && hoveredItem !== me._hoveredItem) {
+				if (me._hoveredItem) {
+					opts.onLeave.call(me, e.native, me._hoveredItem);
+				}
+				me._hoveredItem = hoveredItem;
+			}
+
+			if (opts.onHover && hoveredItem) {
+				// use e.native for backwards compatibility
+				opts.onHover.call(me, e.native, hoveredItem);
+			}
+		}
 	}
 });
 

--- a/test/specs/plugin.legend.tests.js
+++ b/test/specs/plugin.legend.tests.js
@@ -11,6 +11,7 @@ describe('Legend block tests', function() {
 			// a callback that will handle
 			onClick: jasmine.any(Function),
 			onHover: null,
+			onLeave: null,
 
 			labels: {
 				boxWidth: 40,
@@ -651,6 +652,55 @@ describe('Legend block tests', function() {
 			chart.update();
 			expect(chart.legend).not.toBe(undefined);
 			expect(chart.legend.options).toEqual(jasmine.objectContaining(Chart.defaults.global.legend));
+		});
+	});
+
+	describe('callbacks', function() {
+		it('should call onClick, onHover and onLeave at the correct times', function() {
+			var clickItem = null;
+			var hoverItem = null;
+			var leaveItem = null;
+
+			var chart = acquireChart({
+				type: 'line',
+				data: {
+					labels: ['A', 'B', 'C', 'D'],
+					datasets: [{
+						data: [10, 20, 30, 100]
+					}]
+				},
+				options: {
+					legend: {
+						onClick: function(_, item) {
+							clickItem = item;
+						},
+						onHover: function(_, item) {
+							hoverItem = item;
+						},
+						onLeave: function(_, item) {
+							leaveItem = item;
+						}
+					}
+				}
+			});
+
+			var hb = chart.legend.legendHitBoxes[0];
+			var el = {
+				x: hb.left + (hb.width / 2),
+				y: hb.top + (hb.height / 2)
+			};
+
+			jasmine.triggerMouseEvent(chart, 'click', el);
+
+			expect(clickItem).toBe(chart.legend.legendItems[0]);
+
+			jasmine.triggerMouseEvent(chart, 'mousemove', el);
+
+			expect(hoverItem).toBe(chart.legend.legendItems[0]);
+
+			jasmine.triggerMouseEvent(chart, 'mousemove', chart.getDatasetMeta(0).data[0]);
+
+			expect(leaveItem).toBe(chart.legend.legendItems[0]);
 		});
 	});
 });


### PR DESCRIPTION
This PR adds an `onLeave` callback to the legend plugin. This complements the `onHover` callback, allowing the user to detect when the user has moused away from a formerly hovered legend item.

This helps achieve the use-case of highlighting a [particular series on hover](https://stackoverflow.com/questions/42621127/highlight-line-series-on-legend-hover) as supported by [other charting libraries](https://swimlane.github.io/ngx-charts/#/ngx-charts/line-chart).

It also adds an example page and tests for the legend plugin callbacks.