### PR TITLE
Tighten check for Moment

### DIFF
--- a/src/adapters/adapter.moment.js
+++ b/src/adapters/adapter.moment.js
@@ -18,7 +18,7 @@ var FORMATS = {
 	year: 'YYYY'
 };
 
-adapters._date.override(moment ? {
+adapters._date.override(typeof moment === 'function' ? {
 	_id: 'moment', // DEBUG ONLY
 
 	formats: function() {


### PR DESCRIPTION
This slightly tightens the check for Moment. This is so you can use the [browser field](https://github.com/defunctzombie/package-browser-field-spec#ignore-a-module) to exclude Moment from the bundle (as per #5978). By default, ignoring a module makes it return an empty object, and this was passing the check.
