### PR TITLE
Assign unique scale IDs

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -137,6 +137,19 @@ function updateConfig(chart) {
 	chart.tooltip.initialize();
 }
 
+function nextAvailableScaleId(axesOpts, prefix, index) {
+	var id;
+	var hasId = function(obj) {
+		return obj.id === id;
+	};
+
+	do {
+		id = prefix + index++;
+	} while (helpers.findIndex(axesOpts, hasId) >= 0);
+
+	return id;
+}
+
 function positionIsHorizontal(position) {
 	return position === 'top' || position === 'bottom';
 }
@@ -295,11 +308,15 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 		var scaleOptions = options.scale;
 
 		helpers.each(scalesOptions.xAxes, function(xAxisOptions, index) {
-			xAxisOptions.id = xAxisOptions.id || ('x-axis-' + index);
+			if (!xAxisOptions.id) {
+				xAxisOptions.id = nextAvailableScaleId(scalesOptions.xAxes, 'x-axis-', index);
+			}
 		});
 
 		helpers.each(scalesOptions.yAxes, function(yAxisOptions, index) {
-			yAxisOptions.id = yAxisOptions.id || ('y-axis-' + index);
+			if (!yAxisOptions.id) {
+				yAxisOptions.id = nextAvailableScaleId(scalesOptions.yAxes, 'y-axis-', index);
+			}
 		});
 
 		if (scaleOptions) {

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -1059,6 +1059,23 @@ describe('Chart', function() {
 			expect(yScale.options.ticks.max).toBe(10);
 		});
 
+		it ('should assign unique scale IDs', function() {
+			var chart = acquireChart({
+				type: 'line',
+				options: {
+					scales: {
+						xAxes: [{id: 'x-axis-0'}, {}, {}],
+						yAxes: [{id: 'y-axis-1'}, {}, {}]
+					}
+				}
+			});
+
+			expect(Object.keys(chart.scales).sort()).toEqual([
+				'x-axis-0', 'x-axis-1', 'x-axis-2',
+				'y-axis-1', 'y-axis-2', 'y-axis-3'
+			]);
+		});
+
 		it ('should remove discarded scale', function() {
 			var chart = acquireChart({
 				type: 'line',


### PR DESCRIPTION
If the first x or y scale has `id: 'x-axis-1'` or `'id: y-axis-1'`, and more scales are added without `id`, ID will be duplicated, and the they will not be correctly configured.

The example below shows that only 2 scales are configured in a scatter chart even if the config has 3 scales because the default scale IDs in scatter charts are `'x-axis-1'` and `'y-axis-1'` but the controller try to assign a number using the array index starting from 0.

This PR fixes it by checking the existing IDs to assign unique one. 

**Master: https://jsfiddle.net/nagix/6ar792zo/**
<img width="537" alt="Screen Shot 2019-05-23 at 12 13 09 AM" src="https://user-images.githubusercontent.com/723188/58190895-09356400-7cf0-11e9-8868-63da3bac2b95.png">

**This PR: https://jsfiddle.net/nagix/dLs956je/**
<img width="537" alt="Screen Shot 2019-05-23 at 12 13 22 AM" src="https://user-images.githubusercontent.com/723188/58190676-9deb9200-7cef-11e9-85fd-00ebb0bcda6b.png">