### PR TITLE
[perf] simplify line drawing

### DIFF
--- a/src/elements/element.line.js
+++ b/src/elements/element.line.js
@@ -77,7 +77,6 @@ module.exports = Element.extend({
 
 		// Stroke Line
 		ctx.beginPath();
-		lastDrawnIndex = -1;
 
 		// First point moves to it's starting position no matter what
 		currentVM = points[0]._view;

--- a/src/elements/element.line.js
+++ b/src/elements/element.line.js
@@ -40,7 +40,11 @@ module.exports = Element.extend({
 		var closePath = me._loop;
 		var index, previous, currentVM;
 
-		if (me._loop && points.length) {
+		if (!points.length) {
+			return;
+		}
+
+		if (me._loop) {
 			for (index = 0; index < points.length; ++index) {
 				previous = helpers.previousItem(points, index);
 				// If the line has an open path, shift the point array
@@ -75,29 +79,26 @@ module.exports = Element.extend({
 		ctx.beginPath();
 		lastDrawnIndex = -1;
 
-		for (index = 0; index < points.length; ++index) {
-			previous = helpers.previousItem(points, index);
+		// First point moves to it's starting position no matter what
+		currentVM = points[0]._view;
+		if (!currentVM.skip) {
+			ctx.moveTo(currentVM.x, currentVM.y);
+			lastDrawnIndex = 0;
+		}
+
+		for (index = 1; index < points.length; ++index) {
 			currentVM = points[index]._view;
+			previous = lastDrawnIndex === -1 ? helpers.previousItem(points, index) : points[lastDrawnIndex];
 
-			// First point moves to it's starting position no matter what
-			if (index === 0) {
-				if (!currentVM.skip) {
+			if (!currentVM.skip) {
+				if ((lastDrawnIndex !== (index - 1) && !spanGaps) || lastDrawnIndex === -1) {
+					// There was a gap and this is the first point after the gap
 					ctx.moveTo(currentVM.x, currentVM.y);
-					lastDrawnIndex = index;
+				} else {
+					// Line to next point
+					helpers.canvas.lineTo(ctx, previous._view, currentVM);
 				}
-			} else {
-				previous = lastDrawnIndex === -1 ? previous : points[lastDrawnIndex];
-
-				if (!currentVM.skip) {
-					if ((lastDrawnIndex !== (index - 1) && !spanGaps) || lastDrawnIndex === -1) {
-						// There was a gap and this is the first point after the gap
-						ctx.moveTo(currentVM.x, currentVM.y);
-					} else {
-						// Line to next point
-						helpers.canvas.lineTo(ctx, previous._view, currentVM);
-					}
-					lastDrawnIndex = index;
-				}
+				lastDrawnIndex = index;
 			}
 		}
 


### PR DESCRIPTION
This does one less `if` / `else` check for each point in the line by handling the first point outside the loop. It also calls `helpers.previousItem` only when the result will be used. These two improvements should be a performance boost