### PR TITLE
ticks.display: 'above'

### DIFF
--- a/docs/axes/styling.md
+++ b/docs/axes/styling.md
@@ -30,7 +30,7 @@ The tick configuration is nested under the scale configuration in the `ticks` ke
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
 | `callback` | `function` | | Returns the string representation of the tick value as it should be displayed on the chart. See [callback](../axes/labelling.md#creating-custom-tick-formats).
-| `display` | `boolean` | `true` | If true, show tick marks.
+| `display` | <code>boolean&#124;string</code> | `true` | Controls visibility of tick marks (visible when `true`, hidden when `false`). When `'above'`, tick marks are drawn above datasets.
 | `fontColor` | `Color` | `'#666'` | Font color for tick labels.
 | `fontFamily` | `string` | `"'Helvetica Neue', 'Helvetica', 'Arial', sans-serif"` | Font family for the tick labels, follows CSS font-family options.
 | `fontSize` | `number` | `12` | Font size for the tick labels.

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -645,10 +645,15 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 
 		// Draw all the scales
 		helpers.each(me.boxes, function(box) {
-			box.draw(me.chartArea);
+			box.draw(me.chartArea, false);
 		}, me);
 
 		me.drawDatasets(easingValue);
+
+		helpers.each(me.boxes, function(box) {
+			box.draw(me.chartArea, true);
+		}, me);
+
 		me._drawTooltip(easingValue);
 
 		plugins.notify(me, 'afterDraw', [easingValue]);

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -733,7 +733,7 @@ module.exports = Element.extend({
 		var options = me.options;
 		var optionTicks = options.ticks;
 
-		if (!me._isVisible()) {
+		if (!me._isVisible() || (above && optionTicks.display !== 'above')) {
 			return;
 		}
 

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -726,14 +726,14 @@ module.exports = Element.extend({
 	/**
 	 * Actually draw the scale on the canvas
 	 * @param {object} chartArea - the area of the chart to draw full grid lines on
-	 * @param {boolean} top - drawing on top / after datasets
+	 * @param {boolean} above - drawing above (after) of datasets
 	 */
-	draw: function(chartArea, top) {
+	draw: function(chartArea, above) {
 		var me = this;
 		var options = me.options;
 		var optionTicks = options.ticks;
 
-		if (!me._isVisible() || (top && optionTicks.display !== 'top')) {
+		if (!me._isVisible()) {
 			return;
 		}
 
@@ -892,7 +892,7 @@ module.exports = Element.extend({
 			var glWidth = itemToDraw.glWidth;
 			var glColor = itemToDraw.glColor;
 
-			if (gridLines.display && glWidth && glColor && !top) {
+			if (gridLines.display && glWidth && glColor && !above) {
 				context.save();
 				context.lineWidth = glWidth;
 				context.strokeStyle = glColor;
@@ -917,7 +917,7 @@ module.exports = Element.extend({
 				context.restore();
 			}
 
-			if (optionTicks.display && (optionTicks.display === 'top') === top) {
+			if (optionTicks.display && (optionTicks.display === 'above') === above) {
 				var tickFont = itemToDraw.major ? tickFonts.major : tickFonts.minor;
 
 				// Make sure we draw text in the correct color and font

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -726,18 +726,19 @@ module.exports = Element.extend({
 	/**
 	 * Actually draw the scale on the canvas
 	 * @param {object} chartArea - the area of the chart to draw full grid lines on
+	 * @param {boolean} top - drawing on top / after datasets
 	 */
-	draw: function(chartArea) {
+	draw: function(chartArea, top) {
 		var me = this;
 		var options = me.options;
+		var optionTicks = options.ticks;
 
-		if (!me._isVisible()) {
+		if (!me._isVisible() || (top && optionTicks.display !== 'top')) {
 			return;
 		}
 
 		var chart = me.chart;
 		var context = me.ctx;
-		var optionTicks = options.ticks;
 		var gridLines = options.gridLines;
 		var scaleLabel = options.scaleLabel;
 		var position = options.position;
@@ -891,7 +892,7 @@ module.exports = Element.extend({
 			var glWidth = itemToDraw.glWidth;
 			var glColor = itemToDraw.glColor;
 
-			if (gridLines.display && glWidth && glColor) {
+			if (gridLines.display && glWidth && glColor && !top) {
 				context.save();
 				context.lineWidth = glWidth;
 				context.strokeStyle = glColor;
@@ -916,7 +917,7 @@ module.exports = Element.extend({
 				context.restore();
 			}
 
-			if (optionTicks.display) {
+			if (optionTicks.display && (optionTicks.display === 'top') === top) {
 				var tickFont = itemToDraw.major ? tickFonts.major : tickFonts.minor;
 
 				// Make sure we draw text in the correct color and font

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -484,7 +484,7 @@ module.exports = LinearScaleBase.extend({
 		var gridLineOpts = opts.gridLines;
 		var tickOpts = opts.ticks;
 
-		if (!opts.display) {
+		if (!opts.display || (above && tickOpts.display !== 'above')) {
 			return;
 		}
 

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -476,15 +476,15 @@ module.exports = LinearScaleBase.extend({
 	/**
 	 * Actually draw the scale on the canvas
 	 * @param {object} chartArea - the area of the chart
-	 * @param {boolean} top - drawing on top / after datasets
+	 * @param {boolean} above - drawing above (after) of datasets
 	 */
-	draw: function(chartArea, top) {
+	draw: function(chartArea, above) {
 		var me = this;
 		var opts = me.options;
 		var gridLineOpts = opts.gridLines;
 		var tickOpts = opts.ticks;
 
-		if (!opts.display || (top && tickOpts.display !== 'top')) {
+		if (!opts.display) {
 			return;
 		}
 
@@ -492,7 +492,7 @@ module.exports = LinearScaleBase.extend({
 		var startAngle = this.getIndexAngle(0);
 		var tickFont = helpers.options._parseFont(tickOpts);
 
-		if (!top && (opts.angleLines.display || opts.pointLabels.display)) {
+		if (!above && (opts.angleLines.display || opts.pointLabels.display)) {
 			drawPointLabels(me);
 		}
 
@@ -502,7 +502,7 @@ module.exports = LinearScaleBase.extend({
 				var yCenterOffset = me.getDistanceFromCenterForValue(me.ticksAsNumbers[index]);
 
 				// Draw circular lines around the scale
-				if (gridLineOpts.display && index !== 0 && !top) {
+				if (gridLineOpts.display && index !== 0 && !above) {
 					drawRadiusLine(me, gridLineOpts, yCenterOffset, index);
 				}
 
@@ -514,8 +514,8 @@ module.exports = LinearScaleBase.extend({
 					ctx.translate(me.xCenter, me.yCenter);
 					ctx.rotate(startAngle);
 
-					// Backdrop is drawn behind even if label is drawn on top
-					if (tickOpts.showLabelBackdrop && !top) {
+					// Backdrop is drawn below even if label is drawn above
+					if (tickOpts.showLabelBackdrop && !above) {
 						var labelWidth = ctx.measureText(label).width;
 						ctx.fillStyle = tickOpts.backdropColor;
 						ctx.fillRect(
@@ -526,7 +526,7 @@ module.exports = LinearScaleBase.extend({
 						);
 					}
 
-					if ((tickOpts.display === 'top') === top) {
+					if ((tickOpts.display === 'above') === above) {
 						ctx.textAlign = 'center';
 						ctx.textBaseline = 'middle';
 						ctx.fillStyle = tickFontColor;


### PR DESCRIPTION
Allow drawing tick labels after datasets.

Fixes: #2808 
Fixes: #3724
Fixes: #3738
Fixes: #3722

[Demo](https://codepen.io/kurkle/pen/zXymNY)

