### PR TITLE
Draw the rightmost grid line when offsetGridLines is true

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -886,6 +886,7 @@ var Scale = Element.extend({
 		var isHorizontal = me.isHorizontal();
 
 		var ticks = optionTicks.display && optionTicks.autoSkip ? me._autoSkip(me.getTicks()) : me.getTicks();
+		var ticksLength = ticks.length;
 		var tickFonts = parseTickFontOptions(optionTicks);
 		var tickPadding = optionTicks.padding;
 		var labelOffset = optionTicks.labelOffset;
@@ -899,7 +900,7 @@ var Scale = Element.extend({
 
 		var axisWidth = gridLines.drawBorder ? valueAtIndexOrDefault(gridLines.lineWidth, 0, 0) : 0;
 		var alignPixel = helpers._alignPixel;
-		var borderValue, tickStart, tickEnd;
+		var borderValue, tickStart, tickEnd, i, ilen, tick;
 
 		if (position === 'top') {
 			borderValue = alignPixel(chart, me.bottom, axisWidth);
@@ -919,31 +920,29 @@ var Scale = Element.extend({
 			tickEnd = me.left + tl;
 		}
 
-		if (offsetGridLines) {
-			ticks = ticks.concat([{extra: true}]);
-		}
+		for (i = 0, ilen = ticksLength + (offsetGridLines ? 1 : 0); i < ilen; ++i) {
+			tick = ticks[i] || {};
 
-		helpers.each(ticks, function(tick, index) {
 			var label = tick.label;
-			var extra = tick.extra;
+			var extra = i >= ticksLength;
 
 			// autoskipper skipped this tick (#4635)
 			if (helpers.isNullOrUndef(label) && !extra) {
-				return;
+				continue;
 			}
 
 			var tickFont = tick.major ? tickFonts.major : tickFonts.minor;
 			var lineHeight = tickFont.lineHeight;
 			var lineWidth, lineColor, borderDash, borderDashOffset;
-			if (index === me.zeroLineIndex && options.offset === offsetGridLines) {
+			if (i === me.zeroLineIndex && options.offset === offsetGridLines) {
 				// Draw the first index specially
 				lineWidth = gridLines.zeroLineWidth;
 				lineColor = gridLines.zeroLineColor;
 				borderDash = gridLines.zeroLineBorderDash || [];
 				borderDashOffset = gridLines.zeroLineBorderDashOffset || 0.0;
 			} else {
-				lineWidth = valueAtIndexOrDefault(gridLines.lineWidth, index, 1);
-				lineColor = valueAtIndexOrDefault(gridLines.color, index, 'rgba(0,0,0,0.1)');
+				lineWidth = valueAtIndexOrDefault(gridLines.lineWidth, i, 1);
+				lineColor = valueAtIndexOrDefault(gridLines.color, i, 'rgba(0,0,0,0.1)');
 				borderDash = gridLines.borderDash || [];
 				borderDashOffset = gridLines.borderDashOffset || 0.0;
 			}
@@ -951,7 +950,7 @@ var Scale = Element.extend({
 			// Common properties
 			var tx1, ty1, tx2, ty2, x1, y1, x2, y2, labelX, labelY, textOffset, textAlign;
 			var labelCount = helpers.isArray(label) ? label.length : 1;
-			var lineValue = getPixelForGridLine(me, index, offsetGridLines);
+			var lineValue = getPixelForGridLine(me, i, offsetGridLines);
 
 			if (isHorizontal) {
 				var labelYOffset = tl + tickPadding;
@@ -959,7 +958,7 @@ var Scale = Element.extend({
 				tx1 = tx2 = x1 = x2 = alignPixel(chart, lineValue, lineWidth);
 				ty1 = tickStart;
 				ty2 = tickEnd;
-				labelX = me.getPixelForTick(index) + labelOffset; // x values for optionTicks (need to consider offsetLabel option)
+				labelX = me.getPixelForTick(i) + labelOffset; // x values for optionTicks (need to consider offsetLabel option)
 
 				if (position === 'top') {
 					y1 = alignPixel(chart, chartArea.top, axisWidth) + axisWidth / 2;
@@ -980,7 +979,7 @@ var Scale = Element.extend({
 				tx1 = tickStart;
 				tx2 = tickEnd;
 				ty1 = ty2 = y1 = y2 = alignPixel(chart, lineValue, lineWidth);
-				labelY = me.getPixelForTick(index) + labelOffset;
+				labelY = me.getPixelForTick(i) + labelOffset;
 				textOffset = (1 - labelCount) * lineHeight / 2;
 
 				if (position === 'left') {
@@ -1024,9 +1023,9 @@ var Scale = Element.extend({
 					textAlign: textAlign
 				});
 			}
-		});
+		}
 
-		gridLineItems.ticksLength = ticks.length;
+		gridLineItems.ticksLength = ilen;
 		gridLineItems.borderValue = borderValue;
 
 		return {
@@ -1052,9 +1051,10 @@ var Scale = Element.extend({
 		var axisWidth = gridLines.drawBorder ? valueAtIndexOrDefault(gridLines.lineWidth, 0, 0) : 0;
 		var items = me._itemsToDraw || (me._itemsToDraw = me._computeItemsToDraw(chartArea));
 		var gridLineItems = items.gridLines;
-		var width, color;
+		var width, color, i, ilen, item;
 
-		helpers.each(gridLineItems, function(item) {
+		for (i = 0, ilen = gridLineItems.length; i < ilen; ++i) {
+			item = gridLineItems[i];
 			width = item.width;
 			color = item.color;
 
@@ -1082,12 +1082,12 @@ var Scale = Element.extend({
 				ctx.stroke();
 				ctx.restore();
 			}
-		});
+		}
 
 		if (axisWidth) {
 			// Draw the line at the edge of the axis
 			var firstLineWidth = axisWidth;
-			var lastLineWidth = valueAtIndexOrDefault(gridLines.lineWidth, gridLineItems.ticksLength - 1, 0);
+			var lastLineWidth = valueAtIndexOrDefault(gridLines.lineWidth, gridLineItems.ticksLength - 1, 1);
 			var borderValue = gridLineItems.borderValue;
 			var x1, x2, y1, y2;
 
@@ -1123,9 +1123,11 @@ var Scale = Element.extend({
 		}
 
 		var items = me._itemsToDraw || (me._itemsToDraw = me._computeItemsToDraw(chartArea));
-		var tickFont;
+		var labelItems = items.labels;
+		var i, j, ilen, jlen, item, tickFont, label, y;
 
-		helpers.each(items.labels, function(item) {
+		for (i = 0, ilen = labelItems.length; i < ilen; ++i) {
+			item = labelItems[i];
 			tickFont = item.font;
 
 			// Make sure we draw text in the correct color and font
@@ -1137,19 +1139,19 @@ var Scale = Element.extend({
 			ctx.textBaseline = 'middle';
 			ctx.textAlign = item.textAlign;
 
-			var label = item.label;
-			var y = item.textOffset;
+			label = item.label;
+			y = item.textOffset;
 			if (helpers.isArray(label)) {
-				for (var i = 0; i < label.length; ++i) {
+				for (j = 0, jlen = label.length; j < jlen; ++j) {
 					// We just make sure the multiline element is a string here..
-					ctx.fillText('' + label[i], 0, y);
+					ctx.fillText('' + label[j], 0, y);
 					y += tickFont.lineHeight;
 				}
 			} else {
 				ctx.fillText(label, 0, y);
 			}
 			ctx.restore();
-		});
+		}
 	},
 
 	/**

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -886,7 +886,7 @@ var Scale = Element.extend({
 		var isHorizontal = me.isHorizontal();
 
 		var ticks = optionTicks.display && optionTicks.autoSkip ? me._autoSkip(me.getTicks()) : me.getTicks();
-		var ticksLength = ticks.length;
+		var ticksLength = ticks.length + (offsetGridLines ? 1 : 0);
 		var tickFonts = parseTickFontOptions(optionTicks);
 		var tickPadding = optionTicks.padding;
 		var labelOffset = optionTicks.labelOffset;
@@ -900,7 +900,7 @@ var Scale = Element.extend({
 
 		var axisWidth = gridLines.drawBorder ? valueAtIndexOrDefault(gridLines.lineWidth, 0, 0) : 0;
 		var alignPixel = helpers._alignPixel;
-		var borderValue, tickStart, tickEnd, i, ilen, tick;
+		var borderValue, tickStart, tickEnd, i, tick;
 
 		if (position === 'top') {
 			borderValue = alignPixel(chart, me.bottom, axisWidth);
@@ -920,11 +920,11 @@ var Scale = Element.extend({
 			tickEnd = me.left + tl;
 		}
 
-		for (i = 0, ilen = ticksLength + (offsetGridLines ? 1 : 0); i < ilen; ++i) {
+		for (i = 0; i < ticksLength; ++i) {
 			tick = ticks[i] || {};
 
 			var label = tick.label;
-			var extra = i >= ticksLength;
+			var extra = i >= ticks.length;
 
 			// autoskipper skipped this tick (#4635)
 			if (helpers.isNullOrUndef(label) && !extra) {
@@ -1025,7 +1025,7 @@ var Scale = Element.extend({
 			}
 		}
 
-		gridLineItems.ticksLength = ilen;
+		gridLineItems.ticksLength = ticksLength;
 		gridLineItems.borderValue = borderValue;
 
 		return {

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -65,22 +65,24 @@ defaults._set('scale', {
 	}
 });
 
-function getPixelForGridLine(scale, index, isRightmost) {
-	var lineValue = scale.getPixelForTick(index);
+function getPixelForGridLine(scale, index, offsetGridLines) {
+	var length = scale.getTicks().length;
+	var validIndex = Math.min(index, length - 1);
+	var lineValue = scale.getPixelForTick(validIndex);
 	var start = scale._startPixel;
 	var end = scale._endPixel;
 	var epsilon = 1e-6; // 1e-6 is margin in pixels for accumulated error.
 	var offset;
 
-	if (scale.options.gridLines.offsetGridLines) {
-		if (scale.getTicks().length === 1) {
+	if (offsetGridLines) {
+		if (length === 1) {
 			offset = Math.max(lineValue - start, end - lineValue);
 		} else if (index === 0) {
 			offset = (scale.getPixelForTick(1) - lineValue) / 2;
 		} else {
-			offset = (lineValue - scale.getPixelForTick(index - 1)) / 2;
+			offset = (lineValue - scale.getPixelForTick(validIndex - 1)) / 2;
 		}
-		lineValue += isRightmost ? offset : -offset;
+		lineValue += validIndex < index ? offset : -offset;
 
 		// Return undefined if the pixel is out of the range
 		if (lineValue < start - epsilon || lineValue > end + epsilon) {
@@ -917,13 +919,19 @@ var Scale = Element.extend({
 			tickEnd = me.left + tl;
 		}
 
+		if (offsetGridLines) {
+			ticks = ticks.concat([{extra: true}]);
+		}
+
 		helpers.each(ticks, function(tick, index) {
+			var label = tick.label;
+			var extra = tick.extra;
+
 			// autoskipper skipped this tick (#4635)
-			if (helpers.isNullOrUndef(tick.label)) {
+			if (helpers.isNullOrUndef(label) && !extra) {
 				return;
 			}
 
-			var label = tick.label;
 			var tickFont = tick.major ? tickFonts.major : tickFonts.minor;
 			var lineHeight = tickFont.lineHeight;
 			var lineWidth, lineColor, borderDash, borderDashOffset;
@@ -943,7 +951,7 @@ var Scale = Element.extend({
 			// Common properties
 			var tx1, ty1, tx2, ty2, x1, y1, x2, y2, labelX, labelY, textOffset, textAlign;
 			var labelCount = helpers.isArray(label) ? label.length : 1;
-			var lineValue = getPixelForGridLine(me, index);
+			var lineValue = getPixelForGridLine(me, index, offsetGridLines);
 
 			if (isHorizontal) {
 				var labelYOffset = tl + tickPadding;
@@ -1005,40 +1013,17 @@ var Scale = Element.extend({
 				});
 			}
 
-			if (index === ticks.length - 1 && offsetGridLines) {
-				lineValue = getPixelForGridLine(me, index, true);
-				if (lineValue !== undefined) {
-					if (isHorizontal) {
-						tx1 = tx2 = x1 = x2 = alignPixel(chart, lineValue, lineWidth);
-					} else {
-						ty1 = ty2 = y1 = y2 = alignPixel(chart, lineValue, lineWidth);
-					}
-					gridLineItems.push({
-						tx1: tx1,
-						ty1: ty1,
-						tx2: tx2,
-						ty2: ty2,
-						x1: x1,
-						y1: y1,
-						x2: x2,
-						y2: y2,
-						width: valueAtIndexOrDefault(gridLines.lineWidth, index + 1, 1),
-						color: valueAtIndexOrDefault(gridLines.color, index + 1, 'rgba(0,0,0,0.1)'),
-						borderDash: gridLines.borderDash || [],
-						borderDashOffset: gridLines.borderDashOffset || 0.0,
-					});
-				}
+			if (!extra) {
+				labelItems.push({
+					x: labelX,
+					y: labelY,
+					rotation: -labelRotationRadians,
+					label: label,
+					font: tick.major ? tickFonts.major : tickFonts.minor,
+					textOffset: textOffset,
+					textAlign: textAlign
+				});
 			}
-
-			labelItems.push({
-				x: labelX,
-				y: labelY,
-				rotation: -labelRotationRadians,
-				label: label,
-				font: tick.major ? tickFonts.major : tickFonts.minor,
-				textOffset: textOffset,
-				textAlign: textAlign
-			});
 		});
 
 		gridLineItems.ticksLength = ticks.length;

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -18,7 +18,7 @@ var defaultConfig = {
 
 	angleLines: {
 		display: true,
-		color: 'rgba(0, 0, 0, 0.1)',
+		color: 'rgba(0,0,0,0.1)',
 		lineWidth: 1,
 		borderDash: [],
 		borderDashOffset: 0.0

--- a/test/specs/core.scale.tests.js
+++ b/test/specs/core.scale.tests.js
@@ -89,12 +89,12 @@ describe('Core.scale', function() {
 		labels: ['tick1', 'tick2', 'tick3', 'tick4', 'tick5'],
 		offsetGridLines: true,
 		offset: false,
-		expected: [-63.5, 64.5, 192.5, 320.5, 448.5]
+		expected: [64.5, 192.5, 320.5, 448.5]
 	}, {
 		labels: ['tick1', 'tick2', 'tick3', 'tick4', 'tick5'],
 		offsetGridLines: true,
 		offset: true,
-		expected: [0.5, 102.5, 204.5, 307.5, 409.5]
+		expected: [0.5, 102.5, 204.5, 307.5, 409.5, 512.5]
 	}, {
 		labels: ['tick1'],
 		offsetGridLines: false,
@@ -109,16 +109,16 @@ describe('Core.scale', function() {
 		labels: ['tick1'],
 		offsetGridLines: true,
 		offset: false,
-		expected: [-511.5]
+		expected: [512.5]
 	}, {
 		labels: ['tick1'],
 		offsetGridLines: true,
 		offset: true,
-		expected: [0.5]
+		expected: [0.5, 512.5]
 	}];
 
 	gridLineTests.forEach(function(test) {
-		it('should get the correct pixels for ' + test.labels.length + ' gridLine(s) for the horizontal scale when offsetGridLines is ' + test.offsetGridLines + ' and offset is ' + test.offset, function() {
+		it('should get the correct pixels for gridLine(s) for the horizontal scale when offsetGridLines is ' + test.offsetGridLines + ' and offset is ' + test.offset, function() {
 			var chart = window.acquireChart({
 				type: 'line',
 				data: {
@@ -163,7 +163,7 @@ describe('Core.scale', function() {
 	});
 
 	gridLineTests.forEach(function(test) {
-		it('should get the correct pixels for ' + test.labels.length + ' gridLine(s) for the vertical scale when offsetGridLines is ' + test.offsetGridLines + ' and offset is ' + test.offset, function() {
+		it('should get the correct pixels for gridLine(s) for the vertical scale when offsetGridLines is ' + test.offsetGridLines + ' and offset is ' + test.offset, function() {
 			var chart = window.acquireChart({
 				type: 'line',
 				data: {

--- a/test/specs/scale.category.tests.js
+++ b/test/specs/scale.category.tests.js
@@ -13,7 +13,7 @@ describe('Category scale tests', function() {
 			display: true,
 
 			gridLines: {
-				color: 'rgba(0, 0, 0, 0.1)',
+				color: 'rgba(0,0,0,0.1)',
 				drawBorder: true,
 				drawOnChartArea: true,
 				drawTicks: true, // draw ticks extending towards the label

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -11,7 +11,7 @@ describe('Linear Scale', function() {
 			display: true,
 
 			gridLines: {
-				color: 'rgba(0, 0, 0, 0.1)',
+				color: 'rgba(0,0,0,0.1)',
 				drawBorder: true,
 				drawOnChartArea: true,
 				drawTicks: true, // draw ticks extending towards the label

--- a/test/specs/scale.logarithmic.tests.js
+++ b/test/specs/scale.logarithmic.tests.js
@@ -10,7 +10,7 @@ describe('Logarithmic Scale tests', function() {
 		expect(defaultConfig).toEqual({
 			display: true,
 			gridLines: {
-				color: 'rgba(0, 0, 0, 0.1)',
+				color: 'rgba(0,0,0,0.1)',
 				drawBorder: true,
 				drawOnChartArea: true,
 				drawTicks: true,

--- a/test/specs/scale.radialLinear.tests.js
+++ b/test/specs/scale.radialLinear.tests.js
@@ -13,7 +13,7 @@ describe('Test the radial linear scale', function() {
 		expect(defaultConfig).toEqual({
 			angleLines: {
 				display: true,
-				color: 'rgba(0, 0, 0, 0.1)',
+				color: 'rgba(0,0,0,0.1)',
 				lineWidth: 1,
 				borderDash: [],
 				borderDashOffset: 0.0
@@ -22,7 +22,7 @@ describe('Test the radial linear scale', function() {
 			display: true,
 			gridLines: {
 				circular: false,
-				color: 'rgba(0, 0, 0, 0.1)',
+				color: 'rgba(0,0,0,0.1)',
 				drawBorder: true,
 				drawOnChartArea: true,
 				drawTicks: true,

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -58,7 +58,7 @@ describe('Time scale tests', function() {
 		expect(defaultConfig).toEqual({
 			display: true,
 			gridLines: {
-				color: 'rgba(0, 0, 0, 0.1)',
+				color: 'rgba(0,0,0,0.1)',
 				drawBorder: true,
 				drawOnChartArea: true,
 				drawTicks: true,


### PR DESCRIPTION
With this PR, the rightmost grid line in bar charts, where `offset` and `gridLines.offsetGridLines` are `true` by default, will be drawn. It also fixes the following minor issue.

- If `gridLines.color` is an array but some element is undefined, that line won't be drawn. It should rather be drawn in the default color.

I'm aware of #5480 trying to solve this by a new plugin, but there have been many changes in the core scale code since it was opened, and a lot of effort would be needed to rebase it. This PR doesn't prevent to introduce a separate grid line plugin, but proposes a simpler approach to address the issue based on the latest code base.

**Master: https://jsfiddle.net/nagix/9ak5L48q/**
<img width="687" alt="Screen Shot 2019-06-08 at 10 54 57 PM" src="https://user-images.githubusercontent.com/723188/59148859-84ad4a00-8a40-11e9-8a33-52a5cd2474b9.png">

**This PR: https://jsfiddle.net/nagix/dLv84ujs/**
<img width="686" alt="Screen Shot 2019-06-08 at 10 55 15 PM" src="https://user-images.githubusercontent.com/723188/59148860-8840d100-8a40-11e9-81eb-83dab5855379.png">

Fixes #3804