### PR TITLE
[2.9] Remove unnecessary clone

### DIFF
--- a/src/core/core.element.js
+++ b/src/core/core.element.js
@@ -81,7 +81,7 @@ helpers.extend(Element.prototype, {
 
 		// No animation -> No Transition
 		if (!model || ease === 1) {
-			me._view = helpers.extend({}, model);
+			me._view = model;
 			me._start = null;
 			return me;
 		}

--- a/test/specs/core.element.tests.js
+++ b/test/specs/core.element.tests.js
@@ -46,6 +46,5 @@ describe('Core element tests', function() {
 		element.transition(1);
 
 		expect(element._view).toEqual(element._model);
-		expect(element._view).not.toBe(element._model);
 	});
 });


### PR DESCRIPTION
There no reason to do this clone. Removing it is a speedup when animation is disabled. All tests pass and this shouldn't break any plugins since it's a private variable.