### PR TITLE
Improve label capacity calculation in time scale

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -283,11 +283,10 @@ function determineMajorUnit(unit) {
 /**
  * Figures out what unit results in an appropriate number of auto-generated ticks
  */
-function determineUnitsForAutoTicks(scale) {
+function determineUnitsForAutoTicks(scale, min, max) {
 	var timeOpts = scale.options.time;
 	var minor = timeOpts.unit;
-	var max = scale.max;
-	var range = max - scale.min;
+	var range = max - min;
 	var ilen = UNITS.length;
 	var i, major, interval, steps, factor, capacity;
 
@@ -342,13 +341,11 @@ function determineUnitForFormatting(scale, ticks, minUnit, min, max) {
  * Important: this method can return ticks outside the min and max range, it's the
  * responsibility of the calling code to clamp values if needed.
  */
-function generate(scale) {
-	var min = scale.min;
-	var max = scale.max;
+function generate(scale, min, max) {
 	var adapter = scale._adapter;
 	var options = scale.options;
 	var timeOpts = options.time;
-	var units = determineUnitsForAutoTicks(scale);
+	var units = determineUnitsForAutoTicks(scale, min, max);
 	var minor = units.minor;
 	var major = units.major;
 	var stepSize = valueOrDefault(timeOpts.stepSize, timeOpts.unitStepSize);
@@ -646,7 +643,7 @@ module.exports = Scale.extend({
 			break;
 		case 'auto':
 		default:
-			timestamps = generate(me);
+			timestamps = generate(me, min, max);
 		}
 
 		if (options.bounds === 'ticks' && timestamps.length) {

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -124,7 +124,7 @@ describe('Time scale tests', function() {
 			};
 
 			var scaleOptions = Chart.scaleService.getScaleDefaults('time');
-			var scale = createScale(mockData, scaleOptions, {width: 1000, height: 200});
+			var scale = createScale(mockData, scaleOptions, {width: 500, height: 200});
 			var ticks = getTicksLabels(scale);
 
 			// `bounds === 'data'`: first and last ticks removed since outside the data range
@@ -135,7 +135,7 @@ describe('Time scale tests', function() {
 			var mockData = {
 				labels: [newDateFromRef(0), newDateFromRef(1), newDateFromRef(2), newDateFromRef(4), newDateFromRef(6), newDateFromRef(7), newDateFromRef(9)], // days
 			};
-			var scale = createScale(mockData, Chart.scaleService.getScaleDefaults('time'), {width: 1000, height: 200});
+			var scale = createScale(mockData, Chart.scaleService.getScaleDefaults('time'), {width: 500, height: 200});
 			var ticks = getTicksLabels(scale);
 
 			// `bounds === 'data'`: first and last ticks removed since outside the data range
@@ -181,7 +181,7 @@ describe('Time scale tests', function() {
 						}],
 					}
 				}
-			}, {canvas: {width: 800, height: 200}});
+			}, {canvas: {width: 400, height: 200}});
 
 			var xScale = chart.scales.xScale0;
 			var ticks = getTicksLabels(xScale);
@@ -229,7 +229,7 @@ describe('Time scale tests', function() {
 						}],
 					}
 				}
-			}, {canvas: {width: 800, height: 200}});
+			}, {canvas: {width: 400, height: 200}});
 
 			var tScale = chart.scales.tScale0;
 			var ticks = getTicksLabels(tScale);
@@ -595,7 +595,7 @@ describe('Time scale tests', function() {
 						}],
 					}
 				}
-			}, {canvas: {width: 800, height: 200}});
+			}, {canvas: {width: 300, height: 200}});
 
 			this.scale = this.chart.scales.xScale0;
 		});


### PR DESCRIPTION
### Problem 1

Currently `getLabelCapacity` uses the `displayFormats` for `'millisecond'` if `unit` is not specified. This results in less label capacity than actual (and this often happens). The example below shows that the unit is automatically set to `'month'` when there are two labels `['2015-01-01', '2015-02-01']`.

### Problem 2

#6265 changed to compute the capacity using the major unit if applicable, but `me._majorUnit` is not set when `getLabelCapacity` is called. Furthermore, it is not always true that the label width of a major tick is larger than that of a minor tick or vise versa.

### Solution

This PR takes into account the label capacity of both minor and major ticks in `getLabelCapacity`. And, `determineUnitForAutoTicks` checks the label capacity for each unit.

Potential problem of this change is that more labels will be rotated because `getLabelCapacity` calculates the capacity using rotation. But I think this should be controlled by the `maxRotation` option.

**Master: https://jsfiddle.net/nagix/zdkcaerb/**
<img width="405" alt="Screen Shot 2019-05-24 at 5 15 28 PM" src="https://user-images.githubusercontent.com/723188/58317076-a35bf000-7e47-11e9-8a71-e7122b601d74.png">


**This PR: https://jsfiddle.net/nagix/5kersouy/**
<img width="405" alt="Screen Shot 2019-05-24 at 5 15 39 PM" src="https://user-images.githubusercontent.com/723188/58317086-a656e080-7e47-11e9-8d6e-461db220007d.png">

Fixes #5093