### PR TITLE
Perf improvement for ticks.source:'labels'

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -534,16 +534,16 @@ module.exports = Scale.extend({
 		var unit = options.time.unit || 'day';
 		var min = MAX_INTEGER;
 		var max = MIN_INTEGER;
-		var timestamps = [];
 		var datasets = [];
 		var labels = [];
-		var i, j, ilen, jlen, data, timestamp;
+		var timestamps, i, j, ilen, jlen, data, timestamp;
 		var dataLabels = me._getLabels();
 
 		// Convert labels to timestamps
 		for (i = 0, ilen = dataLabels.length; i < ilen; ++i) {
 			labels.push(parse(me, dataLabels[i]));
 		}
+		timestamps = labels.slice(0);
 
 		// Convert data to timestamps
 		for (i = 0, ilen = (chart.data.datasets || []).length; i < ilen; ++i) {
@@ -560,9 +560,6 @@ module.exports = Scale.extend({
 						datasets[i][j] = timestamp;
 					}
 				} else {
-					for (j = 0, jlen = labels.length; j < jlen; ++j) {
-						timestamps.push(labels[j]);
-					}
 					datasets[i] = labels.slice(0);
 				}
 			} else {
@@ -571,8 +568,6 @@ module.exports = Scale.extend({
 		}
 
 		if (labels.length) {
-			// Sort labels **after** data have been converted
-			labels = arrayUnique(labels).sort(sorter);
 			min = Math.min(min, labels[0]);
 			max = Math.max(max, labels[labels.length - 1]);
 		}

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -534,18 +534,18 @@ module.exports = Scale.extend({
 		var unit = options.time.unit || 'day';
 		var min = MAX_INTEGER;
 		var max = MIN_INTEGER;
+		var timestamps = [];
 		var datasets = [];
 		var labels = [];
-		var timestamps, i, j, ilen, jlen, data, timestamp;
+		var i, j, ilen, jlen, data, timestamp, labelsAdded;
 		var dataLabels = me._getLabels();
 
-		// Convert labels to timestamps
+		// Set labels
 		for (i = 0, ilen = dataLabels.length; i < ilen; ++i) {
 			labels.push(parse(me, dataLabels[i]));
 		}
-		timestamps = labels.slice(0);
 
-		// Convert data to timestamps
+		// Set timestamps
 		for (i = 0, ilen = (chart.data.datasets || []).length; i < ilen; ++i) {
 			if (chart.isDatasetVisible(i)) {
 				data = chart.data.datasets[i].data;
@@ -561,6 +561,10 @@ module.exports = Scale.extend({
 					}
 				} else {
 					datasets[i] = labels.slice(0);
+					if (!labelsAdded) {
+						timestamps = timestamps.concat(labels);
+						labelsAdded = true;
+					}
 				}
 			} else {
 				datasets[i] = [];
@@ -573,7 +577,9 @@ module.exports = Scale.extend({
 		}
 
 		if (timestamps.length) {
-			timestamps = arrayUnique(timestamps).sort(sorter);
+			if (ilen > 1) {
+				timestamps = arrayUnique(timestamps).sort(sorter);
+			}
 			min = Math.min(min, timestamps[0]);
 			max = Math.max(max, timestamps[timestamps.length - 1]);
 		}

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -540,12 +540,10 @@ module.exports = Scale.extend({
 		var i, j, ilen, jlen, data, timestamp, labelsAdded;
 		var dataLabels = me._getLabels();
 
-		// Set labels
 		for (i = 0, ilen = dataLabels.length; i < ilen; ++i) {
 			labels.push(parse(me, dataLabels[i]));
 		}
 
-		// Set timestamps
 		for (i = 0, ilen = (chart.data.datasets || []).length; i < ilen; ++i) {
 			if (chart.isDatasetVisible(i)) {
 				data = chart.data.datasets[i].data;
@@ -577,9 +575,7 @@ module.exports = Scale.extend({
 		}
 
 		if (timestamps.length) {
-			if (ilen > 1) {
-				timestamps = arrayUnique(timestamps).sort(sorter);
-			}
+			timestamps = ilen > 1 ? arrayUnique(timestamps).sort(sorter) : timestamps.sort(sorter);
 			min = Math.min(min, timestamps[0]);
 			max = Math.max(max, timestamps[timestamps.length - 1]);
 		}


### PR DESCRIPTION
We only need to add the `labels` to `timestamps` once - not once per dataset

We also don't need to call `arrayUnique` on the labels because duplicate labels aren't supported. If you pass duplicate labels and then we call `arrayUnique` then we end up with fewer labels than data points, so this code never worked. `arrayUnique` is quite expensive for large datasets, so it's very helpful to remove. And then we no longer need to call `sort` which is also expensive. That was done only because `arrayUnique` may not return items in the order they were passed in