### PR TITLE
Avoid deprecation warnings in tests

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -449,7 +449,6 @@ var defaultConfig = {
 	adapters: {},
 	time: {
 		parser: false, // false == a pattern string from https://momentjs.com/docs/#/parsing/string-format/ or a custom callback that converts its argument to a moment
-		format: false, // DEPRECATED false == date objects, moment object, callback or a pattern string from https://momentjs.com/docs/#/parsing/string-format/
 		unit: false, // false == automatic or override with week, month, year, etc.
 		round: false, // none, or override with week, month, year, etc.
 		displayFormat: false, // DEPRECATED

--- a/test/fixtures/controller.bar/bar-thickness-absolute.json
+++ b/test/fixtures/controller.bar/bar-thickness-absolute.json
@@ -20,6 +20,9 @@
                     "barPercentage": 1,
                     "categoryPercentage": 1,
                     "barThickness": 128,
+                    "time": {
+                        "parser": "YYYY"
+                    },
                     "ticks": {
                         "source": "labels"
                     }

--- a/test/fixtures/controller.bar/bar-thickness-flex-offset.json
+++ b/test/fixtures/controller.bar/bar-thickness-flex-offset.json
@@ -20,6 +20,9 @@
                     "barPercentage": 1,
                     "categoryPercentage": 1,
                     "barThickness": "flex",
+                    "time": {
+                        "parser": "YYYY"
+                    },
                     "ticks": {
                         "source": "labels"
                     }

--- a/test/fixtures/controller.bar/bar-thickness-flex-single-reverse.json
+++ b/test/fixtures/controller.bar/bar-thickness-flex-single-reverse.json
@@ -19,6 +19,9 @@
                     "barThickness": "flex",
                     "barPercentage": 1,
                     "categoryPercentage": 1,
+                    "time": {
+                        "parser": "YYYY"
+                    },
                     "ticks": {
                         "source": "labels",
                         "reverse": true

--- a/test/fixtures/controller.bar/bar-thickness-flex-single.json
+++ b/test/fixtures/controller.bar/bar-thickness-flex-single.json
@@ -19,6 +19,9 @@
                     "barThickness": "flex",
                     "barPercentage": 1,
                     "categoryPercentage": 1,
+                    "time": {
+                        "parser": "YYYY"
+                    },
                     "ticks": {
                         "source": "labels"
                     }

--- a/test/fixtures/controller.bar/bar-thickness-flex.json
+++ b/test/fixtures/controller.bar/bar-thickness-flex.json
@@ -19,6 +19,9 @@
                     "barPercentage": 1,
                     "categoryPercentage": 1,
                     "barThickness": "flex",
+                    "time": {
+                        "parser": "YYYY"
+                    },
                     "ticks": {
                         "source": "labels"
                     }

--- a/test/fixtures/controller.bar/bar-thickness-max.json
+++ b/test/fixtures/controller.bar/bar-thickness-max.json
@@ -19,6 +19,9 @@
                     "barPercentage": 1,
                     "categoryPercentage": 1,
                     "maxBarThickness": 8,
+                    "time": {
+                        "parser": "YYYY"
+                    },
                     "ticks": {
                         "source": "labels"
                     }

--- a/test/fixtures/controller.bar/bar-thickness-min-interval.json
+++ b/test/fixtures/controller.bar/bar-thickness-min-interval.json
@@ -18,6 +18,9 @@
                     "display": false,
                     "barPercentage": 1,
                     "categoryPercentage": 1,
+                    "time": {
+                        "parser": "YYYY"
+                    },
                     "ticks": {
                         "source": "labels"
                     }

--- a/test/fixtures/controller.bar/bar-thickness-multiple.json
+++ b/test/fixtures/controller.bar/bar-thickness-multiple.json
@@ -24,6 +24,9 @@
                     "display": false,
                     "barPercentage": 1,
                     "categoryPercentage": 1,
+                    "time": {
+                        "parser": "YYYY"
+                    },
                     "ticks": {
                         "source": "labels"
                     }

--- a/test/fixtures/controller.bar/bar-thickness-no-overlap.json
+++ b/test/fixtures/controller.bar/bar-thickness-no-overlap.json
@@ -24,6 +24,9 @@
                     "display": false,
                     "barPercentage": 1,
                     "categoryPercentage": 1,
+                    "time": {
+                        "parser": "YYYY-MM"
+                    },
                     "ticks": {
                         "source": "labels"
                     }

--- a/test/fixtures/controller.bar/bar-thickness-offset.json
+++ b/test/fixtures/controller.bar/bar-thickness-offset.json
@@ -25,6 +25,9 @@
                     "display": false,
                     "barPercentage": 1,
                     "categoryPercentage": 1,
+                    "time": {
+                        "parser": "YYYY"
+                    },
                     "ticks": {
                         "source": "labels"
                     }

--- a/test/fixtures/controller.bar/bar-thickness-reverse.json
+++ b/test/fixtures/controller.bar/bar-thickness-reverse.json
@@ -24,6 +24,9 @@
                     "display": false,
                     "barPercentage": 1,
                     "categoryPercentage": 1,
+                    "time": {
+                        "parser": "YYYY"
+                    },
                     "ticks": {
                         "source": "labels",
                         "reverse": true

--- a/test/fixtures/controller.bar/bar-thickness-single-xy.json
+++ b/test/fixtures/controller.bar/bar-thickness-single-xy.json
@@ -18,6 +18,9 @@
                     "display": false,
                     "barPercentage": 1,
                     "categoryPercentage": 1,
+                    "time": {
+                        "parser": "YYYY"
+                    },
                     "ticks": {
                         "source": "labels"
                     }

--- a/test/fixtures/controller.bar/bar-thickness-single.json
+++ b/test/fixtures/controller.bar/bar-thickness-single.json
@@ -18,10 +18,11 @@
                     "display": false,
                     "barPercentage": 1,
                     "categoryPercentage": 1,
-                    "ticks": {
-                        "source": "labels"
-                    },
                     "time": {
+                        "parser": "YYYY"
+                    },
+                    "ticks": {
+                        "source": "labels",
                         "min": "2013"
                     }
                 }],

--- a/test/fixtures/controller.bar/bar-thickness-stacked.json
+++ b/test/fixtures/controller.bar/bar-thickness-stacked.json
@@ -25,6 +25,9 @@
                     "display": false,
                     "barPercentage": 1,
                     "categoryPercentage": 1,
+                    "time": {
+                        "parser": "YYYY"
+                    },
                     "ticks": {
                         "source": "labels"
                     }

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -1170,7 +1170,7 @@ describe('Chart', function() {
 					responsive: true,
 					scales: {
 						xAxes: [{
-							type: 'time'
+							type: 'category'
 						}],
 						yAxes: [{
 							scaleLabel: {

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -97,7 +97,6 @@ describe('Time scale tests', function() {
 			},
 			time: {
 				parser: false,
-				format: false,
 				unit: false,
 				round: false,
 				isoWeekday: false,
@@ -433,28 +432,28 @@ describe('Time scale tests', function() {
 		});
 
 		it('should use the min option when less than first label for building ticks', function() {
-			config.time.min = '2014-12-29T04:00:00';
+			config.ticks.min = '2014-12-29T04:00:00';
 
 			var scale = createScale(mockData, config);
 			expect(scale.ticks[0]).toEqual('Jan 1');
 		});
 
 		it('should use the min option when greater than first label for building ticks', function() {
-			config.time.min = '2015-01-02T04:00:00';
+			config.ticks.min = '2015-01-02T04:00:00';
 
 			var scale = createScale(mockData, config);
 			expect(scale.ticks[0]).toEqual('Jan 2');
 		});
 
 		it('should use the max option when greater than last label for building ticks', function() {
-			config.time.max = '2015-01-05T06:00:00';
+			config.ticks.max = '2015-01-05T06:00:00';
 
 			var scale = createScale(mockData, config);
 			expect(scale.ticks[scale.ticks.length - 1]).toEqual('Jan 3');
 		});
 
 		it('should use the max option when less than last label for building ticks', function() {
-			config.time.max = '2015-01-02T23:00:00';
+			config.ticks.max = '2015-01-02T23:00:00';
 
 			var scale = createScale(mockData, config);
 			expect(scale.ticks[scale.ticks.length - 1]).toEqual('Jan 2');
@@ -853,7 +852,7 @@ describe('Time scale tests', function() {
 				scales: {
 					xAxes: [{
 						type: 'time',
-						time: {
+						ticks: {
 							min: moment().subtract(1, 'months'),
 							max: moment(),
 						}
@@ -910,8 +909,8 @@ describe('Time scale tests', function() {
 				var scale = chart.scales.x;
 				var options = chart.options.scales.xAxes[0];
 
-				options.time.min = '2012';
-				options.time.max = '2051';
+				options.ticks.min = '2012';
+				options.ticks.max = '2051';
 				chart.update();
 
 				expect(scale.min).toEqual(+moment('2012', 'YYYY'));
@@ -924,8 +923,8 @@ describe('Time scale tests', function() {
 				var scale = chart.scales.x;
 				var options = chart.options.scales.xAxes[0];
 
-				options.time.min = '2017';
-				options.time.max = '2042';
+				options.ticks.min = '2017';
+				options.ticks.max = '2042';
 				chart.update();
 
 				expect(scale.min).toEqual(+moment('2017', 'YYYY'));
@@ -1004,8 +1003,8 @@ describe('Time scale tests', function() {
 				var scale = chart.scales.x;
 				var options = chart.options.scales.xAxes[0];
 
-				options.time.min = '2012';
-				options.time.max = '2051';
+				options.ticks.min = '2012';
+				options.ticks.max = '2051';
 				chart.update();
 
 				expect(scale.min).toEqual(+moment('2012', 'YYYY'));
@@ -1018,8 +1017,8 @@ describe('Time scale tests', function() {
 				var scale = chart.scales.x;
 				var options = chart.options.scales.xAxes[0];
 
-				options.time.min = '2017';
-				options.time.max = '2043';
+				options.ticks.min = '2017';
+				options.ticks.max = '2043';
 				chart.update();
 
 				expect(scale.min).toEqual(+moment('2017', 'YYYY'));
@@ -1103,7 +1102,7 @@ describe('Time scale tests', function() {
 				var scale = chart.scales.x;
 				var options = chart.options.scales.xAxes[0];
 
-				options.time.min = '2012';
+				options.ticks.min = '2012';
 				chart.update();
 
 				var start = scale.left;
@@ -1117,7 +1116,7 @@ describe('Time scale tests', function() {
 				var scale = chart.scales.x;
 				var options = chart.options.scales.xAxes[0];
 
-				options.time.max = '2050';
+				options.ticks.max = '2050';
 				chart.update();
 
 				var start = scale.left;
@@ -1131,8 +1130,8 @@ describe('Time scale tests', function() {
 				var scale = chart.scales.x;
 				var options = chart.options.scales.xAxes[0];
 
-				options.time.min = '2012';
-				options.time.max = '2050';
+				options.ticks.min = '2012';
+				options.ticks.max = '2050';
 				chart.update();
 
 				var start = scale.left;
@@ -1187,8 +1186,8 @@ describe('Time scale tests', function() {
 				var scale = chart.scales.x;
 				var options = chart.options.scales.xAxes[0];
 
-				options.time.min = '2012';
-				options.time.max = '2050';
+				options.ticks.min = '2012';
+				options.ticks.max = '2050';
 				chart.update();
 
 				var start = scale.left;
@@ -1280,7 +1279,7 @@ describe('Time scale tests', function() {
 		});
 	});
 
-	describe('when time.min and/or time.max are defined', function() {
+	describe('when ticks.min and/or ticks.max are defined', function() {
 		['auto', 'data', 'labels'].forEach(function(source) {
 			['data', 'ticks'].forEach(function(bounds) {
 				describe('and ticks.source is "' + source + '" and bounds "' + bounds + '"', function() {
@@ -1320,8 +1319,8 @@ describe('Time scale tests', function() {
 						var min = '02/19 07:00';
 						var max = '02/24 08:00';
 
-						options.time.min = min;
-						options.time.max = max;
+						options.ticks.min = min;
+						options.ticks.max = max;
 						chart.update();
 
 						expect(scale.min).toEqual(+moment(min, 'MM/DD HH:mm'));
@@ -1340,8 +1339,8 @@ describe('Time scale tests', function() {
 						var min = '02/21 07:00';
 						var max = '02/22 20:00';
 
-						options.time.min = min;
-						options.time.max = max;
+						options.ticks.min = min;
+						options.ticks.max = max;
 						chart.update();
 
 						expect(scale.min).toEqual(+moment(min, 'MM/DD HH:mm'));
@@ -1414,8 +1413,8 @@ describe('Time scale tests', function() {
 					var scale = chart.scales.x;
 					var options = chart.options.scales.xAxes[0];
 
-					options.time.min = '2012';
-					options.time.max = '2051';
+					options.ticks.min = '2012';
+					options.ticks.max = '2051';
 					chart.update();
 
 					expect(scale.getPixelForValue('2012')).toBeCloseToPixel(scale.left);
@@ -1427,8 +1426,8 @@ describe('Time scale tests', function() {
 					var scale = chart.scales.x;
 					var options = chart.options.scales.xAxes[0];
 
-					options.time.min = '2012';
-					options.time.max = '2051';
+					options.ticks.min = '2012';
+					options.ticks.max = '2051';
 					options.offset = true;
 					chart.update();
 
@@ -1541,7 +1540,7 @@ describe('Time scale tests', function() {
 				var scale = chart.scales.x;
 				var options = chart.options.scales.xAxes[0];
 
-				options.time.min = '2012';
+				options.ticks.min = '2012';
 				chart.update();
 
 				var start = scale.left;
@@ -1556,7 +1555,7 @@ describe('Time scale tests', function() {
 				var scale = chart.scales.x;
 				var options = chart.options.scales.xAxes[0];
 
-				options.time.max = '2050';
+				options.ticks.max = '2050';
 				chart.update();
 
 				var start = scale.left;
@@ -1571,8 +1570,8 @@ describe('Time scale tests', function() {
 				var scale = chart.scales.x;
 				var options = chart.options.scales.xAxes[0];
 
-				options.time.min = '2012';
-				options.time.max = '2050';
+				options.ticks.min = '2012';
+				options.ticks.max = '2050';
 				chart.update();
 
 				var start = scale.left;
@@ -1629,8 +1628,8 @@ describe('Time scale tests', function() {
 				var scale = chart.scales.x;
 				var options = chart.options.scales.xAxes[0];
 
-				options.time.min = '2012';
-				options.time.max = '2050';
+				options.ticks.min = '2012';
+				options.ticks.max = '2050';
 				chart.update();
 
 				var start = scale.left;


### PR DESCRIPTION
* Move `time.min/max` to `ticks`
* Remove `time.format` from defaults & test
* Supply `parser` when using incomplete date strings