### PR TITLE
WIP Scale options as an object instead of an array

### DIFF
--- a/samples/charts/area/line-boundaries.html
+++ b/samples/charts/area/line-boundaries.html
@@ -59,12 +59,12 @@
 				}
 			},
 			scales: {
-				xAxes: [{
+				x: {
 					ticks: {
 						autoSkip: false,
 						maxRotation: 0
 					}
-				}]
+				}
 			}
 		};
 

--- a/samples/charts/area/line-datasets.html
+++ b/samples/charts/area/line-datasets.html
@@ -114,9 +114,9 @@
 				}
 			},
 			scales: {
-				yAxes: [{
-					stacked: true
-				}]
+				y: {
+					stacked: true,
+				}
 			},
 			plugins: {
 				filler: {

--- a/samples/charts/area/line-stacked.html
+++ b/samples/charts/area/line-stacked.html
@@ -98,19 +98,19 @@
 					mode: 'index'
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						scaleLabel: {
 							display: true,
 							labelString: 'Month'
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						stacked: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'Value'
 						}
-					}]
+					}
 				}
 			}
 		};

--- a/samples/charts/bar/multi-axis.html
+++ b/samples/charts/bar/multi-axis.html
@@ -33,7 +33,7 @@
 					window.chartColors.purple,
 					window.chartColors.red
 				],
-				yAxisID: 'y-axis-1',
+				yAxisID: 'y',
 				data: [
 					randomScalingFactor(),
 					randomScalingFactor(),
@@ -46,7 +46,7 @@
 			}, {
 				label: 'Dataset 2',
 				backgroundColor: window.chartColors.grey,
-				yAxisID: 'y-axis-2',
+				yAxisID: 'y1',
 				data: [
 					randomScalingFactor(),
 					randomScalingFactor(),
@@ -75,20 +75,19 @@
 						intersect: true
 					},
 					scales: {
-						yAxes: [{
-							type: 'linear', // only linear but allow scale type registration. This allows extensions to exist solely for log scale for instance
+						y: {
+							type: 'linear',
 							display: true,
 							position: 'left',
-							id: 'y-axis-1',
-						}, {
-							type: 'linear', // only linear but allow scale type registration. This allows extensions to exist solely for log scale for instance
+						},
+						y1: {
+							type: 'linear',
 							display: true,
 							position: 'right',
-							id: 'y-axis-2',
 							gridLines: {
 								drawOnChartArea: false
 							}
-						}],
+						},
 					}
 				}
 			});

--- a/samples/charts/bar/stacked-group.html
+++ b/samples/charts/bar/stacked-group.html
@@ -80,12 +80,12 @@
 					},
 					responsive: true,
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: true,
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: true
-						}]
+						}
 					}
 				}
 			});

--- a/samples/charts/bar/stacked.html
+++ b/samples/charts/bar/stacked.html
@@ -3,7 +3,7 @@
 
 <head>
 	<title>Stacked Bar Chart</title>
-	<script src="../../../dist/Chart.min.js"></script>
+	<script src="../../../dist/Chart.js"></script>
 	<script src="../../utils.js"></script>
 	<style>
 	canvas {
@@ -77,12 +77,12 @@
 					},
 					responsive: true,
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: true,
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: true
-						}]
+						}
 					}
 				}
 			});

--- a/samples/charts/bar/stacked.html
+++ b/samples/charts/bar/stacked.html
@@ -3,7 +3,7 @@
 
 <head>
 	<title>Stacked Bar Chart</title>
-	<script src="../../../dist/Chart.js"></script>
+	<script src="../../../dist/Chart.min.js"></script>
 	<script src="../../utils.js"></script>
 	<style>
 	canvas {

--- a/samples/charts/line/basic.html
+++ b/samples/charts/line/basic.html
@@ -76,20 +76,20 @@
 					intersect: true
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						display: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'Month'
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'Value'
 						}
-					}]
+					}
 				}
 			}
 		};

--- a/samples/charts/line/interpolation-modes.html
+++ b/samples/charts/line/interpolation-modes.html
@@ -64,13 +64,13 @@
 					mode: 'index'
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						display: true,
 						scaleLabel: {
 							display: true
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: true,
 						scaleLabel: {
 							display: true,
@@ -80,7 +80,7 @@
 							suggestedMin: -10,
 							suggestedMax: 200,
 						}
-					}]
+					}
 				}
 			}
 		};

--- a/samples/charts/line/line-styles.html
+++ b/samples/charts/line/line-styles.html
@@ -83,20 +83,20 @@
 					intersect: true
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						display: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'Month'
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'Value'
 						}
-					}]
+					}
 				}
 			}
 		};

--- a/samples/charts/line/multi-axis.html
+++ b/samples/charts/line/multi-axis.html
@@ -36,7 +36,7 @@
 					randomScalingFactor(),
 					randomScalingFactor()
 				],
-				yAxisID: 'y-axis-1',
+				yAxisID: 'y',
 			}, {
 				label: 'My Second dataset',
 				borderColor: window.chartColors.blue,
@@ -51,7 +51,7 @@
 					randomScalingFactor(),
 					randomScalingFactor()
 				],
-				yAxisID: 'y-axis-2'
+				yAxisID: 'y1'
 			}]
 		};
 
@@ -68,22 +68,21 @@
 						text: 'Chart.js Line Chart - Multi Axis'
 					},
 					scales: {
-						yAxes: [{
+						y: {
 							type: 'linear', // only linear but allow scale type registration. This allows extensions to exist solely for log scale for instance
 							display: true,
 							position: 'left',
-							id: 'y-axis-1',
-						}, {
+						},
+						y1: {
 							type: 'linear', // only linear but allow scale type registration. This allows extensions to exist solely for log scale for instance
 							display: true,
 							position: 'right',
-							id: 'y-axis-2',
 
 							// grid line settings
 							gridLines: {
 								drawOnChartArea: false, // only want the grid lines for one axis to show up
 							},
-						}],
+						},
 					}
 				}
 			});

--- a/samples/charts/line/point-sizes.html
+++ b/samples/charts/line/point-sizes.html
@@ -97,20 +97,20 @@
 					mode: 'index'
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						display: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'Month'
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'Value'
 						}
-					}]
+					}
 				},
 				title: {
 					display: true,

--- a/samples/charts/line/skip-points.html
+++ b/samples/charts/line/skip-points.html
@@ -67,20 +67,20 @@
 					mode: 'index'
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						display: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'Month'
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'Value'
 						},
-					}]
+					}
 				}
 			}
 		};

--- a/samples/charts/scatter/multi-axis.html
+++ b/samples/charts/scatter/multi-axis.html
@@ -24,8 +24,8 @@
 	var scatterChartData = {
 		datasets: [{
 			label: 'My First dataset',
-			xAxisID: 'x-axis-1',
-			yAxisID: 'y-axis-1',
+			xAxisID: 'x',
+			yAxisID: 'y',
 			borderColor: window.chartColors.red,
 			backgroundColor: color(window.chartColors.red).alpha(0.2).rgbString(),
 			data: [{
@@ -52,8 +52,8 @@
 			}]
 		}, {
 			label: 'My Second dataset',
-			xAxisID: 'x-axis-1',
-			yAxisID: 'y-axis-2',
+			xAxisID: 'x',
+			yAxisID: 'y2',
 			borderColor: window.chartColors.blue,
 			backgroundColor: color(window.chartColors.blue).alpha(0.2).rgbString(),
 			data: [{
@@ -94,29 +94,28 @@
 					text: 'Chart.js Scatter Chart - Multi Axis'
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						position: 'bottom',
 						gridLines: {
 							zeroLineColor: 'rgba(0,0,0,1)'
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'linear', // only linear but allow scale type registration. This allows extensions to exist solely for log scale for instance
 						display: true,
 						position: 'left',
-						id: 'y-axis-1',
-					}, {
+					},
+					y2: {
 						type: 'linear', // only linear but allow scale type registration. This allows extensions to exist solely for log scale for instance
 						display: true,
 						position: 'right',
 						reverse: true,
-						id: 'y-axis-2',
 
 						// grid line settings
 						gridLines: {
 							drawOnChartArea: false, // only want the grid lines for one axis to show up
 						},
-					}],
+					},
 				}
 			}
 		});

--- a/samples/legend/callbacks.html
+++ b/samples/legend/callbacks.html
@@ -99,20 +99,20 @@
 					text: 'Chart.js Line Chart'
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						display: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'Month'
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'Value'
 						}
-					}]
+					}
 				}
 			}
 		};

--- a/samples/legend/point-style.html
+++ b/samples/legend/point-style.html
@@ -68,20 +68,20 @@
 						}
 					},
 					scales: {
-						xAxes: [{
+						x: {
 							display: true,
 							scaleLabel: {
 								display: true,
 								labelString: 'Month'
 							}
-						}],
-						yAxes: [{
+						},
+						y: {
 							display: true,
 							scaleLabel: {
 								display: true,
 								labelString: 'Value'
 							}
-						}]
+						}
 					},
 					title: {
 						display: true,

--- a/samples/legend/positioning.html
+++ b/samples/legend/positioning.html
@@ -69,20 +69,20 @@
 						position: legendPosition,
 					},
 					scales: {
-						xAxes: [{
+						x: {
 							display: true,
 							scaleLabel: {
 								display: true,
 								labelString: 'Month'
 							}
-						}],
-						yAxes: [{
+						},
+						y: {
 							display: true,
 							scaleLabel: {
 								display: true,
 								labelString: 'Value'
 							}
-						}]
+						}
 					},
 					title: {
 						display: true,

--- a/samples/scales/filtering-labels.html
+++ b/samples/scales/filtering-labels.html
@@ -64,7 +64,7 @@
 					text: 'Chart.js Line Chart - X-Axis Filter'
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						display: true,
 						ticks: {
 							callback: function(dataLabel, index) {
@@ -72,11 +72,11 @@
 								return index % 2 === 0 ? dataLabel : '';
 							}
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: true,
 						beginAtZero: false
-					}]
+					}
 				}
 			}
 		};

--- a/samples/scales/gridlines-display.html
+++ b/samples/scales/gridlines-display.html
@@ -55,17 +55,17 @@
 						text: title
 					},
 					scales: {
-						xAxes: [{
+						x: {
 							gridLines: gridlines
-						}],
-						yAxes: [{
+						},
+						y: {
 							gridLines: gridlines,
 							ticks: {
 								min: 0,
 								max: 100,
 								stepSize: 10
 							}
-						}]
+						}
 					}
 				}
 			};

--- a/samples/scales/gridlines-style.html
+++ b/samples/scales/gridlines-style.html
@@ -44,7 +44,7 @@
 					text: 'Grid Line Settings'
 				},
 				scales: {
-					yAxes: [{
+					y: {
 						gridLines: {
 							drawBorder: false,
 							color: ['pink', 'red', 'orange', 'yellow', 'green', 'blue', 'indigo', 'purple']
@@ -54,7 +54,7 @@
 							max: 100,
 							stepSize: 10
 						}
-					}]
+					}
 				}
 			}
 		};

--- a/samples/scales/linear/min-max-suggested.html
+++ b/samples/scales/linear/min-max-suggested.html
@@ -44,7 +44,7 @@
 					text: 'Min and Max Settings'
 				},
 				scales: {
-					yAxes: [{
+					y: {
 						ticks: {
 							// the data minimum used for determining the ticks is Math.min(dataMin, suggestedMin)
 							suggestedMin: 10,
@@ -52,7 +52,7 @@
 							// the data maximum used for determining the ticks is Math.max(dataMax, suggestedMax)
 							suggestedMax: 50
 						}
-					}]
+					}
 				}
 			}
 		};

--- a/samples/scales/linear/min-max.html
+++ b/samples/scales/linear/min-max.html
@@ -44,12 +44,12 @@
 					text: 'Min and Max Settings'
 				},
 				scales: {
-					yAxes: [{
+					y: {
 						ticks: {
 							min: 10,
 							max: 50
 						}
-					}]
+					}
 				}
 			}
 		};

--- a/samples/scales/linear/step-size.html
+++ b/samples/scales/linear/step-size.html
@@ -81,14 +81,14 @@
 					intersect: true
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						display: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'Month'
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: true,
 						scaleLabel: {
 							display: true,
@@ -101,7 +101,7 @@
 							// forces step size to be 5 units
 							stepSize: 5
 						}
-					}]
+					}
 				}
 			}
 		};

--- a/samples/scales/logarithmic/line.html
+++ b/samples/scales/logarithmic/line.html
@@ -65,13 +65,13 @@
 				text: 'Chart.js Line Chart - Logarithmic'
 			},
 			scales: {
-				xAxes: [{
+				x: {
 					display: true,
-				}],
-				yAxes: [{
+				},
+				y: {
 					display: true,
 					type: 'logarithmic',
-				}]
+				}
 			}
 		}
 	};

--- a/samples/scales/logarithmic/scatter.html
+++ b/samples/scales/logarithmic/scatter.html
@@ -132,7 +132,7 @@
 					text: 'Chart.js Scatter Chart - Logarithmic X-Axis'
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'logarithmic',
 						position: 'bottom',
 						ticks: {
@@ -148,8 +148,8 @@
 							labelString: 'Frequency',
 							display: true,
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'linear',
 						ticks: {
 							userCallback: function(tick) {
@@ -160,7 +160,7 @@
 							labelString: 'Voltage',
 							display: true
 						}
-					}]
+					}
 				}
 			}
 		});

--- a/samples/scales/non-numeric-y.html
+++ b/samples/scales/non-numeric-y.html
@@ -39,14 +39,14 @@
 					text: 'Chart with Non Numeric Y Axis'
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						display: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'Month'
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'category',
 						position: 'left',
 						display: true,
@@ -57,7 +57,7 @@
 						ticks: {
 							reverse: true
 						}
-					}]
+					}
 				}
 			}
 		};

--- a/samples/scales/time/combo.html
+++ b/samples/scales/time/combo.html
@@ -96,14 +96,14 @@
 					text: 'Chart.js Combo Time Scale'
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'time',
 						display: true,
 						time: {
 							format: timeFormat,
 							// round: 'day'
 						}
-					}],
+					},
 				},
 			}
 		};

--- a/samples/scales/time/financial.html
+++ b/samples/scales/time/financial.html
@@ -115,7 +115,7 @@
 					duration: 0
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'time',
 						distribution: 'series',
 						offset: true,
@@ -156,8 +156,9 @@
 							}
 							return ticks;
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
+						type: 'linear',
 						gridLines: {
 							drawBorder: false
 						},
@@ -165,7 +166,7 @@
 							display: true,
 							labelString: 'Closing price ($)'
 						}
-					}]
+					}
 				},
 				tooltips: {
 					intersect: false,

--- a/samples/scales/time/line-point-data.html
+++ b/samples/scales/time/line-point-data.html
@@ -82,7 +82,7 @@
 					text: 'Chart.js Time Point Data'
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'time',
 						display: true,
 						scaleLabel: {
@@ -95,14 +95,14 @@
 								fontColor: '#FF0000'
 							}
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'value'
 						}
-					}]
+					}
 				}
 			}
 		};

--- a/samples/scales/time/line.html
+++ b/samples/scales/time/line.html
@@ -103,7 +103,7 @@
 					text: 'Chart.js Time Scale'
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'time',
 						time: {
 							parser: timeFormat,
@@ -114,13 +114,13 @@
 							display: true,
 							labelString: 'Date'
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						scaleLabel: {
 							display: true,
 							labelString: 'value'
 						}
-					}]
+					}
 				},
 			}
 		};

--- a/samples/scales/toggle-scale-type.html
+++ b/samples/scales/toggle-scale-type.html
@@ -67,13 +67,13 @@
 					text: 'Chart.js Line Chart - ' + type
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						display: true,
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: true,
 						type: type
-					}]
+					}
 				}
 			}
 		};
@@ -86,7 +86,7 @@
 		document.getElementById('toggleScale').addEventListener('click', function() {
 			type = type === 'linear' ? 'logarithmic' : 'linear';
 			window.myLine.options.title.text = 'Chart.js Line Chart - ' + type;
-			window.myLine.options.scales.yAxes[0] = {
+			window.myLine.options.scales.y = {
 				display: true,
 				type: type
 			};

--- a/samples/tooltips/callbacks.html
+++ b/samples/tooltips/callbacks.html
@@ -79,20 +79,20 @@
 					intersect: true
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						display: true,
 						scaleLabel: {
 							show: true,
 							labelString: 'Month'
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: true,
 						scaleLabel: {
 							show: true,
 							labelString: 'Value'
 						}
-					}]
+					}
 				}
 			}
 		};

