### PR TITLE
[performance] faster major tick calculation

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -404,21 +404,39 @@ function computeOffsets(table, ticks, min, max, options) {
 	return {start: start, end: end};
 }
 
+function setMajorTicks(scale, indices, ticks, majorUnit) {
+	var adapter = scale._adapter;
+	var first = +adapter.startOf(ticks[0].value, majorUnit);
+	var last = ticks[ticks.length - 1].value;
+	var major, index;
+
+	for (major = first; major <= last; major = +adapter.add(major, 1, majorUnit)) {
+		index = indices[major];
+		if (typeof index !== 'undefined') {
+			ticks[index].major = true;
+		}
+	}
+	return ticks;
+}
+
 function ticksFromTimestamps(scale, values, majorUnit) {
 	var ticks = [];
-	var i, ilen, value, major;
+	var ts = {};
+	var ilen = values.length;
+	var i, value;
 
-	for (i = 0, ilen = values.length; i < ilen; ++i) {
+	for (i = 0; i < ilen; ++i) {
 		value = values[i];
-		major = majorUnit ? value === +scale._adapter.startOf(value, majorUnit) : false;
+		ts[value] = i;
 
 		ticks.push({
-			value: value,
-			major: major
+			value: value
 		});
 	}
 
-	return ticks;
+	// We set the major ticks separately from the above loop because calling startOf for every tick
+	// is expensive when there is a large number of ticks
+	return (ilen === 0 || !majorUnit) ? ticks : setMajorTicks(scale, ts, ticks, majorUnit);
 }
 
 var defaultConfig = {

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -404,15 +404,15 @@ function computeOffsets(table, ticks, min, max, options) {
 	return {start: start, end: end};
 }
 
-function setMajorTicks(scale, indices, ticks, majorUnit) {
+function setMajorTicks(scale, ticks, map, majorUnit) {
 	var adapter = scale._adapter;
 	var first = +adapter.startOf(ticks[0].value, majorUnit);
 	var last = ticks[ticks.length - 1].value;
 	var major, index;
 
 	for (major = first; major <= last; major = +adapter.add(major, 1, majorUnit)) {
-		index = indices[major];
-		if (typeof index !== 'undefined') {
+		index = map[major];
+		if (!isNaN(index)) {
 			ticks[index].major = true;
 		}
 	}
@@ -421,22 +421,23 @@ function setMajorTicks(scale, indices, ticks, majorUnit) {
 
 function ticksFromTimestamps(scale, values, majorUnit) {
 	var ticks = [];
-	var ts = {};
+	var map = {};
 	var ilen = values.length;
 	var i, value;
 
 	for (i = 0; i < ilen; ++i) {
 		value = values[i];
-		ts[value] = i;
+		map[value] = i;
 
 		ticks.push({
-			value: value
+			value: value,
+			major: false
 		});
 	}
 
 	// We set the major ticks separately from the above loop because calling startOf for every tick
 	// is expensive when there is a large number of ticks
-	return (ilen === 0 || !majorUnit) ? ticks : setMajorTicks(scale, ts, ticks, majorUnit);
+	return (ilen === 0 || !majorUnit) ? ticks : setMajorTicks(scale, ticks, map, majorUnit);
 }
 
 var defaultConfig = {

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -412,7 +412,7 @@ function setMajorTicks(scale, ticks, map, majorUnit) {
 
 	for (major = first; major <= last; major = +adapter.add(major, 1, majorUnit)) {
 		index = map[major];
-		if (!isNaN(index)) {
+		if (index >= 0) {
 			ticks[index].major = true;
 		}
 	}

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -703,7 +703,7 @@ describe('Time scale tests', function() {
 
 			expect(scale._ticks.map(function(tick) {
 				return tick.major;
-			})).toEqual([true, undefined, undefined, undefined, true]);
+			})).toEqual([true, false, false, false, true]);
 			expect(scale.ticks).toEqual(['<8:00:00 pm>', '<8:00:15 pm>', '<8:00:30 pm>', '<8:00:45 pm>', '<8:01:00 pm>']);
 		});
 
@@ -763,7 +763,7 @@ describe('Time scale tests', function() {
 
 			expect(scale._ticks.map(function(tick) {
 				return tick.major;
-			})).toEqual([true, undefined, undefined, undefined, true]);
+			})).toEqual([true, false, false, false, true]);
 			expect(scale.ticks).toEqual(['[[8:00 pm]]', '(8:00:15 pm)', '(8:00:30 pm)', '(8:00:45 pm)', '[[8:01 pm]]']);
 		});
 

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -703,7 +703,7 @@ describe('Time scale tests', function() {
 
 			expect(scale._ticks.map(function(tick) {
 				return tick.major;
-			})).toEqual([true, false, false, false, true]);
+			})).toEqual([true, undefined, undefined, undefined, true]);
 			expect(scale.ticks).toEqual(['<8:00:00 pm>', '<8:00:15 pm>', '<8:00:30 pm>', '<8:00:45 pm>', '<8:01:00 pm>']);
 		});
 
@@ -763,7 +763,7 @@ describe('Time scale tests', function() {
 
 			expect(scale._ticks.map(function(tick) {
 				return tick.major;
-			})).toEqual([true, false, false, false, true]);
+			})).toEqual([true, undefined, undefined, undefined, true]);
 			expect(scale.ticks).toEqual(['[[8:00 pm]]', '(8:00:15 pm)', '(8:00:30 pm)', '(8:00:45 pm)', '[[8:01 pm]]']);
 		});
 


### PR DESCRIPTION
This is a major speedup when `ticks.source` is `data` or `labels`. The speed up is because it avoids calling `startOf` on every tick, which is expensive since it creates a moment object and does a non-trivial calculation. It's also necessary to implement https://github.com/chartjs/Chart.js/pull/6274 efficiently. I'll rebase that PR and reopen a re-worked version of it after this change and https://github.com/chartjs/Chart.js/pull/6304 are merged

Before:
![before](https://user-images.githubusercontent.com/322311/58578501-cd256600-81fd-11e9-8061-14ad7be7a074.png)

After:
![after](https://user-images.githubusercontent.com/322311/58578509-d44c7400-81fd-11e9-8157-47683db61874.png)
