### PR TITLE
Improvements to helpers.almostWhole

### DIFF
--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -71,7 +71,7 @@ module.exports = function() {
 	};
 	helpers.almostWhole = function(x, epsilon) {
 		var rounded = Math.round(x);
-		return (((rounded - epsilon) < x) && ((rounded + epsilon) > x));
+		return ((rounded - epsilon) <= x) && ((rounded + epsilon) >= x);
 	};
 	helpers.max = function(array) {
 		return array.reduce(function(max, value) {

--- a/test/specs/core.helpers.tests.js
+++ b/test/specs/core.helpers.tests.js
@@ -46,6 +46,8 @@ describe('Core helper tests', function() {
 	it('should correctly determine if a numbers are essentially whole', function() {
 		expect(helpers.almostWhole(0.99999, 0.0001)).toBe(true);
 		expect(helpers.almostWhole(0.9, 0.0001)).toBe(false);
+		expect(helpers.almostWhole(1234567890123, 0.0001)).toBe(true);
+		expect(helpers.almostWhole(1234567890123.001, 0.0001)).toBe(false);
 	});
 
 	it('should generate integer ids', function() {
@@ -81,6 +83,8 @@ describe('Core helper tests', function() {
 		expect(helpers._decimalPlaces('1')).toBe(undefined);
 		expect(helpers._decimalPlaces('')).toBe(undefined);
 		expect(helpers._decimalPlaces(undefined)).toBe(undefined);
+		expect(helpers._decimalPlaces(12345678.1234)).toBe(4);
+		expect(helpers._decimalPlaces(1234567890.1234567)).toBe(7);
 	});
 
 	it('should get an angle from a point', function() {


### PR DESCRIPTION
This is the agreed upon parts of https://github.com/chartjs/Chart.js/pull/5992. I'm going to close that PR for the time being to keep the review queue clear until we have an agreed upon path forward

- Makes `epsilon` inclusive and adds corresponding tests for `almostWhole`. Thanks @costerwi for the suggestion in https://github.com/chartjs/Chart.js/pull/5992
- Add additional tests for `decimalPlaces` as suggested by @kurkle in https://github.com/chartjs/Chart.js/pull/5992/files#r249953203