--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -15,7 +15,6 @@ defaults._set('bar', {
 	scales: {
 		x: {
 			type: 'category',
-			position: 'bottom',
 			offset: true,
 			gridLines: {
 				offsetGridLines: true
@@ -23,7 +22,6 @@ defaults._set('bar', {
 		},
 		y: {
 			type: 'linear',
-			position: 'left'
 		}
 	}
 });

--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -13,17 +13,18 @@ defaults._set('bar', {
 	},
 
 	scales: {
-		xAxes: [{
+		x: {
 			type: 'category',
+			position: 'bottom',
 			offset: true,
 			gridLines: {
 				offsetGridLines: true
 			}
-		}],
-
-		yAxes: [{
-			type: 'linear'
-		}]
+		},
+		y: {
+			type: 'linear',
+			position: 'left'
+		}
 	}
 });
 

--- a/src/controllers/controller.bubble.js
+++ b/src/controllers/controller.bubble.js
@@ -14,16 +14,14 @@ defaults._set('bubble', {
 	},
 
 	scales: {
-		xAxes: [{
-			type: 'linear', // bubble should probably use a linear scale by default
-			position: 'bottom',
-			id: 'x-axis-0' // need an ID so datasets can reference the scale
-		}],
-		yAxes: [{
+		x: {
 			type: 'linear',
-			position: 'left',
-			id: 'y-axis-0'
-		}]
+			position: 'bottom'
+		},
+		y: {
+			type: 'linear',
+			position: 'left'
+		}
 	},
 
 	tooltips: {

--- a/src/controllers/controller.horizontalBar.js
+++ b/src/controllers/controller.horizontalBar.js
@@ -10,19 +10,18 @@ defaults._set('horizontalBar', {
 	},
 
 	scales: {
-		xAxes: [{
+		x: {
 			type: 'linear',
 			position: 'bottom'
-		}],
-
-		yAxes: [{
+		},
+		y: {
 			type: 'category',
 			position: 'left',
 			offset: true,
 			gridLines: {
 				offsetGridLines: true
 			}
-		}]
+		}
 	},
 
 	elements: {

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -20,11 +20,9 @@ defaults._set('line', {
 	scales: {
 		x: {
 			type: 'category',
-			position: 'bottom',
 		},
 		y: {
 			type: 'linear',
-			position: 'left',
 		},
 	}
 });

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -18,14 +18,14 @@ defaults._set('line', {
 	},
 
 	scales: {
-		xAxes: [{
+		x: {
 			type: 'category',
-			id: 'x-axis-0'
-		}],
-		yAxes: [{
+			position: 'bottom',
+		},
+		y: {
 			type: 'linear',
-			id: 'y-axis-0'
-		}]
+			position: 'left',
+		},
 	}
 });
 

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -10,6 +10,7 @@ var resolve = helpers.options.resolve;
 defaults._set('polarArea', {
 	scale: {
 		type: 'radialLinear',
+		position: 'chartArea',
 		angleLines: {
 			display: false
 		},

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -10,7 +10,6 @@ var resolve = helpers.options.resolve;
 defaults._set('polarArea', {
 	scale: {
 		type: 'radialLinear',
-		position: 'chartArea',
 		angleLines: {
 			display: false
 		},

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -11,7 +11,6 @@ defaults._set('radar', {
 	spanGaps: false,
 	scale: {
 		type: 'radialLinear',
-		position: 'chartArea'
 	},
 	elements: {
 		line: {

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -10,7 +10,8 @@ var valueOrDefault = helpers.valueOrDefault;
 defaults._set('radar', {
 	spanGaps: false,
 	scale: {
-		type: 'radialLinear'
+		type: 'radialLinear',
+		position: 'chartArea'
 	},
 	elements: {
 		line: {

--- a/src/controllers/controller.scatter.js
+++ b/src/controllers/controller.scatter.js
@@ -9,16 +9,14 @@ defaults._set('scatter', {
 	},
 
 	scales: {
-		xAxes: [{
-			id: 'x-axis-1',    // need an ID so datasets can reference the scale
-			type: 'linear',    // scatter should not use a category axis
-			position: 'bottom'
-		}],
-		yAxes: [{
-			id: 'y-axis-1',
+		x: {
 			type: 'linear',
-			position: 'left'
-		}]
+			position: 'bottom'
+		},
+		y: {
+			type: 'linear',
+			position: 'left',
+		}
 	},
 
 	tooltips: {

--- a/src/controllers/controller.scatter.js
+++ b/src/controllers/controller.scatter.js
@@ -15,7 +15,7 @@ defaults._set('scatter', {
 		},
 		y: {
 			type: 'linear',
-			position: 'left',
+			position: 'left'
 		}
 	},
 

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -131,6 +131,10 @@ function updateConfig(chart) {
 	chart.tooltip.initialize();
 }
 
+function positionIsHorizontal(position) {
+	return position === 'top' || position === 'bottom';
+}
+
 function compare2Level(l1, l2) {
 	return function(a, b) {
 		return a[l1] === b[l1]
@@ -302,8 +306,15 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 
 		if (options.scales) {
 			items = items.concat(
-				Object.values(options.scales).map(function(axisOptions) {
-					return {options: axisOptions};
+				Object.entries(options.scales).map(function(entry) {
+					var axisID = entry[0];
+					var axisOptions = entry[1];
+					var isHorizontal = axisID.charAt(0).toLowerCase() === 'x';
+					return {
+						options: axisOptions,
+						dposition: isHorizontal ? 'bottom' : 'left',
+						dtype: isHorizontal ? 'category' : 'linear'
+					};
 				})
 			);
 		}
@@ -320,10 +331,10 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 		helpers.each(items, function(item) {
 			var scaleOptions = item.options;
 			var id = scaleOptions.id;
-			var scaleType = scaleOptions.type;
+			var scaleType = valueOrDefault(scaleOptions.type, item.dtype);
 
-			if (!scaleOptions.position) {
-				throw new Error('Axis ' + id + ' has an invalid position of ' + scaleOptions.position);
+			if (positionIsHorizontal(scaleOptions.position) !== positionIsHorizontal(item.dposition)) {
+				scaleOptions.position = item.dposition;
 			}
 
 			updated[id] = true;

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -53,10 +53,6 @@ function mergeScaleConfig(/* config objects ... */) {
 			scale = source[key];
 			type = scale.type;
 
-			if (helpers.isNullOrUndef(type) && helpers.isNullOrUndef(target[key].type)) {
-				throw new Error('Axis config "' + key + '" has no type specified.');
-			}
-
 			if (!target[key].type || (scale.type && scale.type !== target[key].type)) {
 				// new/untyped scale or type changed: let's apply the new defaults
 				// then merge source scale to correctly overwrite the defaults.

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -54,7 +54,7 @@ function mergeScaleConfig(/* config objects ... */) {
 			type = scale.type;
 
 			if (helpers.isNullOrUndef(type) && helpers.isNullOrUndef(target[key].type)) {
-				throw new Error('Axis config ' + key + ' has no "type" specified');
+				throw new Error('Axis config "' + key + '" has no type specified.');
 			}
 
 			if (!target[key].type || (scale.type && scale.type !== target[key].type)) {

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -145,10 +145,10 @@ helpers.extend(DatasetController.prototype, {
 		var scalesOpts = chart.options.scales;
 
 		if (meta.xAxisID === null || !(meta.xAxisID in scales) || dataset.xAxisID) {
-			meta.xAxisID = dataset.xAxisID || scalesOpts.xAxes[0].id;
+			meta.xAxisID = dataset.xAxisID || scalesOpts.x.id;
 		}
 		if (meta.yAxisID === null || !(meta.yAxisID in scales) || dataset.yAxisID) {
-			meta.yAxisID = dataset.yAxisID || scalesOpts.yAxes[0].id;
+			meta.yAxisID = dataset.yAxisID || scalesOpts.y.id;
 		}
 	},
 

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -144,11 +144,14 @@ helpers.extend(DatasetController.prototype, {
 		var dataset = me.getDataset();
 		var scalesOpts = chart.options.scales;
 
+		var firstX = Object.keys(scales).filter(key => scales[key].position === 'top' || scales[key].position === 'bottom').shift();
+		var firstY = Object.keys(scales).filter(key => scales[key].position === 'left' || scales[key].position === 'right').shift();
+
 		if (meta.xAxisID === null || !(meta.xAxisID in scales) || dataset.xAxisID) {
-			meta.xAxisID = dataset.xAxisID || scalesOpts.x.id;
+			meta.xAxisID = dataset.xAxisID || firstX;
 		}
 		if (meta.yAxisID === null || !(meta.yAxisID in scales) || dataset.yAxisID) {
-			meta.yAxisID = dataset.yAxisID || scalesOpts.y.id;
+			meta.yAxisID = dataset.yAxisID || firstY;
 		}
 	},
 

--- a/test/specs/controller.bar.tests.js
+++ b/test/specs/controller.bar.tests.js
@@ -41,21 +41,11 @@ describe('Chart.controllers.bar', function() {
 				],
 				labels: []
 			},
-			options: {
-				scales: {
-					xAxes: [{
-						id: 'firstXScaleID'
-					}],
-					yAxes: [{
-						id: 'firstYScaleID'
-					}]
-				}
-			}
 		});
 
 		var meta = chart.getDatasetMeta(1);
-		expect(meta.xAxisID).toBe('firstXScaleID');
-		expect(meta.yAxisID).toBe('firstYScaleID');
+		expect(meta.xAxisID).toBe('x');
+		expect(meta.yAxisID).toBe('y');
 	});
 
 	it('should correctly count the number of stacks ignoring datasets of other types and hidden datasets', function() {
@@ -122,12 +112,12 @@ describe('Chart.controllers.bar', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: true
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: true
-						}]
+						}
 					}
 				}
 			});
@@ -155,12 +145,12 @@ describe('Chart.controllers.bar', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: false
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: false
-						}]
+						}
 					}
 				}
 			});
@@ -211,12 +201,12 @@ describe('Chart.controllers.bar', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: true
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: true
-						}]
+						}
 					}
 				}
 			});
@@ -244,12 +234,12 @@ describe('Chart.controllers.bar', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: false
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: false
-						}]
+						}
 					}
 				}
 			});
@@ -300,12 +290,12 @@ describe('Chart.controllers.bar', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: true
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: true
-						}]
+						}
 					}
 				}
 			});
@@ -333,12 +323,12 @@ describe('Chart.controllers.bar', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: false
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: false
-						}]
+						}
 					}
 				}
 			});
@@ -416,12 +406,12 @@ describe('Chart.controllers.bar', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: true
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: true
-						}]
+						}
 					}
 				}
 			});
@@ -452,12 +442,12 @@ describe('Chart.controllers.bar', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: false
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: false
-						}]
+						}
 					}
 				}
 			});
@@ -514,12 +504,12 @@ describe('Chart.controllers.bar', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: true
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: true
-						}]
+						}
 					}
 				}
 			});
@@ -550,12 +540,12 @@ describe('Chart.controllers.bar', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: false
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: false
-						}]
+						}
 					}
 				}
 			});
@@ -612,12 +602,12 @@ describe('Chart.controllers.bar', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: true
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: true
-						}]
+						}
 					}
 				}
 			});
@@ -648,12 +638,12 @@ describe('Chart.controllers.bar', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: false
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: false
-						}]
+						}
 					}
 				}
 			});
@@ -712,16 +702,14 @@ describe('Chart.controllers.bar', function() {
 					}
 				},
 				scales: {
-					xAxes: [{
-						id: 'firstXScaleID',
+					x: {
 						type: 'category',
 						display: false
-					}],
-					yAxes: [{
-						id: 'firstYScaleID',
+					},
+					y: {
 						type: 'linear',
 						display: false
-					}]
+					}
 				}
 			}
 		});
@@ -782,14 +770,14 @@ describe('Chart.controllers.bar', function() {
 				legend: false,
 				title: false,
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'category',
 						display: false
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'linear',
 						display: false
-					}]
+					}
 				}
 			}
 		});
@@ -823,15 +811,15 @@ describe('Chart.controllers.bar', function() {
 				legend: false,
 				title: false,
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'category',
 						display: false
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'linear',
 						display: false,
 						stacked: true
-					}]
+					}
 				}
 			}
 		});
@@ -882,11 +870,11 @@ describe('Chart.controllers.bar', function() {
 				legend: false,
 				title: false,
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'category',
 						display: false
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'linear',
 						display: false,
 						stacked: true,
@@ -894,7 +882,7 @@ describe('Chart.controllers.bar', function() {
 							min: 50,
 							max: 100
 						}
-					}]
+					}
 				}
 			}
 		});
@@ -945,15 +933,15 @@ describe('Chart.controllers.bar', function() {
 				legend: false,
 				title: false,
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'category',
 						display: false,
 						stacked: true
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'linear',
 						display: false
-					}]
+					}
 				}
 			}
 		});
@@ -1004,15 +992,15 @@ describe('Chart.controllers.bar', function() {
 				legend: false,
 				title: false,
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'category',
 						display: false
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'linear',
 						display: false,
 						stacked: true
-					}]
+					}
 				}
 			}
 		});
@@ -1065,15 +1053,15 @@ describe('Chart.controllers.bar', function() {
 				legend: false,
 				title: false,
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'category',
 						display: false
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'linear',
 						display: false,
 						stacked: true
-					}]
+					}
 				}
 			}
 		});
@@ -1124,15 +1112,15 @@ describe('Chart.controllers.bar', function() {
 				legend: false,
 				title: false,
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'category',
 						display: false
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'linear',
 						display: false,
 						stacked: true,
-					}]
+					}
 				}
 			}
 		});
@@ -1170,15 +1158,15 @@ describe('Chart.controllers.bar', function() {
 				legend: false,
 				title: false,
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'category',
 						display: false
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'linear',
 						display: false,
 						stacked: true
-					}]
+					}
 				}
 			}
 		});
@@ -1218,16 +1206,16 @@ describe('Chart.controllers.bar', function() {
 					}
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'category',
 						display: false,
 						stacked: true,
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'logarithmic',
 						display: false,
 						stacked: true
-					}]
+					}
 				}
 			}
 		});
@@ -1283,16 +1271,16 @@ describe('Chart.controllers.bar', function() {
 					}
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'category',
 						display: false,
 						stacked: true,
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'logarithmic',
 						display: false,
 						stacked: true
-					}]
+					}
 				}
 			}
 		});
@@ -1517,12 +1505,12 @@ describe('Chart.controllers.bar', function() {
 				data: this.data,
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							ticks: {
 								min: 'March',
 								max: 'May',
 							},
-						}]
+						}
 					}
 				}
 			};
@@ -1534,15 +1522,15 @@ describe('Chart.controllers.bar', function() {
 				data: this.data,
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							ticks: {
 								min: 'March',
 								max: 'May',
 							}
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: true
-						}]
+						}
 					}
 				}
 			};
@@ -1595,12 +1583,12 @@ describe('Chart.controllers.bar', function() {
 				data: this.data,
 				options: {
 					scales: {
-						yAxes: [{
+						y: {
 							ticks: {
 								min: 'March',
 								max: 'May',
 							},
-						}]
+						}
 					}
 				}
 			};
@@ -1612,15 +1600,15 @@ describe('Chart.controllers.bar', function() {
 				data: this.data,
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: true
-						}],
-						yAxes: [{
+						},
+						y: {
 							ticks: {
 								min: 'March',
 								max: 'May',
 							}
-						}]
+						}
 					}
 				}
 			};
@@ -1650,13 +1638,13 @@ describe('Chart.controllers.bar', function() {
 								}
 							},
 							scales: {
-								xAxes: [{
+								x: {
 									id: 'x',
 									type: 'category',
-								}],
-								yAxes: [{
+								},
+								y: {
 									type: 'linear',
-								}]
+								}
 							}
 						}
 					});
@@ -1738,5 +1726,4 @@ describe('Chart.controllers.bar', function() {
 		expect(data[0]._model.base + minBarLength).toEqual(data[0]._model.x);
 		expect(data[1]._model.base - minBarLength).toEqual(data[1]._model.x);
 	});
-
 });

--- a/test/specs/controller.bubble.tests.js
+++ b/test/specs/controller.bubble.tests.js
@@ -33,22 +33,12 @@ describe('Chart.controllers.bubble', function() {
 					data: []
 				}]
 			},
-			options: {
-				scales: {
-					xAxes: [{
-						id: 'firstXScaleID'
-					}],
-					yAxes: [{
-						id: 'firstYScaleID'
-					}]
-				}
-			}
 		});
 
 		var meta = chart.getDatasetMeta(0);
 
-		expect(meta.xAxisID).toBe('firstXScaleID');
-		expect(meta.yAxisID).toBe('firstYScaleID');
+		expect(meta.xAxisID).toBe('x');
+		expect(meta.yAxisID).toBe('y');
 	});
 
 	it('should create point elements for each data item during initialization', function() {
@@ -128,14 +118,14 @@ describe('Chart.controllers.bubble', function() {
 				legend: false,
 				title: false,
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'category',
 						display: false
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'linear',
 						display: false
-					}]
+					}
 				}
 			}
 		});

--- a/test/specs/controller.line.tests.js
+++ b/test/specs/controller.line.tests.js
@@ -35,21 +35,11 @@ describe('Chart.controllers.line', function() {
 				}],
 				labels: []
 			},
-			options: {
-				scales: {
-					xAxes: [{
-						id: 'firstXScaleID'
-					}],
-					yAxes: [{
-						id: 'firstYScaleID'
-					}]
-				}
-			}
 		});
 
 		var meta = chart.getDatasetMeta(0);
-		expect(meta.xAxisID).toBe('firstXScaleID');
-		expect(meta.yAxisID).toBe('firstYScaleID');
+		expect(meta.xAxisID).toBe('x');
+		expect(meta.yAxisID).toBe('y');
 	});
 
 	it('Should create line elements and point elements for each data item during initialization', function() {
@@ -189,14 +179,12 @@ describe('Chart.controllers.line', function() {
 					}
 				},
 				scales: {
-					xAxes: [{
-						id: 'firstXScaleID',
+					x: {
 						display: false
-					}],
-					yAxes: [{
-						id: 'firstYScaleID',
+					},
+					y: {
 						display: false
-					}]
+					}
 				}
 			},
 		});
@@ -247,15 +235,15 @@ describe('Chart.controllers.line', function() {
 					mode: 'single'
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						display: false,
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: false,
 						ticks: {
 							beginAtZero: true
 						}
-					}]
+					}
 				}
 			}
 		});
@@ -316,13 +304,13 @@ describe('Chart.controllers.line', function() {
 				legend: false,
 				title: false,
 				scales: {
-					xAxes: [{
+					x: {
 						display: false,
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: false,
 						stacked: true
-					}]
+					}
 				}
 			}
 		});
@@ -366,7 +354,7 @@ describe('Chart.controllers.line', function() {
 				}, {
 					data: [10, 10, -10, -10],
 					label: 'dataset3',
-					yAxisID: 'secondAxis'
+					yAxisID: 'y2'
 				}],
 				labels: ['label1', 'label2', 'label3', 'label4']
 			},
@@ -374,17 +362,18 @@ describe('Chart.controllers.line', function() {
 				legend: false,
 				title: false,
 				scales: {
-					xAxes: [{
+					x: {
 						display: false,
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: false,
 						stacked: true
-					}, {
-						id: 'secondAxis',
+					}, 
+					y2: {
 						type: 'linear',
+						position: 'right',
 						display: false
-					}]
+					}
 				}
 			}
 		});
@@ -456,13 +445,13 @@ describe('Chart.controllers.line', function() {
 				legend: false,
 				title: false,
 				scales: {
-					xAxes: [{
+					x: {
 						display: false,
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: false,
 						stacked: true
-					}]
+					}
 				}
 			}
 		});
@@ -510,13 +499,13 @@ describe('Chart.controllers.line', function() {
 				legend: false,
 				title: false,
 				scales: {
-					xAxes: [{
+					x: {
 						display: false,
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: false,
 						stacked: true
-					}]
+					}
 				}
 			}
 		});

--- a/test/specs/controller.line.tests.js
+++ b/test/specs/controller.line.tests.js
@@ -163,8 +163,8 @@ describe('Chart.controllers.line', function() {
 				datasets: [{
 					data: [10, 15, 0, -4],
 					label: 'dataset',
-					xAxisID: 'firstXScaleID',
-					yAxisID: 'firstYScaleID'
+					xAxisID: 'x',
+					yAxisID: 'y'
 				}],
 				labels: ['label1', 'label2', 'label3', 'label4']
 			},
@@ -368,7 +368,7 @@ describe('Chart.controllers.line', function() {
 					y: {
 						display: false,
 						stacked: true
-					}, 
+					},
 					y2: {
 						type: 'linear',
 						position: 'right',

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -126,26 +126,6 @@ describe('Chart', function() {
 			defaults.line.spanGaps = false;
 		});
 
-		it('should override axis positions that are incorrect', function() {
-			var chart = acquireChart({
-				type: 'line',
-				options: {
-					scales: {
-						xAxes: [{
-							position: 'left',
-						}],
-						yAxes: [{
-							position: 'bottom'
-						}]
-					}
-				}
-			});
-
-			var scaleOptions = chart.options.scales;
-			expect(scaleOptions.xAxes[0].position).toBe('bottom');
-			expect(scaleOptions.yAxes[0].position).toBe('left');
-		});
-
 		it('should throw an error if the chart type is incorrect', function() {
 			function createChart() {
 				acquireChart({
@@ -159,17 +139,38 @@ describe('Chart', function() {
 					},
 					options: {
 						scales: {
-							xAxes: [{
+							x: {
 								position: 'left',
-							}],
-							yAxes: [{
+							},
+							y: {
 								position: 'bottom'
-							}]
+							}
 						}
 					}
 				});
 			}
 			expect(createChart).toThrow(new Error('"area" is not a chart type.'));
+		});
+
+		it('should throw an error if an axis has no type', function() {
+			function createChart() {
+				acquireChart({
+					type: 'line',
+					data: {
+						datasets: [{
+							label: 'first',
+							data: [10, 20]
+						}],
+						labels: ['0', '1'],
+					},
+					options: {
+						scales: {
+							x1: {},
+						}
+					}
+				});
+			}
+			expect(createChart).toThrow(new Error('Axis "x1" has no type specified.'));
 		});
 	});
 
@@ -193,29 +194,6 @@ describe('Chart', function() {
 			delete Chart.defaults.scale._jasmineCheckC;
 			delete Chart.scaleService.defaults.logarithmic._jasmineCheckB;
 			delete Chart.scaleService.defaults.logarithmic._jasmineCheckC;
-		});
-
-		it('should default to "category" for x scales and "linear" for y scales', function() {
-			var chart = acquireChart({
-				type: 'line',
-				options: {
-					scales: {
-						xAxes: [
-							{id: 'foo0'},
-							{id: 'foo1'}
-						],
-						yAxes: [
-							{id: 'bar0'},
-							{id: 'bar1'}
-						]
-					}
-				}
-			});
-
-			expect(chart.scales.foo0.type).toBe('category');
-			expect(chart.scales.foo1.type).toBe('category');
-			expect(chart.scales.bar0.type).toBe('linear');
-			expect(chart.scales.bar1.type).toBe('linear');
 		});
 
 		it('should correctly apply defaults on central scale', function() {
@@ -249,25 +227,23 @@ describe('Chart', function() {
 				type: 'line',
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'foo',
+						x: {
 							type: 'logarithmic',
 							_jasmineCheckC: 'c2',
 							_jasmineCheckD: 'd2'
-						}],
-						yAxes: [{
-							id: 'bar',
+						},
+						y: {
 							type: 'time',
 							_jasmineCheckC: 'c2',
 							_jasmineCheckE: 'e2'
-						}]
+						}
 					}
 				}
 			});
 
