### PR TITLE
Fix the missing Chart.Chart (deprecated) alias

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -53,6 +53,15 @@ if (typeof window !== 'undefined') {
 
 /**
  * Provided for backward compatibility, not available anymore
+ * @namespace Chart.Chart
+ * @deprecated since version 2.8.0
+ * @todo remove at version 3
+ * @private
+ */
+Chart.Chart = Chart;
+
+/**
+ * Provided for backward compatibility, not available anymore
  * @namespace Chart.Legend
  * @deprecated since version 2.1.5
  * @todo remove at version 3

--- a/test/specs/global.deprecations.tests.js
+++ b/test/specs/global.deprecations.tests.js
@@ -24,6 +24,12 @@ describe('Deprecations', function() {
 			});
 		});
 
+		describe('Chart.Chart', function() {
+			it('should be defined as an alias to Chart', function() {
+				expect(Chart.Chart).toBe(Chart);
+			});
+		});
+
 		describe('Chart.helpers.aliasPixel', function() {
 			it('should be defined as a function', function() {
 				expect(typeof Chart.helpers.aliasPixel).toBe('function');


### PR DESCRIPTION
The `Chart.Chart` alias has been unintentionally removed in #5969 (existed at [this line](/chartjs/Chart.js/pull/5969/files#diff-dfe07c186488ee794e2200e24b2bd54aL47)) but while debugging [optional moment in Angular](/chartjs/Chart.js/pull/5978#issuecomment-462841060), I found that this alias is [still in use](/lsn793/calc-weight/blob/master/src/app/calc-weight/calc/calc.component.ts#L2).

```javascript
// GOOD
import Chart from 'chart.js';

// WRONG
import { Chart } from 'chart.js';
```