### PR TITLE
Backward compatible default `fill` for radar charts

### DIFF
--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -14,6 +14,7 @@ defaults._set('radar', {
 	},
 	elements: {
 		line: {
+			fill: 'start',
 			tension: 0 // no bezier in radar
 		}
 	}

--- a/test/fixtures/controller.radar/backgroundColor/scriptable.js
+++ b/test/fixtures/controller.radar/backgroundColor/scriptable.js
@@ -25,6 +25,7 @@ module.exports = {
 			title: false,
 			elements: {
 				line: {
+					fill: true,
 					backgroundColor: function(ctx) {
 						var index = (ctx.dataIndex === undefined ? ctx.datasetIndex : ctx.dataIndex);
 						return index === 0 ? '#ff0000'

--- a/test/fixtures/controller.radar/backgroundColor/value.js
+++ b/test/fixtures/controller.radar/backgroundColor/value.js
@@ -20,6 +20,7 @@ module.exports = {
 			title: false,
 			elements: {
 				line: {
+					fill: true,
 					backgroundColor: '#00ff00'
 				},
 				point: {

--- a/test/fixtures/controller.radar/borderDash/scriptable.js
+++ b/test/fixtures/controller.radar/borderDash/scriptable.js
@@ -22,6 +22,7 @@ module.exports = {
 			title: false,
 			elements: {
 				line: {
+					fill: true,
 					borderColor: '#00ff00',
 					borderDash: function(ctx) {
 						return ctx.datasetIndex === 0 ? [5] : [10];


### PR DESCRIPTION
Fixes: #6637