### PR TITLE
Add link of plugin hooks’ prototype in documentation

### DIFF
--- a/docs/developers/plugins.md
+++ b/docs/developers/plugins.md
@@ -106,7 +106,8 @@ var chart = new Chart(ctx, {
 
 ## Plugin Core API
 
-Available hooks (as of version 2.7):
+Available hooks (as of version 2.7):  
+(For more informations like parameters or return value of hooks, please refer to [this](https://github.com/chartjs/Chart.js/blob/2f874fde622ebd2c3b45c668861659f17e1254e9/src/core/core.plugins.js#L173-L382).)
 
 * `beforeInit`
 * `afterInit`


### PR DESCRIPTION
[Official documentation](https://www.chartjs.org/docs/latest/developers/plugins.html#plugin-core-api) lacks information about plugins so I added a link to below code. How about this?
https://github.com/chartjs/Chart.js/blob/2f874fde622ebd2c3b45c668861659f17e1254e9/src/core/core.plugins.js#L173-L382