### PR TITLE
Vertical time scale generates too few ticks

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -765,7 +765,9 @@ module.exports = Scale.extend({
 		var sinRotation = Math.sin(angle);
 		var tickFontSize = valueOrDefault(ticksOpts.fontSize, defaults.global.defaultFontSize);
 
-		return (tickLabelWidth * cosRotation) + (tickFontSize * sinRotation);
+		return me.isHorizontal()
+			? (tickLabelWidth * cosRotation) + (tickFontSize * sinRotation)
+			: (tickLabelWidth * sinRotation) + (tickFontSize * cosRotation);
 	},
 
 	/**

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -753,10 +753,9 @@ module.exports = Scale.extend({
 	},
 
 	/**
-	 * Crude approximation of what the label width might be
 	 * @private
 	 */
-	getLabelWidth: function(label) {
+	_getLabelSize: function(label) {
 		var me = this;
 		var ticksOpts = me.options.ticks;
 		var tickLabelWidth = me.ctx.measureText(label).width;
@@ -765,9 +764,18 @@ module.exports = Scale.extend({
 		var sinRotation = Math.sin(angle);
 		var tickFontSize = valueOrDefault(ticksOpts.fontSize, defaults.global.defaultFontSize);
 
-		return me.isHorizontal()
-			? (tickLabelWidth * cosRotation) + (tickFontSize * sinRotation)
-			: (tickLabelWidth * sinRotation) + (tickFontSize * cosRotation);
+		return {
+			w: (tickLabelWidth * cosRotation) + (tickFontSize * sinRotation),
+			h: (tickLabelWidth * sinRotation) + (tickFontSize * cosRotation)
+		};
+	},
+
+	/**
+	 * Crude approximation of what the label width might be
+	 * @private
+	 */
+	getLabelWidth: function(label) {
+		return this._getLabelSize(label).w;
 	},
 
 	/**
@@ -781,17 +789,15 @@ module.exports = Scale.extend({
 
 		// pick the longest format (milliseconds) for guestimation
 		var format = displayFormats[timeOpts.unit] || displayFormats.millisecond;
-
 		var exampleLabel = me.tickFormatFunction(exampleTime, 0, [], format);
-		var tickLabelWidth = me.getLabelWidth(exampleLabel);
+		var size = me._getLabelSize(exampleLabel);
 
 		// Using margins instead of padding because padding is not calculated
 		// at this point (buildTicks). Margins are provided from previous calculation
 		// in layout steps 5/6
-		var innerWidth = me.isHorizontal()
-			? me.width - (margins.left + margins.right)
-			: me.height - (margins.top + margins.bottom);
-		var capacity = Math.floor(innerWidth / tickLabelWidth);
+		var capacity = Math.floor(me.isHorizontal()
+			? (me.width - margins.left - margins.right) / size.w
+			: (me.height - margins.top - margins.bottom) / size.h);
 
 		return capacity > 0 ? capacity : 1;
 	}

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -799,6 +799,10 @@ module.exports = Scale.extend({
 			? (me.width - margins.left - margins.right) / size.w
 			: (me.height - margins.top - margins.bottom) / size.h);
 
+		if (me.options.offset) {
+			capacity--;
+		}
+
 		return capacity > 0 ? capacity : 1;
 	}
 });


### PR DESCRIPTION
Vertical time scale generates too few ticks, due to considering tick length in capacity calculation.

This might not be a correct fix however, because the function is called `getLabelWidth`.

Master: [Pen](https://codepen.io/kurkle/pen/KLdqJd)
![image](https://user-images.githubusercontent.com/27971921/57380888-84f0c600-71b2-11e9-836b-8318ef2ddaf2.png)

PR: [Pen](https://codepen.io/kurkle/pen/byVRyb)
![image](https://user-images.githubusercontent.com/27971921/57380907-8d490100-71b2-11e9-85da-20c8e345a1d9.png)

With offset: [Pen](https://codepen.io/kurkle/pen/RmrVdK)
