### PR TITLE
Update tooltip content and styling on update()

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -1017,7 +1017,7 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 			me._lastEvent = null;
 		} else {
 			me.active = me.getElementsAtEventForMode(e, hoverOptions.mode, hoverOptions);
-			if (me._lastEvent !== 'click') {
+			if (e.type !== 'click') {
 				me._lastEvent = e;
 			}
 		}

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -676,7 +676,7 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 		me.tooltip.transition(easingValue);
 
 		if (me._lastEvent && me.animating) {
-			// If, during animation, element under mouse changes, lets react to that.
+			// If, during animation, element under mouse changes, let's react to that.
 			me.active = me.getElementsAtEventForMode(me._lastEvent, hoverOptions.mode, hoverOptions);
 			if (!helpers.arrayEquals(me.active, me.lastActive)) {
 				me._updateHoverStyles();
@@ -947,7 +947,7 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 			me.updateHoverStyle(me.lastActive, hoverOptions.mode, false);
 		}
 
-		// Built in hover styling
+		// Built-in hover styling
 		if (me.active.length && hoverOptions.mode) {
 			me.updateHoverStyle(me.active, hoverOptions.mode, true);
 		}

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -663,8 +663,6 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 	 */
 	transition: function(easingValue) {
 		var me = this;
-		var options = me.options || {};
-		var hoverOptions = options.hover;
 		var i, ilen;
 
 		for (i = 0, ilen = (me.data.datasets || []).length; i < ilen; ++i) {
@@ -677,11 +675,7 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 
 		if (me._lastEvent && me.animating) {
 			// If, during animation, element under mouse changes, let's react to that.
-			me.active = me.getElementsAtEventForMode(me._lastEvent, hoverOptions.mode, hoverOptions);
-			if (!helpers.arrayEquals(me.active, me.lastActive)) {
-				me._updateHoverStyles();
-				me.lastActive = me.active;
-			}
+			me.handleEvent(me._lastEvent);
 		}
 	},
 
@@ -1023,7 +1017,9 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 			me._lastEvent = null;
 		} else {
 			me.active = me.getElementsAtEventForMode(e, hoverOptions.mode, hoverOptions);
-			me._lastEvent = e;
+			if (me._lastEvent !== 'click') {
+				me._lastEvent = e;
+			}
 		}
 
 		// Invoke onHover hook

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -1017,9 +1017,7 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 			me._lastEvent = null;
 		} else {
 			me.active = me.getElementsAtEventForMode(e, hoverOptions.mode, hoverOptions);
-			if (e.type !== 'click') {
-				me._lastEvent = e;
-			}
+			me._lastEvent = e.type === 'click' ? null : e;
 		}
 
 		// Invoke onHover hook

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -489,7 +489,7 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 		me.tooltip.initialize();
 
 		// Last active contains items that were previously hovered.
-		me.lastActive = me.lastActive || [];
+		me.lastActive = [];
 
 		// Do this before render so that any plugins that need final scale updates can use it
 		plugins.notify(me, 'afterUpdate');

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -503,7 +503,7 @@ var exports = Element.extend({
 		var options = me._options;
 
 		if (me._lastEvent && me._chart.animating) {
-			// Lets react to changes during animation
+			// Let's react to changes during animation
 			me._active = me._chart.getElementsAtEventForMode(me._lastEvent, options.mode, options);
 			me.update(true);
 			me.pivot();

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -987,7 +987,9 @@ var exports = Element.extend({
 			me._lastEvent = null;
 		} else {
 			me._active = me._chart.getElementsAtEventForMode(e, options.mode, options);
-			me._lastEvent = e;
+			if (me._lastEvent !== 'click') {
+				me._lastEvent = e;
+			}
 		}
 
 		// Remember Last Actives

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -987,7 +987,7 @@ var exports = Element.extend({
 			me._lastEvent = null;
 		} else {
 			me._active = me._chart.getElementsAtEventForMode(e, options.mode, options);
-			if (me._lastEvent !== 'click') {
+			if (e.type !== 'click') {
 				me._lastEvent = e;
 			}
 		}

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -1121,7 +1121,7 @@ describe('Chart', function() {
 			expect(chart.tooltip._options).toEqual(jasmine.objectContaining(newTooltipConfig));
 		});
 
-		it ('should reset the tooltip on update', function() {
+		it('should update the tooltip on update', function() {
 			var chart = acquireChart({
 				type: 'line',
 				data: {
@@ -1151,10 +1151,10 @@ describe('Chart', function() {
 			expect(chart.lastActive).toEqual([point]);
 			expect(tooltip._lastActive).toEqual([point]);
 
-			// Update and confirm tooltip is reset
+			// Update and confirm tooltip is updated
 			chart.update();
-			expect(chart.lastActive).toEqual([]);
-			expect(tooltip._lastActive).toEqual([]);
+			expect(chart.lastActive).toEqual([point]);
+			expect(tooltip._lastActive).toEqual([point]);
 		});
 
 		it ('should update the metadata', function() {


### PR DESCRIPTION
Fixes issue #4991

Another attempt at this issue, credits go to @kurkle.

The tooltip is now updated based on the new data that is visible under the mouse and hides if that point is no longer visible.

To do this the last mouse event is stored and passed to the eventhandler upon update. The data for the tooltip is updated during transition as well as the hover styling of the point.

For a working example of this PR: https://codepen.io/Evertvdw/pen/PgqbWq

Current behaviour: https://codepen.io/Evertvdw/pen/QPbdLQ

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
