### PR TITLE
Use array spread to push multiple items to labelColors

### DIFF
--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -626,8 +626,8 @@ var exports = Element.extend({
 
 			// Determine colors for boxes
 			helpers.each(tooltipItems, function(tooltipItem) {
-				labelColors.push(opts.callbacks.labelColor.call(me, tooltipItem, me._chart));
-				labelTextColors.push(opts.callbacks.labelTextColor.call(me, tooltipItem, me._chart));
+				labelColors.push(...opts.callbacks.labelColor.call(me, tooltipItem, me._chart));
+				labelTextColors.push(...opts.callbacks.labelTextColor.call(me, tooltipItem, me._chart));
 			});
 
 


### PR DESCRIPTION
I believe this should allow for arrays to be returned from `labelColor`. I have not tested it yet, but I am going to now.
