### PR TITLE
autoSkip support for calculateTickRotation (OLD. DO NOT MERGE - comparison purposes only)

### DIFF
--- a/test/specs/core.scale.tests.js
+++ b/test/specs/core.scale.tests.js
@@ -73,6 +73,38 @@ describe('Core.scale', function() {
 
 			expect(lastTick(chart).label).toBeUndefined();
 		});
+
+		it('should not rotate ticks when there is lots of padding', function() {
+			var chart = window.acquireChart({
+				type: 'line',
+				data: {
+					labels: [
+						'January 2018', 'February 2018', 'March 2018', 'April 2018',
+						'May 2018', 'June 2018', 'July 2018', 'August 2018',
+						'September 2018', 'October 2018', 'November 2018', 'December 2018',
+						'January 2019', 'February 2019', 'March 2019', 'April 2019',
+						'May 2019', 'June 2019', 'July 2019', 'August 2019',
+						'September 2019', 'October 2019', 'November 2019', 'December 2019',
+						'January 2020', 'February 2020'
+					],
+					datasets: [{
+						data: [12, 19, 3, 5, 2, 3, 7, 8, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+					}]
+				},
+				options: {
+					scales: {
+						xAxes: [{
+							ticks: {
+								autoSkip: true,
+								autoSkipPadding: 200
+							}
+						}]
+					}
+				}
+			});
+
+			expect(chart.scales['x-axis-0'].labelRotation).toBe(0);
+		});
 	});
 
 	var gridLineTests = [{


### PR DESCRIPTION
Closes https://github.com/chartjs/Chart.js/issues/3981

`calculateTickRotation` needs to happen after auto-skipping. Otherwise we are doing far too much rotation because we're assuming lots of extra labels are present