### PR TITLE
Add cross-platform CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+    - name: Setup xvfb
+      run: |
+        Xvfb :99 -screen 0 1024x768x24 &
+        echo "::set-env name=DISPLAY:::99.0"
+      if: runner.os == 'Linux'
+    - name: Build and Test
+      run: |
+        npm install
+        gulp build
+        gulp test --coverage
+    - name: Package
+      run: |
+        gulp docs
+        gulp package
+        gulp bower
+    - name: Publish Test Results
+      run: cat ./coverage/lcov.info | ./node_modules/.bin/coveralls
+      continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: false
 
     steps:
@@ -20,11 +20,25 @@ jobs:
         Xvfb :99 -screen 0 1024x768x24 &
         echo "::set-env name=DISPLAY:::99.0"
       if: runner.os == 'Linux'
+    - name: Install gulp
+      run: npm install --global gulp
+      if: runner.os == 'macOS'
+    - name: Install chrome
+      run: |
+        brew update
+        brew cask install google-chrome
+      if: runner.os == 'macOS'
+    - name: Select browsers
+      run: |
+        if [ "${{ runner.os }}" == "macOS" ]; then
+          echo "::set-env name=BROWSERS::--browsers chrome"
+        fi
+      shell: bash
     - name: Build and Test
       run: |
         npm install
         gulp build
-        gulp test --coverage
+        gulp test --coverage ${BROWSERS}
     - name: Package
       run: |
         gulp docs

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -36,6 +36,7 @@ The following commands are now available from the repository root:
 > gulp unittest --coverage  // run tests and generate coverage reports in ./coverage
 > gulp lint                 // perform code linting (ESLint)
 > gulp test                 // perform code linting and run unit tests
+> gulp test --browsers ...  // test with specified browsers (comma-separated)
 > gulp docs                 // build the documentation in ./dist/docs
 > gulp docs --watch         // starts the gitbook live reloaded server
 ```

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -145,6 +145,7 @@ function unittestTask(done) {
     args: {
       coverage: !!argv.coverage,
       inputs: (argv.inputs || 'test/specs/**/*.js').split(';'),
+      browsers: (argv.browsers || 'chrome,firefox').split(','),
       watch: argv.watch
     }
   },

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -41,6 +41,9 @@ module.exports = function(karma) {
 					'layers.acceleration.disabled': true
 				}
 			},
+			safari: {
+				base: 'SafariPrivate'
+			},
 			edge: {
 				base: 'Edge'
 			}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -40,6 +40,9 @@ module.exports = function(karma) {
 				prefs: {
 					'layers.acceleration.disabled': true
 				}
+			},
+			edge: {
+				base: 'Edge'
 			}
 		},
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -22,7 +22,7 @@ module.exports = function(karma) {
 	karma.set({
 		frameworks: ['jasmine'],
 		reporters: ['progress', 'kjhtml'],
-		browsers: ['chrome', 'firefox'],
+		browsers: args.browsers,
 		logLevel: karma.LOG_WARN,
 
 		// Explicitly disable hardware acceleration to make image

--- a/package-lock.json
+++ b/package-lock.json
@@ -2969,6 +2969,12 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "edge-launcher": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/edge-launcher/-/edge-launcher-1.2.2.tgz",
+      "integrity": "sha1-60Cq+9Bnpup27/+rBke81VCbN7I=",
+      "dev": true
+    },
     "editions": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
@@ -6055,6 +6061,15 @@
         "lodash": "^4.17.11",
         "minimatch": "^3.0.0",
         "source-map": "^0.5.1"
+      }
+    },
+    "karma-edge-launcher": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/karma-edge-launcher/-/karma-edge-launcher-0.4.2.tgz",
+      "integrity": "sha512-YAJZb1fmRcxNhMIWYsjLuxwODBjh2cSHgTW/jkVmdpGguJjLbs9ZgIK/tEJsMQcBLUkO+yO4LBbqYxqgGW2HIw==",
+      "dev": true,
+      "requires": {
+        "edge-launcher": "1.2.2"
       }
     },
     "karma-firefox-launcher": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -938,6 +938,12 @@
         "buffer-equal": "^1.0.0"
       }
     },
+    "applescript": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/applescript/-/applescript-1.0.0.tgz",
+      "integrity": "sha1-u4evVoytA0pOSMS9r2Bno6JwExc=",
+      "dev": true
+    },
     "archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
@@ -6202,6 +6208,15 @@
             "is-number": "^7.0.0"
           }
         }
+      }
+    },
+    "karma-safari-private-launcher": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/karma-safari-private-launcher/-/karma-safari-private-launcher-1.0.0.tgz",
+      "integrity": "sha1-d/zpBIgrNBvRNBWv01KcuSJkC0M=",
+      "dev": true,
+      "requires": {
+        "applescript": "^1.0.0"
       }
     },
     "kind-of": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "karma-jasmine": "^2.0.1",
     "karma-jasmine-html-reporter": "^1.4.0",
     "karma-rollup-preprocessor": "^7.0.0",
+    "karma-safari-private-launcher": "^1.0.0",
     "merge-stream": "^1.0.1",
     "pixelmatch": "^5.0.0",
     "rollup": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "karma": "^4.0.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
+    "karma-edge-launcher": "^0.4.2",
     "karma-firefox-launcher": "^1.0.1",
     "karma-jasmine": "^2.0.1",
     "karma-jasmine-html-reporter": "^1.4.0",


### PR DESCRIPTION
I was hoping to add some continuous integration builds to test on some more obscure browsers (for example, Edge on Windows and Safari on macOS).

This pull request adds a GitHub Actions setup that runs the build, test and packaging steps for the project.  It also adds the `karma-edge-launcher` and `karma-safari-private-launcher` packages.  Finally, it adds a command-line argument `--browsers` so that users can specify a comma-separated list of browsers to test with on the command line.  For example:

```
gulp test --browsers chrome,firefox,edge
```

(The defaults remain chrome and firefox.)

The CI setup will run tests on these browsers:

1. Linux: chrome, firefox
2. macOS: chrome
3. Windows: chrome, firefox

Oh no - what happened to Edge and Safari?

Regrettably, Edge doesn't work on Windows Server, it's only available in Windows 10.  And CI systems run Windows Server, because that's the lightweight thing to run on VMs.

Safari, on the other hand, has always existed on all versions of macOS.  So what's going on here?  Well, funny story.  Mojave has improved security, and you're now required to opt-in to having Safari being controlled by another application.  By clicking OK.

<img width="421" alt="Screen Shot 2019-11-01 at 18 08 20" src="https://user-images.githubusercontent.com/1130014/68061599-b6ff6280-fcd3-11e9-8bb1-4041b3271eff.png">

Obviously you can't click OK easily in a headless CI setup.  😡

I spent quite a while working on a workaround for this, and failing.

So, ultimately, this doesn't actually enable Edge or Safari.  I've left the plugins in so that you can run them locally (`gulp test --browsers edge` or `gulp test --browsers safari`) but if this is undesirable, it's easy enough for me to remove parts of this.