### PR TITLE
Replace helpers.extend with Object.assign when available or use helpers.merge

### DIFF
--- a/src/helpers/helpers.core.js
+++ b/src/helpers/helpers.core.js
@@ -275,10 +275,10 @@ var helpers = {
 	 * @param {object} argN - Additional objects containing properties to merge in target.
 	 * @returns {object} The `target` object.
 	 */
-	extend: Object.assign || function() {
-		return helpers.merge(arguments[0], [].slice.call(arguments, 1), {
-			merger: function(key, target, source) {
-				target[key] = source[key];
+	extend: Object.assign || function(target) {
+		return helpers.merge(target, [].slice.call(arguments, 1), {
+			merger: function(key, dst, src) {
+				dst[key] = src[key];
 			}
 		});
 	},

--- a/src/helpers/helpers.core.js
+++ b/src/helpers/helpers.core.js
@@ -275,7 +275,7 @@ var helpers = {
 	 * @param {object} argN - Additional objects containing properties to merge in target.
 	 * @returns {object} The `target` object.
 	 */
-	extend: function(target) {
+	extend: Object.assing ? Object.assign : function(target) {
 		var setFn = function(value, key) {
 			target[key] = value;
 		};

--- a/src/helpers/helpers.core.js
+++ b/src/helpers/helpers.core.js
@@ -275,14 +275,12 @@ var helpers = {
 	 * @param {object} argN - Additional objects containing properties to merge in target.
 	 * @returns {object} The `target` object.
 	 */
-	extend: Object.assing ? Object.assign : function(target) {
-		var setFn = function(value, key) {
-			target[key] = value;
-		};
-		for (var i = 1, ilen = arguments.length; i < ilen; ++i) {
-			helpers.each(arguments[i], setFn);
-		}
-		return target;
+	extend: Object.assign || function() {
+		return helpers.merge(arguments[0], [].slice.call(arguments, 1), {
+			merger: function(key, target, source) {
+				target[key] = source[key];
+			}
+		});
 	},
 
 	/**


### PR DESCRIPTION
Its a lot faster in Chrome (>50%). Not available in IE, so using merge (also >30% faster)

Some performance tests:
https://jsperf.com/extend-vs-shallow-clone
https://jsperf.com/extend-versions

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
