### PR TITLE
Remove `relativePoints` option support

### DIFF
--- a/src/scales/scale.linear.js
+++ b/src/scales/scale.linear.js
@@ -50,9 +50,7 @@ function stackData(scale, stacks, meta, data) {
 		pos[i] = pos[i] || 0;
 		neg[i] = neg[i] || 0;
 
-		if (opts.relativePoints) {
-			pos[i] = 100;
-		} else if (value.min < 0 || value.max < 0) {
+		if (value.min < 0 || value.max < 0) {
 			neg[i] += value.min;
 		} else {
 			pos[i] += value.max;


### PR DESCRIPTION
Remove undocumented `relativePoints` option support.
This only affects linear scale when its stacked. The effect was really to set `min: 0, max: 100` (and only when stacked), which does not need a magic switch IMO.
