### PR TITLE
Fix logarithmic test to use correct scale

### DIFF
--- a/test/specs/scale.logarithmic.tests.js
+++ b/test/specs/scale.logarithmic.tests.js
@@ -749,7 +749,7 @@ describe('Logarithmic Scale tests', function() {
 			}
 		});
 
-		expect(chart.scales.yScale1.getLabelForIndex(0, 2)).toBe(150);
+		expect(chart.scales.yScale0.getLabelForIndex(0, 2)).toBe(150);
 	});
 
 	describe('when', function() {


### PR DESCRIPTION
Test using correct scale. Using a scale that is not attached to given dataset should really not return any label for it.

This is extracted from #6576 to make the reviewing easier.