### PR TITLE
Fix regression with getLabelCapacity

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -779,25 +779,32 @@ module.exports = Scale.extend({
 	 */
 	getLabelCapacity: function(exampleTime) {
 		var me = this;
-		var timeOpts = me.options.time;
+		var options = me.options;
+		var timeOpts = options.time;
 		var displayFormats = timeOpts.displayFormats;
-		var margins = me.margins;
 
 		// pick the longest format (milliseconds) for guestimation
 		var format = displayFormats[timeOpts.unit] || displayFormats.millisecond;
 		var exampleLabel = me.tickFormatFunction(exampleTime, 0, ticksFromTimestamps(me, [exampleTime], me._majorUnit), format);
 		var size = me._getLabelSize(exampleLabel);
+		var labelSize, scaleSize, chartSize, capacity;
 
-		// Using margins instead of padding because padding is not calculated
-		// at this point (buildTicks). Margins are provided from previous calculation
-		// in layout steps 5/6
-		var capacity = Math.floor(me.isHorizontal()
-			? (me.width - margins.left - margins.right) / size.w
-			: (me.height - margins.top - margins.bottom) / size.h);
-
-		if (me.options.offset) {
-			capacity--;
+		if (me.isHorizontal()) {
+			labelSize = size.w;
+			scaleSize = me.width;
+			chartSize = me.chart.width;
+		} else {
+			labelSize = size.h;
+			scaleSize = me.height;
+			chartSize = me.chart.height;
 		}
+
+		if (options.offset) {
+			scaleSize -= labelSize;
+		} else {
+			scaleSize = Math.min(scaleSize, chartSize - labelSize / 2) - labelSize / 2;
+		}
+		capacity = Math.floor(scaleSize / labelSize);
 
 		return capacity > 0 ? capacity : 1;
 	}

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -787,7 +787,7 @@ module.exports = Scale.extend({
 		var format = displayFormats[timeOpts.unit] || displayFormats.millisecond;
 		var exampleLabel = me.tickFormatFunction(exampleTime, 0, ticksFromTimestamps(me, [exampleTime], me._majorUnit), format);
 		var size = me._getLabelSize(exampleLabel);
-		var labelSize, scaleSize, chartSize, capacity;
+		var labelSize, scaleSize, chartSize;
 
 		if (me.isHorizontal()) {
 			labelSize = size.w;
@@ -799,14 +799,16 @@ module.exports = Scale.extend({
 			chartSize = me.chart.height;
 		}
 
+		// If offset is true, the scale size is reduced by the half label size on each edge.
+		// If false, it is reduced if the chart doesn't have enough margin for the half label
+		// size on one edge and by the half size on the other edge. See #6300 for details.
 		if (options.offset) {
 			scaleSize -= labelSize;
 		} else {
 			scaleSize = Math.min(scaleSize, chartSize - labelSize / 2) - labelSize / 2;
 		}
-		capacity = Math.floor(scaleSize / labelSize);
 
-		return capacity > 0 ? capacity : 1;
+		return Math.max(Math.floor(scaleSize / labelSize), 1);
 	}
 });
 

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -13,6 +13,7 @@ describe('Time scale tests', function() {
 			id: scaleID
 		});
 
+		scale.chart.width = 400;
 		scale.update(400, 50);
 		return scale;
 	}
@@ -123,7 +124,8 @@ describe('Time scale tests', function() {
 
 			var scaleOptions = Chart.scaleService.getScaleDefaults('time');
 			var scale = createScale(mockData, scaleOptions);
-			scale.update(1000, 200);
+			scale.chart.width = 1100;
+			scale.update(1100, 200);
 			var ticks = getTicksLabels(scale);
 
 			// `bounds === 'data'`: first and last ticks removed since outside the data range
@@ -135,7 +137,8 @@ describe('Time scale tests', function() {
 				labels: [newDateFromRef(0), newDateFromRef(1), newDateFromRef(2), newDateFromRef(4), newDateFromRef(6), newDateFromRef(7), newDateFromRef(9)], // days
 			};
 			var scale = createScale(mockData, Chart.scaleService.getScaleDefaults('time'));
-			scale.update(1000, 200);
+			scale.chart.width = 1100;
+			scale.update(1100, 200);
 			var ticks = getTicksLabels(scale);
 
 			// `bounds === 'data'`: first and last ticks removed since outside the data range
@@ -184,6 +187,7 @@ describe('Time scale tests', function() {
 			});
 
 			var xScale = chart.scales.xScale0;
+			xScale.chart.width = 800;
 			xScale.update(800, 200);
 			var ticks = getTicksLabels(xScale);
 
@@ -233,6 +237,7 @@ describe('Time scale tests', function() {
 			});
 
 			var tScale = chart.scales.tScale0;
+			tScale.chart.width = 800;
 			tScale.update(800, 200);
 			var ticks = getTicksLabels(tScale);
 
@@ -291,6 +296,7 @@ describe('Time scale tests', function() {
 		config.time.unit = 'hour';
 
 		var scale = createScale(mockData, config);
+		scale.chart.width = 2500;
 		scale.update(2500, 200);
 		var ticks = getTicksLabels(scale);
 
@@ -384,6 +390,7 @@ describe('Time scale tests', function() {
 		}, Chart.scaleService.getScaleDefaults('time'));
 
 		var scale = createScale(mockData, config);
+		scale.chart.width = 800;
 		scale.update(800, 200);
 		var ticks = getTicksLabels(scale);
 
@@ -703,8 +710,8 @@ describe('Time scale tests', function() {
 
 			expect(scale._ticks.map(function(tick) {
 				return tick.major;
-			})).toEqual([true, false, false, false, true]);
-			expect(scale.ticks).toEqual(['<8:00:00 pm>', '<8:00:15 pm>', '<8:00:30 pm>', '<8:00:45 pm>', '<8:01:00 pm>']);
+			})).toEqual([true, false, false, false, false, false, true]);
+			expect(scale.ticks).toEqual(['<8:00:00 pm>', '<8:00:10 pm>', '<8:00:20 pm>', '<8:00:30 pm>', '<8:00:40 pm>', '<8:00:50 pm>', '<8:01:00 pm>']);
 		});
 
 		it('should update ticks.callback correctly', function() {
@@ -715,7 +722,7 @@ describe('Time scale tests', function() {
 				return '{' + value + '}';
 			};
 			chart.update();
-			expect(scale.ticks).toEqual(['{8:00:00 pm}', '{8:00:15 pm}', '{8:00:30 pm}', '{8:00:45 pm}', '{8:01:00 pm}']);
+			expect(scale.ticks).toEqual(['{8:00:00 pm}', '{8:00:10 pm}', '{8:00:20 pm}', '{8:00:30 pm}', '{8:00:40 pm}', '{8:00:50 pm}', '{8:01:00 pm}']);
 		});
 	});
 
@@ -763,8 +770,8 @@ describe('Time scale tests', function() {
 
 			expect(scale._ticks.map(function(tick) {
 				return tick.major;
-			})).toEqual([true, false, false, false, true]);
-			expect(scale.ticks).toEqual(['[[8:00 pm]]', '(8:00:15 pm)', '(8:00:30 pm)', '(8:00:45 pm)', '[[8:01 pm]]']);
+			})).toEqual([true, false, false, false, false, false, true]);
+			expect(scale.ticks).toEqual(['[[8:00 pm]]', '(8:00:10 pm)', '(8:00:20 pm)', '(8:00:30 pm)', '(8:00:40 pm)', '(8:00:50 pm)', '[[8:01 pm]]']);
 		});
 
 		it('should only use ticks.minor callback if ticks.major.enabled is false', function() {
@@ -773,7 +780,7 @@ describe('Time scale tests', function() {
 
 			chart.options.scales.xAxes[0].ticks.major.enabled = false;
 			chart.update();
-			expect(scale.ticks).toEqual(['(8:00:00 pm)', '(8:00:15 pm)', '(8:00:30 pm)', '(8:00:45 pm)', '(8:01:00 pm)']);
+			expect(scale.ticks).toEqual(['(8:00:00 pm)', '(8:00:10 pm)', '(8:00:20 pm)', '(8:00:30 pm)', '(8:00:40 pm)', '(8:00:50 pm)', '(8:01:00 pm)']);
 		});
 
 		it('should use ticks.callback if ticks.major.callback is omitted', function() {
@@ -782,7 +789,7 @@ describe('Time scale tests', function() {
 
 			chart.options.scales.xAxes[0].ticks.major.callback = undefined;
 			chart.update();
-			expect(scale.ticks).toEqual(['<8:00 pm>', '(8:00:15 pm)', '(8:00:30 pm)', '(8:00:45 pm)', '<8:01 pm>']);
+			expect(scale.ticks).toEqual(['<8:00 pm>', '(8:00:10 pm)', '(8:00:20 pm)', '(8:00:30 pm)', '(8:00:40 pm)', '(8:00:50 pm)', '<8:01 pm>']);
 		});
 
 		it('should use ticks.callback if ticks.minor.callback is omitted', function() {
@@ -791,7 +798,7 @@ describe('Time scale tests', function() {
 
 			chart.options.scales.xAxes[0].ticks.minor.callback = undefined;
 			chart.update();
-			expect(scale.ticks).toEqual(['[[8:00 pm]]', '<8:00:15 pm>', '<8:00:30 pm>', '<8:00:45 pm>', '[[8:01 pm]]']);
+			expect(scale.ticks).toEqual(['[[8:00 pm]]', '<8:00:10 pm>', '<8:00:20 pm>', '<8:00:30 pm>', '<8:00:40 pm>', '<8:00:50 pm>', '[[8:01 pm]]']);
 		});
 	});
 


### PR DESCRIPTION
The right padding in a time chart may not be correctly calculated depending on the labels and canvas width.

This occurs because `getLabelCapacity` is calculating the capacity using `margins` but it is only available in the second call (By the way, `margin` is not synchronized with `width` even in the second call as shown in the picture below). On the other hand, the scale padding is determined based on the result of the first `getLabelCapacity` call. If there is a difference in the results of first and second `getLabelCapacity` calls, this problem appears. This regression was introduced in #6115.

This PR fixes it by using the chart width to estimate the final scale width in the first `getLabelCapacity` call. The picture below would help to understand the calculation in each case.

If the chart has y axis on both the left and the right side, the result may not be accurate, but I think a label overlap won't occur at least.

<img width="864" alt="Screen Shot 2019-05-27 at 1 00 34 AM" src="https://user-images.githubusercontent.com/723188/58384875-f4700d80-801a-11e9-9fe1-2dc2cab2ca54.png">

**Master: https://jsfiddle.net/nagix/qkuLo506/**
<img width="526" alt="Screen Shot 2019-05-26 at 11 47 27 PM" src="https://user-images.githubusercontent.com/723188/58384127-b53cbf00-8010-11e9-9639-926f3f81a0a9.png">

**This PR: https://jsfiddle.net/nagix/0c597p4a/**
<img width="523" alt="Screen Shot 2019-05-26 at 11 47 39 PM" src="https://user-images.githubusercontent.com/723188/58384128-b837af80-8010-11e9-8592-fcfd24073883.png">