### PR TITLE
[perf] cache resolved data element options

### DIFF
--- a/src/controllers/controller.bubble.js
+++ b/src/controllers/controller.bubble.js
@@ -138,6 +138,14 @@ module.exports = DatasetController.extend({
 	/**
 	 * @private
 	 */
+	_areDataOptsDynamicallyResolved: function() {
+		// disable caching for now since this controller has custom _resolveDataElementOptions implementation
+		return true;
+	},
+
+	/**
+	 * @private
+	 */
 	_resolveDataElementOptions: function(point, index) {
 		var me = this;
 		var chart = me.chart;

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -3,6 +3,7 @@
 var helpers = require('../helpers/index');
 
 var resolve = helpers.options.resolve;
+var _areDynamicallyResolved = helpers.options._areDynamicallyResolved;
 
 var arrayEvents = ['push', 'pop', 'shift', 'splice', 'unshift'];
 
@@ -290,6 +291,12 @@ helpers.extend(DatasetController.prototype, {
 	_update: function(reset) {
 		var me = this;
 		me._configure();
+
+		me._cachedDataOpts = null;
+		if (!me._areDataOptsDynamicallyResolved()) {
+			me._cachedDataOpts = Object.freeze(me._resolveDataElementOptions());
+		}
+
 		me.update(reset);
 	},
 
@@ -389,13 +396,17 @@ helpers.extend(DatasetController.prototype, {
 	 */
 	_resolveDataElementOptions: function(element, index) {
 		var me = this;
+		var custom = element && element.custom;
+		var cached = me._cachedDataOpts;
+		if (cached && !custom) {
+			return cached;
+		}
+
 		var chart = me.chart;
 		var datasetOpts = me._config;
-		var custom = element.custom || {};
 		var options = chart.options.elements[me.dataElementType.prototype._type] || {};
 		var elementOptions = me._dataElementOptions;
 		var values = {};
-		var keys, i, ilen, key;
 
 		// Scriptable options
 		var context = {
@@ -405,6 +416,9 @@ helpers.extend(DatasetController.prototype, {
 			datasetIndex: me.index
 		};
 
+		var keys, i, ilen, key;
+
+		custom = custom || {};
 		if (helpers.isArray(elementOptions)) {
 			for (i = 0, ilen = elementOptions.length; i < ilen; ++i) {
 				key = elementOptions[i];
@@ -428,6 +442,42 @@ helpers.extend(DatasetController.prototype, {
 		}
 
 		return values;
+	},
+
+	/**
+	 * @private
+	 */
+	_areDataOptsDynamicallyResolved: function() {
+		var me = this;
+		var chart = me.chart;
+		var datasetOpts = me._config;
+		var options = chart.options.elements[me.dataElementType.prototype._type] || {};
+		var elementOptions = me._dataElementOptions;
+		var keys, i, ilen, key;
+		if (helpers.isArray(elementOptions)) {
+			for (i = 0, ilen = elementOptions.length; i < ilen; ++i) {
+				key = elementOptions[i];
+				if (_areDynamicallyResolved([
+					datasetOpts[key],
+					options[key]
+				])) {
+					return true;
+				}
+			}
+		} else {
+			keys = Object.keys(elementOptions);
+			for (i = 0, ilen = keys.length; i < ilen; ++i) {
+				key = keys[i];
+				if (_areDynamicallyResolved([
+					datasetOpts[elementOptions[key]],
+					datasetOpts[key],
+					options[key]
+				])) {
+					return true;
+				}
+			}
+		}
+		return false;
 	},
 
 	removeHoverStyle: function(element) {

--- a/src/helpers/helpers.options.js
+++ b/src/helpers/helpers.options.js
@@ -109,6 +109,20 @@ module.exports = {
 	},
 
 	/**
+	 * @private
+	 */
+	_areDynamicallyResolved: function(options) {
+		var i, ilen, option;
+		for (i = 0, ilen = options.length; i < ilen; ++i) {
+			option = options[i];
+			if (helpers.isArray(option) || typeof option === 'function') {
+				return true;
+			}
+		}
+		return false;
+	},
+
+	/**
 	 * Evaluates the given `inputs` sequentially and returns the first defined value.
 	 * @param {Array} inputs - An array of values, falling back to the last value.
 	 * @param {object} [context] - If defined and the current value is a function, the value


### PR DESCRIPTION
The motivation for this PR is to improve Chart.js performance on the benchmark below
https://github.com/leeoniya/uPlot#performance

This reduces render time by 45% on the benchmark for me

Closes https://github.com/chartjs/Chart.js/issues/6382