### PR TITLE
Don't use deprecated options in tests

### DIFF
--- a/test/fixtures/controller.bar/bar-thickness-absolute.json
+++ b/test/fixtures/controller.bar/bar-thickness-absolute.json
@@ -5,6 +5,9 @@
             "labels": ["2017", "2018", "2019", "2024", "2025"],
             "datasets": [{
                 "backgroundColor": "rgba(255, 99, 132, 0.5)",
+                "barPercentage": 1,
+                "categoryPercentage": 1,
+                "barThickness": 128,
                 "data": [1, null, 3, 4, 5]
             }]
         },
@@ -17,9 +20,6 @@
                     "type": "time",
                     "offset": true,
                     "display": false,
-                    "barPercentage": 1,
-                    "categoryPercentage": 1,
-                    "barThickness": 128,
                     "time": {
                         "parser": "YYYY"
                     },

--- a/test/fixtures/controller.bar/bar-thickness-flex-offset.json
+++ b/test/fixtures/controller.bar/bar-thickness-flex-offset.json
@@ -5,6 +5,9 @@
             "labels": ["2017", "2018", "2020", "2024", "2038"],
             "datasets": [{
                 "backgroundColor": "#FF6384",
+                "barPercentage": 1,
+                "categoryPercentage": 1,
+                "barThickness": "flex",
                 "data": [1, null, 3, 4, 5]
             }]
         },
@@ -17,9 +20,6 @@
                     "type": "time",
                     "offset": true,
                     "display": false,
-                    "barPercentage": 1,
-                    "categoryPercentage": 1,
-                    "barThickness": "flex",
                     "time": {
                         "parser": "YYYY"
                     },

--- a/test/fixtures/controller.bar/bar-thickness-flex-single-reverse.json
+++ b/test/fixtures/controller.bar/bar-thickness-flex-single-reverse.json
@@ -5,6 +5,9 @@
             "labels": ["2016", "2018", "2020", "2024", "2030"],
             "datasets": [{
                 "backgroundColor": "#FF6384",
+                "barThickness": "flex",
+                "barPercentage": 1,
+                "categoryPercentage": 1,
                 "data": [1]
             }]
         },
