### PR TITLE
Return timestamp from getValueForPixel

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -766,10 +766,7 @@ module.exports = Scale.extend({
 			(me._horizontal ? me.right : me.bottom) - pixel :
 			pixel - (me._horizontal ? me.left : me.top);
 		var pos = offset / size / offsets.factor - offsets.start;
-		var time = interpolate(me._table, 'pos', pos, 'time');
-
-		// DEPRECATION, we should return time directly
-		return me._adapter._create(time);
+		return interpolate(me._table, 'pos', pos, 'time');
 	},
 
 	/**

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -31,7 +31,7 @@ describe('Time scale tests', function() {
 					compare: function(actual, expected) {
 						var result = false;
 
-						var diff = actual.diff(expected.value, expected.unit, true);
+						var diff = moment(actual).diff(expected.value, expected.unit, true);
 						result = Math.abs(diff) < (expected.threshold !== undefined ? expected.threshold : 0.01);
 
 						return {


### PR DESCRIPTION
I noticed that `chartjs-plugin-zoom` is broken when panning time scales. There's no way for `chartjs-plugin-zoom` to understand the value that `getValueForPixel` is currently returning because it may be a moment object, Luxon object, dayjs object, etc.

This is not backwards compatible, but there's not really a good solution. The other options would be make `chartjs-plugin-zoom` aware of all time libraries, access private variables in `chartjs-plugin-zoom`, or to leave `chartjs-plugin-zoom` broken. I tend to think this is perhaps the lesser of evils because we wanted to make this change eventually anyway, but wanted to get everyone else's opinion. I know that breaking compatibility isn't great, but I do think it makes the code better and that we can mitigate the impact of breaking compatibility by documenting it as a breaking change in the release notes.