### PR TITLE
Make autoSkip aware of major ticks

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -260,7 +260,7 @@ function skipMajors(ticks, majorIndices, spacing) {
 }
 
 function skip(ticks, spacing, majorStart, majorEnd) {
-	var ticksToKeep = [];
+	var ticksToKeep = {};
 	var start = valueOrDefault(majorStart, 0);
 	var end = Math.min(valueOrDefault(majorEnd, ticks.length), ticks.length);
 	var length, i, tick;
@@ -272,10 +272,10 @@ function skip(ticks, spacing, majorStart, majorEnd) {
 	}
 	for (i = 0, tick = start; tick < end; i++) {
 		tick = Math.round(start + i * spacing);
-		ticksToKeep.push(tick);
+		ticksToKeep[tick] = 1;
 	}
 	for (i = Math.max(start, 0); i < end; i++) {
-		if (ticksToKeep.indexOf(i) < 0) {
+		if (!ticksToKeep[i]) {
 			delete ticks[i].label;
 		}
 	}

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -202,7 +202,7 @@ function factorize(value) {
 			result.push(value / i);
 		}
 	}
-	if (Number.isInteger(sqrt)) {
+	if (sqrt === (sqrt | 0)) { // if value is a square number
 		result.push(sqrt);
 	}
 
@@ -233,16 +233,27 @@ function calculateSpacing(majorIndices, ticks, axisLength, ticksLimit) {
 	return Math.max(spacing || ticks.length / ticksLimit, 1);
 }
 
+function getMajorIndices(ticks) {
+	var result = [];
+	var i, ilen;
+	for (i = 0, ilen = ticks.length; i < ilen; i++) {
+		if (ticks[i].major) {
+			result.push(i);
+		}
+	}
+	return result;
+}
+
 function skipMajors(ticks, majorIndices, spacing) {
-	var ticksToKeep = [];
+	var ticksToKeep = {};
 	var i;
 
 	spacing = Math.ceil(spacing);
 	for (i = 0; i < majorIndices.length; i += spacing) {
-		ticksToKeep.push(majorIndices[i]);
+		ticksToKeep[majorIndices[i]] = 1;
 	}
 	for (i = 0; i < ticks.length; i++) {
-		if (ticksToKeep.indexOf(i) < 0) {
+		if (!ticksToKeep[i]) {
 			delete ticks[i].label;
 		}
 	}
@@ -781,11 +792,7 @@ var Scale = Element.extend({
 		var tickOpts = me.options.ticks;
 		var axisLength = me._axisLength();
 		var ticksLimit = tickOpts.maxTicksLimit || axisLength / me._tickSize() + 1;
-		var majorIndices = tickOpts.major.enabled ? ticks.map(function(tick, i) {
-			return tick.major ? i : -1;
-		}).filter(function(val) {
-			return val >= 0;
-		}) : [];
+		var majorIndices = tickOpts.major.enabled ? getMajorIndices(ticks) : [];
 		var first = majorIndices[0];
 		var last = majorIndices[majorIndices.length - 1];
 		var i, ilen, spacing, avgMajorSpacing;

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -539,17 +539,15 @@ module.exports = Scale.extend({
 		var timestamps = [];
 		var ticks = [];
 		var capacity = me.getLabelCapacity(min);
+		var source = options.ticks.source;
+		var distribution = options.distribution;
 		var i, ilen, timestamp;
 
-		switch (options.ticks.source) {
-		case 'data':
+		if (source === 'data' || (source === 'auto' && distribution === 'series')) {
 			timestamps = me._timestamps.data;
-			break;
-		case 'labels':
+		} else if (source === 'labels') {
 			timestamps = me._timestamps.labels;
-			break;
-		case 'auto':
-		default:
+		} else {
 			timestamps = generate(me, min, max, capacity, options);
 		}
 
@@ -579,7 +577,7 @@ module.exports = Scale.extend({
 		// But if you have a lot of ticks it could be larger. E.g. if you have 8000 day ticks the majorUnit may be year
 		me._majorUnit = !options.ticks.major.enabled || me._unit === 'year' ? undefined
 			: determineUnitForAutoTicks(UNITS[UNITS.indexOf(me._unit) + 1], me.min, me.max, capacity);
-		me._table = buildLookupTable(me._timestamps.data, min, max, options.distribution);
+		me._table = buildLookupTable(me._timestamps.data, min, max, distribution);
 		me._offsets = computeOffsets(me._table, ticks, min, max, options);
 
 		if (options.ticks.reverse) {

--- a/test/specs/core.scale.tests.js
+++ b/test/specs/core.scale.tests.js
@@ -69,7 +69,14 @@ describe('Core.scale', function() {
 
 			var xAxis = chart.scales['x-axis-0'];
 			var ticks = xAxis.getTicks();
-			expect(ticks[1].label).toBeUndefined();
+			for (var i = 0; i < ticks.length; i++) {
+				var label = ticks[i].label;
+				if (i % 2 === 0) {
+					expect(label).toBeDefined();
+				} else {
+					expect(label).toBeUndefined();
+				}
+			}
 		});
 	});
 

--- a/test/specs/core.scale.tests.js
+++ b/test/specs/core.scale.tests.js
@@ -34,12 +34,6 @@ describe('Core.scale', function() {
 			});
 		}
 
-		function lastTick(chart) {
-			var xAxis = chart.scales['x-axis-0'];
-			var ticks = xAxis.getTicks();
-			return ticks[ticks.length - 1];
-		}
-
 		it('should display the last tick if it fits evenly with other ticks', function() {
 			var chart = getChart({
 				labels: [
@@ -52,10 +46,12 @@ describe('Core.scale', function() {
 				}]
 			});
 
-			expect(lastTick(chart).label).toEqual('September 2018');
+			var xAxis = chart.scales['x-axis-0'];
+			var ticks = xAxis.getTicks();
+			expect(ticks[ticks.length - 1].label).toEqual('September 2018');
 		});
 
-		it('should not display the last tick if it does not fit evenly', function() {
+		it('should skip every other tick if there are too many to display', function() {
 			var chart = getChart({
 				labels: [
 					'January 2018', 'February 2018', 'March 2018', 'April 2018',
@@ -64,14 +60,16 @@ describe('Core.scale', function() {
 					'January 2019', 'February 2019', 'March 2019', 'April 2019',
 					'May 2019', 'June 2019', 'July 2019', 'August 2019',
 					'September 2019', 'October 2019', 'November 2019', 'December 2019',
-					'January 2020', 'February 2020'
+					'January 2020', 'February 2020', 'March 2020', 'April 2020'
 				],
 				datasets: [{
-					data: [12, 19, 3, 5, 2, 3, 7, 8, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+					data: [12, 19, 3, 5, 2, 3, 7, 8, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
 				}]
 			});
 
-			expect(lastTick(chart).label).toBeUndefined();
+			var xAxis = chart.scales['x-axis-0'];
+			var ticks = xAxis.getTicks();
+			expect(ticks[1].label).toBeUndefined();
 		});
 	});
 

--- a/test/specs/global.deprecations.tests.js
+++ b/test/specs/global.deprecations.tests.js
@@ -333,7 +333,7 @@ describe('Deprecations', function() {
 				var chart = window.acquireChart({
 					type: 'line',
 					data: {
-						labels: ['2015-01-01T20:00:00', '2015-01-01T22:00:00'],
+						labels: ['2015-01-01T20:00:00', '2015-01-01T23:00:00'],
 					},
 					options: {
 						scales: {

--- a/test/specs/global.deprecations.tests.js
+++ b/test/specs/global.deprecations.tests.js
@@ -333,7 +333,7 @@ describe('Deprecations', function() {
 				var chart = window.acquireChart({
 					type: 'line',
 					data: {
-						labels: ['2015-01-01T20:00:00', '2015-01-01T21:00:00'],
+						labels: ['2015-01-01T20:00:00', '2015-01-01T22:00:00'],
 					},
 					options: {
 						scales: {

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -127,7 +127,9 @@ describe('Time scale tests', function() {
 			var ticks = getTicksLabels(scale);
 
 			// `bounds === 'data'`: first and last ticks removed since outside the data range
-			expect(ticks).toEqual(['Jan 2', 'Jan 3', 'Jan 4', 'Jan 5', 'Jan 6', 'Jan 7', 'Jan 8', 'Jan 9', 'Jan 10']);
+			expect(ticks.length).toEqual(217);
+			expect(ticks[0]).toEqual('12PM');
+			expect(ticks[ticks.length - 1]).toEqual('12PM');
 		});
 
 		it('should accept labels as date objects', function() {
@@ -139,7 +141,9 @@ describe('Time scale tests', function() {
 			var ticks = getTicksLabels(scale);
 
 			// `bounds === 'data'`: first and last ticks removed since outside the data range
-			expect(ticks).toEqual(['Jan 2', 'Jan 3', 'Jan 4', 'Jan 5', 'Jan 6', 'Jan 7', 'Jan 8', 'Jan 9', 'Jan 10']);
+			expect(ticks.length).toEqual(217);
+			expect(ticks[0]).toEqual('12PM');
+			expect(ticks[ticks.length - 1]).toEqual('12PM');
 		});
 
 		it('should accept data as xy points', function() {
@@ -188,7 +192,9 @@ describe('Time scale tests', function() {
 			var ticks = getTicksLabels(xScale);
 
 			// `bounds === 'data'`: first and last ticks removed since outside the data range
-			expect(ticks).toEqual(['Jan 2', 'Jan 3', 'Jan 4', 'Jan 5', 'Jan 6', 'Jan 7', 'Jan 8', 'Jan 9', 'Jan 10']);
+			expect(ticks.length).toEqual(217);
+			expect(ticks[0]).toEqual('12PM');
+			expect(ticks[ticks.length - 1]).toEqual('12PM');
 		});
 
 		it('should accept data as ty points', function() {
@@ -237,7 +243,9 @@ describe('Time scale tests', function() {
 			var ticks = getTicksLabels(tScale);
 
 			// `bounds === 'data'`: first and last ticks removed since outside the data range
-			expect(ticks).toEqual(['Jan 2', 'Jan 3', 'Jan 4', 'Jan 5', 'Jan 6', 'Jan 7', 'Jan 8', 'Jan 9', 'Jan 10']);
+			expect(ticks.length).toEqual(217);
+			expect(ticks[0]).toEqual('12PM');
+			expect(ticks[ticks.length - 1]).toEqual('12PM');
 		});
 	});
 
@@ -312,7 +320,7 @@ describe('Time scale tests', function() {
 		var scale = createScale(mockData, config);
 		var ticks = getTicksLabels(scale);
 
-		expect(ticks).toEqual(['Jan 1', 'Jan 2', 'Jan 3']);
+		expect(ticks).toEqual(['Jan 1', 'Jan 2']);
 	});
 
 	it('should correctly determine the unit', function() {
@@ -394,7 +402,7 @@ describe('Time scale tests', function() {
 	describe('config step size', function() {
 		it('should use the stepSize property', function() {
 			var mockData = {
-				labels: ['2015-01-01T20:00:00', '2015-01-01T21:00:00'],
+				labels: ['2015-01-01T20:00:00', '2015-01-01T22:00:00'],
 			};
 
 			var config = Chart.helpers.mergeIf({
@@ -498,9 +506,14 @@ describe('Time scale tests', function() {
 	it('should use the isoWeekday option', function() {
 		var mockData = {
 			labels: [
+				'2014-12-31T20:00:00', // Wednesday
 				'2015-01-01T20:00:00', // Thursday
 				'2015-01-02T20:00:00', // Friday
-				'2015-01-03T20:00:00' // Saturday
+				'2015-01-03T20:00:00', // Saturday
+				'2015-01-04T20:00:00', // Sunday
+				'2015-01-05T20:00:00', // Monday
+				'2015-01-06T20:00:00', // Tuesday
+				'2015-01-07T20:00:00'  // Wednesday
 			]
 		};
 
@@ -623,21 +636,22 @@ describe('Time scale tests', function() {
 		});
 
 		it('should build the correct ticks', function() {
-			// Where 'correct' is a two year spacing.
-			expect(getTicksLabels(this.scale)).toEqual(['2005', '2007', '2009', '2011', '2013', '2015', '2017', '2019']);
+			expect(getTicksLabels(this.scale)).toEqual(['2005', '2006', '2007', '2008', '2009', '2010', '2011', '2012', '2013', '2014', '2015', '2016', '2017']);
 		});
 
 		it('should have ticks with accurate labels', function() {
 			var scale = this.scale;
 			var ticks = scale.getTicks();
-			var pixelsPerYear = scale.width / 14;
+			// pixelsPerTick is an aproximation which assumes same number of milliseconds per year (not true)
+			// we use a threshold of 1 day so that we still match these values
+			var pixelsPerTick = scale.width / (ticks.length - 1);
 
 			for (var i = 0; i < ticks.length - 1; i++) {
-				var offset = 2 * pixelsPerYear * i;
+				var offset = pixelsPerTick * i;
 				expect(scale.getValueForPixel(scale.left + offset)).toBeCloseToTime({
 					value: moment(ticks[i].label + '-01-01'),
 					unit: 'day',
-					threshold: 0.5,
+					threshold: 1,
 				});
 			}
 		});
@@ -701,10 +715,9 @@ describe('Time scale tests', function() {
 		it('should get the correct labels for ticks', function() {
 			var scale = this.scale;
 
-			expect(scale._ticks.map(function(tick) {
-				return tick.major;
-			})).toEqual([true, false, false, false, true]);
-			expect(scale.ticks).toEqual(['<8:00:00 pm>', '<8:00:15 pm>', '<8:00:30 pm>', '<8:00:45 pm>', '<8:01:00 pm>']);
+			expect(scale.ticks.length).toEqual(61);
+			expect(scale.ticks[0]).toEqual('<8:00:00 pm>');
+			expect(scale.ticks[scale.ticks.length - 1]).toEqual('<8:01:00 pm>');
 		});
 
 		it('should update ticks.callback correctly', function() {
@@ -715,7 +728,9 @@ describe('Time scale tests', function() {
 				return '{' + value + '}';
 			};
 			chart.update();
-			expect(scale.ticks).toEqual(['{8:00:00 pm}', '{8:00:15 pm}', '{8:00:30 pm}', '{8:00:45 pm}', '{8:01:00 pm}']);
+			expect(scale.ticks.length).toEqual(61);
+			expect(scale.ticks[0]).toEqual('{8:00:00 pm}');
+			expect(scale.ticks[scale.ticks.length - 1]).toEqual('{8:01:00 pm}');
 		});
 	});
 
@@ -761,10 +776,9 @@ describe('Time scale tests', function() {
 		it('should get the correct labels for major and minor ticks', function() {
 			var scale = this.scale;
 
-			expect(scale._ticks.map(function(tick) {
-				return tick.major;
-			})).toEqual([true, false, false, false, true]);
-			expect(scale.ticks).toEqual(['[[8:00 pm]]', '(8:00:15 pm)', '(8:00:30 pm)', '(8:00:45 pm)', '[[8:01 pm]]']);
+			expect(scale.ticks.length).toEqual(61);
+			expect(scale.ticks[0]).toEqual('[[8:00 pm]]');
+			expect(scale.ticks[scale.ticks.length - 1]).toEqual('[[8:01 pm]]');
 		});
 
 		it('should only use ticks.minor callback if ticks.major.enabled is false', function() {
@@ -773,7 +787,9 @@ describe('Time scale tests', function() {
 
 			chart.options.scales.xAxes[0].ticks.major.enabled = false;
 			chart.update();
-			expect(scale.ticks).toEqual(['(8:00:00 pm)', '(8:00:15 pm)', '(8:00:30 pm)', '(8:00:45 pm)', '(8:01:00 pm)']);
+			expect(scale.ticks.length).toEqual(61);
+			expect(scale.ticks[0]).toEqual('(8:00:00 pm)');
+			expect(scale.ticks[scale.ticks.length - 1]).toEqual('(8:01:00 pm)');
 		});
 
 		it('should use ticks.callback if ticks.major.callback is omitted', function() {
@@ -782,7 +798,9 @@ describe('Time scale tests', function() {
 
 			chart.options.scales.xAxes[0].ticks.major.callback = undefined;
 			chart.update();
-			expect(scale.ticks).toEqual(['<8:00 pm>', '(8:00:15 pm)', '(8:00:30 pm)', '(8:00:45 pm)', '<8:01 pm>']);
+			expect(scale.ticks.length).toEqual(61);
+			expect(scale.ticks[0]).toEqual('<8:00 pm>');
+			expect(scale.ticks[scale.ticks.length - 1]).toEqual('<8:01 pm>');
 		});
 
 		it('should use ticks.callback if ticks.minor.callback is omitted', function() {
@@ -791,7 +809,9 @@ describe('Time scale tests', function() {
 
 			chart.options.scales.xAxes[0].ticks.minor.callback = undefined;
 			chart.update();
-			expect(scale.ticks).toEqual(['[[8:00 pm]]', '<8:00:15 pm>', '<8:00:30 pm>', '<8:00:45 pm>', '[[8:01 pm]]']);
+			expect(scale.ticks.length).toEqual(61);
+			expect(scale.ticks[0]).toEqual('[[8:00 pm]]');
+			expect(scale.ticks[scale.ticks.length - 1]).toEqual('[[8:01 pm]]');
 		});
 	});
 
@@ -1306,10 +1326,10 @@ describe('Time scale tests', function() {
 
 				expect(scale.min).toEqual(ticks[0].value);
 				expect(scale.max).toEqual(ticks[ticks.length - 1].value);
-				expect(scale.getPixelForValue('02/20 08:00')).toBeCloseToPixel(60);
-				expect(scale.getPixelForValue('02/23 11:00')).toBeCloseToPixel(426);
+				expect(scale.getPixelForValue('02/20 08:00')).toBeCloseToPixel(74);
+				expect(scale.getPixelForValue('02/23 11:00')).toBeCloseToPixel(562);
 				expect(getTicksLabels(scale)).toEqual([
-					'Feb 20', 'Feb 21', 'Feb 22', 'Feb 23', 'Feb 24']);
+					'Feb 20', 'Feb 21', 'Feb 22', 'Feb 23']);
 			});
 		});
 	});


### PR DESCRIPTION
This does the following:
- Skip major ticks only if they can't all fit
- If showing all major ticks, then skip minor ticks such that they're evenly distributed between major ticks
- Remove much of the time scale tick auto generation by generating every tick and then auto-skipping instead. This is so that we don't have two different "auto" algorithms to maintain. Also, by putting it in auto-skip it is available to all scales instead of just one. Thanks @simonbrunel for this suggestion

Interactive examples:
- This PR: https://plnkr.co/edit/REeume?p=preview
- Master: https://plnkr.co/edit/O9FincnNAZVmwtDA1mL9?p=preview

Closes https://github.com/chartjs/Chart.js/issues/4600 https://github.com/chartjs/Chart.js/issues/4612