### PR TITLE
Add reverse support to category scale

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -67,12 +67,12 @@ defaults._set('scale', {
 
 function getPixelForGridLine(scale, index, offsetGridLines) {
 	var lineValue = scale.getPixelForTick(index);
-	var range;
+	var dimension;
 
 	if (offsetGridLines) {
 		if (scale.getTicks().length === 1) {
-			range = scale._getRange();
-			lineValue -= Math.max(lineValue - range.start, range.end - lineValue);
+			dimension = scale._getDimension();
+			lineValue -= Math.max(lineValue - dimension.start, dimension.end - lineValue);
 		} else if (index === 0) {
 			lineValue -= (scale.getPixelForTick(1) - lineValue) / 2;
 		} else {
@@ -651,7 +651,7 @@ var Scale = Element.extend({
 	/**
 	 * @private
 	 */
-	_getRange: function() {
+	_getDimension: function() {
 		var me = this;
 		if (me.isHorizontal()) {
 			return {

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -67,12 +67,12 @@ defaults._set('scale', {
 
 function getPixelForGridLine(scale, index, offsetGridLines) {
 	var lineValue = scale.getPixelForTick(index);
-	var dimension;
+	var dimensions;
 
 	if (offsetGridLines) {
 		if (scale.getTicks().length === 1) {
-			dimension = scale._getDimension();
-			lineValue -= Math.max(lineValue - dimension.start, dimension.end - lineValue);
+			dimensions = scale._getDimensions();
+			lineValue -= Math.max(lineValue - dimensions.start, dimensions.end - lineValue);
 		} else if (index === 0) {
 			lineValue -= (scale.getPixelForTick(1) - lineValue) / 2;
 		} else {
@@ -651,7 +651,7 @@ var Scale = Element.extend({
 	/**
 	 * @private
 	 */
-	_getDimension: function() {
+	_getDimensions: function() {
 		var me = this;
 		if (me.isHorizontal()) {
 			return {

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -67,12 +67,12 @@ defaults._set('scale', {
 
 function getPixelForGridLine(scale, index, offsetGridLines) {
 	var lineValue = scale.getPixelForTick(index);
+	var range;
 
 	if (offsetGridLines) {
 		if (scale.getTicks().length === 1) {
-			lineValue -= scale.isHorizontal() ?
-				Math.max(lineValue - scale.left, scale.right - lineValue) :
-				Math.max(lineValue - scale.top, scale.bottom - lineValue);
+			range = scale._getRange();
+			lineValue -= Math.max(lineValue - range.start, range.end - lineValue);
 		} else if (index === 0) {
 			lineValue -= (scale.getPixelForTick(1) - lineValue) / 2;
 		} else {
@@ -648,6 +648,24 @@ var Scale = Element.extend({
 		return +this.getRightValue(rawValue);
 	},
 
+	/**
+	 * @private
+	 */
+	_getRange: function() {
+		var me = this;
+		if (me.isHorizontal()) {
+			return {
+				start: me.left,
+				end: me.right,
+				size: me.right - me.left
+			};
+		}
+		return {
+			start: me.top,
+			end: me.bottom,
+			size: me.bottom - me.top
+		};
+	},
 	/**
 	 * Used to get the value to display in the tooltip for the data at the given index
 	 * @param index

--- a/src/scales/scale.category.js
+++ b/src/scales/scale.category.js
@@ -81,8 +81,8 @@ module.exports = Scale.extend({
 		var options = me.options;
 		var offset = options.offset;
 		var offsetAmt = Math.max(me._ticks.length - (offset ? 0 : 1), 1);
-		var range = me._getRange();
-		var valueDimension = range.size / offsetAmt;
+		var dimension = me._getDimension();
+		var valueDimension = dimension.size / offsetAmt;
 		var valueCategory, labels, idx, pixel;
 
 		if (!isNullOrUndef(index) && !isNullOrUndef(datasetIndex)) {
@@ -107,7 +107,7 @@ module.exports = Scale.extend({
 			pixel += valueDimension / 2;
 		}
 
-		return options.ticks.reverse ? range.end - pixel : range.start + pixel;
+		return options.ticks.reverse ? dimension.end - pixel : dimension.start + pixel;
 	},
 
 	getPixelForTick: function(index) {
@@ -125,10 +125,10 @@ module.exports = Scale.extend({
 		var options = me.options;
 		var offset = options.offset;
 		var offsetAmt = Math.max(me._ticks.length - (offset ? 0 : 1), 1);
-		var range = me._getRange();
-		var valueDimension = range.size / offsetAmt;
+		var dimension = me._getDimension();
+		var valueDimension = dimension.size / offsetAmt;
 
-		pixel = options.ticks.reverse ? range.end - pixel : pixel - range.start;
+		pixel = options.ticks.reverse ? dimension.end - pixel : pixel - dimension.start;
 
 		if (offset) {
 			pixel -= valueDimension / 2;

--- a/src/scales/scale.category.js
+++ b/src/scales/scale.category.js
@@ -124,9 +124,11 @@ module.exports = Scale.extend({
 		var me = this;
 		var options = me.options;
 		var offset = options.offset;
-		var offsetAmt = Math.max(me._ticks.length - (offset ? 0 : 1), 1);
+		var tickCount = me._ticks.length;
+		var offsetAmt = Math.max(tickCount - (offset ? 0 : 1), 1);
 		var dimension = me._getDimension();
 		var valueDimension = dimension.size / offsetAmt;
+		var value;
 
 		pixel = options.ticks.reverse ? dimension.end - pixel : pixel - dimension.start;
 
@@ -134,7 +136,9 @@ module.exports = Scale.extend({
 			pixel -= valueDimension / 2;
 		}
 
-		return Math.round(pixel / valueDimension) + me.minIndex;
+		value = Math.round(pixel / valueDimension);
+
+		return Math.min(Math.max(value, 0), tickCount - 1) + me.minIndex;
 	},
 
 	getBasePixel: function() {

--- a/src/scales/scale.category.js
+++ b/src/scales/scale.category.js
@@ -59,7 +59,9 @@ module.exports = Scale.extend({
 	convertTicksToLabels: function() {
 		var me = this;
 
+		// Storing the original labels as they can be modified by user's callback
 		me._tickValues = me.ticks.slice();
+
 		Scale.prototype.convertTicksToLabels.call(me);
 	},
 
@@ -81,8 +83,8 @@ module.exports = Scale.extend({
 		var options = me.options;
 		var offset = options.offset;
 		var offsetAmt = Math.max(me._ticks.length - (offset ? 0 : 1), 1);
-		var dimension = me._getDimension();
-		var valueDimension = dimension.size / offsetAmt;
+		var dimensions = me._getDimensions();
+		var valueDimension = dimensions.size / offsetAmt;
 		var valueCategory, labels, idx, pixel;
 
 		if (!isNullOrUndef(index) && !isNullOrUndef(datasetIndex)) {
@@ -107,7 +109,7 @@ module.exports = Scale.extend({
 			pixel += valueDimension / 2;
 		}
 
-		return options.ticks.reverse ? dimension.end - pixel : dimension.start + pixel;
+		return options.ticks.reverse ? dimensions.end - pixel : dimensions.start + pixel;
 	},
 
 	getPixelForTick: function(index) {
@@ -126,11 +128,11 @@ module.exports = Scale.extend({
 		var offset = options.offset;
 		var tickCount = me._ticks.length;
 		var offsetAmt = Math.max(tickCount - (offset ? 0 : 1), 1);
-		var dimension = me._getDimension();
-		var valueDimension = dimension.size / offsetAmt;
+		var dimensions = me._getDimensions();
+		var valueDimension = dimensions.size / offsetAmt;
 		var value;
 
-		pixel = options.ticks.reverse ? dimension.end - pixel : pixel - dimension.start;
+		pixel = options.ticks.reverse ? dimensions.end - pixel : pixel - dimensions.start;
 
 		if (offset) {
 			pixel -= valueDimension / 2;

--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -272,25 +272,24 @@ module.exports = Scale.extend({
 		var log10 = helpers.log10;
 		var firstTickValue = me._getFirstTickValue(me.minNotZero);
 		var offset = 0;
-		var innerDimension, pixel, start, end, sign;
+		var dimensions = me._getDimensions();
+		var innerDimension = dimensions.size;
+		var pixel, start, end, sign;
 
 		value = +me.getRightValue(value);
 		if (reverse) {
 			start = me.end;
 			end = me.start;
-			sign = -1;
 		} else {
 			start = me.start;
 			end = me.end;
-			sign = 1;
 		}
-		if (me.isHorizontal()) {
-			innerDimension = me.width;
-			pixel = reverse ? me.right : me.left;
+		if (me.isHorizontal() === !reverse) {
+			pixel = dimensions.start;
+			sign = 1;
 		} else {
-			innerDimension = me.height;
-			sign *= -1; // invert, since the upper-left corner of the canvas is at pixel (0, 0)
-			pixel = reverse ? me.top : me.bottom;
+			pixel = dimensions.end;
+			sign = -1; // invert, since the upper-left corner of the canvas is at pixel (0, 0)
 		}
 		if (value !== start) {
 			if (start === 0) { // include zero tick
@@ -312,7 +311,10 @@ module.exports = Scale.extend({
 		var reverse = tickOpts.reverse;
 		var log10 = helpers.log10;
 		var firstTickValue = me._getFirstTickValue(me.minNotZero);
-		var innerDimension, start, end, value;
+		var dimensions = me._getDimensions();
+		var innerDimension = dimensions.size;
+		var value = me.isHorizontal() === !reverse ? pixel - dimensions.start : dimensions.end - pixel;
+		var start, end;
 
 		if (reverse) {
 			start = me.end;
@@ -320,13 +322,6 @@ module.exports = Scale.extend({
 		} else {
 			start = me.start;
 			end = me.end;
-		}
-		if (me.isHorizontal()) {
-			innerDimension = me.width;
-			value = reverse ? me.right - pixel : pixel - me.left;
-		} else {
-			innerDimension = me.height;
-			value = reverse ? pixel - me.top : me.bottom - pixel;
 		}
 		if (value !== start) {
 			if (start === 0) { // include zero tick

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -724,13 +724,11 @@ module.exports = Scale.extend({
 	getPixelForOffset: function(time) {
 		var me = this;
 		var offsets = me._offsets;
-		var size = me._horizontal ? me.width : me.height;
+		var range = me._getRange();
 		var pos = interpolate(me._table, 'time', time, 'pos');
-		var offset = size * (offsets.start + pos) * offsets.factor;
+		var offset = range.size * (offsets.start + pos) * offsets.factor;
 
-		return me.options.ticks.reverse ?
-			(me._horizontal ? me.right : me.bottom) - offset :
-			(me._horizontal ? me.left : me.top) + offset;
+		return me.options.ticks.reverse ? range.end - offset : range.start + offset;
 	},
 
 	getPixelForValue: function(value, index, datasetIndex) {
@@ -760,11 +758,9 @@ module.exports = Scale.extend({
 	getValueForPixel: function(pixel) {
 		var me = this;
 		var offsets = me._offsets;
-		var size = me._horizontal ? me.width : me.height;
-		var offset = me.options.ticks.reverse ?
-			(me._horizontal ? me.right : me.bottom) - pixel :
-			pixel - (me._horizontal ? me.left : me.top);
-		var pos = offset / size / offsets.factor - offsets.start;
+		var range = me._getRange();
+		var offset = me.options.ticks.reverse ? range.end - pixel : pixel - range.start;
+		var pos = offset / range.size / offsets.factor - offsets.start;
 		var time = interpolate(me._table, 'pos', pos, 'time');
 
 		// DEPRECATION, we should return time directly

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -724,11 +724,11 @@ module.exports = Scale.extend({
 	getPixelForOffset: function(time) {
 		var me = this;
 		var offsets = me._offsets;
-		var dimension = me._getDimension();
+		var dimensions = me._getDimensions();
 		var pos = interpolate(me._table, 'time', time, 'pos');
-		var offset = dimension.size * (offsets.start + pos) * offsets.factor;
+		var offset = dimensions.size * (offsets.start + pos) * offsets.factor;
 
-		return me.options.ticks.reverse ? dimension.end - offset : dimension.start + offset;
+		return me.options.ticks.reverse ? dimensions.end - offset : dimensions.start + offset;
 	},
 
 	getPixelForValue: function(value, index, datasetIndex) {
@@ -758,9 +758,9 @@ module.exports = Scale.extend({
 	getValueForPixel: function(pixel) {
 		var me = this;
 		var offsets = me._offsets;
-		var dimension = me._getDimension();
-		var offset = me.options.ticks.reverse ? dimension.end - pixel : pixel - dimension.start;
-		var pos = offset / dimension.size / offsets.factor - offsets.start;
+		var dimensions = me._getDimensions();
+		var offset = me.options.ticks.reverse ? dimensions.end - pixel : pixel - dimensions.start;
+		var pos = offset / dimensions.size / offsets.factor - offsets.start;
 		var time = interpolate(me._table, 'pos', pos, 'time');
 
 		// DEPRECATION, we should return time directly

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -724,11 +724,11 @@ module.exports = Scale.extend({
 	getPixelForOffset: function(time) {
 		var me = this;
 		var offsets = me._offsets;
-		var range = me._getRange();
+		var dimension = me._getDimension();
 		var pos = interpolate(me._table, 'time', time, 'pos');
-		var offset = range.size * (offsets.start + pos) * offsets.factor;
+		var offset = dimension.size * (offsets.start + pos) * offsets.factor;
 
-		return me.options.ticks.reverse ? range.end - offset : range.start + offset;
+		return me.options.ticks.reverse ? dimension.end - offset : dimension.start + offset;
 	},
 
 	getPixelForValue: function(value, index, datasetIndex) {
@@ -758,9 +758,9 @@ module.exports = Scale.extend({
 	getValueForPixel: function(pixel) {
 		var me = this;
 		var offsets = me._offsets;
-		var range = me._getRange();
-		var offset = me.options.ticks.reverse ? range.end - pixel : pixel - range.start;
-		var pos = offset / range.size / offsets.factor - offsets.start;
+		var dimension = me._getDimension();
+		var offset = me.options.ticks.reverse ? dimension.end - pixel : pixel - dimension.start;
+		var pos = offset / dimension.size / offsets.factor - offsets.start;
 		var time = interpolate(me._table, 'pos', pos, 'time');
 
 		// DEPRECATION, we should return time directly

--- a/test/specs/scale.category.tests.js
+++ b/test/specs/scale.category.tests.js
@@ -543,4 +543,91 @@ describe('Category scale tests', function() {
 		expect(yScale.getPixelForValue(null, 3, 0)).toBeCloseToPixel(426);
 		expect(yScale.getPixelForValue(null, 4, 0)).toBeCloseToPixel(88);
 	});
+
+	describe('when ticks.reverse is true', function() {
+		beforeEach(function() {
+			this.chart = window.acquireChart({
+				type: 'line',
+				data: {
+					datasets: [{
+						xAxisID: 'xScale0',
+						yAxisID: 'yScale0',
+						data: [10, 5, 0, 25, 78]
+					}],
+					labels: ['tick1', 'tick2', 'tick3', 'tick4', 'tick5']
+				},
+				options: {
+					scales: {
+						xAxes: [{
+							id: 'xScale0',
+							type: 'category',
+							ticks: {
+								reverse: true
+							}
+						}],
+						yAxes: [{
+							id: 'yScale0',
+							type: 'linear'
+						}]
+					}
+				}
+			});
+		});
+
+		it('should get the correct label for the index', function() {
+			var scale = this.chart.scales.xScale0;
+
+			expect(scale.getLabelForIndex(1, 0)).toBe('tick2');
+		});
+
+		it('should generate the correct tick labels', function() {
+			var scale = this.chart.scales.xScale0;
+
+			expect(scale.ticks).toEqual(['tick5', 'tick4', 'tick3', 'tick2', 'tick1']);
+		});
+
+		it('Should get the correct pixel for a value', function() {
+			var chart = this.chart;
+			var scale = chart.scales.xScale0;
+
+			expect(scale.getPixelForValue(null, 4, 0)).toBeCloseToPixel(29);
+			expect(scale.getPixelForValue('tick5')).toBeCloseToPixel(29);
+
+			expect(scale.getPixelForValue(null, 0, 0)).toBeCloseToPixel(496);
+			expect(scale.getPixelForValue('tick1')).toBeCloseToPixel(496);
+
+			scale.options.offset = true;
+			chart.update();
+
+			expect(scale.getPixelForValue(null, 4, 0)).toBeCloseToPixel(77);
+			expect(scale.getPixelForValue('tick5')).toBeCloseToPixel(77);
+
+			expect(scale.getPixelForValue(null, 0, 0)).toBeCloseToPixel(461);
+			expect(scale.getPixelForValue('tick1')).toBeCloseToPixel(461);
+		});
+
+		it('Should get the correct pixel for a value when zoomed', function() {
+			var chart = this.chart;
+			var scale = chart.scales.xScale0;
+
+			scale.options.ticks.min = 'tick2';
+			scale.options.ticks.max = 'tick4';
+			chart.update();
+
+			expect(scale.getPixelForValue(null, 3, 0)).toBeCloseToPixel(29);
+			expect(scale.getPixelForValue('tick4')).toBeCloseToPixel(29);
+
+			expect(scale.getPixelForValue(null, 1, 0)).toBeCloseToPixel(496);
+			expect(scale.getPixelForValue('tick2')).toBeCloseToPixel(496);
+
+			scale.options.offset = true;
+			chart.update();
+
+			expect(scale.getPixelForValue(null, 3, 0)).toBeCloseToPixel(109);
+			expect(scale.getPixelForValue('tick4')).toBeCloseToPixel(109);
+
+			expect(scale.getPixelForValue(null, 1, 0)).toBeCloseToPixel(429);
+			expect(scale.getPixelForValue('tick2')).toBeCloseToPixel(429);
+		});
+	});
 });


### PR DESCRIPTION
This PR adds `ticks.reverse` support to category scale as well as the refactoring discussed in https://github.com/chartjs/Chart.js/pull/6323#discussion_r292862894.

**This PR: https://jsfiddle.net/nagix/at8vfh6x/**
<img width="306" alt="Screen Shot 2019-06-15 at 5 31 47 PM" src="https://user-images.githubusercontent.com/723188/59549707-452cb380-8f94-11e9-8103-1d09a716dac9.png">

Closes #3306