### PR TITLE
Fix unit determination when autoSkip is enabled

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -257,7 +257,7 @@ function determineUnitForAutoTicks(minUnit, min, max, capacity) {
 
 	for (i = UNITS.indexOf(minUnit); i < ilen - 1; ++i) {
 		interval = INTERVALS[UNITS[i]];
-		factor = interval.steps ? interval.steps / 2 : MAX_INTEGER;
+		factor = interval.steps ? interval.steps : MAX_INTEGER;
 
 		if (interval.common && Math.ceil((max - min) / (factor * interval.size)) <= capacity) {
 			return UNITS[i];
@@ -270,12 +270,12 @@ function determineUnitForAutoTicks(minUnit, min, max, capacity) {
 /**
  * Figures out what unit to format a set of ticks with
  */
-function determineUnitForFormatting(scale, ticks, minUnit, min, max) {
+function determineUnitForFormatting(scale, numTicks, minUnit, min, max) {
 	var i, unit;
 
 	for (i = UNITS.length - 1; i >= UNITS.indexOf(minUnit); i--) {
 		unit = UNITS[i];
-		if (INTERVALS[unit].common && scale._adapter.diff(max, min, unit) >= ticks.length - 1) {
+		if (INTERVALS[unit].common && scale._adapter.diff(max, min, unit) >= numTicks - 1) {
 			return unit;
 		}
 	}
@@ -562,11 +562,12 @@ module.exports = Scale.extend({
 		var min = me.min;
 		var max = me.max;
 		var options = me.options;
+		var tickOpts = options.ticks;
 		var timeOpts = options.time;
 		var timestamps = me._timestamps;
 		var ticks = [];
 		var capacity = me.getLabelCapacity(min);
-		var source = options.ticks.source;
+		var source = tickOpts.source;
 		var distribution = options.distribution;
 		var i, ilen, timestamp;
 
@@ -599,13 +600,17 @@ module.exports = Scale.extend({
 		me.max = max;
 
 		// PRIVATE
-		me._unit = timeOpts.unit || determineUnitForFormatting(me, ticks, timeOpts.minUnit, me.min, me.max);
-		me._majorUnit = !options.ticks.major.enabled || me._unit === 'year' ? undefined
+		// determineUnitForFormatting relies on the number of ticks so we don't use it when
+		// autoSkip is enabled because we don't yet know what the final number of ticks will be
+		me._unit = timeOpts.unit || (tickOpts.autoSkip
+			? determineUnitForAutoTicks(timeOpts.minUnit, me.min, me.max, capacity)
+			: determineUnitForFormatting(me, ticks.length, timeOpts.minUnit, me.min, me.max));
+		me._majorUnit = !tickOpts.major.enabled || me._unit === 'year' ? undefined
 			: determineMajorUnit(me._unit);
 		me._table = buildLookupTable(me._timestamps.data, min, max, distribution);
 		me._offsets = computeOffsets(me._table, ticks, min, max, options);
 
-		if (options.ticks.reverse) {
+		if (tickOpts.reverse) {
 			ticks.reverse();
 		}
 

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -128,7 +128,7 @@ describe('Time scale tests', function() {
 			var ticks = getTicksLabels(scale);
 
 			// `bounds === 'data'`: first and last ticks removed since outside the data range
-			expect(ticks).toEqual(['Jan 2', 'Jan 3', 'Jan 4', 'Jan 5', 'Jan 6', 'Jan 7', 'Jan 8', 'Jan 9', 'Jan 10']);
+			expect(ticks.length).toEqual(217);
 		});
 
 		it('should accept labels as date objects', function() {
@@ -139,7 +139,7 @@ describe('Time scale tests', function() {
 			var ticks = getTicksLabels(scale);
 
 			// `bounds === 'data'`: first and last ticks removed since outside the data range
-			expect(ticks).toEqual(['Jan 2', 'Jan 3', 'Jan 4', 'Jan 5', 'Jan 6', 'Jan 7', 'Jan 8', 'Jan 9', 'Jan 10']);
+			expect(ticks.length).toEqual(217);
 		});
 
 		it('should accept data as xy points', function() {
@@ -187,7 +187,7 @@ describe('Time scale tests', function() {
 			var ticks = getTicksLabels(xScale);
 
 			// `bounds === 'data'`: first and last ticks removed since outside the data range
-			expect(ticks).toEqual(['Jan 2', 'Jan 3', 'Jan 4', 'Jan 5', 'Jan 6', 'Jan 7', 'Jan 8', 'Jan 9', 'Jan 10']);
+			expect(ticks.length).toEqual(217);
 		});
 
 		it('should accept data as ty points', function() {
@@ -235,7 +235,7 @@ describe('Time scale tests', function() {
 			var ticks = getTicksLabels(tScale);
 
 			// `bounds === 'data'`: first and last ticks removed since outside the data range
-			expect(ticks).toEqual(['Jan 2', 'Jan 3', 'Jan 4', 'Jan 5', 'Jan 6', 'Jan 7', 'Jan 8', 'Jan 9', 'Jan 10']);
+			expect(ticks.length).toEqual(217);
 		});
 	});
 


### PR DESCRIPTION
`determineUnitForFormatting` doesn't work well when `autoSkip` is enabled because it relies on the number of ticks, which changes when the autoSkip is applied. Now that autoSkip is aware of major ticks this is a more noticeable issue

I removed a division by 2. Two test failed without this change, but changing it also meant I had to change a couple other tests. It's somewhat subjective as to what produces better results. However, I felt this produced better results for the related tests. I could not find a compelling reason as to why this division was introduced in the first place and it seemed somewhat arbitrary to do it. The number of ticks in the test is larger because it switched from days to hours (so x 24) and it's before autoSkip is applied. After autoSkip the number of ticks doesn't change all that much

**Before**

![Screenshot from 2019-10-20 19-45-31](https://user-images.githubusercontent.com/322311/67173148-97327b00-f372-11e9-9c8a-d16619b568f1.png)

**After**

![Screenshot from 2019-10-20 19-45-36](https://user-images.githubusercontent.com/322311/67173156-9dc0f280-f372-11e9-9e27-392ef7ab97b8.png)