### PR TITLE
Treat 0 as a valid point label

### DIFF
--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -156,7 +156,7 @@ function fitWithPointLabels(scale) {
 	var valueCount = getValueCount(scale);
 	for (i = 0; i < valueCount; i++) {
 		pointPosition = scale.getPointPosition(i, scale.drawingArea + 5);
-		textSize = measureLabelSize(scale.ctx, plFont.lineHeight, scale.pointLabels[i] || '');
+		textSize = measureLabelSize(scale.ctx, plFont.lineHeight, scale.pointLabels[i]);
 		scale._pointLabelSizes[i] = textSize;
 
 		// Add quarter circle to make degree 0 mean top of circle
@@ -247,7 +247,7 @@ function drawPointLabels(scale) {
 		var angle = helpers.toDegrees(angleRadians);
 		ctx.textAlign = getTextAlignForAngle(angle);
 		adjustPointPositionForLabelHeight(angle, scale._pointLabelSizes[i], pointLabelPosition);
-		fillText(ctx, scale.pointLabels[i] || '', pointLabelPosition, plFont.lineHeight);
+		fillText(ctx, scale.pointLabels[i], pointLabelPosition, plFont.lineHeight);
 	}
 	ctx.restore();
 }
@@ -348,7 +348,10 @@ module.exports = LinearScaleBase.extend({
 		LinearScaleBase.prototype.convertTicksToLabels.call(me);
 
 		// Point labels
-		me.pointLabels = me.chart.data.labels.map(me.options.pointLabels.callback, me);
+		me.pointLabels = me.chart.data.labels.map(function() {
+			var label = helpers.callback(me.options.pointLabels.callback, arguments, me);
+			return label || label === 0 ? label : '';
+		});
 	},
 
 	getLabelForIndex: function(index, datasetIndex) {

--- a/test/specs/scale.radialLinear.tests.js
+++ b/test/specs/scale.radialLinear.tests.js
@@ -366,6 +366,20 @@ describe('Test the radial linear scale', function() {
 		expect(chart.scale.pointLabels).toEqual(['0', '1', '2', '3', '4']);
 	});
 
+	it('Should build point labels from falsy values', function() {
+		var chart = window.acquireChart({
+			type: 'radar',
+			data: {
+				datasets: [{
+					data: [10, 5, 0, 25, 78, 20]
+				}],
+				labels: [0, '', undefined, null, NaN, false]
+			}
+		});
+
+		expect(chart.scale.pointLabels).toEqual([0, '', '', '', '', '']);
+	});
+
 	it('should correctly set the center point', function() {
 		var chart = window.acquireChart({
 			type: 'radar',


### PR DESCRIPTION
When a point label is a number `0`, it is treated a falsy value and overwritten by `''`. This PR fixes it so that `0` is treated as a valid point label.

**Master: https://jsfiddle.net/nagix/4mjqtLz0/**
<img width="201" alt="Screen Shot 2019-05-16 at 1 56 52 PM" src="https://user-images.githubusercontent.com/723188/57855459-52cc0d80-781d-11e9-8165-c0b8aa89b718.png">

**This PR: https://jsfiddle.net/nagix/htbuyj3L/**
<img width="196" alt="Screen Shot 2019-05-16 at 1 57 50 PM" src="https://user-images.githubusercontent.com/723188/57855463-565f9480-781d-11e9-8a7c-2309e8f4dfb0.png">