### PR TITLE
Handle reverse support in core.scale

### DIFF
--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -32,7 +32,7 @@ defaults._set('bar', {
  * @private
  */
 function computeMinSampleSize(scale, pixels) {
-	var min = scale.isHorizontal() ? scale.width : scale.height;
+	var min = scale._length;
 	var ticks = scale.getTicks();
 	var prev, curr, i, ilen;
 
@@ -42,7 +42,7 @@ function computeMinSampleSize(scale, pixels) {
 
 	for (i = 0, ilen = ticks.length; i < ilen; ++i) {
 		curr = scale.getPixelForTick(i);
-		min = i > 0 ? Math.min(min, curr - prev) : min;
+		min = i > 0 ? Math.min(min, Math.abs(curr - prev)) : min;
 		prev = curr;
 	}
 
@@ -262,9 +262,6 @@ module.exports = DatasetController.extend({
 		var scale = me._getIndexScale();
 		var stackCount = me.getStackCount();
 		var datasetIndex = me.index;
-		var isHorizontal = scale.isHorizontal();
-		var start = isHorizontal ? scale.left : scale.top;
-		var end = start + (isHorizontal ? scale.width : scale.height);
 		var pixels = [];
 		var i, ilen, min;
 
@@ -279,8 +276,8 @@ module.exports = DatasetController.extend({
 		return {
 			min: min,
 			pixels: pixels,
-			start: start,
-			end: end,
+			start: scale._startPixel,
+			end: scale._endPixel,
 			stackCount: stackCount,
 			scale: scale
 		};

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -546,6 +546,11 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 
 		me._layers = [];
 		helpers.each(me.boxes, function(box) {
+			// _configure is called twice, once in core.scale.update and once here.
+			// Here the boxes are fully updated and at their final positions.
+			if (box._configure) {
+				box._configure();
+			}
 			me._layers.push.apply(me._layers, box._layers());
 		}, me);
 

--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -100,19 +100,6 @@ module.exports = function() {
 			}
 			return x > 0 ? 1 : -1;
 		};
-	helpers.log10 = Math.log10 ?
-		function(x) {
-			return Math.log10(x);
-		} :
-		function(x) {
-			var exponent = Math.log(x) * Math.LOG10E; // Math.LOG10E = 1 / Math.LN10.
-			// Check for whole powers of 10,
-			// which due to floating point rounding error should be corrected.
-			var powerOf10 = Math.round(exponent);
-			var isPowerOf10 = x === Math.pow(10, powerOf10);
-
-			return isPowerOf10 ? powerOf10 : exponent;
-		};
 	helpers.toRadians = function(degrees) {
 		return degrees * (Math.PI / 180);
 	};

--- a/src/helpers/helpers.math.js
+++ b/src/helpers/helpers.math.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var helpers = require('./helpers.core');
+
 /**
  * @alias Chart.helpers.math
  * @namespace
@@ -28,7 +30,28 @@ var exports = {
 			return a - b;
 		}).pop();
 		return result;
+	},
+
+	log10: Math.log10 || function(x) {
+		var exponent = Math.log(x) * Math.LOG10E; // Math.LOG10E = 1 / Math.LN10.
+		// Check for whole powers of 10,
+		// which due to floating point rounding error should be corrected.
+		var powerOf10 = Math.round(exponent);
+		var isPowerOf10 = x === Math.pow(10, powerOf10);
+
+		return isPowerOf10 ? powerOf10 : exponent;
 	}
 };
 
 module.exports = exports;
+
+// DEPRECATIONS
+
+/**
+ * Provided for backward compatibility, use Chart.helpers.math.log10 instead.
+ * @namespace Chart.helpers.log10
+ * @deprecated since version 2.9.0
+ * @todo remove at version 3
+ * @private
+ */
+helpers.log10 = exports.log10;

--- a/src/scales/scale.linear.js
+++ b/src/scales/scale.linear.js
@@ -149,29 +149,12 @@ module.exports = LinearScaleBase.extend({
 
 	// Utils
 	getPixelForValue: function(value) {
-		// This must be called after fit has been run so that
-		// this.left, this.top, this.right, and this.bottom have been defined
 		var me = this;
-		var start = me.start;
-
-		var rightValue = +me.getRightValue(value);
-		var pixel;
-		var range = me.end - start;
-
-		if (me.isHorizontal()) {
-			pixel = me.left + (me.width / range * (rightValue - start));
-		} else {
-			pixel = me.bottom - (me.height / range * (rightValue - start));
-		}
-		return pixel;
+		return me.getPixelForDecimal((+me.getRightValue(value) - me._startValue) / me._valueRange);
 	},
 
 	getValueForPixel: function(pixel) {
-		var me = this;
-		var isHorizontal = me.isHorizontal();
-		var innerDimension = isHorizontal ? me.width : me.height;
-		var offset = (isHorizontal ? pixel - me.left : me.bottom - pixel) / innerDimension;
-		return me.start + ((me.end - me.start) * offset);
+		return this._startValue + this.getDecimalForPixel(pixel) * this._valueRange;
 	},
 
 	getPixelForTick: function(index) {

--- a/src/scales/scale.linearbase.js
+++ b/src/scales/scale.linearbase.js
@@ -231,5 +231,24 @@ module.exports = Scale.extend({
 		me.zeroLineIndex = me.ticks.indexOf(0);
 
 		Scale.prototype.convertTicksToLabels.call(me);
+	},
+
+	_configure: function() {
+		var me = this;
+		var ticks = me.getTicks();
+		var start = me.min;
+		var end = me.max;
+		var offset;
+
+		Scale.prototype._configure.call(me);
+
+		if (me.options.offset && ticks.length) {
+			offset = (end - start) / Math.max(ticks.length - 1, 1) / 2;
+			start -= offset;
+			end += offset;
+		}
+		me._startValue = start;
+		me._endValue = end;
+		me._valueRange = end - start;
 	}
 });

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -596,7 +596,6 @@ module.exports = Scale.extend({
 		me.max = Math.max(min + 1, max);
 
 		// PRIVATE
-		me._horizontal = me.isHorizontal();
 		me._table = [];
 		me._timestamps = {
 			data: timestamps,
@@ -611,16 +610,16 @@ module.exports = Scale.extend({
 		var max = me.max;
 		var options = me.options;
 		var timeOpts = options.time;
-		var timestamps = [];
+		var timestamps = me._timestamps;
 		var ticks = [];
 		var i, ilen, timestamp;
 
 		switch (options.ticks.source) {
 		case 'data':
-			timestamps = me._timestamps.data;
+			timestamps = timestamps.data;
 			break;
 		case 'labels':
-			timestamps = me._timestamps.labels;
+			timestamps = timestamps.labels;
 			break;
 		case 'auto':
 		default:
@@ -725,13 +724,8 @@ module.exports = Scale.extend({
 	getPixelForOffset: function(time) {
 		var me = this;
 		var offsets = me._offsets;
-		var size = me._horizontal ? me.width : me.height;
 		var pos = interpolate(me._table, 'time', time, 'pos');
-		var offset = size * (offsets.start + pos) * offsets.factor;
-
-		return me.options.ticks.reverse ?
-			(me._horizontal ? me.right : me.bottom) - offset :
-			(me._horizontal ? me.left : me.top) + offset;
+		return me.getPixelForDecimal((offsets.start + pos) * offsets.factor);
 	},
 
 	getPixelForValue: function(value, index, datasetIndex) {
@@ -761,11 +755,7 @@ module.exports = Scale.extend({
 	getValueForPixel: function(pixel) {
 		var me = this;
 		var offsets = me._offsets;
-		var size = me._horizontal ? me.width : me.height;
-		var offset = me.options.ticks.reverse ?
-			(me._horizontal ? me.right : me.bottom) - pixel :
-			pixel - (me._horizontal ? me.left : me.top);
-		var pos = offset / size / offsets.factor - offsets.start;
+		var pos = me.getDecimalForPixel(pixel) / offsets.factor - offsets.end;
 		var time = interpolate(me._table, 'pos', pos, 'time');
 
 		// DEPRECATION, we should return time directly

--- a/test/specs/core.helpers.tests.js
+++ b/test/specs/core.helpers.tests.js
@@ -26,16 +26,6 @@ describe('Core helper tests', function() {
 		expect(helpers.sign(-5)).toBe(-1);
 	});
 
-	it('should do a log10 operation', function() {
-		expect(helpers.log10(0)).toBe(-Infinity);
-
-		// Check all allowed powers of 10, which should return integer values
-		var maxPowerOf10 = Math.floor(helpers.log10(Number.MAX_VALUE));
-		for (var i = 0; i < maxPowerOf10; i += 1) {
-			expect(helpers.log10(Math.pow(10, i))).toBe(i);
-		}
-	});
-
 	it('should correctly determine if two numbers are essentially equal', function() {
 		expect(helpers.almostEquals(0, Number.EPSILON, 2 * Number.EPSILON)).toBe(true);
 		expect(helpers.almostEquals(1, 1.1, 0.0001)).toBe(false);

--- a/test/specs/core.scale.tests.js
+++ b/test/specs/core.scale.tests.js
@@ -94,7 +94,7 @@ describe('Core.scale', function() {
 		labels: ['tick1', 'tick2', 'tick3', 'tick4', 'tick5'],
 		offsetGridLines: true,
 		offset: true,
-		expected: [-0.5, 102.5, 204.5, 307.5, 409.5]
+		expected: [0.5, 102.5, 204.5, 307.5, 409.5]
 	}, {
 		labels: ['tick1'],
 		offsetGridLines: false,

--- a/test/specs/helpers.math.tests.js
+++ b/test/specs/helpers.math.tests.js
@@ -1,7 +1,9 @@
 'use strict';
 
+
 describe('Chart.helpers.math', function() {
-	var factorize = Chart.helpers.math._factorize;
+	var math = Chart.helpers.math;
+	var factorize = math._factorize;
 
 	it('should factorize', function() {
 		expect(factorize(1000)).toEqual([1, 2, 4, 5, 8, 10, 20, 25, 40, 50, 100, 125, 200, 250, 500]);
@@ -12,5 +14,15 @@ describe('Chart.helpers.math', function() {
 		expect(factorize(4)).toEqual([1, 2]);
 		expect(factorize(-1)).toEqual([]);
 		expect(factorize(2.76)).toEqual([]);
+	});
+
+	it('should do a log10 operation', function() {
+		expect(math.log10(0)).toBe(-Infinity);
+
+		// Check all allowed powers of 10, which should return integer values
+		var maxPowerOf10 = Math.floor(math.log10(Number.MAX_VALUE));
+		for (var i = 0; i < maxPowerOf10; i += 1) {
+			expect(math.log10(Math.pow(10, i))).toBe(i);
+		}
 	});
 });

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -1196,4 +1196,86 @@ describe('Linear Scale', function() {
 		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
 		expect(chart.scales.yScale0.max).toBeGreaterThan(chart.scales.yScale0.min);
 	});
+
+	it('Should get correct pixel values when horizontal', function() {
+		var chart = window.acquireChart({
+			type: 'horizontalBar',
+			data: {
+				datasets: [{
+					data: [0.05, -25, 10, 15, 20, 25, 30, 35]
+				}]
+			},
+			options: {
+				scales: {
+					xAxes: [{
+						id: 'x',
+						type: 'linear',
+					}]
+				}
+			}
+		});
+
+		var start = chart.chartArea.left;
+		var end = chart.chartArea.right;
+		var min = -30;
+		var max = 40;
+		var scale = chart.scales.x;
+
+		expect(scale.getPixelForValue(max)).toBeCloseToPixel(end);
+		expect(scale.getPixelForValue(min)).toBeCloseToPixel(start);
+		expect(scale.getValueForPixel(end)).toBeCloseTo(max, 4);
+		expect(scale.getValueForPixel(start)).toBeCloseTo(min, 4);
+
+		scale.options.ticks.reverse = true;
+		chart.update();
+
+		start = chart.chartArea.left;
+		end = chart.chartArea.right;
+
+		expect(scale.getPixelForValue(max)).toBeCloseToPixel(start);
+		expect(scale.getPixelForValue(min)).toBeCloseToPixel(end);
+		expect(scale.getValueForPixel(end)).toBeCloseTo(min, 4);
+		expect(scale.getValueForPixel(start)).toBeCloseTo(max, 4);
+	});
+
+	it('Should get correct pixel values when vertical', function() {
+		var chart = window.acquireChart({
+			type: 'bar',
+			data: {
+				datasets: [{
+					data: [0.05, -25, 10, 15, 20, 25, 30, 35]
+				}]
+			},
+			options: {
+				scales: {
+					yAxes: [{
+						id: 'y',
+						type: 'linear',
+					}]
+				}
+			}
+		});
+
+		var start = chart.chartArea.bottom;
+		var end = chart.chartArea.top;
+		var min = -30;
+		var max = 40;
+		var scale = chart.scales.y;
+
+		expect(scale.getPixelForValue(max)).toBeCloseToPixel(end);
+		expect(scale.getPixelForValue(min)).toBeCloseToPixel(start);
+		expect(scale.getValueForPixel(end)).toBeCloseTo(max, 4);
+		expect(scale.getValueForPixel(start)).toBeCloseTo(min, 4);
+
+		scale.options.ticks.reverse = true;
+		chart.update();
+
+		start = chart.chartArea.bottom;
+		end = chart.chartArea.top;
+
+		expect(scale.getPixelForValue(max)).toBeCloseToPixel(start);
+		expect(scale.getPixelForValue(min)).toBeCloseToPixel(end);
+		expect(scale.getValueForPixel(end)).toBeCloseTo(min, 4);
+		expect(scale.getValueForPixel(start)).toBeCloseTo(max, 4);
+	});
 });

--- a/test/specs/scale.logarithmic.tests.js
+++ b/test/specs/scale.logarithmic.tests.js
@@ -862,6 +862,8 @@ describe('Logarithmic Scale tests', function() {
 				type: 'logarithmic'
 			}];
 			Chart.helpers.extend(scaleConfig, setup.scale);
+			scaleConfig[setup.axis + 'Axes'][0].type = 'logarithmic';
+
 			var description = 'dataset has stack option and ' + setup.describe
 				+ ' and axis is "' + setup.axis + '";';
 			describe(description, function() {

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -1551,11 +1551,11 @@ describe('Time scale tests', function() {
 				var firstTickInterval = scale.getPixelForTick(1) - scale.getPixelForTick(0);
 				var lastTickInterval = scale.getPixelForTick(numTicks - 1) - scale.getPixelForTick(numTicks - 2);
 
-				expect(scale.getValueForPixel(scale.left + firstTickInterval / 2)).toBeCloseToTime({
+				expect(scale.getValueForPixel(scale.left + lastTickInterval / 2)).toBeCloseToTime({
 					value: moment('2042-01-01T00:00:00'),
 					unit: 'hour',
 				});
-				expect(scale.getValueForPixel(scale.left + scale.width - lastTickInterval / 2)).toBeCloseToTime({
+				expect(scale.getValueForPixel(scale.left + scale.width - firstTickInterval / 2)).toBeCloseToTime({
 					value: moment('2017-01-01T00:00:00'),
 					unit: 'hour',
 				});


### PR DESCRIPTION
* `_configure` scales after placing them
* handle `ticks.reverse` in `getPixelForDecimal`
* add `getDecimalForPixel`
* utilize `getPixelForDecimal` and `_configure` results in scales
* some of scale.logarithmic.tests were actually targeting linear scale (this took a while to figure out)
* <del>-472</del> -403 bytes (much of this by moving helpers.log10)

Doing essentially the same thing as #6342, just a bit more abstractly.

[Forked fiddle](https://jsfiddle.net/8qjd1k3w/) (notice `horizontalBar` reverse is reversed compared to 6342)

Closes #3306
Closes #6342