### PR TITLE
Correct descriptions on ticks.display and add pointLabels.display

### DIFF
--- a/docs/axes/radial/linear.md
+++ b/docs/axes/radial/linear.md
@@ -104,6 +104,7 @@ The following options are used to configure the point labels that are shown on t
 
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
+| `display` | `boolean` | `true` | if true, point labels are shown.
 | `callback` | `function` | | Callback function to transform data labels to point labels. The default implementation simply returns the current string.
 | `fontColor` | <code>Color&#124;Color[]</code> | `'#666'` | Font color for point labels.
 | `fontFamily` | `string` | `"'Helvetica Neue', 'Helvetica', 'Arial', sans-serif"` | Font family to use when rendering labels.

--- a/docs/axes/radial/linear.md
+++ b/docs/axes/radial/linear.md
@@ -88,7 +88,7 @@ let options = {
 
 ## Angle Line Options
 
-The following options are used to configure angled lines that radiate from the center of the chart to the point labels. They can be found in the `angleLines` sub options. Note that these options only apply if `angleLines.display` is true.
+The following options are used to configure angled lines that radiate from the center of the chart to the point labels. They can be found in the `angleLines` sub options.
 
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
@@ -100,7 +100,7 @@ The following options are used to configure angled lines that radiate from the c
 
 ## Point Label Options
 
-The following options are used to configure the point labels that are shown on the perimeter of the scale. They can be found in the `pointLabels` sub options. Note that these options only apply if `pointLabels.display` is true.
+The following options are used to configure the point labels that are shown on the perimeter of the scale. They can be found in the `pointLabels` sub options.
 
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------

--- a/docs/axes/styling.md
+++ b/docs/axes/styling.md
@@ -31,7 +31,7 @@ The tick configuration is nested under the scale configuration in the `ticks` ke
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
 | `callback` | `function` | | Returns the string representation of the tick value as it should be displayed on the chart. See [callback](../axes/labelling.md#creating-custom-tick-formats).
-| `display` | `boolean` | `true` | If true, show tick marks.
+| `display` | `boolean` | `true` | If true, show tick labels.
 | `fontColor` | `Color` | `'#666'` | Font color for tick labels.
 | `fontFamily` | `string` | `"'Helvetica Neue', 'Helvetica', 'Arial', sans-serif"` | Font family for the tick labels, follows CSS font-family options.
 | `fontSize` | `number` | `12` | Font size for the tick labels.


### PR DESCRIPTION
`ticks.display` controls whether to show or hide tick labels, but not tick mark lines or gridlines. I assume the term "ticks" or "tick marks" indicate both tick labels and tick mark lines.

`pointLabels.display` are mentioned but not in the table, so it is added.