### PR TITLE
autoSkip support for calculateTickRotation

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -322,28 +322,34 @@ module.exports = Element.extend({
 	},
 	calculateTickRotation: function() {
 		var me = this;
-		var context = me.ctx;
 		var tickOpts = me.options.ticks;
-		var labels = labelsFromTicks(me._ticks);
+		var labelRotation = tickOpts.minRotation || 0;
+		var context = me.ctx;
+		var labels, tickFont, originalLabelWidth, labelWidth, cosRotation, sinRotation, tickWidth, angleRadians;
+
+		// If we can skip ticks instead of rotating them then do that
+		if (tickOpts.autoSkip) {
+			me.labelRotation = labelRotation;
+			return;
+		}
+
+		labels = labelsFromTicks(me._ticks);
 
 		// Get the width of each grid by calculating the difference
 		// between x offsets between 0 and 1.
-		var tickFont = helpers.options._parseFont(tickOpts);
+		tickFont = helpers.options._parseFont(tickOpts);
 		context.font = tickFont.string;
 
-		var labelRotation = tickOpts.minRotation || 0;
-
 		if (labels.length && me.options.display && me.isHorizontal()) {
-			var originalLabelWidth = helpers.longestText(context, tickFont.string, labels, me.longestTextCache);
-			var labelWidth = originalLabelWidth;
-			var cosRotation, sinRotation;
+			originalLabelWidth = helpers.longestText(context, tickFont.string, labels, me.longestTextCache);
+			labelWidth = originalLabelWidth;
 
 			// Allow 3 pixels x2 padding either side for label readability
-			var tickWidth = me.getPixelForTick(1) - me.getPixelForTick(0) - 6;
+			tickWidth = me.getPixelForTick(1) - me.getPixelForTick(0) - 6;
 
 			// Max label rotation can be set or default to 90 - also act as a loop counter
 			while (labelWidth > tickWidth && labelRotation < tickOpts.maxRotation) {
-				var angleRadians = helpers.toRadians(labelRotation);
+				angleRadians = helpers.toRadians(labelRotation);
 				cosRotation = Math.cos(angleRadians);
 				sinRotation = Math.sin(angleRadians);
 

--- a/test/specs/core.scale.tests.js
+++ b/test/specs/core.scale.tests.js
@@ -73,6 +73,37 @@ describe('Core.scale', function() {
 
 			expect(lastTick(chart).label).toBeUndefined();
 		});
+
+		it('should not rotate ticks when autoSkip is on', function() {
+			var chart = window.acquireChart({
+				type: 'line',
+				data: {
+					labels: [
+						'January 2018', 'February 2018', 'March 2018', 'April 2018',
+						'May 2018', 'June 2018', 'July 2018', 'August 2018',
+						'September 2018', 'October 2018', 'November 2018', 'December 2018',
+						'January 2019', 'February 2019', 'March 2019', 'April 2019',
+						'May 2019', 'June 2019', 'July 2019', 'August 2019',
+						'September 2019', 'October 2019', 'November 2019', 'December 2019',
+						'January 2020', 'February 2020'
+					],
+					datasets: [{
+						data: [12, 19, 3, 5, 2, 3, 7, 8, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+					}]
+				},
+				options: {
+					scales: {
+						xAxes: [{
+							ticks: {
+								autoSkip: true
+							}
+						}]
+					}
+				}
+			});
+
+			expect(chart.scales['x-axis-0'].labelRotation).toBe(0);
+		});
 	});
 
 	var gridLineTests = [{


### PR DESCRIPTION
If you have autoSkip on then you can have `calculateTickRotation` return 0. This addresses space constraints via auto-skipping instead of rotation. As a result, it leaves more room for the chart contents by keeping the scale height low since there's no rotation. The current logic is not cohesive and calculates the `labelRotation` and `_autoSkip` independently often coming up with results that are fairly sub-optimal when combined

Closes user reports https://github.com/chartjs/Chart.js/issues/3981 and https://github.com/chartjs/Chart.js/pull/5765. Closes my previous attempt https://github.com/chartjs/Chart.js/pull/6072. Partially addresses https://github.com/chartjs/Chart.js/issues/6074