### PR TITLE
Update dataset metadata when axisID changes

### DIFF
--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -139,13 +139,16 @@ helpers.extend(DatasetController.prototype, {
 	linkScales: function() {
 		var me = this;
 		var meta = me.getMeta();
+		var chart = me.chart;
+		var scales = chart.scales;
 		var dataset = me.getDataset();
+		var scalesOpts = chart.options.scales;
 
-		if (meta.xAxisID === null || !(meta.xAxisID in me.chart.scales)) {
-			meta.xAxisID = dataset.xAxisID || me.chart.options.scales.xAxes[0].id;
+		if (meta.xAxisID === null || !(meta.xAxisID in scales) || dataset.xAxisID) {
+			meta.xAxisID = dataset.xAxisID || scalesOpts.xAxes[0].id;
 		}
-		if (meta.yAxisID === null || !(meta.yAxisID in me.chart.scales)) {
-			meta.yAxisID = dataset.yAxisID || me.chart.options.scales.yAxes[0].id;
+		if (meta.yAxisID === null || !(meta.yAxisID in scales) || dataset.yAxisID) {
+			meta.yAxisID = dataset.yAxisID || scalesOpts.yAxes[0].id;
 		}
 	},
 

--- a/test/specs/core.datasetController.tests.js
+++ b/test/specs/core.datasetController.tests.js
@@ -221,6 +221,45 @@ describe('Chart.DatasetController', function() {
 		expect(meta.data.length).toBe(42);
 	});
 
+	it('should re-synchronize metadata when scaleID changes', function() {
+		var chart = acquireChart({
+			type: 'line',
+			data: {
+				datasets: [{
+					data: [],
+					xAxisID: 'firstXScaleID',
+					yAxisID: 'firstYScaleID',
+				}]
+			},
+			options: {
+				scales: {
+					xAxes: [{
+						id: 'firstXScaleID'
+					}, {
+						id: 'secondXScaleID'
+					}],
+					yAxes: [{
+						id: 'firstYScaleID'
+					}, {
+						id: 'secondYScaleID'
+					}]
+				}
+			}
+		});
+
+		var meta = chart.getDatasetMeta(0);
+
+		expect(meta.xAxisID).toBe('firstXScaleID');
+		expect(meta.yAxisID).toBe('firstYScaleID');
+
+		chart.data.datasets[0].xAxisID = 'secondXScaleID';
+		chart.data.datasets[0].yAxisID = 'secondYScaleID';
+		chart.update();
+
+		expect(meta.xAxisID).toBe('secondXScaleID');
+		expect(meta.yAxisID).toBe('secondYScaleID');
+	});
+
 	it('should cleanup attached properties when the reference changes or when the chart is destroyed', function() {
 		var data0 = [0, 1, 2, 3, 4, 5];
 		var data1 = [6, 7, 8];


### PR DESCRIPTION
When the dataset option `xAxisID` or `yAxisID` is changed and `update()` is called, it doesn't make any changes. This PR fixes it by modifying `linkScales` so that metadata is updated if `dataset.xAxisID` or `dataset.yAxisID` exists.

**Master: https://jsfiddle.net/nagix/mwL6obck/**
<img width="409" alt="Screen Shot 2019-06-07 at 12 20 34 AM" src="https://user-images.githubusercontent.com/723188/59049248-2c4c4000-88ba-11e9-9aea-5929ccab8a6a.png">

**This PR: https://jsfiddle.net/nagix/u7wta3ed/**
<img width="410" alt="Screen Shot 2019-06-07 at 12 21 02 AM" src="https://user-images.githubusercontent.com/723188/59049258-2fdfc700-88ba-11e9-8ab8-5f6c3085d0c4.png">

Fixes #6320