-			expect(chart.scales.foo.type).toBe('logarithmic');
-			expect(chart.scales.foo.options).toBe(chart.options.scales.xAxes[0]);
-			expect(chart.scales.foo.options).toEqual(
+			expect(chart.scales.x.type).toBe('logarithmic');
+			expect(chart.scales.x.options).toBe(chart.options.scales.x);
+			expect(chart.scales.x.options).toEqual(
 				jasmine.objectContaining({
 					_jasmineCheckA: 'a0',
 					_jasmineCheckB: 'b1',
@@ -275,9 +251,9 @@ describe('Chart', function() {
 					_jasmineCheckD: 'd2'
 				}));
 
-			expect(chart.scales.bar.type).toBe('time');
-			expect(chart.scales.bar.options).toBe(chart.options.scales.yAxes[0]);
-			expect(chart.scales.bar.options).toEqual(
+			expect(chart.scales.y.type).toBe('time');
+			expect(chart.scales.y.options).toBe(chart.options.scales.y);
+			expect(chart.scales.y.options).toEqual(
 				jasmine.objectContaining({
 					_jasmineCheckA: 'a0',
 					_jasmineCheckB: 'b0',
@@ -292,23 +268,21 @@ describe('Chart', function() {
 				options: {
 					_jasmineCheck: 42,
 					scales: {
-						xAxes: [{
-							id: 'foo',
+						x: {
 							type: 'linear',
 							_jasmineCheck: 42,
-						}],
-						yAxes: [{
-							id: 'bar',
+						},
+						y: {
 							type: 'category',
 							_jasmineCheck: 42,
-						}]
+						}
 					}
 				}
 			});
 
 			expect(chart.options._jasmineCheck).toBeDefined();
-			expect(chart.scales.foo.options._jasmineCheck).toBeDefined();
-			expect(chart.scales.bar.options._jasmineCheck).toBeDefined();
+			expect(chart.scales.x.options._jasmineCheck).toBeDefined();
+			expect(chart.scales.y.options._jasmineCheck).toBeDefined();
 
 			expect(Chart.defaults.line._jasmineCheck).not.toBeDefined();
 			expect(Chart.defaults.global._jasmineCheck).not.toBeDefined();
@@ -990,17 +964,17 @@ describe('Chart', function() {
 			chart.options = {
 				responsive: false,
 				scales: {
-					yAxes: [{
+					y: {
 						ticks: {
 							min: 0,
 							max: 10
 						}
-					}]
+					}
 				}
 			};
 			chart.update();
 
-			var yScale = chart.scales['y-axis-0'];
+			var yScale = chart.scales.y;
 			expect(yScale.options.ticks.min).toBe(0);
 			expect(yScale.options.ticks.max).toBe(10);
 		});
@@ -1019,11 +993,11 @@ describe('Chart', function() {
 				}
 			});
 
-			chart.options.scales.yAxes[0].ticks.min = 0;
-			chart.options.scales.yAxes[0].ticks.max = 10;
+			chart.options.scales.y.ticks.min = 0;
+			chart.options.scales.y.ticks.max = 10;
 			chart.update();
 
-			var yScale = chart.scales['y-axis-0'];
+			var yScale = chart.scales.y;
 			expect(yScale.options.ticks.min).toBe(0);
 			expect(yScale.options.ticks.max).toBe(10);
 		});
@@ -1043,37 +1017,20 @@ describe('Chart', function() {
 			});
 
 			var newScalesConfig = {
-				yAxes: [{
+				y: {
 					ticks: {
 						min: 0,
 						max: 10
 					}
-				}]
+				}
 			};
 			chart.options.scales = newScalesConfig;
 
 			chart.update();
 
-			var yScale = chart.scales['y-axis-0'];
+			var yScale = chart.scales.y;
 			expect(yScale.options.ticks.min).toBe(0);
 			expect(yScale.options.ticks.max).toBe(10);
-		});
-
-		it ('should assign unique scale IDs', function() {
-			var chart = acquireChart({
-				type: 'line',
-				options: {
-					scales: {
-						xAxes: [{id: 'x-axis-0'}, {}, {}],
-						yAxes: [{id: 'y-axis-1'}, {}, {}]
-					}
-				}
-			});
-
-			expect(Object.keys(chart.scales).sort()).toEqual([
-				'x-axis-0', 'x-axis-1', 'x-axis-2',
-				'y-axis-1', 'y-axis-2', 'y-axis-3'
-			]);
 		});
 
 		it ('should remove discarded scale', function() {
@@ -1088,24 +1045,23 @@ describe('Chart', function() {
 				options: {
 					responsive: true,
 					scales: {
-						yAxes: [{
-							id: 'yAxis0',
+						y: {
 							ticks: {
 								min: 0,
 								max: 10
 							}
-						}]
+						}
 					}
 				}
 			});
 
 			var newScalesConfig = {
-				yAxes: [{
+				y: {
 					ticks: {
 						min: 0,
 						max: 10
 					}
-				}]
+				}
 			};
 			chart.options.scales = newScalesConfig;
 
@@ -1113,7 +1069,7 @@ describe('Chart', function() {
 
 			var yScale = chart.scales.yAxis0;
 			expect(yScale).toBeUndefined();
-			var newyScale = chart.scales['y-axis-0'];
+			var newyScale = chart.scales.y;
 			expect(newyScale.options.ticks.min).toBe(0);
 			expect(newyScale.options.ticks.max).toBe(10);
 		});
@@ -1190,15 +1146,15 @@ describe('Chart', function() {
 				options: {
 					responsive: true,
 					scales: {
-						xAxes: [{
+						x: {
 							type: 'category'
-						}],
-						yAxes: [{
+						},
+						y: {
 							scaleLabel: {
 								display: true,
 								labelString: 'Value'
 							}
-						}]
+						}
 					}
 				}
 			};

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -177,6 +177,25 @@ describe('Chart', function() {
 			delete Chart.scaleService.defaults.logarithmic._jasmineCheckC;
 		});
 
+		it('should default to "category" for x scales and "linear" for y scales', function() {
+			var chart = acquireChart({
+				type: 'line',
+				options: {
+					scales: {
+						xFoo0: {},
+						xFoo1: {},
+						yBar0: {},
+						yBar1: {},
+					}
+				}
+			});
+
+			expect(chart.scales.xFoo0.type).toBe('category');
+			expect(chart.scales.xFoo1.type).toBe('category');
+			expect(chart.scales.yBar0.type).toBe('linear');
+			expect(chart.scales.yBar1.type).toBe('linear');
+		});
+
 		it('should correctly apply defaults on central scale', function() {
 			var chart = acquireChart({
 				type: 'line',

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -140,9 +140,11 @@ describe('Chart', function() {
 					options: {
 						scales: {
 							x: {
+								type: 'linear',
 								position: 'left',
 							},
 							y: {
+								type: 'category',
 								position: 'bottom'
 							}
 						}
@@ -150,27 +152,6 @@ describe('Chart', function() {
 				});
 			}
 			expect(createChart).toThrow(new Error('"area" is not a chart type.'));
-		});
-
-		it('should throw an error if an axis has no type', function() {
-			function createChart() {
-				acquireChart({
-					type: 'line',
-					data: {
-						datasets: [{
-							label: 'first',
-							data: [10, 20]
-						}],
-						labels: ['0', '1'],
-					},
-					options: {
-						scales: {
-							x1: {},
-						}
-					}
-				});
-			}
-			expect(createChart).toThrow(new Error('Axis "x1" has no type specified.'));
 		});
 	});
 
@@ -1150,6 +1131,7 @@ describe('Chart', function() {
 							type: 'category'
 						},
 						y: {
+							type: 'linear',
 							scaleLabel: {
 								display: true,
 								labelString: 'Value'

--- a/test/specs/core.datasetController.tests.js
+++ b/test/specs/core.datasetController.tests.js
@@ -233,16 +233,22 @@ describe('Chart.DatasetController', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'firstXScaleID'
-					}, {
-						id: 'secondXScaleID'
-					}],
-					yAxes: [{
-						id: 'firstYScaleID'
-					}, {
-						id: 'secondYScaleID'
-					}]
+					firstXScaleID: {
+						type: 'category',
+						position: 'bottom'
+					},
+					secondXScaleID: {
+						type: 'category',
+						position: 'bottom'
+					},
+					firstYScaleID: {
+						type: 'linear',
+						position: 'left'
+					},
+					secondYScaleID: {
+						type: 'linear',
+						position: 'left'
+					},
 				}
 			}
 		});

--- a/test/specs/core.layouts.tests.js
+++ b/test/specs/core.layouts.tests.js
@@ -17,18 +17,6 @@ describe('Chart.layouts', function() {
 					{data: [10, 5, 0, 25, 78, -10]}
 				],
 				labels: ['tick1', 'tick2', 'tick3', 'tick4', 'tick5', 'tick6']
-			},
-			options: {
-				scales: {
-					xAxes: [{
-						id: 'xScale',
-						type: 'category'
-					}],
-					yAxes: [{
-						id: 'yScale',
-						type: 'linear'
-					}]
-				}
 			}
 		}, {
 			canvas: {
@@ -43,18 +31,18 @@ describe('Chart.layouts', function() {
 		expect(chart.chartArea.top).toBeCloseToPixel(32);
 
 		// Is xScale at the right spot
-		expect(chart.scales.xScale.bottom).toBeCloseToPixel(150);
-		expect(chart.scales.xScale.left).toBeCloseToPixel(34);
-		expect(chart.scales.xScale.right).toBeCloseToPixel(247);
-		expect(chart.scales.xScale.top).toBeCloseToPixel(120);
-		expect(chart.scales.xScale.labelRotation).toBeCloseTo(0);
+		expect(chart.scales.x.bottom).toBeCloseToPixel(150);
+		expect(chart.scales.x.left).toBeCloseToPixel(34);
+		expect(chart.scales.x.right).toBeCloseToPixel(247);
+		expect(chart.scales.x.top).toBeCloseToPixel(120);
+		expect(chart.scales.x.labelRotation).toBeCloseTo(0);
 
 		// Is yScale at the right spot
-		expect(chart.scales.yScale.bottom).toBeCloseToPixel(120);
-		expect(chart.scales.yScale.left).toBeCloseToPixel(0);
-		expect(chart.scales.yScale.right).toBeCloseToPixel(34);
-		expect(chart.scales.yScale.top).toBeCloseToPixel(32);
-		expect(chart.scales.yScale.labelRotation).toBeCloseTo(0);
+		expect(chart.scales.y.bottom).toBeCloseToPixel(120);
+		expect(chart.scales.y.left).toBeCloseToPixel(0);
+		expect(chart.scales.y.right).toBeCloseToPixel(34);
+		expect(chart.scales.y.top).toBeCloseToPixel(32);
+		expect(chart.scales.y.labelRotation).toBeCloseTo(0);
 	});
 
 	it('should fit scales that are in the top and right positions', function() {
@@ -68,16 +56,14 @@ describe('Chart.layouts', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale',
+					x: {
 						type: 'category',
 						position: 'top'
-					}],
-					yAxes: [{
-						id: 'yScale',
+					},
+					y: {
 						type: 'linear',
 						position: 'right'
-					}]
+					}
 				}
 			}
 		}, {
@@ -93,18 +79,18 @@ describe('Chart.layouts', function() {
 		expect(chart.chartArea.top).toBeCloseToPixel(62);
 
 		// Is xScale at the right spot
-		expect(chart.scales.xScale.bottom).toBeCloseToPixel(62);
-		expect(chart.scales.xScale.left).toBeCloseToPixel(3);
-		expect(chart.scales.xScale.right).toBeCloseToPixel(216);
-		expect(chart.scales.xScale.top).toBeCloseToPixel(32);
-		expect(chart.scales.xScale.labelRotation).toBeCloseTo(0);
+		expect(chart.scales.x.bottom).toBeCloseToPixel(62);
+		expect(chart.scales.x.left).toBeCloseToPixel(3);
+		expect(chart.scales.x.right).toBeCloseToPixel(216);
+		expect(chart.scales.x.top).toBeCloseToPixel(32);
+		expect(chart.scales.x.labelRotation).toBeCloseTo(0);
 
 		// Is yScale at the right spot
-		expect(chart.scales.yScale.bottom).toBeCloseToPixel(142);
-		expect(chart.scales.yScale.left).toBeCloseToPixel(216);
-		expect(chart.scales.yScale.right).toBeCloseToPixel(250);
-		expect(chart.scales.yScale.top).toBeCloseToPixel(62);
-		expect(chart.scales.yScale.labelRotation).toBeCloseTo(0);
+		expect(chart.scales.y.bottom).toBeCloseToPixel(142);
+		expect(chart.scales.y.left).toBeCloseToPixel(216);
+		expect(chart.scales.y.right).toBeCloseToPixel(250);
+		expect(chart.scales.y.top).toBeCloseToPixel(62);
+		expect(chart.scales.y.labelRotation).toBeCloseTo(0);
 	});
 
 	it('should fit scales with long labels correctly', function() {
@@ -121,19 +107,17 @@ describe('Chart.layouts', function() {
 					display: false
 				},
 				scales: {
-					xAxes: [{
-						id: 'xScale',
+					x: {
 						type: 'category',
 						ticks: {
 							maxRotation: 0,
 							autoSkip: false
 						}
-					}],
-					yAxes: [{
-						id: 'yScale',
+					},
+					y: {
 						type: 'linear',
 						position: 'right'
-					}]
+					}
 				}
 			}
 		}, {
@@ -149,30 +133,30 @@ describe('Chart.layouts', function() {
 		expect(chart.chartArea.top).toBeCloseToPixel(7);
 
 		// Is xScale at the right spot
-		expect(chart.scales.xScale.bottom).toBeCloseToPixel(150);
-		expect(chart.scales.xScale.left).toBeCloseToPixel(60);
-		expect(chart.scales.xScale.right).toBeCloseToPixel(452);
-		expect(chart.scales.xScale.top).toBeCloseToPixel(120);
-		expect(chart.scales.xScale.labelRotation).toBeCloseTo(0);
+		expect(chart.scales.x.bottom).toBeCloseToPixel(150);
+		expect(chart.scales.x.left).toBeCloseToPixel(60);
+		expect(chart.scales.x.right).toBeCloseToPixel(452);
+		expect(chart.scales.x.top).toBeCloseToPixel(120);
+		expect(chart.scales.x.labelRotation).toBeCloseTo(0);
 
-		expect(chart.scales.xScale.height).toBeCloseToPixel(30);
-		expect(chart.scales.xScale.paddingLeft).toBeCloseToPixel(60);
-		expect(chart.scales.xScale.paddingTop).toBeCloseToPixel(0);
-		expect(chart.scales.xScale.paddingRight).toBeCloseToPixel(60);
-		expect(chart.scales.xScale.paddingBottom).toBeCloseToPixel(0);
+		expect(chart.scales.x.height).toBeCloseToPixel(30);
+		expect(chart.scales.x.paddingLeft).toBeCloseToPixel(60);
+		expect(chart.scales.x.paddingTop).toBeCloseToPixel(0);
+		expect(chart.scales.x.paddingRight).toBeCloseToPixel(60);
+		expect(chart.scales.x.paddingBottom).toBeCloseToPixel(0);
 
 		// Is yScale at the right spot
-		expect(chart.scales.yScale.bottom).toBeCloseToPixel(120);
-		expect(chart.scales.yScale.left).toBeCloseToPixel(452);
-		expect(chart.scales.yScale.right).toBeCloseToPixel(486);
-		expect(chart.scales.yScale.top).toBeCloseToPixel(7);
-		expect(chart.scales.yScale.labelRotation).toBeCloseTo(0);
+		expect(chart.scales.y.bottom).toBeCloseToPixel(120);
+		expect(chart.scales.y.left).toBeCloseToPixel(452);
+		expect(chart.scales.y.right).toBeCloseToPixel(486);
+		expect(chart.scales.y.top).toBeCloseToPixel(7);
+		expect(chart.scales.y.labelRotation).toBeCloseTo(0);
 
-		expect(chart.scales.yScale.width).toBeCloseToPixel(34);
-		expect(chart.scales.yScale.paddingLeft).toBeCloseToPixel(0);
-		expect(chart.scales.yScale.paddingTop).toBeCloseToPixel(7);
-		expect(chart.scales.yScale.paddingRight).toBeCloseToPixel(0);
-		expect(chart.scales.yScale.paddingBottom).toBeCloseToPixel(7);
+		expect(chart.scales.y.width).toBeCloseToPixel(34);
+		expect(chart.scales.y.paddingLeft).toBeCloseToPixel(0);
+		expect(chart.scales.y.paddingTop).toBeCloseToPixel(7);
+		expect(chart.scales.y.paddingRight).toBeCloseToPixel(0);
+		expect(chart.scales.y.paddingBottom).toBeCloseToPixel(7);
 	});
 
 	it('should fit scales that overlap the chart area', function() {
@@ -206,27 +190,25 @@ describe('Chart.layouts', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale1',
+					yAxisID: 'y',
 					data: [10, 5, 0, 25, 78, -10]
 				}, {
-					yAxisID: 'yScale2',
+					yAxisID: 'y2',
 					data: [-19, -20, 0, -99, -50, 0]
 				}],
 				labels: ['tick1', 'tick2', 'tick3', 'tick4', 'tick5', 'tick6']
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale',
+					x: {
 						type: 'category'
-					}],
-					yAxes: [{
-						id: 'yScale1',
+					},
+					y: {
 						type: 'linear'
-					}, {
-						id: 'yScale2',
+					},
+					y2: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		}, {
@@ -242,24 +224,24 @@ describe('Chart.layouts', function() {
 		expect(chart.chartArea.top).toBeCloseToPixel(32);
 
 		// Is xScale at the right spot
-		expect(chart.scales.xScale.bottom).toBeCloseToPixel(150);
-		expect(chart.scales.xScale.left).toBeCloseToPixel(73);
-		expect(chart.scales.xScale.right).toBeCloseToPixel(247);
-		expect(chart.scales.xScale.top).toBeCloseToPixel(118);
-		expect(chart.scales.xScale.labelRotation).toBeCloseTo(40, -1);
+		expect(chart.scales.x.bottom).toBeCloseToPixel(150);
+		expect(chart.scales.x.left).toBeCloseToPixel(73);
+		expect(chart.scales.x.right).toBeCloseToPixel(247);
+		expect(chart.scales.x.top).toBeCloseToPixel(118);
+		expect(chart.scales.x.labelRotation).toBeCloseTo(40, -1);
 
 		// Are yScales at the right spot
-		expect(chart.scales.yScale1.bottom).toBeCloseToPixel(118);
-		expect(chart.scales.yScale1.left).toBeCloseToPixel(41);
-		expect(chart.scales.yScale1.right).toBeCloseToPixel(73);
-		expect(chart.scales.yScale1.top).toBeCloseToPixel(32);
-		expect(chart.scales.yScale1.labelRotation).toBeCloseTo(0);
+		expect(chart.scales.y.bottom).toBeCloseToPixel(118);
+		expect(chart.scales.y.left).toBeCloseToPixel(41);
+		expect(chart.scales.y.right).toBeCloseToPixel(73);
+		expect(chart.scales.y.top).toBeCloseToPixel(32);
+		expect(chart.scales.y.labelRotation).toBeCloseTo(0);
 
-		expect(chart.scales.yScale2.bottom).toBeCloseToPixel(118);
-		expect(chart.scales.yScale2.left).toBeCloseToPixel(0);
-		expect(chart.scales.yScale2.right).toBeCloseToPixel(41);
-		expect(chart.scales.yScale2.top).toBeCloseToPixel(32);
-		expect(chart.scales.yScale2.labelRotation).toBeCloseTo(0);
+		expect(chart.scales.y2.bottom).toBeCloseToPixel(118);
+		expect(chart.scales.y2.left).toBeCloseToPixel(0);
+		expect(chart.scales.y2.right).toBeCloseToPixel(41);
+		expect(chart.scales.y2.top).toBeCloseToPixel(32);
+		expect(chart.scales.y2.labelRotation).toBeCloseTo(0);
 	});
 
 	it ('should fit a full width box correctly', function() {
@@ -267,29 +249,27 @@ describe('Chart.layouts', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale1',
+					xAxisID: 'x',
 					data: [10, 5, 0, 25, 78, -10]
 				}, {
-					xAxisID: 'xScale2',
+					xAxisID: 'x2',
 					data: [-19, -20, 0, -99, -50, 0]
 				}],
 				labels: ['tick1', 'tick2', 'tick3', 'tick4', 'tick5', 'tick6']
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale1',
+					x: {
 						type: 'category'
-					}, {
-						id: 'xScale2',
+					},
+					x2: {
 						type: 'category',
 						position: 'top',
 						fullWidth: true
-					}],
-					yAxes: [{
-						id: 'yScale',
+					},
+					y: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
@@ -300,21 +280,21 @@ describe('Chart.layouts', function() {
 		expect(chart.chartArea.top).toBeCloseToPixel(62);
 
 		// Are xScales at the right spot
-		expect(chart.scales.xScale1.bottom).toBeCloseToPixel(512);
-		expect(chart.scales.xScale1.left).toBeCloseToPixel(40);
-		expect(chart.scales.xScale1.right).toBeCloseToPixel(496);
-		expect(chart.scales.xScale1.top).toBeCloseToPixel(484);
+		expect(chart.scales.x.bottom).toBeCloseToPixel(512);
+		expect(chart.scales.x.left).toBeCloseToPixel(40);
+		expect(chart.scales.x.right).toBeCloseToPixel(496);
+		expect(chart.scales.x.top).toBeCloseToPixel(484);
 
-		expect(chart.scales.xScale2.bottom).toBeCloseToPixel(62);
-		expect(chart.scales.xScale2.left).toBeCloseToPixel(0);
-		expect(chart.scales.xScale2.right).toBeCloseToPixel(512);
-		expect(chart.scales.xScale2.top).toBeCloseToPixel(32);
+		expect(chart.scales.x2.bottom).toBeCloseToPixel(62);
+		expect(chart.scales.x2.left).toBeCloseToPixel(0);
+		expect(chart.scales.x2.right).toBeCloseToPixel(512);
+		expect(chart.scales.x2.top).toBeCloseToPixel(32);
 
 		// Is yScale at the right spot
-		expect(chart.scales.yScale.bottom).toBeCloseToPixel(484);
-		expect(chart.scales.yScale.left).toBeCloseToPixel(0);
-		expect(chart.scales.yScale.right).toBeCloseToPixel(40);
-		expect(chart.scales.yScale.top).toBeCloseToPixel(62);
+		expect(chart.scales.y.bottom).toBeCloseToPixel(484);
+		expect(chart.scales.y.left).toBeCloseToPixel(0);
+		expect(chart.scales.y.right).toBeCloseToPixel(40);
+		expect(chart.scales.y.top).toBeCloseToPixel(62);
 	});
 
 	describe('padding settings', function() {
@@ -331,16 +311,14 @@ describe('Chart.layouts', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'xScale',
+						x: {
 							type: 'category',
 							display: false
-						}],
-						yAxes: [{
-							id: 'yScale',
+						},
+						y: {
 							type: 'linear',
 							display: false
-						}]
+						}
 					},
 					legend: {
 						display: false
@@ -378,16 +356,14 @@ describe('Chart.layouts', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'xScale',
+						x: {
 							type: 'category',
 							display: false
-						}],
-						yAxes: [{
-							id: 'yScale',
+						},
+						y: {
 							type: 'linear',
 							display: false
-						}]
+						}
 					},
 					legend: {
 						display: false
@@ -430,16 +406,14 @@ describe('Chart.layouts', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'xScale',
+						x: {
 							type: 'category',
 							display: false
-						}],
-						yAxes: [{
-							id: 'yScale',
+						},
+						y: {
 							type: 'linear',
 							display: false
-						}]
+						}
 					},
 					legend: {
 						display: false
@@ -494,8 +468,8 @@ describe('Chart.layouts', function() {
 				}
 			});
 
-			var xAxis = chart.scales['x-axis-0'];
-			var yAxis = chart.scales['y-axis-0'];
+			var xAxis = chart.scales.x;
+			var yAxis = chart.scales.y;
 			var legend = chart.legend;
 			var title = chart.titleBlock;
 
@@ -516,60 +490,63 @@ describe('Chart.layouts', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'xScale0',
+						x: {
 							type: 'category',
+							position: 'bottom',
 							display: true,
 							weight: 1
-						}, {
-							id: 'xScale1',
+						},
+						x1: {
 							type: 'category',
+							position: 'bottom',
 							display: true,
 							weight: 2
-						}, {
-							id: 'xScale2',
+						},
+						x2: {
 							type: 'category',
+							position: 'bottom',
 							display: true
-						}, {
-							id: 'xScale3',
+						},
+						x3: {
 							type: 'category',
 							display: true,
 							position: 'top',
 							weight: 1
-						}, {
-							id: 'xScale4',
+						},
+						x4: {
 							type: 'category',
 							display: true,
 							position: 'top',
 							weight: 2
-						}],
-						yAxes: [{
-							id: 'yScale0',
+						},
+						y: {
 							type: 'linear',
 							display: true,
 							weight: 1
-						}, {
-							id: 'yScale1',
+						},
+						y1: {
 							type: 'linear',
+							position: 'left',
 							display: true,
 							weight: 2
-						}, {
-							id: 'yScale2',
+						},
+						y2: {
 							type: 'linear',
+							position: 'left',
 							display: true
-						}, {
-							id: 'yScale3',
+						},
+						y3: {
 							type: 'linear',
 							display: true,
 							position: 'right',
 							weight: 1
-						}, {
-							id: 'yScale4',
+						},
+						y4: {
 							type: 'linear',
 							display: true,
 							position: 'right',
 							weight: 2
-						}]
+						}
 					}
 				}
 			}, {
@@ -579,17 +556,17 @@ describe('Chart.layouts', function() {
 				}
 			});
 
-			var xScale0 = chart.scales.xScale0;
-			var xScale1 = chart.scales.xScale1;
-			var xScale2 = chart.scales.xScale2;
-			var xScale3 = chart.scales.xScale3;
-			var xScale4 = chart.scales.xScale4;
+			var xScale0 = chart.scales.x;
+			var xScale1 = chart.scales.x1;
+			var xScale2 = chart.scales.x2;
+			var xScale3 = chart.scales.x3;
+			var xScale4 = chart.scales.x4;
 
-			var yScale0 = chart.scales.yScale0;
-			var yScale1 = chart.scales.yScale1;
-			var yScale2 = chart.scales.yScale2;
-			var yScale3 = chart.scales.yScale3;
-			var yScale4 = chart.scales.yScale4;
+			var yScale0 = chart.scales.y;
+			var yScale1 = chart.scales.y1;
+			var yScale2 = chart.scales.y2;
+			var yScale3 = chart.scales.y3;
+			var yScale4 = chart.scales.y4;
 
 			expect(xScale0.weight).toBe(1);
 			expect(xScale1.weight).toBe(2);
@@ -646,7 +623,7 @@ describe('Chart.layouts', function() {
 					width: 256
 				}
 			});
-			var yAxis = chart.scales['y-axis-0'];
+			var yAxis = chart.scales.y;
 
 			// issue #4441: y-axis labels partially hidden.
 			// minimum horizontal space required to fit labels

--- a/test/specs/core.scale.tests.js
+++ b/test/specs/core.scale.tests.js
@@ -24,18 +24,18 @@ describe('Core.scale', function() {
 				data: data,
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							ticks: {
 								autoSkip: true
 							}
-						}]
+						}
 					}
 				}
 			});
 		}
 
 		function lastTick(chart) {
-			var xAxis = chart.scales['x-axis-0'];
+			var xAxis = chart.scales.x;
 			var ticks = xAxis.getTicks();
 			return ticks[ticks.length - 1];
 		}
