### PR TITLE
Pass update config to update/render plugin hooks

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -458,7 +458,7 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 		// https://github.com/chartjs/Chart.js/issues/5111#issuecomment-355934167
 		plugins._invalidate(me);
 
-		if (plugins.notify(me, 'beforeUpdate') === false) {
+		if (plugins.notify(me, 'beforeUpdate', [config]) === false) {
 			return;
 		}
 
@@ -493,7 +493,7 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 		me.lastActive = [];
 
 		// Do this before render so that any plugins that need final scale updates can use it
-		plugins.notify(me, 'afterUpdate');
+		plugins.notify(me, 'afterUpdate', [config]);
 
 		if (me._bufferedRender) {
 			me._bufferedRequest = {
@@ -587,12 +587,12 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 		var duration = valueOrDefault(config.duration, animationOptions && animationOptions.duration);
 		var lazy = config.lazy;
 
-		if (plugins.notify(me, 'beforeRender') === false) {
+		if (plugins.notify(me, 'beforeRender', [config]) === false) {
 			return;
 		}
 
 		var onComplete = function(animation) {
-			plugins.notify(me, 'afterRender');
+			plugins.notify(me, 'afterRender', [config]);
 			helpers.callback(animationOptions && animationOptions.onComplete, [animation], me);
 		};
 

--- a/src/core/core.plugins.js
+++ b/src/core/core.plugins.js
@@ -178,20 +178,21 @@ module.exports = {
 /**
  * @method IPlugin#beforeInit
  * @desc Called before initializing `chart`.
- * @param {Chart.Controller} chart - The chart instance.
+ * @param {Chart} chart - The chart instance.
  * @param {object} options - The plugin options.
  */
 /**
  * @method IPlugin#afterInit
  * @desc Called after `chart` has been initialized and before the first update.
- * @param {Chart.Controller} chart - The chart instance.
+ * @param {Chart} chart - The chart instance.
  * @param {object} options - The plugin options.
  */
 /**
  * @method IPlugin#beforeUpdate
  * @desc Called before updating `chart`. If any plugin returns `false`, the update
  * is cancelled (and thus subsequent render(s)) until another `update` is triggered.
- * @param {Chart.Controller} chart - The chart instance.
+ * @param {Chart} chart - The chart instance.
+ * @param {object} config - The update configuration.
  * @param {object} options - The plugin options.
  * @returns {boolean} `false` to cancel the chart update.
  */
@@ -199,14 +200,15 @@ module.exports = {
  * @method IPlugin#afterUpdate
  * @desc Called after `chart` has been updated and before rendering. Note that this
  * hook will not be called if the chart update has been previously cancelled.
- * @param {Chart.Controller} chart - The chart instance.
+ * @param {Chart} chart - The chart instance.
+ * @param {object} config - The update configuration.
  * @param {object} options - The plugin options.
  */
 /**
  * @method IPlugin#beforeDatasetsUpdate
  * @desc Called before updating the `chart` datasets. If any plugin returns `false`,
  * the datasets update is cancelled until another `update` is triggered.
- * @param {Chart.Controller} chart - The chart instance.
+ * @param {Chart} chart - The chart instance.
  * @param {object} options - The plugin options.
  * @returns {boolean} false to cancel the datasets update.
  * @since version 2.1.5
@@ -215,7 +217,7 @@ module.exports = {
  * @method IPlugin#afterDatasetsUpdate
  * @desc Called after the `chart` datasets have been updated. Note that this hook
  * will not be called if the datasets update has been previously cancelled.
- * @param {Chart.Controller} chart - The chart instance.
+ * @param {Chart} chart - The chart instance.
  * @param {object} options - The plugin options.
  * @since version 2.1.5
  */
@@ -244,7 +246,7 @@ module.exports = {
  * @method IPlugin#beforeLayout
  * @desc Called before laying out `chart`. If any plugin returns `false`,
  * the layout update is cancelled until another `update` is triggered.
- * @param {Chart.Controller} chart - The chart instance.
+ * @param {Chart} chart - The chart instance.
  * @param {object} options - The plugin options.
  * @returns {boolean} `false` to cancel the chart layout.
  */
@@ -252,14 +254,15 @@ module.exports = {
  * @method IPlugin#afterLayout
  * @desc Called after the `chart` has been layed out. Note that this hook will not
  * be called if the layout update has been previously cancelled.
- * @param {Chart.Controller} chart - The chart instance.
+ * @param {Chart} chart - The chart instance.
  * @param {object} options - The plugin options.
  */
 /**
  * @method IPlugin#beforeRender
  * @desc Called before rendering `chart`. If any plugin returns `false`,
  * the rendering is cancelled until another `render` is triggered.
- * @param {Chart.Controller} chart - The chart instance.
+ * @param {Chart} chart - The chart instance.
+ * @param {object} config - The update configuration.
  * @param {object} options - The plugin options.
  * @returns {boolean} `false` to cancel the chart rendering.
  */
@@ -267,7 +270,8 @@ module.exports = {
  * @method IPlugin#afterRender
  * @desc Called after the `chart` has been fully rendered (and animation completed). Note
  * that this hook will not be called if the rendering has been previously cancelled.
- * @param {Chart.Controller} chart - The chart instance.
+ * @param {Chart} chart - The chart instance.
+ * @param {object} config - The update configuration.
  * @param {object} options - The plugin options.
  */
 /**
@@ -275,7 +279,7 @@ module.exports = {
  * @desc Called before drawing `chart` at every animation frame specified by the given
  * easing value. If any plugin returns `false`, the frame drawing is cancelled until
  * another `render` is triggered.
- * @param {Chart.Controller} chart - The chart instance.
+ * @param {Chart} chart - The chart instance.
  * @param {number} easingValue - The current animation value, between 0.0 and 1.0.
  * @param {object} options - The plugin options.
  * @returns {boolean} `false` to cancel the chart drawing.
@@ -284,7 +288,7 @@ module.exports = {
  * @method IPlugin#afterDraw
  * @desc Called after the `chart` has been drawn for the specific easing value. Note
  * that this hook will not be called if the drawing has been previously cancelled.
- * @param {Chart.Controller} chart - The chart instance.
+ * @param {Chart} chart - The chart instance.
  * @param {number} easingValue - The current animation value, between 0.0 and 1.0.
  * @param {object} options - The plugin options.
  */
@@ -292,7 +296,7 @@ module.exports = {
  * @method IPlugin#beforeDatasetsDraw
  * @desc Called before drawing the `chart` datasets. If any plugin returns `false`,
  * the datasets drawing is cancelled until another `render` is triggered.
- * @param {Chart.Controller} chart - The chart instance.
+ * @param {Chart} chart - The chart instance.
  * @param {number} easingValue - The current animation value, between 0.0 and 1.0.
  * @param {object} options - The plugin options.
  * @returns {boolean} `false` to cancel the chart datasets drawing.
@@ -301,7 +305,7 @@ module.exports = {
  * @method IPlugin#afterDatasetsDraw
  * @desc Called after the `chart` datasets have been drawn. Note that this hook
  * will not be called if the datasets drawing has been previously cancelled.
- * @param {Chart.Controller} chart - The chart instance.
+ * @param {Chart} chart - The chart instance.
  * @param {number} easingValue - The current animation value, between 0.0 and 1.0.
  * @param {object} options - The plugin options.
  */
@@ -355,7 +359,7 @@ module.exports = {
  * @method IPlugin#beforeEvent
  * @desc Called before processing the specified `event`. If any plugin returns `false`,
  * the event will be discarded.
- * @param {Chart.Controller} chart - The chart instance.
+ * @param {Chart} chart - The chart instance.
  * @param {IEvent} event - The event object.
  * @param {object} options - The plugin options.
  */
@@ -363,20 +367,20 @@ module.exports = {
  * @method IPlugin#afterEvent
  * @desc Called after the `event` has been consumed. Note that this hook
  * will not be called if the `event` has been previously discarded.
- * @param {Chart.Controller} chart - The chart instance.
+ * @param {Chart} chart - The chart instance.
  * @param {IEvent} event - The event object.
  * @param {object} options - The plugin options.
  */
 /**
  * @method IPlugin#resize
  * @desc Called after the chart as been resized.
- * @param {Chart.Controller} chart - The chart instance.
+ * @param {Chart} chart - The chart instance.
  * @param {number} size - The new canvas display size (eq. canvas.style width & height).
  * @param {object} options - The plugin options.
  */
 /**
  * @method IPlugin#destroy
  * @desc Called after the chart as been destroyed.
- * @param {Chart.Controller} chart - The chart instance.
+ * @param {Chart} chart - The chart instance.
  * @param {object} options - The plugin options.
  */


### PR DESCRIPTION
Pass the update config object to the following plugin hooks:
- `beforeUpdate`
- `afterUpdate`
- `beforeRender`
- `afterRender`

This would be useful when customizing the update function using a config object. chartjs-plugin-streaming would use this [to keep the active animation from being interrupted](https://github.com/nagix/chartjs-plugin-streaming#pull-model-polling-based---asynchronous), for example.