### PR TITLE
fix: Properly render multi-line labels in legend and tooltip

### DIFF
--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -813,27 +813,24 @@ var exports = Element.extend({
 			ctx.fillStyle = textColor;
 			helpers.each(bodyItem.before, fillLineOfText);
 
-			lines = bodyItem.lines;
-			for (j = 0, jlen = lines.length; j < jlen; ++j) {
-				// Draw Legend-like boxes if needed
-				if (drawColorBoxes) {
-					// Fill a white rect so that colours merge nicely if the opacity is < 1
-					ctx.fillStyle = vm.legendColorBackground;
-					ctx.fillRect(colorX, pt.y, bodyFontSize, bodyFontSize);
+			// Draw Legend-like boxes if needed
+			if (drawColorBoxes) {
+				// Fill a white rect so that colours merge nicely if the opacity is < 1
+				ctx.fillStyle = vm.legendColorBackground;
+				ctx.fillRect(colorX, pt.y, bodyFontSize, bodyFontSize);
 
-					// Border
-					ctx.lineWidth = 1;
-					ctx.strokeStyle = labelColors.borderColor;
-					ctx.strokeRect(colorX, pt.y, bodyFontSize, bodyFontSize);
+				// Border
+				ctx.lineWidth = 1;
+				ctx.strokeStyle = labelColors.borderColor;
+				ctx.strokeRect(colorX, pt.y, bodyFontSize, bodyFontSize);
 
-					// Inner square
-					ctx.fillStyle = labelColors.backgroundColor;
-					ctx.fillRect(colorX + 1, pt.y + 1, bodyFontSize - 2, bodyFontSize - 2);
-					ctx.fillStyle = textColor;
-				}
-
-				fillLineOfText(lines[j]);
+				// Inner square
+				ctx.fillStyle = labelColors.backgroundColor;
+				ctx.fillRect(colorX + 1, pt.y + 1, bodyFontSize - 2, bodyFontSize - 2);
+				ctx.fillStyle = textColor;
 			}
+
+			helpers.each(bodyItem.lines, fillLineOfText);
 
 			helpers.each(bodyItem.after, fillLineOfText);
 		}

--- a/test/specs/global.defaults.tests.js
+++ b/test/specs/global.defaults.tests.js
@@ -128,21 +128,24 @@ describe('Default Configs', function() {
 				hidden: false,
 				index: 0,
 				strokeStyle: '#000',
-				lineWidth: 2
+				lineWidth: 2,
+				lineOrColumnIndex: 0
 			}, {
 				text: 'label2',
 				fillStyle: 'green',
 				hidden: false,
 				index: 1,
 				strokeStyle: '#000',
-				lineWidth: 2
+				lineWidth: 2,
+				lineOrColumnIndex: 0
 			}, {
 				text: 'label3',
 				fillStyle: 'blue',
 				hidden: true,
 				index: 2,
 				strokeStyle: '#000',
-				lineWidth: 2
+				lineWidth: 2,
+				lineOrColumnIndex: 0
 			}];
 			expect(chart.legend.legendItems).toEqual(expected);
 		});
@@ -244,21 +247,24 @@ describe('Default Configs', function() {
 				hidden: false,
 				index: 0,
 				strokeStyle: '#000',
-				lineWidth: 2
+				lineWidth: 2,
+				lineOrColumnIndex: 0
 			}, {
 				text: 'label2',
 				fillStyle: 'green',
 				hidden: false,
 				index: 1,
 				strokeStyle: '#000',
-				lineWidth: 2
+				lineWidth: 2,
+				lineOrColumnIndex: 0
 			}, {
 				text: 'label3',
 				fillStyle: 'blue',
 				hidden: true,
 				index: 2,
 				strokeStyle: '#000',
-				lineWidth: 2
+				lineWidth: 2,
+				lineOrColumnIndex: 0
 			}];
 			expect(chart.legend.legendItems).toEqual(expected);
 		});

--- a/test/specs/plugin.legend.tests.js
+++ b/test/specs/plugin.legend.tests.js
@@ -63,7 +63,8 @@ describe('Legend block tests', function() {
 			strokeStyle: 'rgba(0,0,0,0.1)',
 			pointStyle: undefined,
 			rotation: undefined,
-			datasetIndex: 0
+			datasetIndex: 0,
+			lineOrColumnIndex: 0
 		}, {
 			text: 'dataset2',
 			fillStyle: 'rgba(0,0,0,0.1)',
@@ -76,7 +77,8 @@ describe('Legend block tests', function() {
 			strokeStyle: 'rgba(0,0,0,0.1)',
 			pointStyle: undefined,
 			rotation: undefined,
-			datasetIndex: 1
+			datasetIndex: 1,
+			lineOrColumnIndex: 0
 		}, {
 			text: 'dataset3',
 			fillStyle: 'rgba(0,0,0,0.1)',
@@ -89,7 +91,8 @@ describe('Legend block tests', function() {
 			strokeStyle: 'green',
 			pointStyle: undefined,
 			rotation: undefined,
-			datasetIndex: 2
+			datasetIndex: 2,
+			lineOrColumnIndex: 0
 		}]);
 	});
 
@@ -159,7 +162,7 @@ describe('Legend block tests', function() {
 			strokeStyle: 'green',
 			pointStyle: undefined,
 			rotation: undefined,
-			datasetIndex: 2
+			datasetIndex: 2,
 		}]);
 	});
 
@@ -213,7 +216,8 @@ describe('Legend block tests', function() {
 			strokeStyle: 'rgba(0,0,0,0.1)',
 			pointStyle: undefined,
 			rotation: undefined,
-			datasetIndex: 0
+			datasetIndex: 0,
+			lineOrColumnIndex: 0
 		}, {
 			text: 'dataset3',
 			fillStyle: 'rgba(0,0,0,0.1)',
@@ -226,7 +230,8 @@ describe('Legend block tests', function() {
 			strokeStyle: 'green',
 			pointStyle: undefined,
 			rotation: undefined,
-			datasetIndex: 2
+			datasetIndex: 2,
+			lineOrColumnIndex: 0
 		}]);
 	});
 


### PR DESCRIPTION
When using multi-line labels for pie, doughnut and polar area charts, the legend shows the label lines joined with a comma, it looks bad and should at least be converted to a space (if not rendered multi line). This PR ~joins the lines with a space instead of a comma.~ properly renders multi line labels in both the legend and in the tooltip.

State of the PR:

![Angular 2 Charts Demo - Edited](https://user-images.githubusercontent.com/1235688/55289316-d052d000-53cd-11e9-96c4-2637c02e7e67.gif)
