### PR TITLE
Fix animation regression from 5331

### DIFF
--- a/src/core/core.animations.js
+++ b/src/core/core.animations.js
@@ -93,21 +93,24 @@ module.exports = {
 	 */
 	advance: function() {
 		var animations = this.animations;
-		var animation, chart, nextStep;
+		var animation, chart, numSteps, nextStep;
 		var i = 0;
 
+		// 1 animation per chart, so we are looping charts here
 		while (i < animations.length) {
 			animation = animations[i];
 			chart = animation.chart;
+			numSteps = animation.numSteps;
 
-			nextStep = (animation.currentStep || 0) + 1;
-			animation.currentStep = Math.floor((Date.now() - animation.startTime) / animation.duration * animation.numSteps);
-			animation.currentStep = Math.min(Math.max(nextStep, animation.currentStep), animation.numSteps);
+			// Make sure that currentStep starts at 1
+			// https://github.com/chartjs/Chart.js/issues/6104
+			nextStep = Math.floor((Date.now() - animation.startTime) / animation.duration * numSteps) + 1;
+			animation.currentStep = Math.min(nextStep, numSteps);
 
 			helpers.callback(animation.render, [chart, animation], chart);
 			helpers.callback(animation.onAnimationProgress, [animation], chart);
 
-			if (animation.currentStep >= animation.numSteps) {
+			if (animation.currentStep >= numSteps) {
 				helpers.callback(animation.onAnimationComplete, [animation], chart);
 				chart.animating = false;
 				animations.splice(i, 1);

--- a/src/core/core.animations.js
+++ b/src/core/core.animations.js
@@ -93,15 +93,16 @@ module.exports = {
 	 */
 	advance: function() {
 		var animations = this.animations;
-		var animation, chart;
+		var animation, chart, nextStep;
 		var i = 0;
 
 		while (i < animations.length) {
 			animation = animations[i];
 			chart = animation.chart;
 
+			nextStep = (animation.currentStep || 0) + 1;
 			animation.currentStep = Math.floor((Date.now() - animation.startTime) / animation.duration * animation.numSteps);
-			animation.currentStep = Math.min(animation.currentStep, animation.numSteps);
+			animation.currentStep = Math.min(Math.max(nextStep, animation.currentStep), animation.numSteps);
 
 			helpers.callback(animation.render, [chart, animation], chart);
 			helpers.callback(animation.onAnimationProgress, [animation], chart);


### PR DESCRIPTION
Fixes: #6104 

[Pen showing 6104 fixed](https://codepen.io/kurkle/pen/PLNQeJ)
[No regression in timing](https://jsfiddle.net/b70fuLwo/)

Its fixed by making sure we are advancing whether the start time was reset or not.