### PR TITLE
Fix data in financial sample

### DIFF
--- a/samples/scales/time/financial.html
+++ b/samples/scales/time/financial.html
@@ -17,6 +17,7 @@
 
 <body>
 	<div style="width:1000px">
+		<p>This example demonstrates a time series scale by drawing a financial line chart using just the core library. For more specific functionality for financial charts, please see <a href="https://github.com/chartjs/chartjs-chart-financial">chartjs-chart-financial</a></p>
 		<canvas id="chart1"></canvas>
 	</div>
 	<br>

--- a/samples/scales/time/financial.html
+++ b/samples/scales/time/financial.html
@@ -74,12 +74,13 @@
 			var date = moment('Jan 01 1990', 'MMM DD YYYY');
 			var now = moment();
 			var data = [];
+			var lessThanDay = unitLessThanDay();
 			for (; data.length < 60 && date.isBefore(now); date = date.clone().add(1, unit).startOf(unit)) {
 				if (outsideMarketHours(date)) {
-					if (unitLessThanDay() && !beforeNineThirty(date)) {
+					if (!lessThanDay || !beforeNineThirty(date)) {
 						date = date.clone().add(date.isoWeekday() > 5 ? 8 - date.isoWeekday() : 1, 'day');
 					}
-					if (unitLessThanDay()) {
+					if (lessThanDay) {
 						date = date.hour(9).minute(30).second(0);
 					}
 				}

--- a/samples/scales/time/financial.html
+++ b/samples/scales/time/financial.html
@@ -37,6 +37,20 @@
 	<button id="update">update</button>
 	<script>
 		function generateData() {
+			/**
+			 * Returns true if outside 9:30am-4pm on a weekday
+			 */
+			function outsideMarketHours(date) {
+				if (date.isoWeekday() > 5) {
+					return true;
+				}
+				if ((unit == 'second' || unit == 'minute' || unit == 'hour')
+						&& ((date.hour() < 9 && date.minute() < 30) || date.hour() > 16)) {
+					return true;
+				}
+				return false;
+			}
+
 			function randomNumber(min, max) {
 				return Math.random() * (max - min) + min;
 			}
@@ -54,10 +68,14 @@
 			var now = moment();
 			var data = [];
 			var unit = document.getElementById('unit').value;
-			for (; data.length < 60 && date.isBefore(now); date = date.clone().add(1, unit)) {
-				if (date.isoWeekday() <= 5) {
-					data.push(randomBar(date, data.length > 0 ? data[data.length - 1].y : 30));
+			for (; data.length < 60 && date.isBefore(now); date = date.clone().add(1, unit).startOf(unit)) {
+				if (outsideMarketHours(date)) {
+					date = date.clone().add(8 - date.isoWeekday(), 'day');
+					if ((unit == 'second' || unit == 'minute' || unit == 'hour')) {
+						date = date.hour(9).minute(30).second(0);
+					}
 				}
+				data.push(randomBar(date, data.length > 0 ? data[data.length - 1].y : 30));
 			}
 
 			return data;

--- a/samples/scales/time/financial.html
+++ b/samples/scales/time/financial.html
@@ -37,14 +37,14 @@
 	<button id="update">update</button>
 	<script>
 		function generateData() {
-			/**
-			 * Returns true if outside 9:30am-4pm on a weekday
-			 */
+			var unit = document.getElementById('unit').value;
+
+			// Returns true if outside 9:30am-4pm on a weekday
 			function outsideMarketHours(date) {
 				if (date.isoWeekday() > 5) {
 					return true;
 				}
-				if ((unit == 'second' || unit == 'minute' || unit == 'hour')
+				if ((unit === 'second' || unit === 'minute' || unit === 'hour')
 						&& ((date.hour() < 9 && date.minute() < 30) || date.hour() > 16)) {
 					return true;
 				}
@@ -67,11 +67,10 @@
 			var date = moment('Jan 01 1990', 'MMM DD YYYY');
 			var now = moment();
 			var data = [];
-			var unit = document.getElementById('unit').value;
 			for (; data.length < 60 && date.isBefore(now); date = date.clone().add(1, unit).startOf(unit)) {
 				if (outsideMarketHours(date)) {
 					date = date.clone().add(8 - date.isoWeekday(), 'day');
-					if ((unit == 'second' || unit == 'minute' || unit == 'hour')) {
+					if ((unit === 'second' || unit === 'minute' || unit === 'hour')) {
 						date = date.hour(9).minute(30).second(0);
 					}
 				}

--- a/samples/scales/time/financial.html
+++ b/samples/scales/time/financial.html
@@ -78,7 +78,7 @@
 			for (; data.length < 60 && date.isBefore(now); date = date.clone().add(1, unit).startOf(unit)) {
 				if (outsideMarketHours(date)) {
 					if (!lessThanDay || !beforeNineThirty(date)) {
-						date = date.clone().add(date.isoWeekday() > 5 ? 8 - date.isoWeekday() : 1, 'day');
+						date = date.clone().add(date.isoWeekday() >= 5 ? 8 - date.isoWeekday() : 1, 'day');
 					}
 					if (lessThanDay) {
 						date = date.hour(9).minute(30).second(0);

--- a/samples/scales/time/financial.html
+++ b/samples/scales/time/financial.html
@@ -39,13 +39,20 @@
 		function generateData() {
 			var unit = document.getElementById('unit').value;
 
+			function unitLessThanDay() {
+				return unit === 'second' || unit === 'minute' || unit === 'hour';
+			}
+
+			function beforeNineThirty(date) {
+				return date.hour() < 9 || (date.hour() === 9 && date.minute() < 30);
+			}
+
 			// Returns true if outside 9:30am-4pm on a weekday
 			function outsideMarketHours(date) {
 				if (date.isoWeekday() > 5) {
 					return true;
 				}
-				if ((unit === 'second' || unit === 'minute' || unit === 'hour')
-						&& ((date.hour() < 9 && date.minute() < 30) || date.hour() > 16)) {
+				if (unitLessThanDay() && (beforeNineThirty(date) || date.hour() > 16)) {
 					return true;
 				}
 				return false;
@@ -69,8 +76,10 @@
 			var data = [];
 			for (; data.length < 60 && date.isBefore(now); date = date.clone().add(1, unit).startOf(unit)) {
 				if (outsideMarketHours(date)) {
-					date = date.clone().add(date.isoWeekday() > 5 ? 8 - date.isoWeekday() : 1, 'day');
-					if ((unit === 'second' || unit === 'minute' || unit === 'hour')) {
+					if (unitLessThanDay() && !beforeNineThirty(date)) {
+						date = date.clone().add(date.isoWeekday() > 5 ? 8 - date.isoWeekday() : 1, 'day');
+					}
+					if (unitLessThanDay()) {
 						date = date.hour(9).minute(30).second(0);
 					}
 				}

--- a/samples/scales/time/financial.html
+++ b/samples/scales/time/financial.html
@@ -69,7 +69,7 @@
 			var data = [];
 			for (; data.length < 60 && date.isBefore(now); date = date.clone().add(1, unit).startOf(unit)) {
 				if (outsideMarketHours(date)) {
-					date = date.clone().add(8 - date.isoWeekday(), 'day');
+					date = date.clone().add(date.isoWeekday() > 5 ? 8 - date.isoWeekday() : 1, 'day');
 					if ((unit === 'second' || unit === 'minute' || unit === 'hour')) {
 						date = date.hour(9).minute(30).second(0);
 					}


### PR DESCRIPTION
I noticed while manually testing autoskip improvements that the financial sample is skipping 1993 and 1994 when unit is set to year because my code for generating sample dates was not too accurate.