### PR TITLE
Fix overlapping auto-generated ticks

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -802,7 +802,8 @@ module.exports = Element.extend({
 		var isMirrored = optionTicks.mirror;
 		var isHorizontal = me.isHorizontal();
 
-		var ticks = optionTicks.display && optionTicks.autoSkip ? me._autoSkip(me.getTicks()) : me.getTicks();
+		var autoSkipEnabled = optionTicks.display && (optionTicks.source === 'auto' || optionTicks.autoSkip);
+		var ticks = autoSkipEnabled ? me._autoSkip(me.getTicks()) : me.getTicks();
 		var tickFonts = parseTickFontOptions(optionTicks);
 		var tickPadding = optionTicks.padding;
 		var labelOffset = optionTicks.labelOffset;


### PR DESCRIPTION
It was reported in https://github.com/chartjs/Chart.js/issues/6109 that the time scale sometimes generates overlapping ticks. @kurkle debugged this and determined in https://github.com/chartjs/Chart.js/pull/6115 that the issue is because the time scale's auto-tick generation doesn't consider padding.

We'd like to take most of the intelligence out of the time scale's auto tick generation and instead generate a tick at every point and use the auto-skipper to automatically decide which ticks to display. For more details see https://github.com/chartjs/Chart.js/issues/4612

While the solution proposed in https://github.com/chartjs/Chart.js/pull/6115 fixes the bug it also adds more logic to the time scale which is not quite going in the direction we'd like to take things longer-term. This PR may seem a bit funny standalone because when `ticks.source: 'auto'` we're auto-generating ticks and then checking to see if we have too many and autoskipping some of them as well. We shouldn't really have two auto-tick logics. I have a branch on my machine locally that moves much of the time scale's auto-generation logic to the auto-skipper so that everything is contained there. The change in this PR is both necessary for that longer term solution and also in the short-term fixes the bug reported in https://github.com/chartjs/Chart.js/issues/6109

Closes https://github.com/chartjs/Chart.js/issues/6109 https://github.com/chartjs/Chart.js/pull/6115