### PR TITLE
Add radar chart config options

### DIFF
--- a/docs/charts/radar.md
+++ b/docs/charts/radar.md
@@ -143,7 +143,7 @@ The interaction with each point can be controlled with the following properties:
 
 ## Configuration Options
 
-The radar chart defines the following configuration option. This option is merged with the global chart configuration option, `Chart.defaults.global`, to form the option passed to the chart.
+The radar chart defines the following configuration options. These options are merged with the global chart configuration options, `Chart.defaults.global`, to form the options passed to the chart.
 
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------

--- a/docs/charts/radar.md
+++ b/docs/charts/radar.md
@@ -143,7 +143,11 @@ The interaction with each point can be controlled with the following properties:
 
 ## Configuration Options
 
-Unlike other charts, the radar chart has no chart specific options.
+The radar chart defines the following configuration option. This option is merged with the global chart configuration option, `Chart.defaults.global`, to form the option passed to the chart.
+
+| Name | Type | Default | Description
+| ---- | ---- | ------- | -----------
+| `spanGaps` | `boolean` | `false` | If false, NaN data causes a break in the line.
 
 ## Scale Options
 

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -8,6 +8,7 @@ var helpers = require('../helpers/index');
 var valueOrDefault = helpers.valueOrDefault;
 
 defaults._set('radar', {
+	spanGaps: false,
 	scale: {
 		type: 'radialLinear'
 	},


### PR DESCRIPTION
The `spanGaps` option was missing in the radar chart configuration doc.

Fixes #6392