### PR TITLE
Keep the previous extensions page link alive

### DIFF
--- a/book.json
+++ b/book.json
@@ -3,7 +3,15 @@
   "title": "Chart.js documentation",
   "author": "chartjs",
   "gitbook": "3.2.2",
-  "plugins": ["-lunr", "-search", "search-plus", "anchorjs", "chartjs", "ga"],
+  "plugins": [
+    "-lunr",
+    "-search",
+    "search-plus",
+    "anchorjs",
+    "chartjs",
+    "ga",
+    "redirect"
+  ],
   "pluginsConfig": {
     "anchorjs": {
       "icon": "#",

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -51,5 +51,5 @@
   * [Contributing](developers/contributing.md)
 * [Additional Notes](notes/README.md)
   * [Comparison Table](notes/comparison.md)
-  * [Popular Extensions](https://github.com/chartjs/awesome)
+  * [Popular Extensions](notes/extensions.md)
   * [License](notes/license.md)

--- a/docs/notes/extensions.md
+++ b/docs/notes/extensions.md
@@ -1,0 +1,1 @@
+!REDIRECT "https://github.com/chartjs/awesome"


### PR DESCRIPTION
Instead of a direct link, restore the `extensions.md` file which now redirects `/notes/extensions.html` to https://github.com/chartjs/awesome in case anyone bookmarked it / there were links to it.

FYI @stockiNail