### PR TITLE
Option for determining if tick is major

### DIFF
--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -94,6 +94,7 @@ describe('Time scale tests', function() {
 				major: {
 					enabled: false
 				},
+				isMajor: defaultConfig.ticks.isMajor,
 			},
 			time: {
 				parser: false,
@@ -108,6 +109,7 @@ describe('Time scale tests', function() {
 
 		// Is this actually a function
 		expect(defaultConfig.ticks.callback).toEqual(jasmine.any(Function));
+		expect(defaultConfig.ticks.isMajor).toEqual(jasmine.any(Function));
 	});
 
 	describe('when given inputs of different types', function() {


### PR DESCRIPTION
The current code has hardcoded that a major tick is one that aligns with `startOf(value, majorUnit)`. However, I've found many cases where I want a different behavior. E.g. in the financial charts we don't have weekends, so we might want to say the major tick is the first weekday of the month so that we have a majorTick begin each month. This adds an option called `isMajor` which takes a `function` to make the logic configurable.