### PR TITLE
Call determineDataLimits only once

### DIFF
--- a/src/core/core.layouts.js
+++ b/src/core/core.layouts.js
@@ -275,9 +275,9 @@ module.exports = {
 
 					// Don't use min size here because of label rotation. When the labels are rotated, their rotation highly depends
 					// on the margin. Sometimes they need to increase in size slightly
-					box.update(box.fullWidth ? chartWidth : maxChartAreaWidth, chartHeight / 2, scaleMargin);
+					box.update(box.fullWidth ? chartWidth : maxChartAreaWidth, chartHeight / 2, scaleMargin, true);
 				} else {
-					box.update(minBoxSize.width, maxChartAreaHeight);
+					box.update(minBoxSize.width, maxChartAreaHeight, undefined, true);
 				}
 			}
 		}
@@ -303,7 +303,7 @@ module.exports = {
 			};
 
 			if (minBoxSize) {
-				box.update(minBoxSize.width, maxChartAreaHeight, scaleMargin);
+				box.update(minBoxSize.width, maxChartAreaHeight, scaleMargin, true);
 			}
 		}
 

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -232,8 +232,9 @@ module.exports = Element.extend({
 		helpers.callback(this.options.beforeUpdate, [this]);
 	},
 
-	update: function(maxWidth, maxHeight, margins) {
+	update: function(maxWidth, maxHeight, margins /** @private subsequentCall */) {
 		var me = this;
+		var subsequentCall = arguments[3];
 		var i, ilen, labels, label, ticks, tick;
 
 		// Update Lifecycle - Probably don't want to ever extend or overwrite this function ;)
@@ -259,9 +260,11 @@ module.exports = Element.extend({
 		me.afterSetDimensions();
 
 		// Data min/max
-		me.beforeDataLimits();
-		me.determineDataLimits();
-		me.afterDataLimits();
+		if (!subsequentCall) {
+			me.beforeDataLimits();
+			me.determineDataLimits();
+			me.afterDataLimits();
+		}
 
 		// Ticks - `this.ticks` is now DEPRECATED!
 		// Internal ticks are now stored as objects in the PRIVATE `this._ticks` member
@@ -320,7 +323,6 @@ module.exports = Element.extend({
 		me.afterUpdate();
 
 		return me.minSize;
-
 	},
 	afterUpdate: function() {
 		helpers.callback(this.options.afterUpdate, [this]);


### PR DESCRIPTION
`determineDataLimits` is a very expensive call. We call it multiple times for each scale, but really only need to calculate it once

My initial idea was that in creating the layout we should call `fit` most of the times and `update` only once, but that proved very difficult. E.g. to fit the scale you need to create the labels, which means you need the format, which in the time scale means you need the unit, which means you need to know how many ticks there are. So the way things are structured right now you can't easily get around building the ticks multiple times. but `determineDataLimits` is by far the most expensive part of `update` for both the time and linear scale that I've been testing with, so this is actually a really big win.