### PR TITLE
Ensure scale options type is included

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -62,7 +62,7 @@ function mergeScaleConfig(/* config objects ... */) {
 					if (!target[key][i].type || (scale.type && scale.type !== target[key][i].type)) {
 						// new/untyped scale or type changed: let's apply the new defaults
 						// then merge source scale to correctly overwrite the defaults.
-						helpers.merge(target[key][i], [scaleService.getScaleDefaults(type), scale]);
+						helpers.merge(target[key][i], [scaleService.getScaleDefaults(type), scale, {type: type}]);
 					} else {
 						// scales type are the same
 						helpers.merge(target[key][i], scale);

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -198,6 +198,11 @@ describe('Chart', function() {
 				}
 			});
 
+			expect(chart.options.scales.xAxes[0].type).toBe('category');
+			expect(chart.options.scales.xAxes[1].type).toBe('category');
+			expect(chart.options.scales.yAxes[0].type).toBe('linear');
+			expect(chart.options.scales.yAxes[1].type).toBe('linear');
+
 			expect(chart.scales.foo0.type).toBe('category');
 			expect(chart.scales.foo1.type).toBe('category');
 			expect(chart.scales.bar0.type).toBe('linear');


### PR DESCRIPTION
I created this to fix https://github.com/chartjs/chartjs-plugin-zoom/issues/223. 

I later found that I could fix that bug just in the zoom plugin: https://github.com/chartjs/chartjs-plugin-zoom/pull/221/commits/f500fedb0a0e04c6bf64dca6d1f952bcfff0f20f

I suppose I'll leave this PR open as it still seems like a good idea, but I'm fine if we think it should be closed