### PR TITLE
Return correct index/value id in radar/polarArea

### DIFF
--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -123,6 +123,20 @@ module.exports = DatasetController.extend({
 		'hoverBorderWidth',
 	],
 
+	/**
+	 * @private
+	 */
+	_getIndexScaleId: function() {
+		return this.chart.scale.id;
+	},
+
+	/**
+	 * @private
+	 */
+	_getValueScaleId: function() {
+		return this.chart.scale.id;
+	},
+
 	update: function(reset) {
 		var me = this;
 		var dataset = me.getDataset();

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -20,13 +20,6 @@ defaults._set('radar', {
 });
 
 module.exports = DatasetController.extend({
-	/**
-	 * @private
-	 */
-	_getValueScaleId: function() {
-		return this.chart.scale.id;
-	},
-
 	datasetElementType: elements.Line,
 
 	dataElementType: elements.Point,
@@ -62,6 +55,20 @@ module.exports = DatasetController.extend({
 		pointStyle: 'pointStyle',
 		radius: 'pointRadius',
 		rotation: 'pointRotation'
+	},
+
+	/**
+	 * @private
+	 */
+	_getIndexScaleId: function() {
+		return this.chart.scale.id;
+	},
+
+	/**
+	 * @private
+	 */
+	_getValueScaleId: function() {
+		return this.chart.scale.id;
 	},
 
 	update: function(reset) {


### PR DESCRIPTION
Override both `_getIndexScaleId` and `_getValueScaleId` in `radar` / `polarArea`
  * Default implementation returns x/y axis id, but radar / polarArea use `options.scale`.

Extracted from #6576 to ease reviewing