### PR TITLE
Add helpers.math._factorize

### DIFF
--- a/src/helpers/helpers.math.js
+++ b/src/helpers/helpers.math.js
@@ -1,0 +1,34 @@
+'use strict';
+
+/**
+ * @alias Chart.helpers.math
+ * @namespace
+ */
+var exports = {
+	/**
+	 * Returns an array of factors sorted from 1 to sqrt(value)
+	 * @private
+	 */
+	_factorize: function(value) {
+		var result = [];
+		var sqrt = Math.sqrt(value);
+		var i;
+
+		for (i = 1; i < sqrt; i++) {
+			if (value % i === 0) {
+				result.push(i);
+				result.push(value / i);
+			}
+		}
+		if (sqrt === (sqrt | 0)) { // if value is a square number
+			result.push(sqrt);
+		}
+
+		result.sort(function(a, b) {
+			return a - b;
+		}).pop();
+		return result;
+	}
+};
+
+module.exports = exports;

--- a/src/helpers/helpers.math.js
+++ b/src/helpers/helpers.math.js
@@ -14,6 +14,10 @@ var exports = {
 		var sqrt = Math.sqrt(value);
 		var i;
 
+		if (!Number.isInteger(value) || value <= 0) {
+			throw new Error('_factorize expects a positive integer, but received ' + value);
+		}
+
 		for (i = 1; i < sqrt; i++) {
 			if (value % i === 0) {
 				result.push(i);

--- a/src/helpers/helpers.math.js
+++ b/src/helpers/helpers.math.js
@@ -14,10 +14,6 @@ var exports = {
 		var sqrt = Math.sqrt(value);
 		var i;
 
-		if (!Number.isInteger(value) || value <= 0) {
-			throw new Error('_factorize expects a positive integer, but received ' + value);
-		}
-
 		for (i = 1; i < sqrt; i++) {
 			if (value % i === 0) {
 				result.push(i);

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -4,3 +4,4 @@ module.exports = require('./helpers.core');
 module.exports.easing = require('./helpers.easing');
 module.exports.canvas = require('./helpers.canvas');
 module.exports.options = require('./helpers.options');
+module.exports.math = require('./helpers.math');

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -6,6 +6,7 @@ var helpers = require('../helpers/index');
 var Scale = require('../core/core.scale');
 
 var valueOrDefault = helpers.valueOrDefault;
+var factorize = helpers.math._factorize;
 
 // Integer constants are from the ES6 spec.
 var MIN_INTEGER = Number.MIN_SAFE_INTEGER || -9007199254740991;
@@ -15,42 +16,42 @@ var INTERVALS = {
 	millisecond: {
 		common: true,
 		size: 1,
-		steps: [1, 2, 5, 10, 20, 50, 100, 250, 500]
+		steps: factorize(1000)
 	},
 	second: {
 		common: true,
 		size: 1000,
-		steps: [1, 2, 5, 10, 15, 30]
+		steps: factorize(60)
 	},
 	minute: {
 		common: true,
 		size: 60000,
-		steps: [1, 2, 5, 10, 15, 30]
+		steps: factorize(60)
 	},
 	hour: {
 		common: true,
 		size: 3600000,
-		steps: [1, 2, 3, 6, 12]
+		steps: factorize(24)
 	},
 	day: {
 		common: true,
 		size: 86400000,
-		steps: [1, 2, 5]
+		steps: factorize(10)
 	},
 	week: {
 		common: false,
 		size: 604800000,
-		steps: [1, 2, 3, 4]
+		steps: factorize(4)
 	},
 	month: {
 		common: true,
 		size: 2.628e9,
-		steps: [1, 2, 3]
+		steps: factorize(12)
 	},
 	quarter: {
 		common: false,
 		size: 7.884e9,
-		steps: [1, 2, 3, 4]
+		steps: factorize(4)
 	},
 	year: {
 		common: true,

--- a/test/specs/helpers.math.tests.js
+++ b/test/specs/helpers.math.tests.js
@@ -10,11 +10,8 @@ describe('Chart.helpers.math', function() {
 		expect(factorize(24)).toEqual([1, 2, 3, 4, 6, 8, 12]);
 		expect(factorize(12)).toEqual([1, 2, 3, 4, 6]);
 		expect(factorize(4)).toEqual([1, 2]);
-		expect(function() {
-			factorize(-1);
-		}).toThrow(new Error('_factorize expects a positive integer, but received -1'));
-		expect(function() {
-			factorize(2.76);
-		}).toThrow(new Error('_factorize expects a positive integer, but received 2.76'));
+		expect(factorize(4)).toEqual([1, 2]);
+		expect(factorize(-1)).toEqual([]);
+		expect(factorize(2.76)).toEqual([]);
 	});
 });

--- a/test/specs/helpers.math.tests.js
+++ b/test/specs/helpers.math.tests.js
@@ -10,7 +10,6 @@ describe('Chart.helpers.math', function() {
 		expect(factorize(24)).toEqual([1, 2, 3, 4, 6, 8, 12]);
 		expect(factorize(12)).toEqual([1, 2, 3, 4, 6]);
 		expect(factorize(4)).toEqual([1, 2]);
-		expect(factorize(4)).toEqual([1, 2]);
 		expect(factorize(-1)).toEqual([]);
 		expect(factorize(2.76)).toEqual([]);
 	});

--- a/test/specs/helpers.math.tests.js
+++ b/test/specs/helpers.math.tests.js
@@ -1,0 +1,14 @@
+'use strict';
+
+describe('Chart.helpers.math', function() {
+	var factorize = Chart.helpers.math._factorize;
+
+	it('should factorize', function() {
+		expect(factorize(1000)).toEqual([1, 2, 4, 5, 8, 10, 20, 25, 40, 50, 100, 125, 200, 250, 500]);
+		expect(factorize(60)).toEqual([1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30]);
+		expect(factorize(30)).toEqual([1, 2, 3, 5, 6, 10, 15]);
+		expect(factorize(24)).toEqual([1, 2, 3, 4, 6, 8, 12]);
+		expect(factorize(12)).toEqual([1, 2, 3, 4, 6]);
+		expect(factorize(4)).toEqual([1, 2]);
+	});
+});

--- a/test/specs/helpers.math.tests.js
+++ b/test/specs/helpers.math.tests.js
@@ -10,5 +10,11 @@ describe('Chart.helpers.math', function() {
 		expect(factorize(24)).toEqual([1, 2, 3, 4, 6, 8, 12]);
 		expect(factorize(12)).toEqual([1, 2, 3, 4, 6]);
 		expect(factorize(4)).toEqual([1, 2]);
+		expect(function() {
+			factorize(-1);
+		}).toThrow(new Error('_factorize expects a positive integer, but received -1'));
+		expect(function() {
+			factorize(2.76);
+		}).toThrow(new Error('_factorize expects a positive integer, but received 2.76'));
 	});
 });


### PR DESCRIPTION
This is splitting off part of https://github.com/chartjs/Chart.js/pull/6274 to make that PR smaller and easier to review. I plan to reopen that PR soon

By exporting this as part of `helpers.math` I'm able to add tests for this method and it also helps organize the code. The `helpers.math` file is also being added in https://github.com/chartjs/Chart.js/pull/6343 in order to add a `helpers.math.log10`