### PR TITLE
Allow specifying labels in time scale options

### DIFF
--- a/docs/axes/cartesian/time.md
+++ b/docs/axes/cartesian/time.md
@@ -149,7 +149,7 @@ The `ticks.source` property controls the ticks generation.
 
 * `'auto'`: generates "optimal" ticks based on scale size and time options
 * `'data'`: generates ticks from data (including labels from data `{t|x|y}` objects)
-* `'labels'`: generates ticks from user given `scale.labels` or `data.labels` values ONLY
+* `'labels'`: generates ticks from user given `labels` ONLY
 
 ### Parser
 If this property is defined as a string, it is interpreted as a custom format to be used by Moment.js to parse the date.

--- a/docs/axes/cartesian/time.md
+++ b/docs/axes/cartesian/time.md
@@ -149,7 +149,7 @@ The `ticks.source` property controls the ticks generation.
 
 * `'auto'`: generates "optimal" ticks based on scale size and time options
 * `'data'`: generates ticks from data (including labels from data `{t|x|y}` objects)
-* `'labels'`: generates ticks from user given `data.labels` values ONLY
+* `'labels'`: generates ticks from user given `scale.labels` or `data.labels` values ONLY
 
 ### Parser
 If this property is defined as a string, it is interpreted as a custom format to be used by Moment.js to parse the date.

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -214,7 +214,6 @@ var Scale = Element.extend({
 		return this._ticks;
 	},
 
-
 	/**
 	* @private
 	*/

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -214,6 +214,15 @@ var Scale = Element.extend({
 		return this._ticks;
 	},
 
+
+	/**
+	* @private
+	*/
+	_getLabels: function() {
+		var data = this.chart.data;
+		return this.options.labels || (this.isHorizontal() ? data.xLabels : data.yLabels) || data.labels;
+	},
+
 	// These methods are ordered by lifecyle. Utilities then follow.
 	// Any function defined here is inherited by all scale types.
 	// Any function can be extended by the scale type

--- a/src/scales/scale.category.js
+++ b/src/scales/scale.category.js
@@ -7,19 +7,9 @@ var defaultConfig = {
 };
 
 module.exports = Scale.extend({
-	/**
-	* Internal function to get the correct labels. If data.xLabels or data.yLabels are defined, use those
-	* else fall back to data.labels
-	* @private
-	*/
-	getLabels: function() {
-		var data = this.chart.data;
-		return this.options.labels || (this.isHorizontal() ? data.xLabels : data.yLabels) || data.labels;
-	},
-
 	determineDataLimits: function() {
 		var me = this;
-		var labels = me.getLabels();
+		var labels = me._getLabels();
 		me.minIndex = 0;
 		me.maxIndex = labels.length - 1;
 		var findIndex;
@@ -42,7 +32,7 @@ module.exports = Scale.extend({
 
 	buildTicks: function() {
 		var me = this;
-		var labels = me.getLabels();
+		var labels = me._getLabels();
 		// If we are viewing some subset of labels, slice the original array
 		me.ticks = (me.minIndex === 0 && me.maxIndex === labels.length - 1) ? labels : labels.slice(me.minIndex, me.maxIndex + 1);
 	},
@@ -72,7 +62,7 @@ module.exports = Scale.extend({
 			valueCategory = me.isHorizontal() ? value.x : value.y;
 		}
 		if (valueCategory !== undefined || (value !== undefined && isNaN(index))) {
-			var labels = me.getLabels();
+			var labels = me._getLabels();
 			value = valueCategory || value;
 			var idx = labels.indexOf(value);
 			index = idx !== -1 ? idx : index;

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -523,7 +523,7 @@ module.exports = Scale.extend({
 		var datasets = [];
 		var labels = [];
 		var i, j, ilen, jlen, data, timestamp;
-		var dataLabels = chart.data.labels || [];
+		var dataLabels = options.labels || chart.data.labels || [];
 
 		// Convert labels to timestamps
 		for (i = 0, ilen = dataLabels.length; i < ilen; ++i) {

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -523,7 +523,7 @@ module.exports = Scale.extend({
 		var datasets = [];
 		var labels = [];
 		var i, j, ilen, jlen, data, timestamp;
-		var dataLabels = options.labels || chart.data.labels || [];
+		var dataLabels = me._getLabels();
 
 		// Convert labels to timestamps
 		for (i = 0, ilen = dataLabels.length; i < ilen; ++i) {

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -1644,6 +1644,58 @@ describe('Time scale tests', function() {
 		});
 	});
 
+	describe('labels', function() {
+		it('should read labels from scale / xLabels / yLabels', function() {
+			var chart = window.acquireChart({
+				type: 'line',
+				data: {
+					labels: ['1975', '1976', '1977'],
+					xLabels: ['1985', '1986', '1987'],
+					yLabels: ['1995', '1996', '1997']
+				},
+				options: {
+					scales: {
+						xAxes: [{
+							id: 'x',
+							type: 'time',
+							labels: ['2015', '2016', '2017'],
+							time: {
+								parser: 'YYYY',
+							}
+						},
+						{
+							id: 'x2',
+							type: 'time',
+							time: {
+								parser: 'YYYY',
+							}
+						}],
+						yAxes: [{
+							id: 'y',
+							type: 'time',
+							time: {
+								parser: 'YYYY',
+							}
+						},
+						{
+							id: 'y2',
+							type: 'time',
+							labels: ['2005', '2006', '2007'],
+							time: {
+								parser: 'YYYY',
+							}
+						}]
+					}
+				}
+			});
+
+			expect(getTicksLabels(chart.scales.x)).toEqual(['Jan 2015', 'Jan 2016', 'Jan 2017']);
+			expect(getTicksLabels(chart.scales.x2)).toEqual(['Jan 1985', 'Jan 1986', 'Jan 1987']);
+			expect(getTicksLabels(chart.scales.y)).toEqual(['Jan 1995', 'Jan 1996', 'Jan 1997']);
+			expect(getTicksLabels(chart.scales.y2)).toEqual(['Jan 2005', 'Jan 2006', 'Jan 2007']);
+		});
+	});
+
 	describe('Deprecations', function() {
 		describe('options.time.displayFormats', function() {
 			it('should generate defaults from adapter presets', function() {

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -1646,6 +1646,13 @@ describe('Time scale tests', function() {
 
 	describe('labels', function() {
 		it('should read labels from scale / xLabels / yLabels', function() {
+			var timeOpts = {
+				parser: 'YYYY',
+				unit: 'year',
+				displayFormats: {
+					year: 'YYYY'
+				}
+			};
 			var chart = window.acquireChart({
 				type: 'line',
 				data: {
@@ -1659,40 +1666,32 @@ describe('Time scale tests', function() {
 							id: 'x',
 							type: 'time',
 							labels: ['2015', '2016', '2017'],
-							time: {
-								parser: 'YYYY',
-							}
+							time: timeOpts
 						},
 						{
 							id: 'x2',
 							type: 'time',
-							time: {
-								parser: 'YYYY',
-							}
+							time: timeOpts
 						}],
 						yAxes: [{
 							id: 'y',
 							type: 'time',
-							time: {
-								parser: 'YYYY',
-							}
+							time: timeOpts
 						},
 						{
 							id: 'y2',
 							type: 'time',
 							labels: ['2005', '2006', '2007'],
-							time: {
-								parser: 'YYYY',
-							}
+							time: timeOpts
 						}]
 					}
 				}
 			});
 
-			expect(getTicksLabels(chart.scales.x)).toEqual(['Jan 2015', 'Jan 2016', 'Jan 2017']);
-			expect(getTicksLabels(chart.scales.x2)).toEqual(['Jan 1985', 'Jan 1986', 'Jan 1987']);
-			expect(getTicksLabels(chart.scales.y)).toEqual(['Jan 1995', 'Jan 1996', 'Jan 1997']);
-			expect(getTicksLabels(chart.scales.y2)).toEqual(['Jan 2005', 'Jan 2006', 'Jan 2007']);
+			expect(getTicksLabels(chart.scales.x)).toEqual(['2015', '2016', '2017']);
+			expect(getTicksLabels(chart.scales.x2)).toEqual(['1985', '1986', '1987']);
+			expect(getTicksLabels(chart.scales.y)).toEqual(['1995', '1996', '1997']);
+			expect(getTicksLabels(chart.scales.y2)).toEqual(['2005', '2006', '2007']);
 		});
 	});
 


### PR DESCRIPTION
Currently time scale only reads labels from `data.labels`.
If both axes are time scales, this is not sufficient.

So this PR allows specifying labels under scale options also.