### PR TITLE
Remove duplicate scale building

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -225,9 +225,6 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 			me.resize(true);
 		}
 
-		// Make sure scales have IDs and are built before we build any controllers.
-		me.ensureScalesHaveIDs();
-		me.buildOrUpdateScales();
 		me.initToolTip();
 
 		// After init plugin notification


### PR DESCRIPTION
Remove duplicate calls to `ensureScalesHaveIDs` and `buildOrUpdateScales` from `initialize`.

These two are also called from `updateConfig`:
https://github.com/chartjs/Chart.js/blob/6b3e43d216591b024fa0125e37e3e3b6d2b51016/src/core/core.controller.js#L132-L133

Which is called from `update`:
https://github.com/chartjs/Chart.js/blob/6b3e43d216591b024fa0125e37e3e3b6d2b51016/src/core/core.controller.js#L452

Which in turn is called from `construct` (right after initialize):
https://github.com/chartjs/Chart.js/blob/6b3e43d216591b024fa0125e37e3e3b6d2b51016/src/core/core.controller.js#L206-L207

Edit: This duplication comes from #4198 where updating of scales after initialization was fixed.