### PR TITLE
Use consistent label capacity calculation

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -739,7 +739,7 @@ var Scale = Element.extend({
 
 		// Total space needed to display all ticks. First and last ticks are
 		// drawn as their center at end of axis, so tickCount-1
-		var ticksLength = me._tickSize() * (tickCount - 1);
+		var ticksLength = me._tickSize() * (tickCount - (me.options.offset ? 0 : 1));
 
 		// Axis length
 		var axisLength = isHorizontal ? me.width : me.height;

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -807,8 +807,8 @@ module.exports = Scale.extend({
 		var size = me._getLabelSize(exampleLabel);
 		var capacity = Math.floor(me.isHorizontal() ? me.width / size.w : me.height / size.h);
 
-		if (me.options.offset) {
-			capacity--;
+		if (!me.options.offset) {
+			capacity++;
 		}
 
 		return capacity > 0 ? capacity : 1;

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -603,7 +603,7 @@ describe('Time scale tests', function() {
 			});
 
 			this.scale = this.chart.scales.xScale0;
-			this.scale.update(800, 200);
+			this.scale.update(700, 200);
 		});
 
 		it('should be bounded by nearest step\'s year start and end', function() {


### PR DESCRIPTION
This fixes two differences between the core and time scales label capacity calculations:
* Makes `core` consider `offset`
* Makes `time` consider that first and last ticks are drawn at their center at end of axis
