### PR TITLE
Remove 'point-style' property from Bubble Chart docs

### DIFF
--- a/docs/charts/bubble.md
+++ b/docs/charts/bubble.md
@@ -50,7 +50,6 @@ The bubble chart allows a number of properties to be specified for each dataset.
 | [`hoverRadius`](#interactions) | `number` | Yes | Yes | `4`
 | [`hitRadius`](#interactions) | `number` | Yes | Yes | `1`
 | [`label`](#labeling) | `string` | - | - | `undefined`
-| [`pointStyle`](#styling) | `string` | Yes | Yes | `'circle'`
 | [`rotation`](#styling) | `number` | Yes | Yes | `0`
 | [`radius`](#styling) | `number` | Yes | Yes | `3`
 


### PR DESCRIPTION
The docs correctly list 'point-style' as a valid property for Bubble Charts, but it doesn't have any effect on the rendered bubbles.
This seems to lead to some confusion (see this issue https://github.com/chartjs/Chart.js/issues/5428 and this SO question https://stackoverflow.com/questions/44402166/chart-js-bubble-chart-pointstyle-not-working ), so I suggest removing it from the docs.

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