@@ -129,8 +129,7 @@ describe('Core.scale', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'xScale0',
+						x: {
 							gridLines: {
 								offsetGridLines: test.offsetGridLines,
 								drawTicks: false
@@ -139,10 +138,10 @@ describe('Core.scale', function() {
 								display: false
 							},
 							offset: test.offset
-						}],
-						yAxes: [{
+						},
+						y: {
 							display: false
-						}]
+						}
 					},
 					legend: {
 						display: false
@@ -150,7 +149,7 @@ describe('Core.scale', function() {
 				}
 			});
 
-			var xScale = chart.scales.xScale0;
+			var xScale = chart.scales.x;
 			xScale.ctx = window.createMockContext();
 			chart.draw();
 
@@ -174,12 +173,11 @@ describe('Core.scale', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							display: false
-						}],
-						yAxes: [{
+						},
+						y: {
 							type: 'category',
-							id: 'yScale0',
 							gridLines: {
 								offsetGridLines: test.offsetGridLines,
 								drawTicks: false
@@ -188,7 +186,7 @@ describe('Core.scale', function() {
 								display: false
 							},
 							offset: test.offset
-						}]
+						}
 					},
 					legend: {
 						display: false
@@ -196,7 +194,7 @@ describe('Core.scale', function() {
 				}
 			});
 
-			var yScale = chart.scales.yScale0;
+			var yScale = chart.scales.y;
 			yScale.ctx = window.createMockContext();
 			chart.draw();
 
@@ -222,12 +220,9 @@ describe('Core.scale', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'foo'
-					}],
-					yAxes: [{
+					y: {
 						display: false
-					}]
+					}
 				},
 				legend: {
 					display: false
@@ -240,7 +235,7 @@ describe('Core.scale', function() {
 			}
 		});
 
-		var scale = chart.scales.foo;
+		var scale = chart.scales.x;
 		expect(scale.left).toBeGreaterThan(100);
 		expect(scale.right).toBeGreaterThan(190);
 	});
@@ -264,19 +259,17 @@ describe('Core.scale', function() {
 					},
 					options: {
 						scales: {
-							xAxes: [{
-								id: 'foo',
+							x: {
 								display: 'auto'
-							}],
-							yAxes: [{
+							},
+							y: {
 								type: 'category',
-								id: 'yScale0'
-							}]
+							}
 						}
 					}
 				});
 
-				var scale = chart.scales.foo;
+				var scale = chart.scales.x;
 				scale.ctx = window.createMockContext();
 				chart.draw();
 
@@ -297,15 +290,14 @@ describe('Core.scale', function() {
 					},
 					options: {
 						scales: {
-							xAxes: [{
-								id: 'foo',
+							x: {
 								display: 'auto'
-							}]
+							}
 						}
 					}
 				});
 
-				var scale = chart.scales.foo;
+				var scale = chart.scales.x;
 				scale.ctx = window.createMockContext();
 				chart.draw();
 
@@ -332,15 +324,14 @@ describe('Core.scale', function() {
 					},
 					options: {
 						scales: {
-							yAxes: [{
-								id: 'foo',
+							y: {
 								display: 'auto'
-							}]
+							}
 						}
 					}
 				});
 
-				var scale = chart.scales.foo;
+				var scale = chart.scales.y;
 				scale.ctx = window.createMockContext();
 				chart.draw();
 
@@ -361,15 +352,14 @@ describe('Core.scale', function() {
 					},
 					options: {
 						scales: {
-							yAxes: [{
-								id: 'foo',
+							y: {
 								display: 'auto'
-							}]
+							}
 						}
 					}
 				});
 
-				var scale = chart.scales.foo;
+				var scale = chart.scales.y;
 				scale.ctx = window.createMockContext();
 				chart.draw();
 
@@ -386,14 +376,13 @@ describe('Core.scale', function() {
 				type: 'line',
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'x',
+						x: {
 							type: 'category',
 							labels: labels,
 							afterBuildTicks: function(axis, ticks) {
 								return ticks.slice(1);
 							}
-						}]
+						}
 					}
 				}
 			});
@@ -410,8 +399,7 @@ describe('Core.scale', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'x',
+						x: {
 							type: 'time',
 							time: {
 								parser: 'YYYY'
@@ -422,7 +410,7 @@ describe('Core.scale', function() {
 							afterBuildTicks: function(axis, ticks) {
 								return ticks.slice(1);
 							}
-						}]
+						}
 					}
 				}
 			});
@@ -437,12 +425,11 @@ describe('Core.scale', function() {
 				type: 'line',
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'x',
+						x: {
 							type: 'category',
 							labels: labels,
 							afterBuildTicks: function() { }
-						}]
+						}
 					}
 				}
 			});
@@ -457,14 +444,13 @@ describe('Core.scale', function() {
 				type: 'line',
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'x',
+						x: {
 							type: 'category',
 							labels: labels,
 							afterBuildTicks: function() {
 								return [];
 							}
-						}]
+						}
 					}
 				}
 			});
@@ -480,10 +466,9 @@ describe('Core.scale', function() {
 				type: 'line',
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'x',
+						x: {
 							type: 'linear',
-						}]
+						}
 					}
 				}
 			});
@@ -505,8 +490,7 @@ describe('Core.scale', function() {
 				type: 'line',
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'x',
+						x: {
 							type: 'customScale',
 							gridLines: {
 								z: 10
@@ -514,7 +498,7 @@ describe('Core.scale', function() {
 							ticks: {
 								z: 20
 							}
-						}]
+						}
 					}
 				}
 			});
@@ -529,8 +513,7 @@ describe('Core.scale', function() {
 				type: 'line',
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'x',
+						x: {
 							type: 'linear',
 							ticks: {
 								z: 10
@@ -538,7 +521,7 @@ describe('Core.scale', function() {
 							gridLines: {
 								z: 10
 							}
-						}]
+						}
 					}
 				}
 			});
@@ -553,13 +536,12 @@ describe('Core.scale', function() {
 				type: 'line',
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'x',
+						x: {
 							type: 'linear',
 							ticks: {
 								z: 10
 							}
-						}]
+						}
 					}
 				}
 			});
@@ -570,13 +552,12 @@ describe('Core.scale', function() {
 				type: 'line',
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'x',
+						x: {
 							type: 'linear',
 							gridLines: {
 								z: 11
 							}
-						}]
+						}
 					}
 				}
 			});
@@ -587,8 +568,7 @@ describe('Core.scale', function() {
 				type: 'line',
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'x',
+						x: {
 							type: 'linear',
 							ticks: {
 								z: 10
@@ -596,7 +576,7 @@ describe('Core.scale', function() {
 							gridLines: {
 								z: 11
 							}
-						}]
+						}
 					}
 				}
 			});

--- a/test/specs/core.ticks.tests.js
+++ b/test/specs/core.ticks.tests.js
@@ -21,7 +21,7 @@ describe('Test tick generators', function() {
 					display: false,
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'linear',
 						position: 'bottom',
 						ticks: {
@@ -29,21 +29,21 @@ describe('Test tick generators', function() {
 								return value.toString();
 							}
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'linear',
 						ticks: {
 							callback: function(value) {
 								return value.toString();
 							}
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		var xAxis = chart.scales['x-axis-0'];
-		var yAxis = chart.scales['y-axis-0'];
+		var xAxis = chart.scales.x;
+		var yAxis = chart.scales.y;
 
 		expect(xAxis.ticks).toEqual(['0', '0.1', '0.2', '0.3', '0.4', '0.5', '0.6', '0.7', '0.8', '0.9', '1']);
 		expect(yAxis.ticks).toEqual(['1', '0.9', '0.8', '0.7', '0.6', '0.5', '0.4', '0.3', '0.2', '0.1', '0']);
@@ -62,7 +62,7 @@ describe('Test tick generators', function() {
 					display: false,
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'logarithmic',
 						position: 'bottom',
 						ticks: {
@@ -72,8 +72,8 @@ describe('Test tick generators', function() {
 								return value.toString();
 							}
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'logarithmic',
 						ticks: {
 							min: 0.1,
@@ -82,13 +82,13 @@ describe('Test tick generators', function() {
 								return value.toString();
 							}
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		var xAxis = chart.scales['x-axis-0'];
-		var yAxis = chart.scales['y-axis-0'];
+		var xAxis = chart.scales.x;
+		var yAxis = chart.scales.y;
 
 		expect(xAxis.ticks).toEqual(['0.1', '0.2', '0.3', '0.4', '0.5', '0.6', '0.7', '0.8', '0.9', '1']);
 		expect(yAxis.ticks).toEqual(['1', '0.9', '0.8', '0.7', '0.6', '0.5', '0.4', '0.3', '0.2', '0.1']);

--- a/test/specs/scale.category.tests.js
+++ b/test/specs/scale.category.tests.js
@@ -282,7 +282,7 @@ describe('Category scale tests', function() {
 			}
 		});
 
-		var xScale = chart.scales.xScale0;
+		var xScale = chart.scales.x;
 		expect(xScale.getPixelForValue(0, 1, 0)).toBeCloseToPixel(23 + 6); // plus lineHeight
 		expect(xScale.getPixelForValue(0, 3, 0)).toBeCloseToPixel(496);
 
@@ -511,7 +511,6 @@ describe('Category scale tests', function() {
 						position: 'bottom'
 					},
 					y: {
-						id: 'yScale0',
 						type: 'category'
 					}
 				}

--- a/test/specs/scale.category.tests.js
+++ b/test/specs/scale.category.tests.js
@@ -143,11 +143,10 @@ describe('Category scale tests', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'x',
+					x: {
 						type: 'category',
 						labels: labels
-					}]
+					}
 				}
 			}
 		});
@@ -161,28 +160,26 @@ describe('Category scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: [10, 5, 0, 25, 78]
 				}],
 				labels: ['tick1', 'tick2', 'tick3', 'tick4', 'tick5']
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'category',
 						position: 'bottom'
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 
-		var scale = chart.scales.xScale0;
+		var scale = chart.scales.x;
 
 		expect(scale.getLabelForIndex(1, 0)).toBe('tick2');
 	});
@@ -192,28 +189,26 @@ describe('Category scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: [10, 5, 0, 25, 78]
 				}],
 				labels: ['tick1', 'tick2', 'tick3', 'tick4', 'tick_last']
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'category',
 						position: 'bottom'
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 
-		var xScale = chart.scales.xScale0;
+		var xScale = chart.scales.x;
 		expect(xScale.getPixelForValue(0, 0, 0)).toBeCloseToPixel(23 + 6); // plus lineHeight
 		expect(xScale.getValueForPixel(23)).toBe(0);
 
@@ -235,28 +230,26 @@ describe('Category scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: [10, 5, 0, 25, 78]
 				}],
 				labels: ['tick1', 'tick2', 'tick3', 'tick4', 'tick_last']
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'category',
 						position: 'bottom'
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 
-		var xScale = chart.scales.xScale0;
+		var xScale = chart.scales.x;
 		expect(xScale.getPixelForValue('tick_1', 0, 0)).toBeCloseToPixel(23 + 6); // plus lineHeight
 		expect(xScale.getPixelForValue('tick_1', 1, 0)).toBeCloseToPixel(143);
 	});
