### PR TITLE
Add link to performance documentation

### DIFF
--- a/docs/general/README.md
+++ b/docs/general/README.md
@@ -8,3 +8,4 @@ These sections describe general configuration options that can apply elsewhere i
 * [Options](./options.md) scriptable and indexable options syntax.
 * [Colors](./colors.md) defines acceptable color values.
 * [Font](./fonts.md) defines various font options.
+* [Performance](./performance.md) gives tips for performance-sensitive applications.


### PR DESCRIPTION
I added this new page in 2.9, but forgot to link to it anywhere :-p 