### PR TITLE
Adjust vertical alignment of tooltip items

### DIFF
--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -748,25 +748,26 @@ var exports = Element.extend({
 
 	drawTitle: function(pt, vm, ctx) {
 		var title = vm.title;
+		var length = title.length;
+		var titleFontSize, titleSpacing, i;
 
-		if (title.length) {
+		if (length) {
 			pt.x = getAlignedX(vm, vm._titleAlign);
 
 			ctx.textAlign = vm._titleAlign;
-			ctx.textBaseline = 'top';
+			ctx.textBaseline = 'middle';
 
-			var titleFontSize = vm.titleFontSize;
-			var titleSpacing = vm.titleSpacing;
+			titleFontSize = vm.titleFontSize;
+			titleSpacing = vm.titleSpacing;
 
 			ctx.fillStyle = vm.titleFontColor;
 			ctx.font = helpers.fontString(titleFontSize, vm._titleFontStyle, vm._titleFontFamily);
 
-			var i, len;
-			for (i = 0, len = title.length; i < len; ++i) {
-				ctx.fillText(title[i], pt.x, pt.y);
+			for (i = 0; i < length; ++i) {
+				ctx.fillText(title[i], pt.x, pt.y + titleFontSize / 2);
 				pt.y += titleFontSize + titleSpacing; // Line Height and spacing
 
-				if (i + 1 === title.length) {
+				if (i + 1 === length) {
 					pt.y += vm.titleMarginBottom - titleSpacing; // If Last, add margin, remove spacing
 				}
 			}
@@ -779,22 +780,21 @@ var exports = Element.extend({
 		var bodyAlign = vm._bodyAlign;
 		var body = vm.body;
 		var drawColorBoxes = vm.displayColors;
-		var labelColors = vm.labelColors;
 		var xLinePadding = 0;
 		var colorX = drawColorBoxes ? getAlignedX(vm, 'left') : 0;
-		var textColor;
+
+		var fillLineOfText = function(line) {
+			ctx.fillText(line, pt.x + xLinePadding, pt.y + bodyFontSize / 2);
+			pt.y += bodyFontSize + bodySpacing;
+		};
+
+		var bodyItem, textColor, labelColors, lines, i, j, ilen, jlen;
 
 		ctx.textAlign = bodyAlign;
-		ctx.textBaseline = 'top';
+		ctx.textBaseline = 'middle';
 		ctx.font = helpers.fontString(bodyFontSize, vm._bodyFontStyle, vm._bodyFontFamily);
 
 		pt.x = getAlignedX(vm, bodyAlign);
-
-		// Before Body
-		var fillLineOfText = function(line) {
-			ctx.fillText(line, pt.x + xLinePadding, pt.y);
-			pt.y += bodyFontSize + bodySpacing;
-		};
 
 		// Before body lines
 		ctx.fillStyle = vm.bodyFontColor;
@@ -805,12 +805,16 @@ var exports = Element.extend({
 			: 0;
 
 		// Draw body lines now
-		helpers.each(body, function(bodyItem, i) {
+		for (i = 0, ilen = body.length; i < ilen; ++i) {
+			bodyItem = body[i];
 			textColor = vm.labelTextColors[i];
+			labelColors = vm.labelColors[i];
+
 			ctx.fillStyle = textColor;
 			helpers.each(bodyItem.before, fillLineOfText);
 
-			helpers.each(bodyItem.lines, function(line) {
+			lines = bodyItem.lines;
+			for (j = 0, jlen = lines.length; j < jlen; ++j) {
 				// Draw Legend-like boxes if needed
 				if (drawColorBoxes) {
 					// Fill a white rect so that colours merge nicely if the opacity is < 1
@@ -819,20 +823,20 @@ var exports = Element.extend({
 
 					// Border
 					ctx.lineWidth = 1;
-					ctx.strokeStyle = labelColors[i].borderColor;
+					ctx.strokeStyle = labelColors.borderColor;
 					ctx.strokeRect(colorX, pt.y, bodyFontSize, bodyFontSize);
 
 					// Inner square
-					ctx.fillStyle = labelColors[i].backgroundColor;
+					ctx.fillStyle = labelColors.backgroundColor;
 					ctx.fillRect(colorX + 1, pt.y + 1, bodyFontSize - 2, bodyFontSize - 2);
 					ctx.fillStyle = textColor;
 				}
 
-				fillLineOfText(line);
-			});
+				fillLineOfText(lines[j]);
+			}
 
 			helpers.each(bodyItem.after, fillLineOfText);
-		});
+		}
 
 		// Reset back to 0 for after body
 		xLinePadding = 0;
@@ -844,21 +848,25 @@ var exports = Element.extend({
 
 	drawFooter: function(pt, vm, ctx) {
 		var footer = vm.footer;
+		var length = footer.length;
+		var footerFontSize, i;
 
-		if (footer.length) {
+		if (length) {
 			pt.x = getAlignedX(vm, vm._footerAlign);
 			pt.y += vm.footerMarginTop;
 
 			ctx.textAlign = vm._footerAlign;
-			ctx.textBaseline = 'top';
+			ctx.textBaseline = 'middle';
+
+			footerFontSize = vm.footerFontSize;
 
 			ctx.fillStyle = vm.footerFontColor;
-			ctx.font = helpers.fontString(vm.footerFontSize, vm._footerFontStyle, vm._footerFontFamily);
+			ctx.font = helpers.fontString(footerFontSize, vm._footerFontStyle, vm._footerFontFamily);
 
-			helpers.each(footer, function(line) {
-				ctx.fillText(line, pt.x, pt.y);
-				pt.y += vm.footerFontSize + vm.footerSpacing;
-			});
+			for (i = 0; i < length; ++i) {
+				ctx.fillText(footer[i], pt.x, pt.y + footerFontSize / 2);
+				pt.y += footerFontSize + vm.footerSpacing;
+			}
 		}
 	},
 

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -256,7 +256,7 @@ var Legend = Element.extend({
 				var totalHeight = 0;
 
 				ctx.textAlign = 'left';
-				ctx.textBaseline = 'top';
+				ctx.textBaseline = 'middle';
 
 				helpers.each(me.legendItems, function(legendItem, i) {
 					var boxWidth = getBoxWidth(labelOpts, fontSize);

--- a/test/specs/core.tooltip.tests.js
+++ b/test/specs/core.tooltip.tests.js
@@ -1208,14 +1208,14 @@ describe('Core.Tooltip', function() {
 			expect(mockContext.getCalls()).toEqual(Array.prototype.concat(drawBody, [
 				{name: 'setTextAlign', args: ['left']},
 				{name: 'setFillStyle', args: ['#fff']},
-				{name: 'fillText', args: ['title', 105, 105]},
+				{name: 'fillText', args: ['title', 105, 111]},
 				{name: 'setTextAlign', args: ['left']},
 				{name: 'setFillStyle', args: ['#fff']},
 				{name: 'setFillStyle', args: ['#fff']},
-				{name: 'fillText', args: ['label', 105, 123]},
+				{name: 'fillText', args: ['label', 105, 129]},
 				{name: 'setTextAlign', args: ['left']},
 				{name: 'setFillStyle', args: ['#fff']},
-				{name: 'fillText', args: ['footer', 105, 141]},
+				{name: 'fillText', args: ['footer', 105, 147]},
 				{name: 'restore', args: []}
 			]));
 		});
@@ -1228,14 +1228,14 @@ describe('Core.Tooltip', function() {
 			expect(mockContext.getCalls()).toEqual(Array.prototype.concat(drawBody, [
 				{name: 'setTextAlign', args: ['right']},
 				{name: 'setFillStyle', args: ['#fff']},
-				{name: 'fillText', args: ['title', 195, 105]},
+				{name: 'fillText', args: ['title', 195, 111]},
 				{name: 'setTextAlign', args: ['right']},
 				{name: 'setFillStyle', args: ['#fff']},
 				{name: 'setFillStyle', args: ['#fff']},
-				{name: 'fillText', args: ['label', 195, 123]},
+				{name: 'fillText', args: ['label', 195, 129]},
 				{name: 'setTextAlign', args: ['right']},
 				{name: 'setFillStyle', args: ['#fff']},
-				{name: 'fillText', args: ['footer', 195, 141]},
+				{name: 'fillText', args: ['footer', 195, 147]},
 				{name: 'restore', args: []}
 			]));
 		});
@@ -1248,14 +1248,14 @@ describe('Core.Tooltip', function() {
 			expect(mockContext.getCalls()).toEqual(Array.prototype.concat(drawBody, [
 				{name: 'setTextAlign', args: ['center']},
 				{name: 'setFillStyle', args: ['#fff']},
-				{name: 'fillText', args: ['title', 150, 105]},
+				{name: 'fillText', args: ['title', 150, 111]},
 				{name: 'setTextAlign', args: ['center']},
 				{name: 'setFillStyle', args: ['#fff']},
 				{name: 'setFillStyle', args: ['#fff']},
-				{name: 'fillText', args: ['label', 150, 123]},
+				{name: 'fillText', args: ['label', 150, 129]},
 				{name: 'setTextAlign', args: ['center']},
 				{name: 'setFillStyle', args: ['#fff']},
-				{name: 'fillText', args: ['footer', 150, 141]},
+				{name: 'fillText', args: ['footer', 150, 147]},
 				{name: 'restore', args: []}
 			]));
 		});
@@ -1268,14 +1268,14 @@ describe('Core.Tooltip', function() {
 			expect(mockContext.getCalls()).toEqual(Array.prototype.concat(drawBody, [
 				{name: 'setTextAlign', args: ['right']},
 				{name: 'setFillStyle', args: ['#fff']},
-				{name: 'fillText', args: ['title', 195, 105]},
+				{name: 'fillText', args: ['title', 195, 111]},
 				{name: 'setTextAlign', args: ['center']},
 				{name: 'setFillStyle', args: ['#fff']},
 				{name: 'setFillStyle', args: ['#fff']},
-				{name: 'fillText', args: ['label', 150, 123]},
+				{name: 'fillText', args: ['label', 150, 129]},
 				{name: 'setTextAlign', args: ['left']},
 				{name: 'setFillStyle', args: ['#fff']},
-				{name: 'fillText', args: ['footer', 105, 141]},
+				{name: 'fillText', args: ['footer', 105, 147]},
 				{name: 'restore', args: []}
 			]));
 		});


### PR DESCRIPTION
Currently, texts in a tooltip are aligned to 'top', but some browsers (in particular, Safari on Mac and IE/Edge on Win) add extra space above the texts, and they are shifted down a few pixels as reported in #3393. As the alignment of legend items were fixed in #4318, this PR makes similar changes to tooltip items by using `textBaseline = 'middle'`.

As shown below, the changes only affect the results in Safari (Mac), IE (Win) and Edge (Win).

**Master: https://jsfiddle.net/nagix/v8qhgczu/**

Browser | Image
--- | ---
Safari (Mac) | <img width="373" alt="Screen Shot 2019-05-23 at 1 34 26 PM" src="https://user-images.githubusercontent.com/723188/58227963-995ec200-7d5f-11e9-9d56-75cfa64b7fd3.png"> | F
FireFox (Mac) | <img width="373" alt="Screen Shot 2019-05-23 at 1 44 34 PM" src="https://user-images.githubusercontent.com/723188/58228340-f4dd7f80-7d60-11e9-9a9f-451d31c2d197.png">
Chrome (Mac) | <img width="374" alt="Screen Shot 2019-05-23 at 1 45 21 PM" src="https://user-images.githubusercontent.com/723188/58228374-0f175d80-7d61-11e9-8114-2da3ccdbbd95.png">
IE (Win) | <img width="376" alt="Screen Shot 2019-05-23 at 2 01 45 PM" src="https://user-images.githubusercontent.com/723188/58229109-5bfc3380-7d63-11e9-8d4c-67ce105761f3.png">
Edge (Win) | <img width="373" alt="Screen Shot 2019-05-23 at 2 02 56 PM" src="https://user-images.githubusercontent.com/723188/58229164-82ba6a00-7d63-11e9-884d-c4132a9fddc3.png">
FireFox (Win) | <img width="375" alt="Screen Shot 2019-05-23 at 2 03 38 PM" src="https://user-images.githubusercontent.com/723188/58229196-9960c100-7d63-11e9-838d-3525c4a4842a.png">
Chrome (Win) | <img width="377" alt="Screen Shot 2019-05-23 at 2 04 10 PM" src="https://user-images.githubusercontent.com/723188/58229219-ada4be00-7d63-11e9-8b72-eb9518e3da48.png">

**This PR: https://jsfiddle.net/nagix/k9gzv5wf/**

Browser | Image
--- | ---
Safari (Mac) | <img width="375" alt="Screen Shot 2019-05-23 at 1 34 44 PM" src="https://user-images.githubusercontent.com/723188/58227968-9c59b280-7d5f-11e9-8b54-71af161b106a.png">
FireFox (Mac) | <img width="377" alt="Screen Shot 2019-05-23 at 1 56 35 PM" src="https://user-images.githubusercontent.com/723188/58228915-b5b02e00-7d62-11e9-86db-f5730c7dbcef.png">
Chrome (Mac) | <img width="375" alt="Screen Shot 2019-05-23 at 1 59 16 PM" src="https://user-images.githubusercontent.com/723188/58228999-0162d780-7d63-11e9-878c-65aa2ed18844.png">
IE (Win) | <img width="374" alt="Screen Shot 2019-05-23 at 2 05 36 PM" src="https://user-images.githubusercontent.com/723188/58229295-e2b11080-7d63-11e9-9cad-93e5d1ea4dd7.png">
Edge (Win) | <img width="376" alt="Screen Shot 2019-05-23 at 2 06 24 PM" src="https://user-images.githubusercontent.com/723188/58229324-fc525800-7d63-11e9-9e3f-9306990b5da1.png">
FireFox (Win) | <img width="376" alt="Screen Shot 2019-05-23 at 2 07 04 PM" src="https://user-images.githubusercontent.com/723188/58229471-6834c080-7d64-11e9-8a3a-fd04f2f38f60.png">
Chrome (Win) | <img width="374" alt="Screen Shot 2019-05-23 at 2 07 36 PM" src="https://user-images.githubusercontent.com/723188/58229373-29066f80-7d64-11e9-9e87-d272d88bea9b.png">

Fixes #3393