### PR TITLE
Add elements.arc.angle in documentation

### DIFF
--- a/docs/configuration/elements.md
+++ b/docs/configuration/elements.md
@@ -82,7 +82,7 @@ Global arc options: `Chart.defaults.global.elements.arc`.
 
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
-| `angle` | `number` | `circumference / (arc count)` - for polar only | Arc angle to cover.
+| `angle` - for polar only | `number` | `circumference / (arc count)` | Arc angle to cover.
 | `backgroundColor` | `Color` | `'rgba(0, 0, 0, 0.1)'` | Arc fill color.
 | `borderAlign` | `string` | `'center'` | Arc stroke alignment.
 | `borderColor` | `Color` | `'#fff'` | Arc stroke color.

--- a/docs/configuration/elements.md
+++ b/docs/configuration/elements.md
@@ -82,6 +82,7 @@ Global arc options: `Chart.defaults.global.elements.arc`.
 
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
+| `angle` | `number` | `circumference / (arc count)` - for polar only | Arc angle to cover.
 | `backgroundColor` | `Color` | `'rgba(0, 0, 0, 0.1)'` | Arc fill color.
 | `borderAlign` | `string` | `'center'` | Arc stroke alignment.
 | `borderColor` | `Color` | `'#fff'` | Arc stroke color.


### PR DESCRIPTION
Using elements.arc.angle option can be a workaround for #4751 and make #6472 useless.

Demo here : https://jsfiddle.net/h1e78vbq/