### PR TITLE
Fix getValueForPixel in time scale

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -401,7 +401,7 @@ function computeOffsets(table, ticks, min, max, options) {
 		}
 	}
 
-	return {start: start, end: end};
+	return {start: start, end: end, factor: 1 / (start + 1 + end)};
 }
 
 function ticksFromTimestamps(scale, values, majorUnit) {
@@ -707,7 +707,7 @@ module.exports = Scale.extend({
 		var offsets = me._offsets;
 		var size = me._horizontal ? me.width : me.height;
 		var pos = interpolate(me._table, 'time', time, 'pos');
-		var offset = size * (offsets.start + pos) / (offsets.start + 1 + offsets.end);
+		var offset = size * (offsets.start + pos) * offsets.factor;
 
 		return me.options.ticks.reverse ?
 			(me._horizontal ? me.right : me.bottom) - offset :
@@ -745,7 +745,7 @@ module.exports = Scale.extend({
 		var offset = me.options.ticks.reverse ?
 			(me._horizontal ? me.right : me.bottom) - pixel :
 			pixel - (me._horizontal ? me.left : me.top);
-		var pos = (size ? offset / size : 0) * (offsets.start + 1 + offsets.end) - offsets.start;
+		var pos = offset / size / offsets.factor - offsets.start;
 		var time = interpolate(me._table, 'pos', pos, 'time');
 
 		// DEPRECATION, we should return time directly

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -704,13 +704,14 @@ module.exports = Scale.extend({
 	 */
 	getPixelForOffset: function(time) {
 		var me = this;
-		var isReverse = me.options.ticks.reverse;
+		var offsets = me._offsets;
 		var size = me._horizontal ? me.width : me.height;
-		var start = me._horizontal ? isReverse ? me.right : me.left : isReverse ? me.bottom : me.top;
 		var pos = interpolate(me._table, 'time', time, 'pos');
-		var offset = size * (me._offsets.start + pos) / (me._offsets.start + 1 + me._offsets.end);
+		var offset = size * (offsets.start + pos) / (offsets.start + 1 + offsets.end);
 
-		return isReverse ? start - offset : start + offset;
+		return me.options.ticks.reverse ?
+			(me._horizontal ? me.right : me.bottom) - offset :
+			(me._horizontal ? me.left : me.top) + offset;
 	},
 
 	getPixelForValue: function(value, index, datasetIndex) {
@@ -739,9 +740,12 @@ module.exports = Scale.extend({
 
 	getValueForPixel: function(pixel) {
 		var me = this;
+		var offsets = me._offsets;
 		var size = me._horizontal ? me.width : me.height;
-		var start = me._horizontal ? me.left : me.top;
-		var pos = (size ? (pixel - start) / size : 0) * (me._offsets.start + 1 + me._offsets.start) - me._offsets.end;
+		var offset = me.options.ticks.reverse ?
+			(me._horizontal ? me.right : me.bottom) - pixel :
+			pixel - (me._horizontal ? me.left : me.top);
+		var pos = (size ? offset / size : 0) * (offsets.start + 1 + offsets.end) - offsets.start;
 		var time = interpolate(me._table, 'pos', pos, 'time');
 
 		// DEPRECATION, we should return time directly

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -1512,6 +1512,18 @@ describe('Time scale tests', function() {
 				expect(scale.getPixelForValue('2042')).toBeCloseToPixel(scale.left);
 			});
 
+			it ('should reverse the values for pixels', function() {
+				var scale = this.chart.chart.scales.x;
+				expect(scale.getValueForPixel(scale.left)).toBeCloseToTime({
+					value: moment('2042-01-01T00:00:00'),
+					unit: 'hour',
+				});
+				expect(scale.getValueForPixel(scale.left + scale.width)).toBeCloseToTime({
+					value: moment('2017-01-01T00:00:00'),
+					unit: 'hour',
+				});
+			});
+
 			it ('should reverse the bars and add offsets if offset is true', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
@@ -1526,6 +1538,28 @@ describe('Time scale tests', function() {
 
 				expect(scale.getPixelForValue('2017')).toBeCloseToPixel(scale.left + scale.width - lastTickInterval / 2);
 				expect(scale.getPixelForValue('2042')).toBeCloseToPixel(scale.left + firstTickInterval / 2);
+			});
+
+			it ('should reverse the values for pixels if offset is true', function() {
+				var chart = this.chart;
+				var scale = chart.scales.x;
+				var options = chart.options.scales.xAxes[0];
+
+				options.offset = true;
+				chart.update();
+
+				var numTicks = scale.ticks.length;
+				var firstTickInterval = scale.getPixelForTick(1) - scale.getPixelForTick(0);
+				var lastTickInterval = scale.getPixelForTick(numTicks - 1) - scale.getPixelForTick(numTicks - 2);
+
+				expect(scale.getValueForPixel(scale.left + firstTickInterval / 2)).toBeCloseToTime({
+					value: moment('2042-01-01T00:00:00'),
+					unit: 'hour',
+				});
+				expect(scale.getValueForPixel(scale.left + scale.width - lastTickInterval / 2)).toBeCloseToTime({
+					value: moment('2017-01-01T00:00:00'),
+					unit: 'hour',
+				});
 			});
 		});
 	});


### PR DESCRIPTION
This PR fixes the following problems of `getValueForPixel` in time scale.

- It doesn't support the `ticks.reverse` option
- There is a bug in the offset calculation if `offset` is `true`

**Master: https://jsfiddle.net/nagix/ot0npu3x/**
<img width="416" alt="Screen Shot 2019-06-10 at 8 30 13 AM" src="https://user-images.githubusercontent.com/723188/59179480-0a70e880-8b5a-11e9-926a-08c47d2c2c02.png">

**This PR: https://jsfiddle.net/nagix/gbd6sq92/**
<img width="401" alt="Screen Shot 2019-06-10 at 8 27 50 AM" src="https://user-images.githubusercontent.com/723188/59179368-af3ef600-8b59-11e9-86fe-8652b6efce60.png">