@@ -266,27 +259,25 @@ describe('Category scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: [10, 5, 0, 25, 78]
 				}],
 				labels: ['tick1', 'tick2', 'tick3', 'tick4', 'tick_last']
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'category',
 						position: 'bottom',
 						ticks: {
 							min: 'tick2',
 							max: 'tick4'
 						}
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
@@ -307,8 +298,8 @@ describe('Category scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: ['3', '5', '1', '4', '2']
 				}],
 				labels: ['tick1', 'tick2', 'tick3', 'tick4', 'tick5'],
@@ -316,21 +307,19 @@ describe('Category scale tests', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'category',
 						position: 'bottom',
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'category',
 						position: 'left'
-					}]
+					}
 				}
 			}
 		});
 
-		var yScale = chart.scales.yScale0;
+		var yScale = chart.scales.y;
 		expect(yScale.getPixelForValue(0, 0, 0)).toBeCloseToPixel(32);
 		expect(yScale.getValueForPixel(32)).toBe(0);
 
@@ -352,8 +341,8 @@ describe('Category scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: ['3', '5', '1', '4', '2']
 				}],
 				labels: ['tick1', 'tick2', 'tick3', 'tick4', 'tick5'],
@@ -361,25 +350,23 @@ describe('Category scale tests', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'category',
 						position: 'bottom',
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'category',
 						position: 'left',
 						ticks: {
 							min: '2',
 							max: '4'
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		var yScale = chart.scales.yScale0;
+		var yScale = chart.scales.y;
 
 		expect(yScale.getPixelForValue(0, 1, 0)).toBeCloseToPixel(32);
 		expect(yScale.getPixelForValue(0, 3, 0)).toBeCloseToPixel(484);
@@ -396,8 +383,8 @@ describe('Category scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: [
 						{x: 0, y: 10},
 						{x: 1, y: 5},
@@ -410,20 +397,18 @@ describe('Category scale tests', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'category',
 						position: 'bottom'
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 
-		var xScale = chart.scales.xScale0;
+		var xScale = chart.scales.x;
 		expect(xScale.getPixelForValue({x: 0, y: 10}, 0, 0)).toBeCloseToPixel(29);
 		expect(xScale.getPixelForValue({x: 3, y: 25}, 3, 0)).toBeCloseToPixel(506);
 		expect(xScale.getPixelForValue({x: 0, y: 78}, 4, 0)).toBeCloseToPixel(29);
@@ -434,8 +419,8 @@ describe('Category scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: [
 						{x: 0, y: 2},
 						{x: 1, y: 4},
@@ -449,21 +434,19 @@ describe('Category scale tests', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'category',
 						position: 'bottom'
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'category',
 						position: 'left'
-					}]
+					}
 				}
 			}
 		});
 
-		var yScale = chart.scales.yScale0;
+		var yScale = chart.scales.y;
 		expect(yScale.getPixelForValue({x: 0, y: 2}, 0, 0)).toBeCloseToPixel(257);
 		expect(yScale.getPixelForValue({x: 0, y: 1}, 4, 0)).toBeCloseToPixel(144);
 	});
@@ -473,8 +456,8 @@ describe('Category scale tests', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: [
 						{x: 0, y: 10},
 						{x: 1, y: 5},
@@ -487,20 +470,18 @@ describe('Category scale tests', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'category',
 						position: 'bottom'
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 
-		var xScale = chart.scales.xScale0;
+		var xScale = chart.scales.x;
 		expect(xScale.getPixelForValue(null, 0, 0)).toBeCloseToPixel(89);
 		expect(xScale.getPixelForValue(null, 3, 0)).toBeCloseToPixel(449);
 		expect(xScale.getPixelForValue(null, 4, 0)).toBeCloseToPixel(89);
@@ -511,8 +492,8 @@ describe('Category scale tests', function() {
 			type: 'horizontalBar',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: [
 						{x: 10, y: 0},
 						{x: 5, y: 1},
@@ -525,20 +506,19 @@ describe('Category scale tests', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'linear',
 						position: 'bottom'
-					}],
-					yAxes: [{
+					},
+					y: {
 						id: 'yScale0',
 						type: 'category'
-					}]
+					}
 				}
 			}
 		});
 
-		var yScale = chart.scales.yScale0;
+		var yScale = chart.scales.y;
 		expect(yScale.getPixelForValue(null, 0, 0)).toBeCloseToPixel(88);
 		expect(yScale.getPixelForValue(null, 3, 0)).toBeCloseToPixel(426);
 		expect(yScale.getPixelForValue(null, 4, 0)).toBeCloseToPixel(88);

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -629,7 +629,7 @@ describe('Linear Scale', function() {
 				},
 				options: {
 					scales: {
-						y: {	
+						y: {
 							type: 'linear',
 							ticks: {
 								precision: 2
@@ -721,7 +721,7 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					y: {	
+					y: {
 						type: 'linear',
 					}
 				}
@@ -820,7 +820,7 @@ describe('Linear Scale', function() {
 						type: 'linear',
 						position: 'bottom'
 					},
-					y: {						
+					y: {
 						type: 'linear'
 					}
 				}
@@ -1008,7 +1008,7 @@ describe('Linear Scale', function() {
 		});
 
 		expect(chart.scales.x.min).toEqual(0);
-		expect(chart.scales.y.max).toEqual(1);
+		expect(chart.scales.x.max).toEqual(1);
 	});
 
 	it('max and min value should be valid when min is set and all datasets are hidden', function() {

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -54,33 +54,33 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [10, 5, 0, -5, 78, -100]
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y2',
 					data: [-1000, 1000],
 				}, {
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [150]
 				}],
 				labels: ['a', 'b', 'c', 'd', 'e', 'f']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear'
-					}, {
-						id: 'yScale1',
-						type: 'linear'
-					}]
+					},
+					y2: {
+						type: 'linear',
+						position: 'right',
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min).toBe(-100);
-		expect(chart.scales.yScale0.max).toBe(150);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min).toBe(-100);
+		expect(chart.scales.y.max).toBe(150);
 	});
 
 	it('Should correctly determine the max & min of string data values', function() {
@@ -88,33 +88,33 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: ['10', '5', '0', '-5', '78', '-100']
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y2',
 					data: ['-1000', '1000'],
 				}, {
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: ['150']
 				}],
 				labels: ['a', 'b', 'c', 'd', 'e', 'f']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear'
-					}, {
-						id: 'yScale1',
-						type: 'linear'
-					}]
+					},
+					y2: {
+						type: 'linear',
+						position: 'right'
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min).toBe(-100);
-		expect(chart.scales.yScale0.max).toBe(150);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min).toBe(-100);
+		expect(chart.scales.y.max).toBe(150);
 	});
 
 	it('Should correctly determine the max & min when no values provided and suggested minimum and maximum are set', function() {
@@ -122,28 +122,27 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: []
 				}],
 				labels: ['a', 'b', 'c', 'd', 'e', 'f']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear',
 						ticks: {
 							suggestedMin: -10,
 							suggestedMax: 15
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min).toBe(-10);
-		expect(chart.scales.yScale0.max).toBe(15);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min).toBe(-10);
+		expect(chart.scales.y.max).toBe(15);
 	});
 
 	it('Should correctly determine the max & min data values ignoring hidden datasets', function() {
@@ -151,13 +150,13 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: ['10', '5', '0', '-5', '78', '-100']
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y2',
 					data: ['-1000', '1000'],
 				}, {
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: ['150'],
 					hidden: true
 				}],
@@ -165,20 +164,20 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear'
-					}, {
-						id: 'yScale1',
+					},
+					y2: {
+						position: 'right',
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min).toBe(-100);
-		expect(chart.scales.yScale0.max).toBe(80);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min).toBe(-100);
+		expect(chart.scales.y.max).toBe(80);
 	});
 
 	it('Should correctly determine the max & min data values ignoring data that is NaN', function() {
@@ -186,30 +185,29 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [null, 90, NaN, undefined, 45, 30, Infinity, -Infinity]
 				}],
 				labels: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0.min).toBe(30);
-		expect(chart.scales.yScale0.max).toBe(90);
+		expect(chart.scales.y.min).toBe(30);
+		expect(chart.scales.y.max).toBe(90);
 
 		// Scale is now stacked
-		chart.scales.yScale0.options.stacked = true;
+		chart.scales.y.options.stacked = true;
 		chart.update();
 
-		expect(chart.scales.yScale0.min).toBe(0);
-		expect(chart.scales.yScale0.max).toBe(90);
+		expect(chart.scales.y.min).toBe(0);
+		expect(chart.scales.y.max).toBe(90);
 	});
 
 	it('Should correctly determine the max & min data values for small numbers', function() {
@@ -217,24 +215,23 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [-1e-8, 3e-8, -4e-8, 6e-8]
 				}],
 				labels: ['a', 'b', 'c', 'd']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min * 1e8).toBeCloseTo(-4);
-		expect(chart.scales.yScale0.max * 1e8).toBeCloseTo(6);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min * 1e8).toBeCloseTo(-4);
+		expect(chart.scales.y.max * 1e8).toBeCloseTo(6);
 	});
 
 	it('Should correctly determine the max & min for scatter data', function() {
@@ -242,8 +239,8 @@ describe('Linear Scale', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: [{
 						x: 10,
 						y: 100
@@ -261,24 +258,22 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'linear',
 						position: 'bottom'
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 		chart.update();
 
-		expect(chart.scales.xScale0.min).toBe(-20);
-		expect(chart.scales.xScale0.max).toBe(100);
-		expect(chart.scales.yScale0.min).toBe(0);
-		expect(chart.scales.yScale0.max).toBe(100);
+		expect(chart.scales.x.min).toBe(-20);
+		expect(chart.scales.x.max).toBe(100);
+		expect(chart.scales.y.min).toBe(0);
+		expect(chart.scales.y.max).toBe(100);
 	});
 
 	it('Should correctly get the label for the given index', function() {
@@ -286,8 +281,8 @@ describe('Linear Scale', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: [{
 						x: 10,
 						y: 100
@@ -305,21 +300,19 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'linear',
 						position: 'bottom'
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 		chart.update();
 
-		expect(chart.scales.yScale0.getLabelForIndex(3, 0)).toBe(7);
+		expect(chart.scales.y.getLabelForIndex(3, 0)).toBe(7);
 	});
 
 	it('Should correctly determine the min and max data values when stacked mode is turned on', function() {
@@ -327,18 +320,18 @@ describe('Linear Scale', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [10, 5, 0, -5, 78, -100],
 					type: 'bar'
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y2',
 					data: [-1000, 1000],
 				}, {
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [150, 0, 0, -100, -10, 9],
 					type: 'bar'
 				}, {
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [10, 10, 10, 10, 10, 10],
 					type: 'line'
 				}],
@@ -346,21 +339,21 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear',
 						stacked: true
-					}, {
-						id: 'yScale1',
+					},
+					y2: {
+						position: 'right',
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 		chart.update();
 
-		expect(chart.scales.yScale0.min).toBe(-150);
-		expect(chart.scales.yScale0.max).toBe(200);
+		expect(chart.scales.y.min).toBe(-150);
+		expect(chart.scales.y.max).toBe(200);
 	});
 
 	it('Should correctly determine the min and max data values when stacked mode is turned on and there are hidden datasets', function() {
@@ -368,16 +361,16 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [10, 5, 0, -5, 78, -100],
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y2',
 					data: [-1000, 1000],
 				}, {
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [150, 0, 0, -100, -10, 9],
 				}, {
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [10, 20, 30, 40, 50, 60],
 					hidden: true
 				}],
@@ -385,21 +378,21 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear',
 						stacked: true
-					}, {
-						id: 'yScale1',
+					},
+					y2: {
+						position: 'right',
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 		chart.update();
 
-		expect(chart.scales.yScale0.min).toBe(-150);
-		expect(chart.scales.yScale0.max).toBe(200);
+		expect(chart.scales.y.min).toBe(-150);
+		expect(chart.scales.y.max).toBe(200);
 	});
 
 	it('Should correctly determine the min and max data values when stacked mode is turned on there are multiple types of datasets', function() {
@@ -407,7 +400,7 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					type: 'bar',
 					data: [10, 5, 0, -5, 78, -100]
 				}, {
@@ -421,18 +414,17 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear',
 						stacked: true
-					}]
+					}
 				}
 			}
 		});
 
-		chart.scales.yScale0.determineDataLimits();
-		expect(chart.scales.yScale0.min).toBe(-105);
-		expect(chart.scales.yScale0.max).toBe(160);
+		chart.scales.y.determineDataLimits();
+		expect(chart.scales.y.min).toBe(-105);
+		expect(chart.scales.y.max).toBe(160);
 	});
 
 	it('Should ensure that the scale has a max and min that are not equal', function() {
@@ -444,17 +436,16 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min).toBe(0);
-		expect(chart.scales.yScale0.max).toBe(1);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min).toBe(0);
+		expect(chart.scales.y.max).toBe(1);
 	});
 
 	it('Should ensure that the scale has a max and min that are not equal when beginAtZero is set', function() {
@@ -466,20 +457,19 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear',
 						ticks: {
 							beginAtZero: true
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min).toBe(0);
-		expect(chart.scales.yScale0.max).toBe(1);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min).toBe(0);
+		expect(chart.scales.y.max).toBe(1);
 	});
 
 	it('Should use the suggestedMin and suggestedMax options', function() {
@@ -487,28 +477,27 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [1, 1, 1, 2, 1, 0]
 				}],
 				labels: ['a', 'b', 'c', 'd', 'e', 'f']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear',
 						ticks: {
 							suggestedMax: 10,
 							suggestedMin: -10
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min).toBe(-10);
-		expect(chart.scales.yScale0.max).toBe(10);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min).toBe(-10);
+		expect(chart.scales.y.max).toBe(10);
 	});
 
 	it('Should use the min and max options', function() {
@@ -516,30 +505,29 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [1, 1, 1, 2, 1, 0]
 				}],
 				labels: ['a', 'b', 'c', 'd', 'e', 'f']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear',
 						ticks: {
 							max: 1010,
 							min: -1010
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min).toBe(-1010);
-		expect(chart.scales.yScale0.max).toBe(1010);
-		expect(chart.scales.yScale0.ticks[0]).toBe('1010');
-		expect(chart.scales.yScale0.ticks[chart.scales.yScale0.ticks.length - 1]).toBe('-1010');
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min).toBe(-1010);
+		expect(chart.scales.y.max).toBe(1010);
+		expect(chart.scales.y.ticks[0]).toBe('1010');
+		expect(chart.scales.y.ticks[chart.scales.y.ticks.length - 1]).toBe('-1010');
 	});
 
 	it('Should use min, max and stepSize to create fixed spaced ticks', function() {
@@ -547,30 +535,29 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [10, 3, 6, 8, 3, 1]
 				}],
 				labels: ['a', 'b', 'c', 'd', 'e', 'f']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear',
 						ticks: {
 							min: 1,
 							max: 11,
 							stepSize: 2
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min).toBe(1);
-		expect(chart.scales.yScale0.max).toBe(11);
-		expect(chart.scales.yScale0.ticks).toEqual(['11', '10', '8', '6', '4', '2', '1']);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min).toBe(1);
+		expect(chart.scales.y.max).toBe(11);
+		expect(chart.scales.y.ticks).toEqual(['11', '10', '8', '6', '4', '2', '1']);
 	});
 
 	it('Should create decimal steps if stepSize is a decimal number', function() {
@@ -578,28 +565,27 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [10, 3, 6, 8, 3, 1]
 				}],
 				labels: ['a', 'b', 'c', 'd', 'e', 'f']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear',
 						ticks: {
 							stepSize: 2.5
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min).toBe(0);
-		expect(chart.scales.yScale0.max).toBe(10);
-		expect(chart.scales.yScale0.ticks).toEqual(['10', '7.5', '5', '2.5', '0']);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min).toBe(0);
+		expect(chart.scales.y.max).toBe(10);
+		expect(chart.scales.y.ticks).toEqual(['10', '7.5', '5', '2.5', '0']);
 	});
 
 	describe('precision', function() {
@@ -608,28 +594,27 @@ describe('Linear Scale', function() {
 				type: 'bar',
 				data: {
 					datasets: [{
-						yAxisID: 'yScale0',
+						yAxisID: 'y',
 						data: [0, 1, 2, 1, 0, 1]
 					}],
 					labels: ['a', 'b', 'c', 'd', 'e', 'f']
 				},
 				options: {
 					scales: {
-						yAxes: [{
-							id: 'yScale0',
+						y: {
 							type: 'linear',
 							ticks: {
 								precision: 0
 							}
-						}]
+						}
 					}
 				}
 			});
 
-			expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-			expect(chart.scales.yScale0.min).toBe(0);
-			expect(chart.scales.yScale0.max).toBe(2);
-			expect(chart.scales.yScale0.ticks).toEqual(['2', '1', '0']);
+			expect(chart.scales.y).not.toEqual(undefined); // must construct
+			expect(chart.scales.y.min).toBe(0);
+			expect(chart.scales.y.max).toBe(2);
+			expect(chart.scales.y.ticks).toEqual(['2', '1', '0']);
 		});
 
 		it('Should round the step size to the given number of decimal places', function() {
@@ -637,28 +622,27 @@ describe('Linear Scale', function() {
 				type: 'bar',
 				data: {
 					datasets: [{
-						yAxisID: 'yScale0',
+						yAxisID: 'y',
 						data: [0, 0.001, 0.002, 0.003, 0, 0.001]
 					}],
 					labels: ['a', 'b', 'c', 'd', 'e', 'f']
 				},
 				options: {
 					scales: {
-						yAxes: [{
-							id: 'yScale0',
+						y: {	
 							type: 'linear',
 							ticks: {
 								precision: 2
 							}
-						}]
+						}
 					}
 				}
 			});
 
-			expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-			expect(chart.scales.yScale0.min).toBe(0);
-			expect(chart.scales.yScale0.max).toBe(0.01);
-			expect(chart.scales.yScale0.ticks).toEqual(['0.01', '0']);
+			expect(chart.scales.y).not.toEqual(undefined); // must construct
+			expect(chart.scales.y.min).toBe(0);
+			expect(chart.scales.y.max).toBe(0.01);
+			expect(chart.scales.y.ticks).toEqual(['0.01', '0']);
 		});
 	});
 
@@ -668,35 +652,34 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [20, 30, 40, 50]
 				}],
 				labels: ['a', 'b', 'c', 'd']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear',
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.ticks).toEqual(['50', '45', '40', '35', '30', '25', '20']);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.ticks).toEqual(['50', '45', '40', '35', '30', '25', '20']);
 
-		chart.scales.yScale0.options.ticks.beginAtZero = true;
+		chart.scales.y.options.ticks.beginAtZero = true;
 		chart.update();
