### PR TITLE
Add link to Google Group

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ## Contributing
 
-Instructions on building and testing Chart.js can be found in [the documentation](https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md#building-and-testing). Before submitting an issue or a pull request, please take a moment to look over the [contributing guidelines](https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md) first. For support, please post questions on [Stack Overflow](https://stackoverflow.com/questions/tagged/chartjs) with the `chartjs` tag.
+Instructions on building and testing Chart.js can be found in [the documentation](https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md#building-and-testing). Before submitting an issue or a pull request, please take a moment to look over the [contributing guidelines](https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md) first. For support, please post questions on [Stack Overflow](https://stackoverflow.com/questions/tagged/chartjs) with the `chartjs` tag or discuss on [the Chart.js group](https://groups.google.com/forum/#!forum/chartjs-user-discussion).
 
 ## License
 


### PR DESCRIPTION
We have had this Google Group open for a while and it is still active. I would like to support this alternative to Stack Overflow.