### PR TITLE
Bump version number to v2.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chart.js",
   "homepage": "https://www.chartjs.org",
   "description": "Simple HTML5 charts using the canvas element.",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "license": "MIT",
   "jsdelivr": "dist/Chart.min.js",
   "unpkg": "dist/Chart.min.js",


### PR DESCRIPTION
In preparation of releasing hotfixes for the following issues:

* https://github.com/chartjs/chartjs-plugin-zoom/issues/279
* #6602 