### PR TITLE
Make decimalPlaces private and update CDN links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 ## Installation
 
-You can download the latest version of Chart.js from the [GitHub releases](https://github.com/chartjs/Chart.js/releases/latest) or use a [Chart.js CDN](https://cdnjs.com/libraries/Chart.js). Detailed installation instructions can be found on the [installation](./getting-started/installation.md) page.
+You can download the latest version of Chart.js from the [GitHub releases](https://github.com/chartjs/Chart.js/releases/latest) or use a [Chart.js CDN](https://www.jsdelivr.com/package/npm/chart.js). Detailed installation instructions can be found on the [installation](./getting-started/installation.md) page.
 
 ## Creating a Chart
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -11,7 +11,7 @@ First, we need to have a canvas in our page.
 Now that we have a canvas we can use, we need to include Chart.js in our page.
 
 ```html
-<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.3/Chart.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@2"></script>
 ```
 
 Now, we can create a chart. We add a script to our page:

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -11,7 +11,7 @@ First, we need to have a canvas in our page.
 Now that we have a canvas we can use, we need to include Chart.js in our page.
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/chart.js@2"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0"></script>
 ```
 
 Now, we can create a chart. We add a script to our page:

--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -125,8 +125,9 @@ module.exports = function() {
 	 * i.e. the number of digits after the decimal point, of the value of this Number.
 	 * @param {number} x - A number.
 	 * @returns {number} The number of decimal places.
+	 * @private
 	 */
-	helpers.decimalPlaces = function(x) {
+	helpers._decimalPlaces = function(x) {
 		if (!helpers.isFinite(x)) {
 			return;
 		}

--- a/src/scales/scale.linearbase.js
+++ b/src/scales/scale.linearbase.js
@@ -44,7 +44,7 @@ function generateTicks(generationOptions, dataRange) {
 
 	if (stepSize || isNullOrUndef(precision)) {
 		// If a precision is not specified, calculate factor based on spacing
-		factor = Math.pow(10, helpers.decimalPlaces(spacing));
+		factor = Math.pow(10, helpers._decimalPlaces(spacing));
 	} else {
 		// If the user specified a precision, round to that number of decimal places
 		factor = Math.pow(10, precision);

--- a/test/specs/core.helpers.tests.js
+++ b/test/specs/core.helpers.tests.js
@@ -73,14 +73,14 @@ describe('Core helper tests', function() {
 	});
 
 	it('should get the correct number of decimal places', function() {
-		expect(helpers.decimalPlaces(100)).toBe(0);
-		expect(helpers.decimalPlaces(1)).toBe(0);
-		expect(helpers.decimalPlaces(0)).toBe(0);
-		expect(helpers.decimalPlaces(0.01)).toBe(2);
-		expect(helpers.decimalPlaces(-0.01)).toBe(2);
-		expect(helpers.decimalPlaces('1')).toBe(undefined);
-		expect(helpers.decimalPlaces('')).toBe(undefined);
-		expect(helpers.decimalPlaces(undefined)).toBe(undefined);
+		expect(helpers._decimalPlaces(100)).toBe(0);
+		expect(helpers._decimalPlaces(1)).toBe(0);
+		expect(helpers._decimalPlaces(0)).toBe(0);
+		expect(helpers._decimalPlaces(0.01)).toBe(2);
+		expect(helpers._decimalPlaces(-0.01)).toBe(2);
+		expect(helpers._decimalPlaces('1')).toBe(undefined);
+		expect(helpers._decimalPlaces('')).toBe(undefined);
+		expect(helpers._decimalPlaces(undefined)).toBe(undefined);
 	});
 
 	it('should get an angle from a point', function() {


### PR DESCRIPTION
Couple of Issues I noticed in #6092 

1. I don't think we need to make `helpers.decimalPlaces` public
2. We should not link to 2.7.3 version. So changed cdn links to jsDelivr for wildcard version support.
