### PR TITLE
Added the global datasets defaults for new extended chart type

### DIFF
--- a/docs/developers/charts.md
+++ b/docs/developers/charts.md
@@ -67,6 +67,7 @@ Extending or replacing an existing controller type is easy. Simply replace the c
 The built in controller types are:
 * `Chart.controllers.line`
 * `Chart.controllers.bar`
+* `Chart.controllers.horizontalBar`
 * `Chart.controllers.radar`
 * `Chart.controllers.doughnut`
 * `Chart.controllers.polarArea`
@@ -79,6 +80,10 @@ For example, to derive a new chart type that extends from a bubble chart, you wo
 // We look for the defaults by doing Chart.defaults[chartType]
 // It looks like a bug exists when the defaults don't exist
 Chart.defaults.derivedBubble = Chart.defaults.bubble;
+
+// Sets the default dataset config for 'derivedBubble' to be the same as the bubble dataset defaults.
+// It looks like a bug exists when the dataset defaults don't exist
+Chart.defaults.global.datasets.derivedBubble = Chart.defaults.global.datasets.bubble;
 
 // I think the recommend using Chart.controllers.bubble.extend({ extensions here });
 var custom = Chart.controllers.bubble.extend({


### PR DESCRIPTION
Added documentation to create a global datasets default for new extended chart type.
This is currently mandatory for BAR/HORIZONTALBAR charts (see issue [#6636](https://github.com/chartjs/Chart.js/issues/6636))

