### PR TITLE
Hover styling for dataset in 'dataset' mode

### DIFF
--- a/docs/charts/line.md
+++ b/docs/charts/line.md
@@ -53,7 +53,11 @@ The line chart allows a number of properties to be specified for each dataset. T
 | [`cubicInterpolationMode`](#cubicinterpolationmode) | `string` | Yes | - | `'default'`
 | [`fill`](#line-styling) | <code>boolean&#124;string</code> | Yes | - | `true`
 | [`hoverBackgroundColor`](#line-styling) | [`Color`](../general/colors.md) | Yes | - | `undefined`
+| [`hoverBorderCapStyle`](#line-styling) | `string` | Yes | - | `undefined`
 | [`hoverBorderColor`](#line-styling) | [`Color`](../general/colors.md) | Yes | - | `undefined`
+| [`hoverBorderDash`](#line-styling) | `number[]` | Yes | - | `undefined`
+| [`hoverBorderDashOffset`](#line-styling) | `number` | Yes | - | `undefined`
+| [`hoverBorderJoinStyle`](#line-styling) | `string` | Yes | - | `undefined`
 | [`hoverBorderWidth`](#line-styling) | `number` | Yes | - | `undefined`
 | [`label`](#general) | `string` | - | - | `''`
 | [`lineTension`](#line-styling) | `number` | - | - | `0.4`

--- a/docs/charts/line.md
+++ b/docs/charts/line.md
@@ -52,6 +52,9 @@ The line chart allows a number of properties to be specified for each dataset. T
 | [`borderWidth`](#line-styling) | `number` | Yes | - | `3`
 | [`cubicInterpolationMode`](#cubicinterpolationmode) | `string` | Yes | - | `'default'`
 | [`fill`](#line-styling) | <code>boolean&#124;string</code> | Yes | - | `true`
+| [`hoverBackgroundColor`](#line-styling) | [`Color`](../general/colors.md) | Yes | - | `undefined`
+| [`hoverBorderColor`](#line-styling) | [`Color`](../general/colors.md) | Yes | - | `undefined`
+| [`hoverBorderWidth`](#line-styling) | `number` | Yes | - | `undefined`
 | [`label`](#general) | `string` | - | - | `''`
 | [`lineTension`](#line-styling) | `number` | - | - | `0.4`
 | [`pointBackgroundColor`](#point-styling) | `Color` | Yes | Yes | `'rgba(0, 0, 0, 0.1)'`

--- a/docs/charts/radar.md
+++ b/docs/charts/radar.md
@@ -73,6 +73,13 @@ The radar chart allows a number of properties to be specified for each dataset. 
 | [`borderDashOffset`](#line-styling) | `number` | Yes | - | `0.0`
 | [`borderJoinStyle`](#line-styling) | `string` | Yes | - | `'miter'`
 | [`borderWidth`](#line-styling) | `number` | Yes | - | `3`
+| [`hoverBackgroundColor`](#line-styling) | [`Color`](../general/colors.md) | Yes | - | `undefined`
+| [`hoverBorderCapStyle`](#line-styling) | `string` | Yes | - | `undefined`
+| [`hoverBorderColor`](#line-styling) | [`Color`](../general/colors.md) | Yes | - | `undefined`
+| [`hoverBorderDash`](#line-styling) | `number[]` | Yes | - | `undefined`
+| [`hoverBorderDashOffset`](#line-styling) | `number` | Yes | - | `undefined`
+| [`hoverBorderJoinStyle`](#line-styling) | `string` | Yes | - | `undefined`
+| [`hoverBorderWidth`](#line-styling) | `number` | Yes | - | `undefined`
 | [`fill`](#line-styling) | <code>boolean&#124;string</code> | Yes | - | `true`
 | [`label`](#general) | `string` | - | - | `''`
 | [`lineTension`](#line-styling) | `number` | - | - | `0`

--- a/docs/general/options.md
+++ b/docs/general/options.md
@@ -43,5 +43,6 @@ The context object contains the following properties:
 - `dataIndex`: index of the current data
 - `dataset`: dataset at index `datasetIndex`
 - `datasetIndex`: index of the current dataset
+- `hover`: true if hovered
 
 **Important**: since the context can represent different types of entities (dataset, data, etc.), some properties may be `undefined` so be sure to test any context property before using it.

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -316,6 +316,9 @@ module.exports = DatasetController.extend({
 		model.radius = valueOrDefault(options.hoverRadius, options.radius);
 	},
 
+	/**
+	 * @protected
+	 */
 	setDatasetHoverStyle: function() {
 		var line = this.getMeta().dataset;
 		var model = line._model;
@@ -324,10 +327,12 @@ module.exports = DatasetController.extend({
 
 		line.$previousStyle = {
 			backgroundColor: model.backgroundColor,
-			borderColor: model.borderColor
+			borderColor: model.borderColor,
+			borderWidth: model.borderWidth
 		};
 
 		model.backgroundColor = valueOrDefault(config.hoverBackgroundColor, getHoverColor(config.backgroundColor));
 		model.borderColor = valueOrDefault(config.hoverBorderColor, getHoverColor(config.borderColor));
+		model.borderWidth = valueOrDefault(config.hoverBorderWidth, config.borderWidth);
 	},
 });

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -315,4 +315,19 @@ module.exports = DatasetController.extend({
 		model.borderWidth = valueOrDefault(options.hoverBorderWidth, options.borderWidth);
 		model.radius = valueOrDefault(options.hoverRadius, options.radius);
 	},
+
+	setDatasetHoverStyle: function() {
+		var line = this.getMeta().dataset;
+		var model = line._model;
+		var config = this._config;
+		var getHoverColor = helpers.getHoverColor;
+
+		line.$previousStyle = {
+			backgroundColor: model.backgroundColor,
+			borderColor: model.borderColor
+		};
+
+		model.backgroundColor = valueOrDefault(config.hoverBackgroundColor, getHoverColor(config.backgroundColor));
+		model.borderColor = valueOrDefault(config.hoverBorderColor, getHoverColor(config.borderColor));
+	},
 });

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -315,24 +315,4 @@ module.exports = DatasetController.extend({
 		model.borderWidth = valueOrDefault(options.hoverBorderWidth, options.borderWidth);
 		model.radius = valueOrDefault(options.hoverRadius, options.radius);
 	},
-
-	/**
-	 * @protected
-	 */
-	setDatasetHoverStyle: function() {
-		var line = this.getMeta().dataset;
-		var model = line._model;
-		var config = this._config;
-		var getHoverColor = helpers.getHoverColor;
-
-		line.$previousStyle = {
-			backgroundColor: model.backgroundColor,
-			borderColor: model.borderColor,
-			borderWidth: model.borderWidth
-		};
-
-		model.backgroundColor = valueOrDefault(config.hoverBackgroundColor, getHoverColor(config.backgroundColor));
-		model.borderColor = valueOrDefault(config.hoverBorderColor, getHoverColor(config.borderColor));
-		model.borderWidth = valueOrDefault(config.hoverBorderWidth, config.borderWidth);
-	},
 });

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -966,7 +966,7 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 		}
 
 		if (mode === 'dataset') {
-			this.getDatasetMeta(elements[0]._datasetIndex).controller[prefix + 'DatasetHoverStyle']();
+			this.getDatasetMeta(elements[0]._datasetIndex).controller['_' + prefix + 'DatasetHoverStyle']();
 		}
 	},
 

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -964,6 +964,11 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 				this.getDatasetMeta(element._datasetIndex).controller[method](element);
 			}
 		}
+
+		if (mode === 'dataset') {
+			method = enabled ? 'setDatasetHoverStyle' : 'removeDatasetHoverStyle';
+			this.getDatasetMeta(elements[0]._datasetIndex).controller[method]();
+		}
 	},
 
 	/**

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -955,19 +955,18 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 	},
 
 	updateHoverStyle: function(elements, mode, enabled) {
-		var method = enabled ? 'setHoverStyle' : 'removeHoverStyle';
+		var prefix = enabled ? 'set' : 'remove';
 		var element, i, ilen;
 
 		for (i = 0, ilen = elements.length; i < ilen; ++i) {
 			element = elements[i];
 			if (element) {
-				this.getDatasetMeta(element._datasetIndex).controller[method](element);
+				this.getDatasetMeta(element._datasetIndex).controller[prefix + 'HoverStyle'](element);
 			}
 		}
 
 		if (mode === 'dataset') {
-			method = enabled ? 'setDatasetHoverStyle' : 'removeDatasetHoverStyle';
-			this.getDatasetMeta(elements[0]._datasetIndex).controller[method]();
+			this.getDatasetMeta(elements[0]._datasetIndex).controller[prefix + 'DatasetHoverStyle']();
 		}
 	},
 

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -468,6 +468,12 @@ helpers.extend(DatasetController.prototype, {
 		model.borderWidth = resolve([custom.hoverBorderWidth, dataset.hoverBorderWidth, model.borderWidth], undefined, index);
 	},
 
+	removeDatasetHoverStyle: function() {
+		this.removeHoverStyle(this.getMeta().dataset);
+	},
+
+	setDatasetHoverStyle: helpers.noop,
+
 	/**
 	 * @private
 	 */

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -470,7 +470,10 @@ helpers.extend(DatasetController.prototype, {
 		model.borderWidth = resolve([custom.hoverBorderWidth, dataset.hoverBorderWidth, model.borderWidth], undefined, index);
 	},
 
-	removeDatasetHoverStyle: function() {
+	/**
+	 * @private
+	 */
+	_removeDatasetHoverStyle: function() {
 		var element = this.getMeta().dataset;
 
 		if (element) {
@@ -478,7 +481,10 @@ helpers.extend(DatasetController.prototype, {
 		}
 	},
 
-	setDatasetHoverStyle: function() {
+	/**
+	 * @private
+	 */
+	_setDatasetHoverStyle: function() {
 		var element = this.getMeta().dataset;
 		var prev = {};
 		var i, ilen, key, keys, hoverOptions, model;

--- a/test/specs/controller.line.tests.js
+++ b/test/specs/controller.line.tests.js
@@ -895,6 +895,34 @@ describe('Chart.controllers.line', function() {
 			expect(point._model.borderWidth).toBe(2);
 			expect(point._model.radius).toBe(3);
 		});
+
+		it ('should handle dataset hover styles defined via dataset properties', function() {
+			var chart = this.chart;
+			var point = chart.getDatasetMeta(0).data[0];
+			var dataset = chart.getDatasetMeta(0).dataset;
+
+			Chart.helpers.merge(chart.data.datasets[0], {
+				backgroundColor: '#AAA',
+				borderColor: '#BBB',
+				borderWidth: 6,
+				hoverBackgroundColor: '#000',
+				hoverBorderColor: '#111',
+				hoverBorderWidth: 12
+			});
+
+			chart.options.hover = {mode: 'dataset'};
+			chart.update();
+
+			jasmine.triggerMouseEvent(chart, 'mousemove', point);
+			expect(dataset._model.backgroundColor).toBe('#000');
+			expect(dataset._model.borderColor).toBe('#111');
+			expect(dataset._model.borderWidth).toBe(12);
+
+			jasmine.triggerMouseEvent(chart, 'mouseout', point);
+			expect(dataset._model.backgroundColor).toBe('#AAA');
+			expect(dataset._model.borderColor).toBe('#BBB');
+			expect(dataset._model.borderWidth).toBe(6);
+		});
 	});
 
 	it('should allow 0 as a point border width', function() {


### PR DESCRIPTION
Dataset level hover styles for `dataset` mode.

[Pen](https://codepen.io/kurkle/pen/aboRdQj)

Closes: #2136
Partially solves: #3880 (hover only triggered by points still, not filled area as requested)