-		expect(chart.scales.yScale0.ticks).toEqual(['50', '45', '40', '35', '30', '25', '20', '15', '10', '5', '0']);
+		expect(chart.scales.y.ticks).toEqual(['50', '45', '40', '35', '30', '25', '20', '15', '10', '5', '0']);
 
 		chart.data.datasets[0].data = [-20, -30, -40, -50];
 		chart.update();
-		expect(chart.scales.yScale0.ticks).toEqual(['0', '-5', '-10', '-15', '-20', '-25', '-30', '-35', '-40', '-45', '-50']);
+		expect(chart.scales.y.ticks).toEqual(['0', '-5', '-10', '-15', '-20', '-25', '-30', '-35', '-40', '-45', '-50']);
 
-		chart.scales.yScale0.options.ticks.beginAtZero = false;
+		chart.scales.y.options.ticks.beginAtZero = false;
 		chart.update();
-		expect(chart.scales.yScale0.ticks).toEqual(['-20', '-25', '-30', '-35', '-40', '-45', '-50']);
+		expect(chart.scales.y.ticks).toEqual(['-20', '-25', '-30', '-35', '-40', '-45', '-50']);
 	});
 
 	it('Should generate tick marks in the correct order in reversed mode', function() {
@@ -704,27 +687,26 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [10, 5, 0, 25, 78]
 				}],
 				labels: ['a', 'b', 'c', 'd']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear',
 						ticks: {
 							reverse: true
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0.ticks).toEqual(['0', '10', '20', '30', '40', '50', '60', '70', '80']);
-		expect(chart.scales.yScale0.start).toBe(80);
-		expect(chart.scales.yScale0.end).toBe(0);
+		expect(chart.scales.y.ticks).toEqual(['0', '10', '20', '30', '40', '50', '60', '70', '80']);
+		expect(chart.scales.y.start).toBe(80);
+		expect(chart.scales.y.end).toBe(0);
 	});
 
 	it('should use the correct number of decimal places in the default format function', function() {
@@ -732,21 +714,20 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [0.06, 0.005, 0, 0.025, 0.0078]
 				}],
 				labels: ['a', 'b', 'c', 'd']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {	
 						type: 'linear',
-					}]
+					}
 				}
 			}
 		});
-		expect(chart.scales.yScale0.ticks).toEqual(['0.06', '0.05', '0.04', '0.03', '0.02', '0.01', '0']);
+		expect(chart.scales.y.ticks).toEqual(['0.06', '0.05', '0.04', '0.03', '0.02', '0.01', '0']);
 	});
 
 	it('Should correctly limit the maximum number of ticks', function() {
@@ -760,40 +741,38 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale'
-					}]
+					y: {}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale.ticks).toEqual(['2.5', '2.0', '1.5', '1.0', '0.5']);
+		expect(chart.scales.y.ticks).toEqual(['2.5', '2.0', '1.5', '1.0', '0.5']);
 
-		chart.options.scales.yAxes[0].ticks.maxTicksLimit = 11;
+		chart.options.scales.y.ticks.maxTicksLimit = 11;
 		chart.update();
 
-		expect(chart.scales.yScale.ticks).toEqual(['2.5', '2.0', '1.5', '1.0', '0.5']);
+		expect(chart.scales.y.ticks).toEqual(['2.5', '2.0', '1.5', '1.0', '0.5']);
 
-		chart.options.scales.yAxes[0].ticks.maxTicksLimit = 21;
+		chart.options.scales.y.ticks.maxTicksLimit = 21;
 		chart.update();
 
-		expect(chart.scales.yScale.ticks).toEqual([
+		expect(chart.scales.y.ticks).toEqual([
 			'2.5', '2.4', '2.3', '2.2', '2.1', '2.0', '1.9', '1.8', '1.7', '1.6',
 			'1.5', '1.4', '1.3', '1.2', '1.1', '1.0', '0.9', '0.8', '0.7', '0.6',
 			'0.5'
 		]);
 
-		chart.options.scales.yAxes[0].ticks.maxTicksLimit = 11;
-		chart.options.scales.yAxes[0].ticks.stepSize = 0.01;
+		chart.options.scales.y.ticks.maxTicksLimit = 11;
+		chart.options.scales.y.ticks.stepSize = 0.01;
 		chart.update();
 
-		expect(chart.scales.yScale.ticks).toEqual(['2.5', '2.0', '1.5', '1.0', '0.5']);
+		expect(chart.scales.y.ticks).toEqual(['2.5', '2.0', '1.5', '1.0', '0.5']);
 
-		chart.options.scales.yAxes[0].ticks.min = 0.3;
-		chart.options.scales.yAxes[0].ticks.max = 2.8;
+		chart.options.scales.y.ticks.min = 0.3;
+		chart.options.scales.y.ticks.max = 2.8;
 		chart.update();
 
-		expect(chart.scales.yScale.ticks).toEqual(['2.8', '2.5', '2.0', '1.5', '1.0', '0.5', '0.3']);
+		expect(chart.scales.y.ticks).toEqual(['2.8', '2.5', '2.0', '1.5', '1.0', '0.5', '0.3']);
 	});
 
 	it('Should build labels using the user supplied callback', function() {
@@ -801,28 +780,27 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [10, 5, 0, 25, 78]
 				}],
 				labels: ['a', 'b', 'c', 'd']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear',
 						ticks: {
 							callback: function(value, index) {
 								return index.toString();
 							}
 						}
-					}]
+					}
 				}
 			}
 		});
 
 		// Just the index