@@ -16,9 +19,6 @@
                 "xAxes": [{
                     "type": "time",
                     "display": false,
-                    "barThickness": "flex",
-                    "barPercentage": 1,
-                    "categoryPercentage": 1,
                     "time": {
                         "parser": "YYYY"
                     },

--- a/test/fixtures/controller.bar/bar-thickness-flex-single.json
+++ b/test/fixtures/controller.bar/bar-thickness-flex-single.json
@@ -5,6 +5,9 @@
             "labels": ["2016", "2018", "2020", "2024", "2030"],
             "datasets": [{
                 "backgroundColor": "#FF6384",
+                "barThickness": "flex",
+                "barPercentage": 1,
+                "categoryPercentage": 1,
                 "data": [1]
             }]
         },
@@ -16,9 +19,6 @@
                 "xAxes": [{
                     "type": "time",
                     "display": false,
-                    "barThickness": "flex",
-                    "barPercentage": 1,
-                    "categoryPercentage": 1,
                     "time": {
                         "parser": "YYYY"
                     },

--- a/test/fixtures/controller.bar/bar-thickness-flex.json
+++ b/test/fixtures/controller.bar/bar-thickness-flex.json
@@ -5,6 +5,9 @@
             "labels": ["2017", "2018", "2020", "2024", "2038"],
             "datasets": [{
                 "backgroundColor": "#FF6384",
+                "barPercentage": 1,
+                "categoryPercentage": 1,
+                "barThickness": "flex",
                 "data": [1, null, 3, 4, 5]
             }]
         },
@@ -16,9 +19,6 @@
                 "xAxes": [{
                     "type": "time",
                     "display": false,
-                    "barPercentage": 1,
-                    "categoryPercentage": 1,
-                    "barThickness": "flex",
                     "time": {
                         "parser": "YYYY"
                     },

--- a/test/fixtures/controller.bar/bar-thickness-max.json
+++ b/test/fixtures/controller.bar/bar-thickness-max.json
@@ -5,6 +5,9 @@
             "labels": ["2016", "2018", "2020", "2024", "2030"],
             "datasets": [{
                 "backgroundColor": "#FF6384",
+                "barPercentage": 1,
+                "categoryPercentage": 1,
+                "maxBarThickness": 8,
                 "data": [1, null, 3, 4, 5]
             }]
         },
@@ -16,9 +19,6 @@
                 "xAxes": [{
                     "type": "time",
                     "display": false,
-                    "barPercentage": 1,
-                    "categoryPercentage": 1,
-                    "maxBarThickness": 8,
                     "time": {
                         "parser": "YYYY"
                     },

--- a/test/fixtures/controller.bar/bar-thickness-min-interval.json
+++ b/test/fixtures/controller.bar/bar-thickness-min-interval.json
@@ -5,6 +5,8 @@
             "labels": ["2016", "2018", "2020", "2024", "2030"],
             "datasets": [{
                 "backgroundColor": "#FF6384",
+                "barPercentage": 1,
+                "categoryPercentage": 1,
                 "data": [1, null, 3, 4, 5]
             }]
         },
@@ -16,8 +18,6 @@
                 "xAxes": [{
                     "type": "time",
                     "display": false,
-                    "barPercentage": 1,
-                    "categoryPercentage": 1,
                     "time": {
                         "parser": "YYYY"
                     },

--- a/test/fixtures/controller.bar/bar-thickness-multiple.json
+++ b/test/fixtures/controller.bar/bar-thickness-multiple.json
@@ -18,12 +18,16 @@
             "responsive": false,
             "legend": false,
             "title": false,
+            "datasets": {
+                "bar": {
+                    "barPercentage": 1,
+                    "categoryPercentage": 1
+                }
+            },
             "scales": {
                 "xAxes": [{
                     "type": "time",
                     "display": false,
-                    "barPercentage": 1,
-                    "categoryPercentage": 1,
                     "time": {
                         "parser": "YYYY"
                     },

--- a/test/fixtures/controller.bar/bar-thickness-no-overlap.json
+++ b/test/fixtures/controller.bar/bar-thickness-no-overlap.json
@@ -18,12 +18,16 @@
             "responsive": false,
             "legend": false,
             "title": false,
+            "datasets": {
+                "bar": {
+                    "barPercentage": 1,
+                    "categoryPercentage": 1
+                }
+            },
             "scales": {
                 "xAxes": [{
                     "type": "time",
                     "display": false,
-                    "barPercentage": 1,
-                    "categoryPercentage": 1,
                     "time": {
                         "parser": "YYYY-MM"
                     },

--- a/test/fixtures/controller.bar/bar-thickness-offset.json
+++ b/test/fixtures/controller.bar/bar-thickness-offset.json
@@ -18,13 +18,17 @@
             "responsive": false,
             "legend": false,
             "title": false,
+            "datasets": {
+                "bar": {
+                    "barPercentage": 1,
+                    "categoryPercentage": 1
+                }
+            },
             "scales": {
                 "xAxes": [{
                     "type": "time",
                     "offset": true,
                     "display": false,
-                    "barPercentage": 1,
-                    "categoryPercentage": 1,
                     "time": {
                         "parser": "YYYY"
                     },

--- a/test/fixtures/controller.bar/bar-thickness-reverse.json
+++ b/test/fixtures/controller.bar/bar-thickness-reverse.json
@@ -18,12 +18,16 @@
             "responsive": false,
             "legend": false,
             "title": false,
+            "datasets": {
+                "bar": {
+                    "barPercentage": 1,
+                    "categoryPercentage": 1
+                }
+            },
             "scales": {
                 "xAxes": [{
                     "type": "time",
                     "display": false,
-                    "barPercentage": 1,
-                    "categoryPercentage": 1,
                     "time": {
                         "parser": "YYYY"
                     },

--- a/test/fixtures/controller.bar/bar-thickness-single-xy.json
+++ b/test/fixtures/controller.bar/bar-thickness-single-xy.json
@@ -4,6 +4,8 @@
         "data": {
             "labels": ["2016", "2018", "2020", "2024", "2030"],
             "datasets": [{
+                "barPercentage": 1,
+                "categoryPercentage": 1,
                 "backgroundColor": "#FF6384",
                 "data": [{"x": "2022", "y": 42}]
             }]
@@ -16,8 +18,6 @@
                 "xAxes": [{
                     "type": "time",
                     "display": false,
-                    "barPercentage": 1,
-                    "categoryPercentage": 1,
                     "time": {
                         "parser": "YYYY"
                     },

--- a/test/fixtures/controller.bar/bar-thickness-single.json
+++ b/test/fixtures/controller.bar/bar-thickness-single.json
@@ -4,6 +4,8 @@
         "data": {
             "labels": ["2016", "2018", "2020", "2024", "2030"],
             "datasets": [{
+                "barPercentage": 1,
+                "categoryPercentage": 1,
                 "backgroundColor": "#FF6384",
                 "data": [1]
             }]
@@ -16,8 +18,6 @@
                 "xAxes": [{
                     "type": "time",
                     "display": false,
-                    "barPercentage": 1,
-                    "categoryPercentage": 1,
                     "time": {
                         "parser": "YYYY"
                     },

--- a/test/fixtures/controller.bar/bar-thickness-stacked.json
+++ b/test/fixtures/controller.bar/bar-thickness-stacked.json
@@ -18,13 +18,17 @@
             "responsive": false,
             "legend": false,
             "title": false,
+            "datasets": {
+                "bar": {
+                    "barPercentage": 1,
+                    "categoryPercentage": 1
+                }
+            },
             "scales": {
                 "xAxes": [{
                     "type": "time",
                     "stacked": true,
                     "display": false,
-                    "barPercentage": 1,
-                    "categoryPercentage": 1,
                     "time": {
                         "parser": "YYYY"
                     },

--- a/test/specs/controller.bar.tests.js
+++ b/test/specs/controller.bar.tests.js
@@ -1214,12 +1214,16 @@ describe('Chart.controllers.bar', function() {
 			options: {
 				legend: false,
 				title: false,
+				datasets: {
+					bar: {
+						barPercentage: 1,
+					}
+				},
 				scales: {
 					xAxes: [{
 						type: 'category',
 						display: false,
 						stacked: true,
-						barPercentage: 1,
 					}],
 					yAxes: [{
 						type: 'logarithmic',
@@ -1275,12 +1279,16 @@ describe('Chart.controllers.bar', function() {
 			options: {
 				legend: false,
 				title: false,
+				datasets: {
+					bar: {
+						barPercentage: 1,
+					}
+				},
 				scales: {
 					xAxes: [{
 						type: 'category',
 						display: false,
 						stacked: true,
-						barPercentage: 1,
 					}],
 					yAxes: [{
 						type: 'logarithmic',
@@ -1670,11 +1678,15 @@ describe('Chart.controllers.bar', function() {
 						options: {
 							legend: false,
 							title: false,
+							datasets: {
+								bar: {
+									barThickness: barThickness
+								}
+							},
 							scales: {
 								xAxes: [{
 									id: 'x',
 									type: 'category',
-									barThickness: barThickness
 								}],
 								yAxes: [{
 									type: 'linear',


### PR DESCRIPTION
Removes deprecation warnings from tests (except the ones where deprecated options are tested)