### PR TITLE
Remove datapoint with duplicate timestamp in order to fix sample

### DIFF
--- a/samples/scales/time/financial.html
+++ b/samples/scales/time/financial.html
@@ -52,11 +52,11 @@
 
 			var date = moment('Jan 01 1990', 'MMM DD YYYY');
 			var now = moment();
-			var data = [randomBar(date, 30)];
+			var data = [];
 			var unit = document.getElementById('unit').value;
 			for (; data.length < 60 && date.isBefore(now); date = date.clone().add(1, unit)) {
 				if (date.isoWeekday() <= 5) {
-					data.push(randomBar(date, data[data.length - 1].y));
+					data.push(randomBar(date, data.length > 0 ? data[data.length - 1].y : 30));
 				}
 			}
 


### PR DESCRIPTION
Thanks to @nagix for catching this mistake

The first two bars had the same timestamp. The bar chart calculates the minimum width and decided that it was 0 as a result and drew all bars with 0 width.