-		expect(chart.scales.yScale0.ticks).toEqual(['0', '1', '2', '3', '4', '5', '6', '7', '8']);
+		expect(chart.scales.y.ticks).toEqual(['0', '1', '2', '3', '4', '5', '6', '7', '8']);
 	});
 
 	it('Should get the correct pixel value for a point', function() {
@@ -831,27 +809,25 @@ describe('Linear Scale', function() {
 			data: {
 				labels: [-1, 1],
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: [-1, 1]
 				}],
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'linear',
 						position: 'bottom'
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {						
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 
-		var xScale = chart.scales.xScale0;
+		var xScale = chart.scales.x;
 		expect(xScale.getPixelForValue(1, 0, 0)).toBeCloseToPixel(501); // right - paddingRight
 		expect(xScale.getPixelForValue(-1, 0, 0)).toBeCloseToPixel(31 + 6); // left + paddingLeft + lineSpace
 		expect(xScale.getPixelForValue(0, 0, 0)).toBeCloseToPixel(266 + 6 / 2); // halfway*/
@@ -860,7 +836,7 @@ describe('Linear Scale', function() {
 		expect(xScale.getValueForPixel(31)).toBeCloseTo(-1, 1e-2);
 		expect(xScale.getValueForPixel(266)).toBeCloseTo(0, 1e-2);
 
-		var yScale = chart.scales.yScale0;
+		var yScale = chart.scales.y;
 		expect(yScale.getPixelForValue(1, 0, 0)).toBeCloseToPixel(32); // right - paddingRight
 		expect(yScale.getPixelForValue(-1, 0, 0)).toBeCloseToPixel(484); // left + paddingLeft
 		expect(yScale.getPixelForValue(0, 0, 0)).toBeCloseToPixel(258); // halfway*/
@@ -875,8 +851,8 @@ describe('Linear Scale', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: [{
 						x: 10,
 						y: 100
@@ -894,21 +870,19 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'linear',
 						position: 'bottom'
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 
-		var xScale = chart.scales.xScale0;
-		var yScale = chart.scales.yScale0;
+		var xScale = chart.scales.x;
+		var yScale = chart.scales.y;
 		expect(xScale.paddingTop).toBeCloseToPixel(0);
 		expect(xScale.paddingBottom).toBeCloseToPixel(0);
 		expect(xScale.paddingLeft).toBeCloseToPixel(12);
@@ -948,8 +922,8 @@ describe('Linear Scale', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: [{
 						x: 10,
 						y: 100
@@ -967,13 +941,11 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'linear',
 						position: 'bottom'
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'linear',
 						gridLines: {
 							drawTicks: false,
@@ -987,12 +959,12 @@ describe('Linear Scale', function() {
 							display: false,
 							padding: 0
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		var yScale = chart.scales.yScale0;
+		var yScale = chart.scales.y;
 		expect(yScale.width).toBeCloseToPixel(0);
 	});
 
@@ -1019,12 +991,12 @@ describe('Linear Scale', function() {
 			data: barData,
 			options: {
 				scales: {
-					xAxes: [{
+					x: {
 						stacked: true
-					}],
-					yAxes: [{
+					},
+					y: {
 						stacked: true
-					}]
+					}
 				}
 			}
 		});
@@ -1035,8 +1007,8 @@ describe('Linear Scale', function() {
 			chart.update();
 		});
 
-		expect(chart.scales['x-axis-0'].min).toEqual(0);
-		expect(chart.scales['x-axis-0'].max).toEqual(1);
+		expect(chart.scales.x.min).toEqual(0);
+		expect(chart.scales.y.max).toEqual(1);
 	});
 
 	it('max and min value should be valid when min is set and all datasets are hidden', function() {
@@ -1055,17 +1027,17 @@ describe('Linear Scale', function() {
 			data: barData,
 			options: {
 				scales: {
-					xAxes: [{
+					x: {
 						ticks: {
 							min: 20
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales['x-axis-0'].min).toEqual(20);
-		expect(chart.scales['x-axis-0'].max).toEqual(21);
+		expect(chart.scales.x.min).toEqual(20);
+		expect(chart.scales.x.max).toEqual(21);
 	});
 
 	it('min settings should be used if set to zero', function() {
@@ -1083,17 +1055,17 @@ describe('Linear Scale', function() {
 			data: barData,
 			options: {
 				scales: {
-					xAxes: [{
+					x: {
 						ticks: {
 							min: 0,
 							max: 3000
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales['x-axis-0'].min).toEqual(0);
+		expect(chart.scales.x.min).toEqual(0);
 	});
 
 	it('max settings should be used if set to zero', function() {
@@ -1111,17 +1083,17 @@ describe('Linear Scale', function() {
 			data: barData,
 			options: {
 				scales: {
-					xAxes: [{
+					x: {
 						ticks: {
 							min: -3000,
 							max: 0
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales['x-axis-0'].max).toEqual(0);
+		expect(chart.scales.x.max).toEqual(0);
 	});
 
 	it('Should generate max and min that are not equal when data contains values that are very close to each other', function() {
@@ -1137,16 +1109,15 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear',
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.max).toBeGreaterThan(chart.scales.yScale0.min);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.max).toBeGreaterThan(chart.scales.y.min);
 	});
 
 	it('Should get correct pixel values when horizontal', function() {
@@ -1159,10 +1130,9 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'x',
+					x: {
 						type: 'linear',
-					}]
+					}
 				}
 			}
 		});
@@ -1200,10 +1170,9 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'y',
+					y: {
 						type: 'linear',
-					}]
+					}
 				}
 			}
 		});

--- a/test/specs/scale.logarithmic.tests.js
+++ b/test/specs/scale.logarithmic.tests.js
@@ -54,57 +54,60 @@ describe('Logarithmic Scale tests', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [42, 1000, 64, 100],
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y1',
 					data: [10, 5, 5000, 78, 450]
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y1',
 					data: [150]
 				}, {
-					yAxisID: 'yScale2',
+					yAxisID: 'y2',
 					data: [20, 0, 150, 1800, 3040]
 				}, {
-					yAxisID: 'yScale3',
+					yAxisID: 'y3',
 					data: [67, 0.0004, 0, 820, 0.001]
 				}],
 				labels: ['a', 'b', 'c', 'd', 'e']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
+						id: 'y',
 						type: 'logarithmic'
-					}, {
-						id: 'yScale1',
+					},
+					y1: {
+						type: 'logarithmic',
+						position: 'right'
+					},
+					y2: {
+						type: 'logarithmic',
+						position: 'right'
+					},
+					y3: {
+						position: 'right',
 						type: 'logarithmic'
-					}, {
-						id: 'yScale2',
-						type: 'logarithmic'
-					}, {
-						id: 'yScale3',
-						type: 'logarithmic'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min).toBe(10);
-		expect(chart.scales.yScale0.max).toBe(1000);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min).toBe(10);
+		expect(chart.scales.y.max).toBe(1000);
 
-		expect(chart.scales.yScale1).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale1.min).toBe(1);
-		expect(chart.scales.yScale1.max).toBe(5000);
+		expect(chart.scales.y1).not.toEqual(undefined); // must construct
+		expect(chart.scales.y1.min).toBe(1);
+		expect(chart.scales.y1.max).toBe(5000);
 
-		expect(chart.scales.yScale2).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale2.min).toBe(0);
-		expect(chart.scales.yScale2.max).toBe(4000);
+		expect(chart.scales.y2).not.toEqual(undefined); // must construct
+		expect(chart.scales.y2.min).toBe(0);
+		expect(chart.scales.y2.max).toBe(4000);
 
-		expect(chart.scales.yScale3).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale3.min).toBe(0);
-		expect(chart.scales.yScale3.max).toBe(900);
+		expect(chart.scales.y3).not.toEqual(undefined); // must construct
+		expect(chart.scales.y3.min).toBe(0);
+		expect(chart.scales.y3.max).toBe(900);
 	});
 
 	it('should correctly determine the max & min of string data values', function() {
@@ -112,57 +115,59 @@ describe('Logarithmic Scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: ['42', '1000', '64', '100'],
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y1',
 					data: ['10', '5', '5000', '78', '450']
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y1',
 					data: ['150']
 				}, {
-					yAxisID: 'yScale2',
+					yAxisID: 'y2',
 					data: ['20', '0', '150', '1800', '3040']
 				}, {
-					yAxisID: 'yScale3',
+					yAxisID: 'y3',
 					data: ['67', '0.0004', '0', '820', '0.001']
 				}],
 				labels: ['a', 'b', 'c', 'd', 'e']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'logarithmic'
-					}, {
-						id: 'yScale1',
+					},
+					y1: {
+						position: 'right',
 						type: 'logarithmic'
-					}, {
-						id: 'yScale2',
+					},
+					y2: {
+						position: 'right',
 						type: 'logarithmic'
-					}, {
-						id: 'yScale3',
+					},
+					y3: {
+						position: 'right',
 						type: 'logarithmic'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min).toBe(10);
-		expect(chart.scales.yScale0.max).toBe(1000);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min).toBe(10);
+		expect(chart.scales.y.max).toBe(1000);
 
-		expect(chart.scales.yScale1).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale1.min).toBe(1);
-		expect(chart.scales.yScale1.max).toBe(5000);
+		expect(chart.scales.y1).not.toEqual(undefined); // must construct
+		expect(chart.scales.y1.min).toBe(1);
+		expect(chart.scales.y1.max).toBe(5000);
 
-		expect(chart.scales.yScale2).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale2.min).toBe(0);
-		expect(chart.scales.yScale2.max).toBe(4000);
+		expect(chart.scales.y2).not.toEqual(undefined); // must construct
+		expect(chart.scales.y2.min).toBe(0);
+		expect(chart.scales.y2.max).toBe(4000);
 
-		expect(chart.scales.yScale3).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale3.min).toBe(0);
-		expect(chart.scales.yScale3.max).toBe(900);
+		expect(chart.scales.y3).not.toEqual(undefined); // must construct
+		expect(chart.scales.y3.min).toBe(0);
+		expect(chart.scales.y3.max).toBe(900);
 	});
 
 	it('should correctly determine the max & min data values when there are hidden datasets', function() {
@@ -170,20 +175,20 @@ describe('Logarithmic Scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale1',
+					yAxisID: 'y1',
 					data: [10, 5, 5000, 78, 450]
 				}, {
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [42, 1000, 64, 100],
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y1',
 					data: [50000],
 					hidden: true
 				}, {
-					yAxisID: 'yScale2',
+					yAxisID: 'y2',
 					data: [20, 0, 7400, 14, 291]
 				}, {
-					yAxisID: 'yScale2',
+					yAxisID: 'y2',
 					data: [6, 0.0007, 9, 890, 60000],
 					hidden: true
 				}],
@@ -191,27 +196,28 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'logarithmic'
-					}, {
-						id: 'yScale1',
+					},
+					y1: {
+						position: 'right',
 						type: 'logarithmic'
-					}, {
-						id: 'yScale2',
+					},
+					y2: {
+						position: 'right',
 						type: 'logarithmic'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale1).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale1.min).toBe(1);
-		expect(chart.scales.yScale1.max).toBe(5000);
+		expect(chart.scales.y1).not.toEqual(undefined); // must construct
+		expect(chart.scales.y1.min).toBe(1);
+		expect(chart.scales.y1.max).toBe(5000);
 
-		expect(chart.scales.yScale2).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale2.min).toBe(0);
-		expect(chart.scales.yScale2.max).toBe(8000);
+		expect(chart.scales.y2).not.toEqual(undefined); // must construct
+		expect(chart.scales.y2.min).toBe(0);
+		expect(chart.scales.y2.max).toBe(8000);
 	});
 
 	it('should correctly determine the max & min data values when there is NaN data', function() {
@@ -219,47 +225,47 @@ describe('Logarithmic Scale tests', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [undefined, 10, null, 5, 5000, NaN, 78, 450]
 				}, {
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [undefined, 28, null, 1000, 500, NaN, 50, 42, Infinity, -Infinity]
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y1',
 					data: [undefined, 30, null, 9400, 0, NaN, 54, 836]
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y1',
 					data: [undefined, 0, null, 800, 9, NaN, 894, 21]
 				}],
 				labels: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'logarithmic'
-					}, {
-						id: 'yScale1',
+					},
+					y1: {
+						position: 'right',
 						type: 'logarithmic'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min).toBe(1);
-		expect(chart.scales.yScale0.max).toBe(5000);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min).toBe(1);
+		expect(chart.scales.y.max).toBe(5000);
 
 		// Turn on stacked mode since it uses it's own
-		chart.options.scales.yAxes[0].stacked = true;
+		chart.options.scales.y.stacked = true;
 		chart.update();
 
-		expect(chart.scales.yScale0.min).toBe(10);
-		expect(chart.scales.yScale0.max).toBe(6000);
+		expect(chart.scales.y.min).toBe(10);
+		expect(chart.scales.y.max).toBe(6000);
 
-		expect(chart.scales.yScale1).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale1.min).toBe(0);
-		expect(chart.scales.yScale1.max).toBe(10000);
+		expect(chart.scales.y1).not.toEqual(undefined); // must construct
+		expect(chart.scales.y1.min).toBe(0);
+		expect(chart.scales.y1.max).toBe(10000);
 	});
 
 	it('should correctly determine the max & min for scatter data', function() {
@@ -277,24 +283,22 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale',
+					x: {
 						type: 'logarithmic',
 						position: 'bottom'
-					}],
-					yAxes: [{
-						id: 'yScale',
+					},
+					y: {
 						type: 'logarithmic'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.xScale.min).toBe(1);
-		expect(chart.scales.xScale.max).toBe(100);
+		expect(chart.scales.x.min).toBe(1);
+		expect(chart.scales.x.max).toBe(100);
 
-		expect(chart.scales.yScale.min).toBe(1);
-		expect(chart.scales.yScale.max).toBe(200);
+		expect(chart.scales.y.min).toBe(1);
+		expect(chart.scales.y.max).toBe(200);
 	});
 
 	it('should correctly determine the max & min for scatter data when 0 values are present', function() {
@@ -312,24 +316,22 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale',
+					x: {
 						type: 'logarithmic',
 						position: 'bottom'
-					}],
-					yAxes: [{
-						id: 'yScale',
+					},
+					y: {
 						type: 'logarithmic'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.xScale.min).toBe(0);
-		expect(chart.scales.xScale.max).toBe(300);
+		expect(chart.scales.x.min).toBe(0);
+		expect(chart.scales.x.max).toBe(300);
 
-		expect(chart.scales.yScale.min).toBe(0);
-		expect(chart.scales.yScale.max).toBe(1000);
+		expect(chart.scales.y.min).toBe(0);
+		expect(chart.scales.y.max).toBe(1000);
 	});
 
 	it('should correctly determine the min and max data values when stacked mode is turned on', function() {
@@ -338,38 +340,38 @@ describe('Logarithmic Scale tests', function() {
 			data: {
 				datasets: [{
 					type: 'bar',
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [10, 5, 1, 5, 78, 100]
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y1',
 					data: [0, 1000],
 				}, {
 					type: 'bar',
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [150, 10, 10, 100, 10, 9]
 				}, {
 					type: 'line',
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [100, 100, 100, 100, 100, 100]
 				}],
 				labels: ['a', 'b', 'c', 'd', 'e', 'f']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'logarithmic',
 						stacked: true
-					}, {
-						id: 'yScale1',
+					},
+					y1: {
+						position: 'right',
 						type: 'logarithmic'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0.min).toBe(10);
-		expect(chart.scales.yScale0.max).toBe(200);
+		expect(chart.scales.y.min).toBe(10);
+		expect(chart.scales.y.max).toBe(200);
 	});
 
 	it('should correctly determine the min and max data values when stacked mode is turned on ignoring hidden datasets', function() {
@@ -377,19 +379,19 @@ describe('Logarithmic Scale tests', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [10, 5, 1, 5, 78, 100],
 					type: 'bar'
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y1',
 					data: [0, 1000],
 					type: 'bar'
 				}, {
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [150, 10, 10, 100, 10, 9],
 					type: 'bar'
 				}, {
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [10000, 10000, 10000, 10000, 10000, 10000],
 					hidden: true,
 					type: 'bar'
@@ -398,20 +400,20 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'logarithmic',
 						stacked: true
-					}, {
-						id: 'yScale1',
+					},
+					y1: {
+						position: 'right',
 						type: 'logarithmic'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0.min).toBe(10);
-		expect(chart.scales.yScale0.max).toBe(200);
+		expect(chart.scales.y.min).toBe(10);
+		expect(chart.scales.y.max).toBe(200);
 	});
 
 	it('should ensure that the scale has a max and min that are not equal', function() {
@@ -425,22 +427,21 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale',
+					y: {
 						type: 'logarithmic'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale.min).toBe(1);
-		expect(chart.scales.yScale.max).toBe(10);
+		expect(chart.scales.y.min).toBe(1);
+		expect(chart.scales.y.max).toBe(10);
 
 		chart.data.datasets[0].data = [0.15, 0.15];
 		chart.update();
 
-		expect(chart.scales.yScale.min).toBe(0.01);
-		expect(chart.scales.yScale.max).toBe(1);
+		expect(chart.scales.y.min).toBe(0.01);
+		expect(chart.scales.y.max).toBe(1);
 	});
 
 	it('should use the min and max options', function() {
@@ -454,8 +455,7 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale',
+					y: {
 						type: 'logarithmic',
 						ticks: {
 							min: 10,
@@ -464,17 +464,17 @@ describe('Logarithmic Scale tests', function() {
 								return value;
 							}
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		var yScale = chart.scales.yScale;
-		var tickCount = yScale.ticks.length;
-		expect(yScale.min).toBe(10);
-		expect(yScale.max).toBe(1010);
-		expect(yScale.ticks[0]).toBe(1010);
-		expect(yScale.ticks[tickCount - 1]).toBe(10);
+		var y = chart.scales.y;
+		var tickCount = y.ticks.length;
+		expect(y.min).toBe(10);
+		expect(y.max).toBe(1010);
+		expect(y.ticks[0]).toBe(1010);
+		expect(y.ticks[tickCount - 1]).toBe(10);
 	});
 
 	it('should ignore negative min and max options', function() {
@@ -488,8 +488,7 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale',
+					y: {
 						type: 'logarithmic',
 						ticks: {
 							min: -10,
@@ -498,14 +497,14 @@ describe('Logarithmic Scale tests', function() {
 								return value;
 							}
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		var yScale = chart.scales.yScale;
-		expect(yScale.min).toBe(0);
-		expect(yScale.max).toBe(2);
+		var y = chart.scales.y;
+		expect(y.min).toBe(0);
+		expect(y.max).toBe(2);
 	});
 
 	it('should ignore invalid min and max options', function() {
@@ -519,8 +518,7 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale',
+					y: {
 						type: 'logarithmic',
 						ticks: {
 							min: '',
@@ -529,14 +527,14 @@ describe('Logarithmic Scale tests', function() {
 								return value;
 							}
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		var yScale = chart.scales.yScale;
-		expect(yScale.min).toBe(0);
-		expect(yScale.max).toBe(2);
+		var y = chart.scales.y;
+		expect(y.min).toBe(0);
+		expect(y.max).toBe(2);
 	});
 
 	it('should generate tick marks', function() {
@@ -550,21 +548,20 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale',
+					y: {
 						type: 'logarithmic',
 						ticks: {
 							callback: function(value) {
 								return value;
 							}
 						}
-					}]
+					}
 				}
 			}
 		});
 
 		// Counts down because the lines are drawn top to bottom
-		expect(chart.scales.yScale).toEqual(jasmine.objectContaining({
+		expect(chart.scales.y).toEqual(jasmine.objectContaining({
 			ticks: [80, 70, 60, 50, 40, 30, 20, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
 			start: 1,
 			end: 80
@@ -582,21 +579,20 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale',
+					y: {
 						type: 'logarithmic',
 						ticks: {
 							callback: function(value) {
 								return value;
 							}
 						}
-					}]
+					}
 				}
 			}
 		});
 
 		// Counts down because the lines are drawn top to bottom
-		expect(chart.scales.yScale).toEqual(jasmine.objectContaining({
+		expect(chart.scales.y).toEqual(jasmine.objectContaining({
 			ticks: [30, 20, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0.9, 0.8, 0],
 			start: 0,
 			end: 30
@@ -615,8 +611,7 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale',
+					y: {
 						type: 'logarithmic',
 						ticks: {
 							reverse: true,
@@ -624,13 +619,13 @@ describe('Logarithmic Scale tests', function() {
 								return value;
 							}
 						}
-					}]
+					}
 				}
 			}
 		});
 
 		// Counts down because the lines are drawn top to bottom
-		expect(chart.scales.yScale).toEqual(jasmine.objectContaining({
+		expect(chart.scales.y).toEqual(jasmine.objectContaining({
 			ticks: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 30, 40, 50, 60, 70, 80],
 			start: 80,
 			end: 1
@@ -648,8 +643,7 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale',
+					y: {
 						type: 'logarithmic',
 						ticks: {
 							reverse: true,
@@ -657,13 +651,13 @@ describe('Logarithmic Scale tests', function() {
 								return value;
 							}
 						}
-					}]
+					}
 				}
 			}
 		});
 
 		// Counts down because the lines are drawn top to bottom
-		expect(chart.scales.yScale).toEqual(jasmine.objectContaining({
+		expect(chart.scales.y).toEqual(jasmine.objectContaining({
 			ticks: [0, 9, 10, 20, 30],
 			start: 30,
 			end: 0
@@ -681,15 +675,14 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale',
+					y: {
 						type: 'logarithmic'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale.ticks).toEqual(['8e+1', '', '', '5e+1', '', '', '2e+1', '1e+1', '', '', '', '', '5e+0', '', '', '2e+0', '1e+0', '0']);
+		expect(chart.scales.y.ticks).toEqual(['8e+1', '', '', '5e+1', '', '', '2e+1', '1e+1', '', '', '', '', '5e+0', '', '', '2e+0', '1e+0', '0']);
 	});
 
 	it('should build labels using the user supplied callback', function() {
@@ -703,21 +696,20 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale',
+					y: {
 						type: 'logarithmic',
 						ticks: {
 							callback: function(value, index) {
 								return index.toString();
 							}
 						}
-					}]
+					}
 				}
 			}
 		});
 
 		// Just the index
-		expect(chart.scales.yScale.ticks).toEqual(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16']);
+		expect(chart.scales.y.ticks).toEqual(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16']);
 	});
 
 	it('should correctly get the correct label for a data item', function() {
@@ -725,31 +717,31 @@ describe('Logarithmic Scale tests', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [10, 5, 5000, 78, 450]
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y1',
 					data: [1, 1000, 10, 100],
 				}, {
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [150]
 				}],
 				labels: []
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'logarithmic'
-					}, {
-						id: 'yScale1',
+					},
+					y1: {
+						position: 'right',
 						type: 'logarithmic'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0.getLabelForIndex(0, 2)).toBe(150);
+		expect(chart.scales.y.getLabelForIndex(0, 2)).toBe(150);
 	});
 
 	describe('when', function() {
@@ -786,11 +778,11 @@ describe('Logarithmic Scale tests', function() {
 			{
 				axis: 'y',
 				scale: {
-					yAxes: [{
+					y: {
 						ticks: {
 							min: 0
 						}
-					}]
+					}
 				},
 				firstTick: 0,
 				describe: 'all stacks are defined and ticks.min: 0'
@@ -799,11 +791,11 @@ describe('Logarithmic Scale tests', function() {
 				axis: 'y',
 				data: dataWithEmptyStacks,
 				scale: {
-					yAxes: [{
+					y: {
 						ticks: {
 							min: 0
 						}
-					}]
+					}
 				},
 				firstTick: 0,
 				describe: 'not stacks are defined and ticks.min: 0'
@@ -822,11 +814,11 @@ describe('Logarithmic Scale tests', function() {
 			{
 				axis: 'x',
 				scale: {
-					xAxes: [{
+					x: {
 						ticks: {
 							min: 0
 						}
-					}]
+					}
 				},
 				firstTick: 0,
 				describe: 'all stacks are defined and ticks.min: 0'
@@ -835,11 +827,11 @@ describe('Logarithmic Scale tests', function() {
 				axis: 'x',
 				data: dataWithEmptyStacks,
 				scale: {
-					xAxes: [{
+					x: {
 						ticks: {
 							min: 0
 						}
-					}]
+					}
 				},
 				firstTick: 0,
 				describe: 'not all stacks are defined and ticks.min: 0'
@@ -858,11 +850,11 @@ describe('Logarithmic Scale tests', function() {
 				chartStart = 'bottom';
 				chartEnd = 'top';
 			}
-			scaleConfig[setup.axis + 'Axes'] = [{
+			scaleConfig[setup.axis] = [{
 				type: 'logarithmic'
 			}];
 			Chart.helpers.extend(scaleConfig, setup.scale);
-			scaleConfig[setup.axis + 'Axes'][0].type = 'logarithmic';
+			scaleConfig[setup.axis].type = 'logarithmic';
 
 			var description = 'dataset has stack option and ' + setup.describe
 				+ ' and axis is "' + setup.axis + '";';
@@ -879,7 +871,7 @@ describe('Logarithmic Scale tests', function() {
 						}
 					});
 
-					var axisID = setup.axis + '-axis-0';
+					var axisID = setup.axis;
 					var scale = chart.scales[axisID];
 					var firstTick = setup.firstTick;
 					var lastTick = 80; // last tick (should be first available tick after: 2 * 39)
@@ -993,27 +985,29 @@ describe('Logarithmic Scale tests', function() {
 				var expectation = 'min = ' + setup.firstTick + ', max = ' + setup.lastTick;
 				describe(setup.describe + ' and axis is "' + axis.id + '"; expect: ' + expectation + ';', function() {
 					beforeEach(function() {
-						var xScaleConfig = {
+						var xConfig = {
 							type: 'logarithmic',
+							position: 'bottom'
 						};
-						var yScaleConfig = {
+						var yConfig = {
 							type: 'logarithmic',
+							position: 'left'
 						};
 						var data = setup.data || {
 							datasets: [{
 								data: setup.dataset
 							}],
 						};
-						Chart.helpers.extend(xScaleConfig, setup.scale);
-						Chart.helpers.extend(yScaleConfig, setup.scale);
+						Chart.helpers.extend(xConfig, setup.scale);
+						Chart.helpers.extend(yConfig, setup.scale);
 						Chart.helpers.extend(data, setup.data || {});
 						this.chart = window.acquireChart({
 							type: 'line',
 							data: data,
 							options: {
 								scales: {
-									xAxes: [xScaleConfig],
-									yAxes: [yScaleConfig]
+									x: xConfig,
+									y: yConfig
 								}
 							}
 						});
@@ -1021,7 +1015,7 @@ describe('Logarithmic Scale tests', function() {
 
 					it('should get the correct pixel value for a point', function() {
 						var chart = this.chart;
-						var axisID = axis.id + '-axis-0';
+						var axisID = axis.id;
 						var scale = chart.scales[axisID];
 						var firstTick = setup.firstTick;
 						var lastTick = setup.lastTick;
@@ -1120,27 +1114,29 @@ describe('Logarithmic Scale tests', function() {
 				var expectation = 'min = 0, max = ' + setup.lastTick + ', first tick = ' + setup.firstTick;
 				describe(setup.describe + ' and axis is "' + axis.id + '"; expect: ' + expectation + ';', function() {
 					beforeEach(function() {
-						var xScaleConfig = {
+						var xConfig = {
 							type: 'logarithmic',
+							position: 'bottom'
 						};
-						var yScaleConfig = {
+						var yConfig = {
 							type: 'logarithmic',
+							position: 'left'
 						};
 						var data = setup.data || {
 							datasets: [{
 								data: setup.dataset
 							}],
 						};
-						Chart.helpers.extend(xScaleConfig, setup.scale);
-						Chart.helpers.extend(yScaleConfig, setup.scale);
+						Chart.helpers.extend(xConfig, setup.scale);
+						Chart.helpers.extend(yConfig, setup.scale);
 						Chart.helpers.extend(data, setup.data || {});
 						this.chart = window.acquireChart({
 							type: 'line',
 							data: data,
 							options: {
 								scales: {
-									xAxes: [xScaleConfig],
-									yAxes: [yScaleConfig]
+									x: xConfig,
+									y: yConfig
 								}
 							}
 						});
@@ -1148,7 +1144,7 @@ describe('Logarithmic Scale tests', function() {
 
 					it('should get the correct pixel value for a point', function() {
 						var chart = this.chart;
-						var axisID = axis.id + '-axis-0';
+						var axisID = axis.id;
 						var scale = chart.scales[axisID];
 						var firstTick = setup.firstTick;
 						var lastTick = setup.lastTick;

--- a/test/specs/scale.logarithmic.tests.js
+++ b/test/specs/scale.logarithmic.tests.js
@@ -850,9 +850,9 @@ describe('Logarithmic Scale tests', function() {
 				chartStart = 'bottom';
 				chartEnd = 'top';
 			}
-			scaleConfig[setup.axis] = [{
+			scaleConfig[setup.axis] = {
 				type: 'logarithmic'
-			}];
+			};
 			Chart.helpers.extend(scaleConfig, setup.scale);
 			scaleConfig[setup.axis].type = 'logarithmic';
 

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -146,7 +146,7 @@ describe('Time scale tests', function() {
 				type: 'line',
 				data: {
 					datasets: [{
-						xAxisID: 'xScale0',
+						xAxisID: 'x',
 						data: [{
 							x: newDateFromRef(0),
 							y: 1
@@ -173,16 +173,15 @@ describe('Time scale tests', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'xScale0',
+						x: {
 							type: 'time',
 							position: 'bottom'
-						}],
+						},
 					}
 				}
 			}, {canvas: {width: 800, height: 200}});
 
-			var xScale = chart.scales.xScale0;
+			var xScale = chart.scales.x;
 			var ticks = getTicksLabels(xScale);
 
 			// `bounds === 'data'`: first and last ticks removed since outside the data range
@@ -221,16 +220,15 @@ describe('Time scale tests', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'tScale0',
+						x: {
 							type: 'time',
 							position: 'bottom'
-						}],
+						},
 					}
 				}
 			}, {canvas: {width: 800, height: 200}});
 
-			var tScale = chart.scales.tScale0;
+			var tScale = chart.scales.x;
 			var ticks = getTicksLabels(tScale);
 
 			// `bounds === 'data'`: first and last ticks removed since outside the data range
@@ -244,14 +242,13 @@ describe('Time scale tests', function() {
 			data: {
 				labels: ['foo', 'bar'],
 				datasets: [{
-					xAxisID: 'xScale0',
+					xAxisID: 'x',
 					data: [0, 1]
 				}],
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'time',
 						position: 'bottom',
 						time: {
@@ -266,13 +263,13 @@ describe('Time scale tests', function() {
 						ticks: {
 							source: 'labels'
 						}
-					}],
+					},
 				}
 			}
 		});
 
 		// Counts down because the lines are drawn top to bottom
-		var xScale = chart.scales.xScale0;
+		var xScale = chart.scales.x;
 
 		// Counts down because the lines are drawn top to bottom
 		expect(xScale.ticks[0]).toBe('Jan 2');
@@ -323,25 +320,24 @@ describe('Time scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
+					xAxisID: 'x',
 					data: data
 				}],
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'time',
 						ticks: {
 							source: 'data',
 							autoSkip: true
 						}
-					}],
+					},
 				}
 			}
 		});
 
-		var scale = chart.scales.xScale0;
+		var scale = chart.scales.x;
 
 		expect(scale._unit).toEqual('month');
 	});
@@ -518,7 +514,7 @@ describe('Time scale tests', function() {
 				type: 'line',
 				data: {
 					datasets: [{
-						xAxisID: 'xScale0',
+						xAxisID: 'x',
 						data: []
 					}],
 					labels: [
@@ -533,16 +529,15 @@ describe('Time scale tests', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'xScale0',
+						x: {
 							type: 'time',
 							position: 'bottom'
-						}],
+						},
 					}
 				}
 			});
 
-			this.scale = this.chart.scales.xScale0;
+			this.scale = this.chart.scales.x;
 		});
 
 		it('should be bounded by the nearest week beginnings', function() {
@@ -586,17 +581,16 @@ describe('Time scale tests', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'xScale0',
+						x: {
 							type: 'time',
 							bounds: 'ticks',
 							position: 'bottom'
-						}],
+						},
 					}
 				}
 			}, {canvas: {width: 800, height: 200}});
 
-			this.scale = this.chart.scales.xScale0;
+			this.scale = this.chart.scales.x;
 		});
 
 		it('should be bounded by nearest step\'s year start and end', function() {
@@ -642,23 +636,22 @@ describe('Time scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
+					xAxisID: 'x',
 					data: [null, 10, 3]
 				}],
 				labels: ['2015-01-01T20:00:00', '2015-01-02T21:00:00', '2015-01-03T22:00:00', '2015-01-05T23:00:00', '2015-01-07T03:00', '2015-01-08T10:00', '2015-01-10T12:00'], // days
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'time',
 						position: 'bottom'
-					}],
+					},
 				}
 			}
 		});
 
-		var xScale = chart.scales.xScale0;
+		var xScale = chart.scales.x;
 		expect(xScale.getLabelForIndex(0, 0)).toBeTruthy();
 		expect(xScale.getLabelForIndex(0, 0)).toBe('2015-01-01T20:00:00');
 		expect(xScale.getLabelForIndex(6, 0)).toBe('2015-01-10T12:00');
@@ -670,15 +663,14 @@ describe('Time scale tests', function() {
 				type: 'line',
 				data: {
 					datasets: [{
-						xAxisID: 'xScale0',
+						xAxisID: 'x',
 						data: [0, 0]
 					}],
 					labels: ['2015-01-01T20:00:00', '2015-01-01T20:01:00']
 				},
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'xScale0',
+						x: {
 							type: 'time',
 							time: {
 								displayFormats: {
@@ -690,11 +682,11 @@ describe('Time scale tests', function() {
 									return '<' + value + '>';
 								}
 							}
-						}]
+						}
 					}
 				}
 			});
-			this.scale = this.chart.scales.xScale0;
+			this.scale = this.chart.scales.x;
 		});
 
 		it('should get the correct labels for ticks', function() {
@@ -709,7 +701,7 @@ describe('Time scale tests', function() {
 			var chart = this.chart;
 			var scale = this.scale;
 
-			chart.options.scales.xAxes[0].ticks.callback = function(value) {
+			chart.options.scales.x.ticks.callback = function(value) {
 				return '{' + value + '}';
 			};
 			chart.update();
@@ -725,15 +717,14 @@ describe('Time scale tests', function() {
 				type: 'line',
 				data: {
 					datasets: [{
-						xAxisID: 'xScale0',
+						xAxisID: 'x',
 						data: [0, 0]
 					}],
 					labels: ['2015-01-01T20:00:00', '2015-01-01T20:01:00']
 				},
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'xScale0',
+						x: {
 							type: 'time',
 							ticks: {
 								callback: function(value) {
@@ -751,11 +742,11 @@ describe('Time scale tests', function() {
 									}
 								}
 							}
-						}]
+						}
 					}
 				}
 			});
-			this.scale = this.chart.scales.xScale0;
+			this.scale = this.chart.scales.x;
 		});
 
 		it('should get the correct labels for major and minor ticks', function() {
@@ -771,7 +762,7 @@ describe('Time scale tests', function() {
 			var chart = this.chart;
 			var scale = this.scale;
 
-			chart.options.scales.xAxes[0].ticks.major.enabled = false;
+			chart.options.scales.x.ticks.major.enabled = false;
 			chart.update();
 			expect(scale.ticks.length).toEqual(61);
 			expect(scale.ticks[0]).toEqual('(8:00:00 pm)');
@@ -782,7 +773,7 @@ describe('Time scale tests', function() {
 			var chart = this.chart;
 			var scale = this.scale;
 
-			chart.options.scales.xAxes[0].ticks.major.callback = undefined;
+			chart.options.scales.x.ticks.major.callback = undefined;
 			chart.update();
 			expect(scale.ticks.length).toEqual(61);
 			expect(scale.ticks[0]).toEqual('<8:00 pm>');
@@ -793,7 +784,7 @@ describe('Time scale tests', function() {
 			var chart = this.chart;
 			var scale = this.scale;
 
-			chart.options.scales.xAxes[0].ticks.minor.callback = undefined;
+			chart.options.scales.x.ticks.minor.callback = undefined;
 			chart.update();
 			expect(scale.ticks.length).toEqual(61);
 			expect(scale.ticks[0]).toEqual('[[8:00 pm]]');
@@ -807,22 +798,21 @@ describe('Time scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
+					xAxisID: 'x',
 					data: [{t: '2015-01-01T20:00:00', y: 10}, {t: '2015-01-02T21:00:00', y: 3}]
 				}],
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'time',
 						position: 'bottom'
-					}],
+					},
 				}
 			}
 		});
 
-		var xScale = chart.scales.xScale0;
+		var xScale = chart.scales.x;
 		expect(xScale.getLabelForIndex(0, 0)).toBeTruthy();
 		expect(xScale.getLabelForIndex(0, 0)).toBe('2015-01-01T20:00:00');
 	});
@@ -832,7 +822,7 @@ describe('Time scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
+					xAxisID: 'x',
 					data: [
 						{t: +new Date('2018-01-08 05:14:23.234'), y: 10},
 						{t: +new Date('2018-01-09 06:17:43.426'), y: 3}
@@ -841,16 +831,15 @@ describe('Time scale tests', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'time',
 						position: 'bottom'
-					}],
+					},
 				}
 			}
 		});
 
-		var xScale = chart.scales.xScale0;
+		var xScale = chart.scales.x;
 		var label = xScale.getLabelForIndex(0, 0);
 		expect(label).toEqual('Jan 8, 2018, 5:14:23 am');
 	});
@@ -861,22 +850,21 @@ describe('Time scale tests', function() {
 			data: {
 				labels: ['2016-05-27'],
 				datasets: [{
-					xAxisID: 'xScale0',
+					xAxisID: 'x',
 					data: [5]
 				}]
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						display: true,
 						type: 'time'
-					}]
+					}
 				}
 			}
 		});
 
-		var xScale = chart.scales.xScale0;
+		var xScale = chart.scales.x;
 		var pixel = xScale.getPixelForValue('', 0, 0);
 
 		expect(xScale.getValueForPixel(pixel).valueOf()).toEqual(moment(chart.data.labels[0]).valueOf());
@@ -892,13 +880,13 @@ describe('Time scale tests', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'time',
 						ticks: {
 							min: moment().subtract(1, 'months'),
 							max: moment(),
 						}
-					}],
+					},
 				},
 				responsive: true,
 			},
