### PR TITLE
Remove bundled builds

### DIFF
--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -13,8 +13,8 @@ Latest documentation and samples, including unreleased features, are available a
 
 Latest builds are available for testing at:
 
+ - https://www.chartjs.org/dist/master/Chart.js
  - https://www.chartjs.org/dist/master/Chart.min.js
- - https://www.chartjs.org/dist/master/Chart.bundle.min.js
 
 > Note: Development builds are currently only available via HTTP, so in order to include them in [JSFiddle](https://jsfiddle.net) or [CodePen](https://codepen.io), you need to access these tools via HTTP as well.
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -38,21 +38,3 @@ https://www.jsdelivr.com/package/npm/chart.js?path=dist
 You can download the latest version of [Chart.js on GitHub](https://github.com/chartjs/Chart.js/releases/latest).
 
 If you download or clone the repository, you must [build](../developers/contributing.md#building-and-testing) Chart.js to generate the dist files. Chart.js no longer comes with prebuilt release versions, so an alternative option to downloading the repo is **strongly** advised.
-
-## Selecting the Correct Build
-
-Chart.js provides two different builds for you to choose: **Stand-Alone Build**, **Bundled Build**.
-
-### Stand-Alone Build
-Files:
-* `dist/Chart.js`
-* `dist/Chart.min.js`
-
-The stand-alone build includes Chart.js as well as the color parsing library. If this version is used, you are required to include [Moment.js](https://momentjs.com/) before Chart.js for the functionality of the time axis.
-
-### Bundled Build
-Files:
-* `dist/Chart.bundle.js`
-* `dist/Chart.bundle.min.js`
-
-The bundled build includes Moment.js in a single file. You should use this version if you require time axes and want to include a single file. You should not use this build if your application already included Moment.js. Otherwise, Moment.js will be included twice which results in increasing page load time and possible version compatibility issues. The Moment.js version in the bundled build is private to Chart.js so if you want to use Moment.js yourself, it's better to use Chart.js (non bundled) and import Moment.js manually.

--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -2,7 +2,11 @@
 
 Chart.js 3.0 introduces a number of breaking changes. Chart.js 2.0 was released in April 2016. In the years since then, as Chart.js has grown in popularity and feature set, we've learned some lessons about how to better create a charting library. In order to improve performance, offer new features, and improve maintainability it was necessary to break backwards compatibility, but we aimed to do so only when necessary.
 
-## Eng user migration
+## Setup
+
+Chart.js is no longer providing the `Chart.bundle.js` and `Chart.bundle.min.js`. Please see the [installation](installation.md) and [integration](integration.md) docs for details on the recommended way to setup Chart.js if you were using these builds.
+
+## End user migration
 
 ### Ticks
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,7 +17,7 @@ const banner = `/*!
  */`;
 
 module.exports = [
-	// ES6 builds (excluding moment)
+	// ES6 builds
 	// dist/Chart.esm.min.js
 	// dist/Chart.esm.js
 	{
@@ -77,7 +77,7 @@ module.exports = [
 			'moment'
 		]
 	},
-	// UMD builds (excluding moment)
+	// UMD builds
 	// dist/Chart.min.js
 	// dist/Chart.js
 	{
@@ -142,96 +142,5 @@ module.exports = [
 		external: [
 			'moment'
 		]
-	},
-
-	// ES6 builds (including moment)
-	// dist/Chart.bundle.esm.min.js
-	// dist/Chart.bundle.esm.js
-	{
-		input: input,
-		plugins: [
-			resolve(),
-			commonjs(),
-			babel({
-				exclude: 'node_modules/**'
-			}),
-			stylesheet()
-		],
-		output: {
-			name: 'Chart',
-			file: 'dist/Chart.bundle.esm.js',
-			banner: banner,
-			format: 'esm',
-			indent: false
-		}
-	},
-	{
-		input: input,
-		plugins: [
-			resolve(),
-			commonjs(),
-			babel({
-				exclude: 'node_modules/**'
-			}),
-			stylesheet({
-				minify: true
-			}),
-			terser({
-				output: {
-					preamble: banner
-				}
-			})
-		],
-		output: {
-			name: 'Chart',
-			file: 'dist/Chart.bundle.esm.min.js',
-			format: 'esm',
-			indent: false
-		}
-	},
-	// UMD builds (including moment)
-	// dist/Chart.bundle.min.js
-	// dist/Chart.bundle.js
-	{
-		input: input,
-		plugins: [
-			resolve(),
-			commonjs(),
-			babel({
-				exclude: 'node_modules/**'
-			}),
-			stylesheet()
-		],
-		output: {
-			name: 'Chart',
-			file: 'dist/Chart.bundle.js',
-			banner: banner,
-			format: 'umd',
-			indent: false
-		}
-	},
-	{
-		input: input,
-		plugins: [
-			resolve(),
-			commonjs(),
-			babel({
-				exclude: 'node_modules/**'
-			}),
-			stylesheet({
-				minify: true
-			}),
-			terser({
-				output: {
-					preamble: banner
-				}
-			})
-		],
-		output: {
-			name: 'Chart',
-			file: 'dist/Chart.bundle.min.js',
-			format: 'umd',
-			indent: false
-		}
 	}
 ];


### PR DESCRIPTION
The bundled builds cause multiple issues:

- Users who don't need moment accidentally end up including it and getting a huge library
- Users who want to use the time scale accidentally end up including moment twice and getting huge download sizes

It's simpler to have just one way to set things up vs multiple