### PR TITLE
Fix regression with lineTension

### DIFF
--- a/docs/charts/radar.md
+++ b/docs/charts/radar.md
@@ -75,7 +75,7 @@ The radar chart allows a number of properties to be specified for each dataset. 
 | [`borderWidth`](#line-styling) | `number` | - | - | `3`
 | [`fill`](#line-styling) | <code>boolean&#124;string</code> | - | - | `true`
 | [`label`](#general) | `string` | - | - | `''`
-| [`lineTension`](#line-styling) | `number` | - | - | `0.4`
+| [`lineTension`](#line-styling) | `number` | - | - | `0`
 | [`pointBackgroundColor`](#point-styling) | `Color` | Yes | Yes | `'rgba(0, 0, 0, 0.1)'`
 | [`pointBorderColor`](#point-styling) | `Color` | Yes | Yes | `'rgba(0, 0, 0, 0.1)'`
 | [`pointBorderWidth`](#point-styling) | `number` | Yes | Yes | `1`

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -73,8 +73,8 @@ module.exports = DatasetController.extend({
 		var line = meta.dataset;
 		var points = meta.data || [];
 		var options = me.chart.options;
-		var dataset = me.getDataset();
-		var showLine = me._showLine = valueOrDefault(me._config.showLine, options.showLines);
+		var datasetOpts = me._config;
+		var showLine = me._showLine = valueOrDefault(datasetOpts.showLine, options.showLines);
 		var i, ilen;
 
 		me._xScale = me.getScaleForId(meta.xAxisID);
@@ -83,8 +83,8 @@ module.exports = DatasetController.extend({
 		// Update Line
 		if (showLine) {
 			// Compatibility: If the properties are defined with only the old name, use those values
-			if ((dataset.tension !== undefined) && (dataset.lineTension === undefined)) {
-				dataset.lineTension = dataset.tension;
+			if ((datasetOpts.tension !== undefined) && (datasetOpts.lineTension === undefined)) {
+				datasetOpts.lineTension = datasetOpts.tension;
 			}
 
 			// Utility

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -73,8 +73,8 @@ module.exports = DatasetController.extend({
 		var line = meta.dataset;
 		var points = meta.data || [];
 		var options = me.chart.options;
-		var datasetOpts = me._config;
-		var showLine = me._showLine = valueOrDefault(datasetOpts.showLine, options.showLines);
+		var config = me._config;
+		var showLine = me._showLine = valueOrDefault(config.showLine, options.showLines);
 		var i, ilen;
 
 		me._xScale = me.getScaleForId(meta.xAxisID);
@@ -83,8 +83,8 @@ module.exports = DatasetController.extend({
 		// Update Line
 		if (showLine) {
 			// Compatibility: If the properties are defined with only the old name, use those values
-			if ((datasetOpts.tension !== undefined) && (datasetOpts.lineTension === undefined)) {
-				datasetOpts.lineTension = datasetOpts.tension;
+			if (config.tension !== undefined && config.lineTension === undefined) {
+				config.lineTension = config.tension;
 			}
 
 			// Utility
@@ -161,7 +161,7 @@ module.exports = DatasetController.extend({
 	 */
 	_resolveDatasetElementOptions: function(element) {
 		var me = this;
-		var datasetOpts = me._config;
+		var config = me._config;
 		var custom = element.custom || {};
 		var options = me.chart.options;
 		var lineOptions = options.elements.line;
@@ -170,9 +170,9 @@ module.exports = DatasetController.extend({
 		// The default behavior of lines is to break at null values, according
 		// to https://github.com/chartjs/Chart.js/issues/2435#issuecomment-216718158
 		// This option gives lines the ability to span gaps
-		values.spanGaps = valueOrDefault(datasetOpts.spanGaps, options.spanGaps);
-		values.tension = valueOrDefault(datasetOpts.lineTension, lineOptions.tension);
-		values.steppedLine = resolve([custom.steppedLine, datasetOpts.steppedLine, lineOptions.stepped]);
+		values.spanGaps = valueOrDefault(config.spanGaps, options.spanGaps);
+		values.tension = valueOrDefault(config.lineTension, lineOptions.tension);
+		values.steppedLine = resolve([custom.steppedLine, config.steppedLine, lineOptions.stepped]);
 
 		return values;
 	},

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -69,12 +69,12 @@ module.exports = DatasetController.extend({
 		var line = meta.dataset;
 		var points = meta.data || [];
 		var scale = me.chart.scale;
-		var dataset = me.getDataset();
+		var datasetOpts = me._config;
 		var i, ilen;
 
 		// Compatibility: If the properties are defined with only the old name, use those values
-		if ((dataset.tension !== undefined) && (dataset.lineTension === undefined)) {
-			dataset.lineTension = dataset.tension;
+		if ((datasetOpts.tension !== undefined) && (datasetOpts.lineTension === undefined)) {
+			datasetOpts.lineTension = datasetOpts.tension;
 		}
 
 		// Utility

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -69,12 +69,12 @@ module.exports = DatasetController.extend({
 		var line = meta.dataset;
 		var points = meta.data || [];
 		var scale = me.chart.scale;
-		var datasetOpts = me._config;
+		var config = me._config;
 		var i, ilen;
 
 		// Compatibility: If the properties are defined with only the old name, use those values
-		if ((datasetOpts.tension !== undefined) && (datasetOpts.lineTension === undefined)) {
-			datasetOpts.lineTension = datasetOpts.tension;
+		if (config.tension !== undefined && config.lineTension === undefined) {
+			config.lineTension = config.tension;
 		}
 
 		// Utility


### PR DESCRIPTION
If the deprecated option `tension` is used for line datasets, it doesn't make effect during animation. This regression was introduced in #5999.

This PR fixes the regression as well as the default `lineTension` value for radar charts in doc.

**Master: https://jsfiddle.net/nagix/Lngz3r60/**
<img width="421" alt="Screen Shot 2019-05-22 at 12 42 33 AM" src="https://user-images.githubusercontent.com/723188/58114567-97dfad80-7c2a-11e9-9f24-077779d8a520.png">

**This PR: https://jsfiddle.net/nagix/7j2rp0tk/**
<img width="420" alt="Screen Shot 2019-05-22 at 12 39 52 AM" src="https://user-images.githubusercontent.com/723188/58114579-9e6e2500-7c2a-11e9-9086-f98789a076cd.png">