@@ -907,8 +895,8 @@ describe('Time scale tests', function() {
 				style: 'display: none',
 			},
 		});
-		expect(chart.scales['y-axis-0'].width).toEqual(0);
-		expect(chart.scales['y-axis-0'].maxWidth).toEqual(0);
+		expect(chart.scales.y.width).toEqual(0);
+		expect(chart.scales.y.maxWidth).toEqual(0);
 		expect(chart.width).toEqual(0);
 	});
 
@@ -923,8 +911,7 @@ describe('Time scale tests', function() {
 					},
 					options: {
 						scales: {
-							xAxes: [{
-								id: 'x',
+							x: {
 								type: 'time',
 								time: {
 									parser: 'YYYY'
@@ -932,7 +919,7 @@ describe('Time scale tests', function() {
 								ticks: {
 									source: 'labels'
 								}
-							}]
+							}
 						}
 					}
 				});
@@ -949,7 +936,7 @@ describe('Time scale tests', function() {
 			it ('should not add ticks for min and max if they extend the labels range', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.ticks.min = '2012';
 				options.ticks.max = '2051';
@@ -963,7 +950,7 @@ describe('Time scale tests', function() {
 			it ('should not duplicate ticks if min and max are the labels limits', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.ticks.min = '2017';
 				options.ticks.max = '2042';
@@ -988,7 +975,7 @@ describe('Time scale tests', function() {
 			it ('should correctly handle empty `data.labels` using `time.unit`', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.time.unit = 'year';
 				chart.data.labels = [];
@@ -1017,8 +1004,7 @@ describe('Time scale tests', function() {
 					},
 					options: {
 						scales: {
-							xAxes: [{
-								id: 'x',
+							x: {
 								type: 'time',
 								time: {
 									parser: 'YYYY'
@@ -1026,7 +1012,7 @@ describe('Time scale tests', function() {
 								ticks: {
 									source: 'data'
 								}
-							}]
+							}
 						}
 					}
 				});
@@ -1043,7 +1029,7 @@ describe('Time scale tests', function() {
 			it ('should not add ticks for min and max if they extend the labels range', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.ticks.min = '2012';
 				options.ticks.max = '2051';
@@ -1057,7 +1043,7 @@ describe('Time scale tests', function() {
 			it ('should not duplicate ticks if min and max are the labels limits', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.ticks.min = '2017';
 				options.ticks.max = '2043';
@@ -1083,7 +1069,7 @@ describe('Time scale tests', function() {
 			it ('should correctly handle empty `data.labels` and hidden datasets using `time.unit`', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.time.unit = 'year';
 				chart.data.labels = [];
@@ -1109,8 +1095,7 @@ describe('Time scale tests', function() {
 					},
 					options: {
 						scales: {
-							xAxes: [{
-								id: 'x',
+							x: {
 								type: 'time',
 								time: {
 									parser: 'YYYY'
@@ -1119,10 +1104,10 @@ describe('Time scale tests', function() {
 								ticks: {
 									source: 'labels'
 								}
-							}],
-							yAxes: [{
+							},
+							y: {
 								display: false
-							}]
+							}
 						}
 					}
 				});
@@ -1142,7 +1127,7 @@ describe('Time scale tests', function() {
 			it ('should add a step before if scale.min is before the first data', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.ticks.min = '2012';
 				chart.update();
@@ -1156,7 +1141,7 @@ describe('Time scale tests', function() {
 			it ('should add a step after if scale.max is after the last data', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.ticks.max = '2050';
 				chart.update();
@@ -1170,7 +1155,7 @@ describe('Time scale tests', function() {
 			it ('should add steps before and after if scale.min/max are outside the data range', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.ticks.min = '2012';
 				options.ticks.max = '2050';
@@ -1193,8 +1178,7 @@ describe('Time scale tests', function() {
 					},
 					options: {
 						scales: {
-							xAxes: [{
-								id: 'x',
+							x: {
 								type: 'time',
 								time: {
 									parser: 'YYYY'
@@ -1203,10 +1187,10 @@ describe('Time scale tests', function() {
 								ticks: {
 									source: 'labels'
 								}
-							}],
-							yAxes: [{
+							},
+							y: {
 								display: false
-							}]
+							}
 						}
 					}
 				});
@@ -1226,7 +1210,7 @@ describe('Time scale tests', function() {
 			it ('should take in account scale min and max if outside the ticks range', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.ticks.min = '2012';
 				options.ticks.max = '2050';
@@ -1255,18 +1239,17 @@ describe('Time scale tests', function() {
 					},
 					options: {
 						scales: {
-							xAxes: [{
-								id: 'x',
+							x: {
 								type: 'time',
 								bounds: 'data',
 								time: {
 									parser: 'MM/DD HH:mm',
 									unit: 'day'
 								}
-							}],
-							yAxes: [{
+							},
+							y: {
 								display: false
-							}]
+							}
 						}
 					}
 				});
@@ -1292,18 +1275,17 @@ describe('Time scale tests', function() {
 					},
 					options: {
 						scales: {
-							xAxes: [{
-								id: 'x',
+							x: {
 								type: 'time',
 								bounds: 'ticks',
 								time: {
 									parser: 'MM/DD HH:mm',
 									unit: 'day'
 								}
-							}],
-							yAxes: [{
+							},
+							y: {
 								display: false
-							}]
+							}
 						}
 					}
 				});
@@ -1334,8 +1316,7 @@ describe('Time scale tests', function() {
 							},
 							options: {
 								scales: {
-									xAxes: [{
-										id: 'x',
+									x: {
 										type: 'time',
 										bounds: bounds,
 										time: {
@@ -1345,10 +1326,10 @@ describe('Time scale tests', function() {
 										ticks: {
 											source: source
 										}
-									}],
-									yAxes: [{
+									},
+									y: {
 										display: false
-									}]
+									}
 								}
 							}
 						});
@@ -1357,7 +1338,7 @@ describe('Time scale tests', function() {
 					it ('should expand scale to the min/max range', function() {
 						var chart = this.chart;
 						var scale = chart.scales.x;
-						var options = chart.options.scales.xAxes[0];
+						var options = chart.options.scales.x;
 						var min = '02/19 07:00';
 						var max = '02/24 08:00';
 
@@ -1377,7 +1358,7 @@ describe('Time scale tests', function() {
 					it ('should shrink scale to the min/max range', function() {
 						var chart = this.chart;
 						var scale = chart.scales.x;
-						var options = chart.options.scales.xAxes[0];
+						var options = chart.options.scales.x;
 						var min = '02/21 07:00';
 						var max = '02/22 20:00';
 
@@ -1411,8 +1392,7 @@ describe('Time scale tests', function() {
 						},
 						options: {
 							scales: {
-								xAxes: [{
-									id: 'x',
+								x: {
 									type: 'time',
 									time: {
 										parser: 'YYYY'
@@ -1421,7 +1401,7 @@ describe('Time scale tests', function() {
 										source: source
 									},
 									distribution: distribution
-								}]
+								}
 							}
 						}
 					});
@@ -1437,7 +1417,7 @@ describe('Time scale tests', function() {
 				it ('should add offset from the edges if offset is true', function() {
 					var chart = this.chart;
 					var scale = chart.scales.x;
-					var options = chart.options.scales.xAxes[0];
+					var options = chart.options.scales.x;
 
 					options.offset = true;
 					chart.update();
@@ -1453,7 +1433,7 @@ describe('Time scale tests', function() {
 				it ('should not add offset if min and max extend the labels range', function() {
 					var chart = this.chart;
 					var scale = chart.scales.x;
-					var options = chart.options.scales.xAxes[0];
+					var options = chart.options.scales.x;
 
 					options.ticks.min = '2012';
 					options.ticks.max = '2051';
@@ -1466,7 +1446,7 @@ describe('Time scale tests', function() {
 				it ('should add offset if min and max extend the labels range and offset is true', function() {
 					var chart = this.chart;
 					var scale = chart.scales.x;
-					var options = chart.options.scales.xAxes[0];
+					var options = chart.options.scales.x;
 
 					options.ticks.min = '2012';
 					options.ticks.max = '2051';
@@ -1494,8 +1474,7 @@ describe('Time scale tests', function() {
 					},
 					options: {
 						scales: {
-							xAxes: [{
-								id: 'x',
+							x: {
 								type: 'time',
 								time: {
 									parser: 'YYYY',
@@ -1504,10 +1483,10 @@ describe('Time scale tests', function() {
 									source: 'labels',
 									reverse: true
 								}
-							}],
-							yAxes: [{
+							},
+							y: {
 								display: false
-							}]
+							}
 						}
 					}
 				});
@@ -1534,7 +1513,7 @@ describe('Time scale tests', function() {
 			it ('should reverse the bars and add offsets if offset is true', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.offset = true;
 				chart.update();
@@ -1550,7 +1529,7 @@ describe('Time scale tests', function() {
 			it ('should reverse the values for pixels if offset is true', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.offset = true;
 				chart.update();
@@ -1582,8 +1561,7 @@ describe('Time scale tests', function() {
 					},
 					options: {
 						scales: {
-							xAxes: [{
-								id: 'x',
+							x: {
 								type: 'time',
 								time: {
 									parser: 'YYYY'
@@ -1593,10 +1571,10 @@ describe('Time scale tests', function() {
 									source: 'labels',
 									reverse: true
 								}
-							}],
-							yAxes: [{
+							},
+							y: {
 								display: false
-							}]
+							}
 						}
 					}
 				});
@@ -1617,7 +1595,7 @@ describe('Time scale tests', function() {
 			it ('should reverse the labels and should add a step before if scale.min is before the first data', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.ticks.min = '2012';
 				chart.update();
@@ -1632,7 +1610,7 @@ describe('Time scale tests', function() {
 			it ('should reverse the labels and should add a step after if scale.max is after the last data', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.ticks.max = '2050';
 				chart.update();
@@ -1647,7 +1625,7 @@ describe('Time scale tests', function() {
 			it ('should reverse the labels and should add steps before and after if scale.min/max are outside the data range', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.ticks.min = '2012';
 				options.ticks.max = '2050';
@@ -1670,8 +1648,7 @@ describe('Time scale tests', function() {
 					},
 					options: {
 						scales: {
-							xAxes: [{
-								id: 'x',
+							x: {
 								type: 'time',
 								time: {
 									parser: 'YYYY'
@@ -1681,10 +1658,10 @@ describe('Time scale tests', function() {
 									source: 'labels',
 									reverse: true
 								}
-							}],
-							yAxes: [{
+							},
+							y: {
 								display: false
-							}]
+							}
 						}
 					}
 				});
@@ -1705,7 +1682,7 @@ describe('Time scale tests', function() {
 			it ('should reverse the labels and should take in account scale min and max if outside the ticks range', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.ticks.min = '2012';
 				options.ticks.max = '2050';
@@ -1741,28 +1718,27 @@ describe('Time scale tests', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'x',
+						x: {
 							type: 'time',
 							labels: ['2015', '2016', '2017'],
 							time: timeOpts
 						},
-						{
-							id: 'x2',
+						x2: {
 							type: 'time',
+							position: 'bottom',
 							time: timeOpts
-						}],
-						yAxes: [{
-							id: 'y',
+						},
+						y: {
 							type: 'time',
 							time: timeOpts
 						},
-						{
+						y2: {
 							id: 'y2',
+							position: 'left',
 							type: 'time',
 							labels: ['2005', '2006', '2007'],
 							time: timeOpts
-						}]
+						}
 					}
 				}
 			});
@@ -1786,14 +1762,13 @@ describe('Time scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
+					xAxisID: 'x',
 					data: data
 				}],
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'time',
 						ticks: {
 							major: {
@@ -1802,12 +1777,12 @@ describe('Time scale tests', function() {
 							source: 'data',
 							autoSkip: true
 						}
-					}],
+					},
 				}
 			}
 		});
 
-		var scale = chart.scales.xScale0;
+		var scale = chart.scales.x;
 
 		var labels = scale._ticksToDraw.map(function(t) {
 			return t.label;
@@ -1828,10 +1803,9 @@ describe('Time scale tests', function() {
 					data: {},
 					options: {
 						scales: {
-							xAxes: [{
-								id: 'x',
+							x: {
 								type: 'time'
-							}]
+							}
 						}
 					}
 				});
@@ -1851,7 +1825,7 @@ describe('Time scale tests', function() {
 				};
 
 				expect(chart.scales.x.options.time.displayFormats).toEqual(expected);
-				expect(chart.options.scales.xAxes[0].time.displayFormats).toEqual(expected);
+				expect(chart.options.scales.x.time.displayFormats).toEqual(expected);
 			});
 
 			it('should merge user formats with adapter presets', function() {
@@ -1860,8 +1834,7 @@ describe('Time scale tests', function() {
 					data: {},
 					options: {
 						scales: {
-							xAxes: [{
-								id: 'x',
+							x: {
 								type: 'time',
 								time: {
 									displayFormats: {
@@ -1870,7 +1843,7 @@ describe('Time scale tests', function() {
 										month: 'bla'
 									}
 								}
-							}]
+							}
 						}
 					}
 				});
@@ -1890,7 +1863,7 @@ describe('Time scale tests', function() {
 				};
 
 				expect(chart.scales.x.options.time.displayFormats).toEqual(expected);
-				expect(chart.options.scales.xAxes[0].time.displayFormats).toEqual(expected);
+				expect(chart.options.scales.x.time.displayFormats).toEqual(expected);
 			});
 		});
 	});

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -193,7 +193,7 @@ describe('Time scale tests', function() {
 				type: 'line',
 				data: {
 					datasets: [{
-						xAxisID: 'tScale0',
+						xAxisID: 'x',
 						data: [{
 							t: newDateFromRef(0),
 							y: 1

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -1733,7 +1733,6 @@ describe('Time scale tests', function() {
 							time: timeOpts
 						},
 						y2: {
-							id: 'y2',
 							position: 'left',
 							type: 'time',
 							labels: ['2005', '2006', '2007'],


### PR DESCRIPTION
I want to get some feedback on this before I go any further.

This PR changes the axis options format to one that is easier to work with. The challenges are that we can't do as many default actions for X vs Y axes. I kept some basic functionality by assuming that axes that have an ID starting with "x" are horizontal.

```

options: {
	scales: {
		xAxes: [{
                        id: 'x',
			display: true,
			scaleLabel: {
				display: true,
				labelString: 'Month'
			}
		}],
		yAxes: [{
                        id: "y",
			display: true,
			scaleLabel: {
				display: true,
				labelString: 'Value'
			}
		}]
	}
}
```

to

```
options: {
	scales: {
		x: {
			display: true,
			scaleLabel: {
				display: true,
				labelString: 'Month'
			}
		},
		y: {
			display: true,
			scaleLabel: {
				display: true,
				labelString: 'Value'
			}
		}
	}
}
```

# To Do

- [ ] Fixture based tests
- [ ] Documentation
