### PR TITLE
Use the appropriate time format for auto tick generation

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -774,9 +774,12 @@ module.exports = Scale.extend({
 	 */
 	getLabelCapacity: function(exampleTime) {
 		var me = this;
+		var timeOpts = me.options.time;
+		var displayFormats = timeOpts.displayFormats;
 
 		// pick the longest format (milliseconds) for guestimation
-		var format = me.options.time.displayFormats.millisecond;
+		var format = displayFormats[timeOpts.unit] || displayFormats.millisecond;
+
 		var exampleLabel = me.tickFormatFunction(exampleTime, 0, [], format);
 		var tickLabelWidth = me.getLabelWidth(exampleLabel);
 		var innerWidth = me.isHorizontal() ? me.width : me.height;

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -298,7 +298,7 @@ describe('Time scale tests', function() {
 		expect(ticks).toEqual(['8PM', '9PM', '10PM', '11PM', '12AM', '1AM', '2AM', '3AM', '4AM', '5AM', '6AM', '7AM', '8AM', '9AM', '10AM', '11AM', '12PM', '1PM', '2PM', '3PM', '4PM', '5PM', '6PM', '7PM', '8PM', '9PM']);
 	});
 
-	it('build ticks honoring the minUnit', function() {
+	it('should build ticks honoring the minUnit', function() {
 		var mockData = {
 			labels: ['2015-01-01T20:00:00', '2015-01-02T21:00:00'], // days
 		};
@@ -314,6 +314,26 @@ describe('Time scale tests', function() {
 		var ticks = getTicksLabels(scale);
 
 		expect(ticks).toEqual(['Jan 1', 'Jan 2', 'Jan 3']);
+	});
+
+	it('should build ticks based on the appropriate label capacity', function() {
+		var mockData = {
+			labels: [
+				'2012-01-01', '2013-01-01', '2014-01-01', '2015-01-01',
+				'2016-01-01', '2017-01-01', '2018-01-01', '2019-01-01'
+			]
+		};
+
+		var config = Chart.helpers.mergeIf({
+			time: {
+				unit: 'year'
+			}
+		}, Chart.scaleService.getScaleDefaults('time'));
+
+		var scale = createScale(mockData, config);
+		var ticks = getTicksLabels(scale);
+
+		expect(ticks).toEqual(['2012', '2013', '2014', '2015', '2016', '2017', '2018', '2019']);
 	});
 
 	it('should build ticks using the config diff', function() {


### PR DESCRIPTION
The label width is currently calculated using `time.displayFormats.millisecond` regardless of `time.unit`. This PR uses the appropriate time format for auto tick generation if `time.unit` is specified.

**Master: https://jsfiddle.net/nagix/6fjh43xy/**
<img width="450" alt="Screen Shot 2019-04-04 at 11 01 45 PM" src="https://user-images.githubusercontent.com/723188/55566189-c4e50900-572d-11e9-9952-412a4a48cc90.png">

**This PR: https://jsfiddle.net/nagix/hfopn34g/**
<img width="450" alt="Screen Shot 2019-04-04 at 11 02 23 PM" src="https://user-images.githubusercontent.com/723188/55566195-c8789000-572d-11e9-914e-cfcd6acd5601.png">

Fixes #4411