### PR TITLE
Improve autoSkip documentation and support for autoSkipPadding

### DIFF
--- a/docs/axes/cartesian/README.md
+++ b/docs/axes/cartesian/README.md
@@ -26,8 +26,8 @@ The following options are common to all cartesian axes but do not apply to other
 
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
-| `autoSkip` | `boolean` | `true` | If true, automatically calculates how many labels that can be shown and hides labels accordingly. Turn it off to show all labels no matter what.
-| `autoSkipPadding` | `number` | `0` | Padding between the ticks on the horizontal axis when `autoSkip` is enabled. *Note: Only applicable to horizontal scales.*
+| `autoSkip` | `boolean` | `true` | If true, automatically calculates how many labels can be shown and hides labels accordingly. Labels will be rotated up to `maxRotation` before skipping any. Turn `autoSkip` off to show all labels no matter what.
+| `autoSkipPadding` | `number` | `0` | Padding between the ticks on the horizontal axis when `autoSkip` is enabled.
 | `labelOffset` | `number` | `0` | Distance in pixels to offset the label from the centre point of the tick (in the x direction for the x axis, and the y direction for the y axis). *Note: this can cause labels at the edges to be cropped by the edge of the canvas*
 | `maxRotation` | `number` | `90` | Maximum rotation for tick labels when rotating to condense labels. Note: Rotation doesn't occur until necessary. *Note: Only applicable to horizontal scales.*
 | `minRotation` | `number` | `0` | Minimum rotation for tick labels. *Note: Only applicable to horizontal scales.*

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -329,9 +329,10 @@ module.exports = Element.extend({
 		// Get the width of each grid by calculating the difference
 		// between x offsets between 0 and 1.
 		var tickFont = helpers.options._parseFont(tickOpts);
-		context.font = tickFont.string;
-
 		var labelRotation = tickOpts.minRotation || 0;
+		var padding = (tickOpts.autoSkip && tickOpts.autoSkipPadding) || 0;
+
+		context.font = tickFont.string;
 
 		if (labels.length && me.options.display && me.isHorizontal()) {
 			var originalLabelWidth = helpers.longestText(context, tickFont.string, labels, me.longestTextCache);
@@ -342,7 +343,7 @@ module.exports = Element.extend({
 			var tickWidth = me.getPixelForTick(1) - me.getPixelForTick(0) - 6;
 
 			// Max label rotation can be set or default to 90 - also act as a loop counter
-			while (labelWidth > tickWidth && labelRotation < tickOpts.maxRotation) {
+			while (labelWidth > (tickWidth + padding) && labelRotation < tickOpts.maxRotation) {
 				var angleRadians = helpers.toRadians(labelRotation);
 				cosRotation = Math.cos(angleRadians);
 				sinRotation = Math.sin(angleRadians);

--- a/test/specs/core.scale.tests.js
+++ b/test/specs/core.scale.tests.js
@@ -73,6 +73,38 @@ describe('Core.scale', function() {
 
 			expect(lastTick(chart).label).toBeUndefined();
 		});
+
+		it('should not rotate ticks when autoSkipPadding is large', function() {
+			var chart = window.acquireChart({
+				type: 'line',
+				data: {
+					labels: [
+						'January 2018', 'February 2018', 'March 2018', 'April 2018',
+						'May 2018', 'June 2018', 'July 2018', 'August 2018',
+						'September 2018', 'October 2018', 'November 2018', 'December 2018',
+						'January 2019', 'February 2019', 'March 2019', 'April 2019',
+						'May 2019', 'June 2019', 'July 2019', 'August 2019',
+						'September 2019', 'October 2019', 'November 2019', 'December 2019',
+						'January 2020', 'February 2020'
+					],
+					datasets: [{
+						data: [12, 19, 3, 5, 2, 3, 7, 8, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+					}]
+				},
+				options: {
+					scales: {
+						xAxes: [{
+							ticks: {
+								autoSkip: true,
+								autoSkipPadding: 200
+							}
+						}]
+					}
+				}
+			});
+
+			expect(chart.scales['x-axis-0'].labelRotation).toBe(0);
+		});
 	});
 
 	var gridLineTests = [{


### PR DESCRIPTION
Improves `calculateLabelRotation` when `autoSkipPadding` is specified.

Successor of past attempts https://github.com/chartjs/Chart.js/pull/6075 and https://github.com/chartjs/Chart.js/pull/6072 based off feedback from @kurkle and @simonbrunel 