### PR TITLE
Remove index and datasetIndex from Element

### DIFF
--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -47,6 +47,7 @@ Chart.js is no longer providing the `Chart.bundle.js` and `Chart.bundle.min.js`.
 * `afterScaleUpdate`
 * `helpers.addEvent`
 * `helpers.aliasPixel`
+* `helpers.arrayEquals`
 * `helpers.configMerge`
 * `helpers.indexOf`
 * `helpers.min`
@@ -101,3 +102,17 @@ Chart.js is no longer providing the `Chart.bundle.js` and `Chart.bundle.min.js`.
 ##### Time Scale
 
 * `getValueForPixel` now returns milliseconds since the epoch
+
+#### Controllers
+
+##### Core Controller
+
+* The first parameter to `updateHoverStyle` is now an array of objects containing the `element`, `datasetIndex`, and `index`
+
+##### Dataset Controllers
+
+* `setHoverStyle` now additionally takes the `datasetIndex` and `index`
+
+#### Interactions
+
+* Interaction mode methods now return an array of objects containing the `element`, `datasetIndex`, and `index`

--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -47,7 +47,6 @@ Chart.js is no longer providing the `Chart.bundle.js` and `Chart.bundle.min.js`.
 * `afterScaleUpdate`
 * `helpers.addEvent`
 * `helpers.aliasPixel`
-* `helpers.arrayEquals`
 * `helpers.configMerge`
 * `helpers.indexOf`
 * `helpers.min`

--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -240,8 +240,6 @@ module.exports = DatasetController.extend({
 		var me = this;
 		var options = me._resolveDataElementOptions(index);
 
-		rectangle._datasetIndex = me.index;
-		rectangle._index = index;
 		rectangle._model = {
 			backgroundColor: options.backgroundColor,
 			borderColor: options.borderColor,

--- a/src/controllers/controller.bubble.js
+++ b/src/controllers/controller.bubble.js
@@ -107,8 +107,6 @@ module.exports = DatasetController.extend({
 		var y = reset ? yScale.getBasePixel() : yScale.getPixelForValue(parsed[yScale.id]);
 
 		point._options = options;
-		point._datasetIndex = me.index;
-		point._index = index;
 		point._model = {
 			backgroundColor: options.backgroundColor,
 			borderColor: options.borderColor,

--- a/src/controllers/controller.doughnut.js
+++ b/src/controllers/controller.doughnut.js
@@ -238,10 +238,6 @@ module.exports = DatasetController.extend({
 		var options = arc._options || {};
 
 		helpers.extend(arc, {
-			// Utility
-			_datasetIndex: me.index,
-			_index: index,
-
 			// Desired view properties
 			_model: {
 				backgroundColor: options.backgroundColor,

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -82,8 +82,6 @@ module.exports = DatasetController.extend({
 
 		// Update Line
 		if (showLine) {
-			// Utility
-			line._datasetIndex = me.index;
 			// Data
 			line._children = points;
 			// Model
@@ -110,7 +108,6 @@ module.exports = DatasetController.extend({
 	updateElement: function(point, index, reset) {
 		var me = this;
 		var meta = me.getMeta();
-		var datasetIndex = me.index;
 		var xScale = me._xScale;
 		var yScale = me._yScale;
 		var lineModel = meta.dataset._model;
@@ -122,8 +119,6 @@ module.exports = DatasetController.extend({
 
 		// Utility
 		point._options = options;
-		point._datasetIndex = datasetIndex;
-		point._index = index;
 
 		// Desired view properties
 		point._model = {

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -201,10 +201,6 @@ module.exports = DatasetController.extend({
 		var options = arc._options || {};
 
 		helpers.extend(arc, {
-			// Utility
-			_datasetIndex: me.index,
-			_index: index,
-
 			// Desired view properties
 			_model: {
 				backgroundColor: options.backgroundColor,

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -82,8 +82,6 @@ module.exports = DatasetController.extend({
 			config.lineTension = config.tension;
 		}
 
-		// Utility
-		line._datasetIndex = me.index;
 		// Data
 		line._children = points;
 		line._loop = true;
@@ -118,8 +116,6 @@ module.exports = DatasetController.extend({
 
 		// Utility
 		point._options = options;
-		point._datasetIndex = me.index;
-		point._index = index;
 
 		// Desired view properties
 		point._model = {

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -985,7 +985,7 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 		for (i = 0, ilen = items.length; i < ilen; ++i) {
 			item = items[i];
 			if (item) {
-				this.getDatasetMeta(item.datasetIndex).controller[prefix + 'HoverStyle'](item.element, item.datasetIndex, i);
+				this.getDatasetMeta(item.datasetIndex).controller[prefix + 'HoverStyle'](item.element, item.datasetIndex, item.index);
 			}
 		}
 	},

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -969,19 +969,24 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 		});
 	},
 
-	updateHoverStyle: function(elements, mode, enabled) {
+	updateHoverStyle: function(items, mode, enabled) {
 		var prefix = enabled ? 'set' : 'remove';
-		var element, i, ilen;
-
-		for (i = 0, ilen = elements.length; i < ilen; ++i) {
-			element = elements[i];
-			if (element) {
-				this.getDatasetMeta(element._datasetIndex).controller[prefix + 'HoverStyle'](element);
-			}
-		}
+		var meta, item, i, ilen;
 
 		if (mode === 'dataset') {
-			this.getDatasetMeta(elements[0]._datasetIndex).controller['_' + prefix + 'DatasetHoverStyle']();
+			meta = this.getDatasetMeta(items[0].datasetIndex);
+			meta.controller['_' + prefix + 'DatasetHoverStyle']();
+			for (i = 0, ilen = meta.data.length; i < ilen; ++i) {
+				meta.controller[prefix + 'HoverStyle'](meta.data[i], items[0].datasetIndex, i);
+			}
+			return;
+		}
+
+		for (i = 0, ilen = items.length; i < ilen; ++i) {
+			item = items[i];
+			if (item) {
+				this.getDatasetMeta(item.datasetIndex).controller[prefix + 'HoverStyle'](item.element, item.datasetIndex, i);
+			}
 		}
 	},
 
@@ -1089,7 +1094,7 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 		}
 
 		me._updateHoverStyles();
-		changed = !helpers.arrayEquals(me.active, me.lastActive);
+		changed = !helpers._elementsEqual(me.active, me.lastActive);
 
 		// Remember Last Actives
 		me.lastActive = me.active;

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -793,9 +793,8 @@ helpers.extend(DatasetController.prototype, {
 		delete element.$previousStyle;
 	},
 
-	setHoverStyle: function(element) {
-		var dataset = this.chart.data.datasets[element._datasetIndex];
-		var index = element._index;
+	setHoverStyle: function(element, datasetIndex, index) {
+		var dataset = this.chart.data.datasets[datasetIndex];
 		var model = element._model;
 		var getHoverColor = helpers.getHoverColor;
 

--- a/src/core/core.element.js
+++ b/src/core/core.element.js
@@ -56,12 +56,13 @@ class Element {
 
 	constructor(configuration) {
 		helpers.extend(this, configuration);
+
+		// this.hidden = false; we assume Element has an attribute called hidden, but do not initialize to save memory
+
 		this.initialize.apply(this, arguments);
 	}
 
-	initialize() {
-		this.hidden = false;
-	}
+	initialize() {}
 
 	pivot() {
 		var me = this;

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -117,7 +117,7 @@ var positioners = {
 		var count = 0;
 
 		for (i = 0, len = elements.length; i < len; ++i) {
-			var el = elements[i];
+			var el = elements[i].element;
 			if (el && el.hasValue()) {
 				var pos = el.tooltipPosition();
 				x += pos.x;
@@ -146,7 +146,7 @@ var positioners = {
 		var i, len, nearestElement;
 
 		for (i = 0, len = elements.length; i < len; ++i) {
-			var el = elements[i];
+			var el = elements[i].element;
 			if (el && el.hasValue()) {
 				var center = el.getCenterPoint();
 				var d = helpers.distanceBetweenPoints(eventPosition, center);
@@ -201,12 +201,13 @@ function splitNewlines(str) {
 
 /**
  * Private helper to create a tooltip item model
- * @param element - the chart element (point, arc, bar) to create the tooltip item for
+ * @param item - the chart element (point, arc, bar) to create the tooltip item for
  * @return new tooltip item
  */
-function createTooltipItem(chart, element) {
-	var datasetIndex = element._datasetIndex;
-	var index = element._index;
+function createTooltipItem(chart, item) {
+	var datasetIndex = item.datasetIndex;
+	var index = item.index;
+	var element = item.element;
 	var controller = chart.getDatasetMeta(datasetIndex).controller;
 	var indexScale = controller._getIndexScale();
 	var valueScale = controller._getValueScale();
@@ -1016,7 +1017,7 @@ class Tooltip extends Element {
 		}
 
 		// Remember Last Actives
-		changed = !helpers.arrayEquals(me._active, me._lastActive);
+		changed = !helpers._elementsEqual(me._active, me._lastActive);
 
 		// Only handle target event on tooltip change
 		if (changed) {

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -205,13 +205,11 @@ function splitNewlines(str) {
  * @return new tooltip item
  */
 function createTooltipItem(chart, item) {
-	var datasetIndex = item.datasetIndex;
-	var index = item.index;
-	var element = item.element;
-	var controller = chart.getDatasetMeta(datasetIndex).controller;
-	var indexScale = controller._getIndexScale();
-	var valueScale = controller._getValueScale();
-	var parsed = controller._getParsed(index);
+	const {datasetIndex, element, index} = item;
+	const controller = chart.getDatasetMeta(datasetIndex).controller;
+	const indexScale = controller._getIndexScale();
+	const valueScale = controller._getValueScale();
+	const parsed = controller._getParsed(index);
 
 	return {
 		label: indexScale ? '' + indexScale.getLabelForValue(parsed[indexScale.id]) : '',

--- a/src/helpers/helpers.core.js
+++ b/src/helpers/helpers.core.js
@@ -140,6 +140,36 @@ var helpers = {
 	 * @param {Array} a1 - The array to compare
 	 * @returns {boolean}
 	 */
+	arrayEquals: function(a0, a1) {
+		var i, ilen, v0, v1;
+
+		if (!a0 || !a1 || a0.length !== a1.length) {
+			return false;
+		}
+
+		for (i = 0, ilen = a0.length; i < ilen; ++i) {
+			v0 = a0[i];
+			v1 = a1[i];
+
+			if (v0 instanceof Array && v1 instanceof Array) {
+				if (!helpers.arrayEquals(v0, v1)) {
+					return false;
+				}
+			} else if (v0 !== v1) {
+				// NOTE: two different object instances will never be equal: {x:20} != {x:20}
+				return false;
+			}
+		}
+
+		return true;
+	},
+
+	/**
+	 * Returns true if the `a0` and `a1` arrays have the same content, else returns false.
+	 * @param {Array} a0 - The array to compare
+	 * @param {Array} a1 - The array to compare
+	 * @returns {boolean}
+	 */
 	_elementsEqual: function(a0, a1) {
 		var i, ilen, v0, v1;
 

--- a/src/helpers/helpers.core.js
+++ b/src/helpers/helpers.core.js
@@ -140,7 +140,7 @@ var helpers = {
 	 * @param {Array} a1 - The array to compare
 	 * @returns {boolean}
 	 */
-	arrayEquals: function(a0, a1) {
+	_elementsEqual: function(a0, a1) {
 		var i, ilen, v0, v1;
 
 		if (!a0 || !a1 || a0.length !== a1.length) {
@@ -151,12 +151,7 @@ var helpers = {
 			v0 = a0[i];
 			v1 = a1[i];
 
-			if (v0 instanceof Array && v1 instanceof Array) {
-				if (!helpers.arrayEquals(v0, v1)) {
-					return false;
-				}
-			} else if (v0 !== v1) {
-				// NOTE: two different object instances will never be equal: {x:20} != {x:20}
+			if (v0.datasetIndex !== v1.datasetIndex || v0.index !== v1.index) {
 				return false;
 			}
 		}

--- a/src/helpers/helpers.core.js
+++ b/src/helpers/helpers.core.js
@@ -171,7 +171,7 @@ var helpers = {
 	 * @returns {boolean}
 	 */
 	_elementsEqual: function(a0, a1) {
-		var i, ilen, v0, v1;
+		let i, ilen, v0, v1;
 
 		if (!a0 || !a1 || a0.length !== a1.length) {
 			return false;

--- a/test/specs/controller.bar.tests.js
+++ b/test/specs/controller.bar.tests.js
@@ -1379,7 +1379,7 @@ describe('Chart.controllers.bar', function() {
 		var meta = chart.getDatasetMeta(1);
 		var bar = meta.data[0];
 
-		meta.controller.setHoverStyle(bar);
+		meta.controller.setHoverStyle(bar, 1, 0);
 		expect(bar._model.backgroundColor).toBe('rgb(230, 0, 0)');
 		expect(bar._model.borderColor).toBe('rgb(0, 0, 230)');
 		expect(bar._model.borderWidth).toBe(2);
@@ -1389,7 +1389,7 @@ describe('Chart.controllers.bar', function() {
 		chart.data.datasets[1].hoverBorderColor = 'rgb(0, 0, 0)';
 		chart.data.datasets[1].hoverBorderWidth = 5;
 
-		meta.controller.setHoverStyle(bar);
+		meta.controller.setHoverStyle(bar, 1, 0);
 		expect(bar._model.backgroundColor).toBe('rgb(128, 128, 128)');
 		expect(bar._model.borderColor).toBe('rgb(0, 0, 0)');
 		expect(bar._model.borderWidth).toBe(5);
@@ -1399,7 +1399,7 @@ describe('Chart.controllers.bar', function() {
 		chart.data.datasets[1].hoverBorderColor = ['rgb(9, 9, 9)', 'rgb(0, 0, 0)'];
 		chart.data.datasets[1].hoverBorderWidth = [2.5, 5];
 
-		meta.controller.setHoverStyle(bar);
+		meta.controller.setHoverStyle(bar, 1, 0);
 		expect(bar._model.backgroundColor).toBe('rgb(255, 255, 255)');
 		expect(bar._model.borderColor).toBe('rgb(9, 9, 9)');
 		expect(bar._model.borderWidth).toBe(2.5);
@@ -1441,7 +1441,7 @@ describe('Chart.controllers.bar', function() {
 		expect(bar._model.backgroundColor).toBe('rgb(128, 128, 128)');
 		expect(bar._model.borderColor).toBe('rgb(15, 15, 15)');
 		expect(bar._model.borderWidth).toBe(3.14);
-		meta.controller.setHoverStyle(bar);
+		meta.controller.setHoverStyle(bar, 1, 0);
 		expect(bar._model.backgroundColor).toBe(helpers.getHoverColor('rgb(128, 128, 128)'));
 		expect(bar._model.borderColor).toBe(helpers.getHoverColor('rgb(15, 15, 15)'));
 		expect(bar._model.borderWidth).toBe(3.14);
@@ -1459,7 +1459,7 @@ describe('Chart.controllers.bar', function() {
 		expect(bar._model.backgroundColor).toBe('rgb(255, 255, 255)');
 		expect(bar._model.borderColor).toBe('rgb(9, 9, 9)');
 		expect(bar._model.borderWidth).toBe(2.5);
-		meta.controller.setHoverStyle(bar);
+		meta.controller.setHoverStyle(bar, 1, 0);
 		expect(bar._model.backgroundColor).toBe(helpers.getHoverColor('rgb(255, 255, 255)'));
 		expect(bar._model.borderColor).toBe(helpers.getHoverColor('rgb(9, 9, 9)'));
 		expect(bar._model.borderWidth).toBe(2.5);

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -1168,13 +1168,13 @@ describe('Chart', function() {
 			// Check and see if tooltip was displayed
 			var tooltip = chart.tooltip;
 
-			expect(chart.lastActive).toEqual([point]);
-			expect(tooltip._lastActive).toEqual([point]);
+			expect(chart.lastActive[0].element).toEqual(point);
+			expect(tooltip._lastActive[0].element).toEqual(point);
 
 			// Update and confirm tooltip is updated
 			chart.update();
-			expect(chart.lastActive).toEqual([point]);
-			expect(tooltip._lastActive).toEqual([point]);
+			expect(chart.lastActive[0].element).toEqual(point);
+			expect(tooltip._lastActive[0].element).toEqual(point);
 		});
 
 		it ('should update the metadata', function() {

--- a/test/specs/core.interaction.tests.js
+++ b/test/specs/core.interaction.tests.js
@@ -37,7 +37,7 @@ describe('Core.Interaction', function() {
 				y: point._model.y,
 			};
 
-			var elements = Chart.Interaction.modes.point(chart, evt);
+			var elements = Chart.Interaction.modes.point(chart, evt).map(item => item.element);
 			expect(elements).toEqual([point, meta1.data[1]]);
 		});
 
@@ -51,7 +51,7 @@ describe('Core.Interaction', function() {
 				y: 0
 			};
 
-			var elements = Chart.Interaction.modes.point(chart, evt);
+			var elements = Chart.Interaction.modes.point(chart, evt).map(item => item.element);
 			expect(elements).toEqual([]);
 		});
 	});
@@ -92,7 +92,7 @@ describe('Core.Interaction', function() {
 					y: point._model.y,
 				};
 
-				var elements = Chart.Interaction.modes.index(chart, evt, {intersect: true});
+				var elements = Chart.Interaction.modes.index(chart, evt, {intersect: true}).map(item => item.element);
 				expect(elements).toEqual([point, meta1.data[1]]);
 			});
 
@@ -106,7 +106,7 @@ describe('Core.Interaction', function() {
 					y: 0,
 				};
 
-				var elements = Chart.Interaction.modes.index(chart, evt, {intersect: true});
+				var elements = Chart.Interaction.modes.index(chart, evt, {intersect: true}).map(item => item.element);
 				expect(elements).toEqual([]);
 			});
 		});
@@ -147,7 +147,7 @@ describe('Core.Interaction', function() {
 					y: 0
 				};
 
-				var elements = Chart.Interaction.modes.index(chart, evt, {intersect: false});
+				var elements = Chart.Interaction.modes.index(chart, evt, {intersect: false}).map(item => item.element);
 				expect(elements).toEqual([meta0.data[0], meta1.data[0]]);
 			});
 
@@ -169,7 +169,7 @@ describe('Core.Interaction', function() {
 					y: center.y + 30,
 				};
 
-				var elements = Chart.Interaction.modes.index(chart, evt, {axis: 'y', intersect: false});
+				var elements = Chart.Interaction.modes.index(chart, evt, {axis: 'y', intersect: false}).map(item => item.element);
 				expect(elements).toEqual([meta0.data[0], meta1.data[0]]);
 			});
 
@@ -186,7 +186,7 @@ describe('Core.Interaction', function() {
 					y: 0
 				};
 
-				var elements = Chart.Interaction.modes.index(chart, evt, {axis: 'xy', intersect: false});
+				var elements = Chart.Interaction.modes.index(chart, evt, {axis: 'xy', intersect: false}).map(item => item.element);
 				expect(elements).toEqual([meta0.data[0], meta1.data[0]]);
 			});
 		});
@@ -228,7 +228,7 @@ describe('Core.Interaction', function() {
 				};
 
 				var elements = Chart.Interaction.modes.dataset(chart, evt, {intersect: true});
-				expect(elements).toEqual(meta.data);
+				expect(elements).toEqual([{datasetIndex: 0}]);
 			});
 
 			it ('should return an empty array if nothing found', function() {
@@ -284,9 +284,7 @@ describe('Core.Interaction', function() {
 				};
 
 				var elements = Chart.Interaction.modes.dataset(chart, evt, {axis: 'x', intersect: false});
-
-				var meta = chart.getDatasetMeta(0);
-				expect(elements).toEqual(meta.data);
+				expect(elements).toEqual([{datasetIndex: 0}]);
 			});
 
 			it ('axis: y gets correct items', function() {
@@ -300,9 +298,7 @@ describe('Core.Interaction', function() {
 				};
 
 				var elements = Chart.Interaction.modes.dataset(chart, evt, {axis: 'y', intersect: false});
-
-				var meta = chart.getDatasetMeta(1);
-				expect(elements).toEqual(meta.data);
+				expect(elements).toEqual([{datasetIndex: 1}]);
 			});
 
 			it ('axis: xy gets correct items', function() {
@@ -316,9 +312,7 @@ describe('Core.Interaction', function() {
 				};
 
 				var elements = Chart.Interaction.modes.dataset(chart, evt, {intersect: false});
-
-				var meta = chart.getDatasetMeta(1);
-				expect(elements).toEqual(meta.data);
+				expect(elements).toEqual([{datasetIndex: 1}]);
 			});
 		});
 	});
@@ -359,7 +353,7 @@ describe('Core.Interaction', function() {
 					};
 
 					// Nearest to 0,0 (top left) will be first point of dataset 2
-					var elements = Chart.Interaction.modes.nearest(chart, evt, {intersect: false});
+					var elements = Chart.Interaction.modes.nearest(chart, evt, {intersect: false}).map(item => item.element);
 					var meta = chart.getDatasetMeta(1);
 					expect(elements).toEqual([meta.data[0]]);
 				});
@@ -384,7 +378,7 @@ describe('Core.Interaction', function() {
 					};
 
 					// Both points are nearest
-					var elements = Chart.Interaction.modes.nearest(chart, evt, {intersect: false});
+					var elements = Chart.Interaction.modes.nearest(chart, evt, {intersect: false}).map(item => item.element);
 					expect(elements).toEqual([meta0.data[1], meta1.data[1]]);
 				});
 			});
@@ -410,7 +404,7 @@ describe('Core.Interaction', function() {
 					};
 
 					// Middle point from both series are nearest
-					var elements = Chart.Interaction.modes.nearest(chart, evt, {axis: 'x', intersect: false});
+					var elements = Chart.Interaction.modes.nearest(chart, evt, {axis: 'x', intersect: false}).map(item => item.element);
 					expect(elements).toEqual([meta0.data[1], meta1.data[1]]);
 				});
 
@@ -434,7 +428,7 @@ describe('Core.Interaction', function() {
 					};
 
 					// Should return all (4) points from 'Point 1' and 'Point 2'
-					var elements = Chart.Interaction.modes.nearest(chart, evt, {axis: 'x', intersect: false});
+					var elements = Chart.Interaction.modes.nearest(chart, evt, {axis: 'x', intersect: false}).map(item => item.element);
 					expect(elements).toEqual([meta0.data[0], meta0.data[1], meta1.data[0], meta1.data[1]]);
 				});
 			});
@@ -459,7 +453,7 @@ describe('Core.Interaction', function() {
 					};
 
 					// Middle point from both series are nearest
-					var elements = Chart.Interaction.modes.nearest(chart, evt, {axis: 'y', intersect: false});
+					var elements = Chart.Interaction.modes.nearest(chart, evt, {axis: 'y', intersect: false}).map(item => item.element);
 					expect(elements).toEqual([meta0.data[2]]);
 				});
 
@@ -483,7 +477,7 @@ describe('Core.Interaction', function() {
 					};
 
 					// Should return points with value 40
-					var elements = Chart.Interaction.modes.nearest(chart, evt, {axis: 'y', intersect: false});
+					var elements = Chart.Interaction.modes.nearest(chart, evt, {axis: 'y', intersect: false}).map(item => item.element);
 					expect(elements).toEqual([meta0.data[1], meta1.data[0], meta1.data[1], meta1.data[2]]);
 				});
 			});
@@ -525,7 +519,7 @@ describe('Core.Interaction', function() {
 					};
 
 					// Nothing intersects so find nothing
-					var elements = Chart.Interaction.modes.nearest(chart, evt, {intersect: true});
+					var elements = Chart.Interaction.modes.nearest(chart, evt, {intersect: true}).map(item => item.element);
 					expect(elements).toEqual([]);
 
 					evt = {
@@ -535,7 +529,7 @@ describe('Core.Interaction', function() {
 						x: point._view.x,
 						y: point._view.y
 					};
-					elements = Chart.Interaction.modes.nearest(chart, evt, {intersect: true});
+					elements = Chart.Interaction.modes.nearest(chart, evt, {intersect: true}).map(item => item.element);
 					expect(elements).toEqual([point]);
 				});
 
@@ -565,7 +559,7 @@ describe('Core.Interaction', function() {
 						y: pt.y
 					};
 
-					var elements = Chart.Interaction.modes.nearest(chart, evt, {intersect: true});
+					var elements = Chart.Interaction.modes.nearest(chart, evt, {intersect: true}).map(item => item.element);
 					expect(elements).toEqual([meta0.data[1]]);
 				});
 
@@ -595,7 +589,7 @@ describe('Core.Interaction', function() {
 						y: pt.y
 					};
 
-					var elements = Chart.Interaction.modes.nearest(chart, evt, {intersect: true});
+					var elements = Chart.Interaction.modes.nearest(chart, evt, {intersect: true}).map(item => item.element);
 					expect(elements).toEqual([meta0.data[1], meta1.data[1]]);
 				});
 			});
@@ -644,7 +638,7 @@ describe('Core.Interaction', function() {
 				y: 0
 			};
 
-			var elements = Chart.Interaction.modes.x(chart, evt, {intersect: false});
+			var elements = Chart.Interaction.modes.x(chart, evt, {intersect: false}).map(item => item.element);
 			expect(elements).toEqual([meta0.data[1], meta1.data[1]]);
 
 			evt = {
@@ -655,7 +649,7 @@ describe('Core.Interaction', function() {
 				y: 0
 			};
 
-			elements = Chart.Interaction.modes.x(chart, evt, {intersect: false});
+			elements = Chart.Interaction.modes.x(chart, evt, {intersect: false}).map(item => item.element);
 			expect(elements).toEqual([]);
 		});
 
@@ -678,7 +672,7 @@ describe('Core.Interaction', function() {
 				y: 0
 			};
 
-			var elements = Chart.Interaction.modes.x(chart, evt, {intersect: true});
+			var elements = Chart.Interaction.modes.x(chart, evt, {intersect: true}).map(item => item.element);
 			expect(elements).toEqual([]); // we don't intersect anything
 
 			evt = {
@@ -689,7 +683,7 @@ describe('Core.Interaction', function() {
 				y: pt.y
 			};
 
-			elements = Chart.Interaction.modes.x(chart, evt, {intersect: true});
+			elements = Chart.Interaction.modes.x(chart, evt, {intersect: true}).map(item => item.element);
 			expect(elements).toEqual([meta0.data[1], meta1.data[1]]);
 		});
 	});
@@ -736,7 +730,7 @@ describe('Core.Interaction', function() {
 				y: pt.y,
 			};
 
-			var elements = Chart.Interaction.modes.y(chart, evt, {intersect: false});
+			var elements = Chart.Interaction.modes.y(chart, evt, {intersect: false}).map(item => item.element);
 			expect(elements).toEqual([meta0.data[1], meta1.data[0], meta1.data[1], meta1.data[2]]);
 
 			evt = {
@@ -747,7 +741,7 @@ describe('Core.Interaction', function() {
 				y: pt.y + 20, // out of range
 			};
 
-			elements = Chart.Interaction.modes.y(chart, evt, {intersect: false});
+			elements = Chart.Interaction.modes.y(chart, evt, {intersect: false}).map(item => item.element);
 			expect(elements).toEqual([]);
 		});
 
@@ -770,7 +764,7 @@ describe('Core.Interaction', function() {
 				y: pt.y
 			};
 
-			var elements = Chart.Interaction.modes.y(chart, evt, {intersect: true});
+			var elements = Chart.Interaction.modes.y(chart, evt, {intersect: true}).map(item => item.element);
 			expect(elements).toEqual([]); // we don't intersect anything
 
 			evt = {
@@ -781,7 +775,7 @@ describe('Core.Interaction', function() {
 				y: pt.y,
 			};
 
-			elements = Chart.Interaction.modes.y(chart, evt, {intersect: true});
+			elements = Chart.Interaction.modes.y(chart, evt, {intersect: true}).map(item => item.element);
 			expect(elements).toEqual([meta0.data[1], meta1.data[0], meta1.data[1], meta1.data[2]]);
 		});
 	});

--- a/test/specs/global.defaults.tests.js
+++ b/test/specs/global.defaults.tests.js
@@ -125,14 +125,14 @@ describe('Default Configs', function() {
 			var expected = [{
 				text: 'label1',
 				fillStyle: 'red',
-				hidden: false,
+				hidden: undefined,
 				index: 0,
 				strokeStyle: '#000',
 				lineWidth: 2
 			}, {
 				text: 'label2',
 				fillStyle: 'green',
-				hidden: false,
+				hidden: undefined,
 				index: 1,
 				strokeStyle: '#000',
 				lineWidth: 2
@@ -241,14 +241,14 @@ describe('Default Configs', function() {
 			var expected = [{
 				text: 'label1',
 				fillStyle: 'red',
-				hidden: false,
+				hidden: undefined,
 				index: 0,
 				strokeStyle: '#000',
 				lineWidth: 2
 			}, {
 				text: 'label2',
 				fillStyle: 'green',
-				hidden: false,
+				hidden: undefined,
 				index: 1,
 				strokeStyle: '#000',
 				lineWidth: 2

--- a/test/specs/global.defaults.tests.js
+++ b/test/specs/global.defaults.tests.js
@@ -18,7 +18,7 @@ describe('Default Configs', function() {
 			});
 
 			// fake out the tooltip hover and force the tooltip to update
-			chart.tooltip._active = [chart.getDatasetMeta(0).data[0]];
+			chart.tooltip._active = [{element: chart.getDatasetMeta(0).data[0], datasetIndex: 0, index: 0}];
 			chart.tooltip.update();
 
 			// Title is always blank
@@ -46,7 +46,7 @@ describe('Default Configs', function() {
 			});
 
 			// fake out the tooltip hover and force the tooltip to update
-			chart.tooltip._active = [chart.getDatasetMeta(0).data[1]];
+			chart.tooltip._active = [{element: chart.getDatasetMeta(0).data[1], datasetIndex: 0, index: 1}];
 			chart.tooltip.update();
 
 			// Title is always blank
@@ -72,7 +72,7 @@ describe('Default Configs', function() {
 			});
 
 			// fake out the tooltip hover and force the tooltip to update
-			chart.tooltip._active = [chart.getDatasetMeta(0).data[1]];
+			chart.tooltip._active = [{element: chart.getDatasetMeta(0).data[1], datasetIndex: 0, index: 1}];
 			chart.tooltip.update();
 
 			// Title is always blank
@@ -192,7 +192,7 @@ describe('Default Configs', function() {
 			});
 
 			// fake out the tooltip hover and force the tooltip to update
-			chart.tooltip._active = [chart.getDatasetMeta(0).data[1]];
+			chart.tooltip._active = [{element: chart.getDatasetMeta(0).data[1], datasetIndex: 0, index: 1}];
 			chart.tooltip.update();
 
 			// Title is always blank

--- a/test/specs/helpers.core.tests.js
+++ b/test/specs/helpers.core.tests.js
@@ -243,24 +243,8 @@ describe('Chart.helpers.core', function() {
 
 	describe('arrayEquals', function() {
 		it('should return false if arrays are not the same', function() {
-			expect(helpers.arrayEquals([], [42])).toBeFalsy();
-			expect(helpers.arrayEquals([42], ['42'])).toBeFalsy();
-			expect(helpers.arrayEquals([1, 2, 3], [1, 2, 3, 4])).toBeFalsy();
-			expect(helpers.arrayEquals(['foo', 'bar'], ['bar', 'foo'])).toBeFalsy();
-			expect(helpers.arrayEquals([1, 2, 3], [1, 2, 'foo'])).toBeFalsy();
-			expect(helpers.arrayEquals([1, 2, [3, 4]], [1, 2, [3, 'foo']])).toBeFalsy();
-			expect(helpers.arrayEquals([{a: 42}], [{a: 42}])).toBeFalsy();
-		});
-		it('should return false if arrays are not the same', function() {
-			var o0 = {};
-			var o1 = {};
-			var o2 = {};
-
-			expect(helpers.arrayEquals([], [])).toBeTruthy();
-			expect(helpers.arrayEquals([1, 2, 3], [1, 2, 3])).toBeTruthy();
-			expect(helpers.arrayEquals(['foo', 'bar'], ['foo', 'bar'])).toBeTruthy();
-			expect(helpers.arrayEquals([true, false, true], [true, false, true])).toBeTruthy();
-			expect(helpers.arrayEquals([o0, o1, o2], [o0, o1, o2])).toBeTruthy();
+			expect(helpers._elementsEqual([], [{datasetIndex: 0, index: 1}])).toBeFalsy();
+			expect(helpers._elementsEqual([{datasetIndex: 0, index: 2}], [{datasetIndex: 0, index: 1}])).toBeFalsy();
 		});
 	});
 

--- a/test/specs/helpers.core.tests.js
+++ b/test/specs/helpers.core.tests.js
@@ -265,6 +265,11 @@ describe('Chart.helpers.core', function() {
 	});
 
 	describe('_elementsEqual', function() {
+		it('should return true if arrays are the same', function() {
+			expect(helpers._elementsEqual(
+				[{datasetIndex: 0, index: 1}, {datasetIndex: 0, index: 2}],
+				[{datasetIndex: 0, index: 1}, {datasetIndex: 0, index: 2}])).toBeTruthy();
+		});
 		it('should return false if arrays are not the same', function() {
 			expect(helpers._elementsEqual([], [{datasetIndex: 0, index: 1}])).toBeFalsy();
 			expect(helpers._elementsEqual([{datasetIndex: 0, index: 2}], [{datasetIndex: 0, index: 1}])).toBeFalsy();

--- a/test/specs/helpers.core.tests.js
+++ b/test/specs/helpers.core.tests.js
@@ -243,6 +243,29 @@ describe('Chart.helpers.core', function() {
 
 	describe('arrayEquals', function() {
 		it('should return false if arrays are not the same', function() {
+			expect(helpers.arrayEquals([], [42])).toBeFalsy();
+			expect(helpers.arrayEquals([42], ['42'])).toBeFalsy();
+			expect(helpers.arrayEquals([1, 2, 3], [1, 2, 3, 4])).toBeFalsy();
+			expect(helpers.arrayEquals(['foo', 'bar'], ['bar', 'foo'])).toBeFalsy();
+			expect(helpers.arrayEquals([1, 2, 3], [1, 2, 'foo'])).toBeFalsy();
+			expect(helpers.arrayEquals([1, 2, [3, 4]], [1, 2, [3, 'foo']])).toBeFalsy();
+			expect(helpers.arrayEquals([{a: 42}], [{a: 42}])).toBeFalsy();
+		});
+		it('should return false if arrays are not the same', function() {
+			var o0 = {};
+			var o1 = {};
+			var o2 = {};
+
+			expect(helpers.arrayEquals([], [])).toBeTruthy();
+			expect(helpers.arrayEquals([1, 2, 3], [1, 2, 3])).toBeTruthy();
+			expect(helpers.arrayEquals(['foo', 'bar'], ['foo', 'bar'])).toBeTruthy();
+			expect(helpers.arrayEquals([true, false, true], [true, false, true])).toBeTruthy();
+			expect(helpers.arrayEquals([o0, o1, o2], [o0, o1, o2])).toBeTruthy();
+		});
+	});
+
+	describe('_elementsEqual', function() {
+		it('should return false if arrays are not the same', function() {
 			expect(helpers._elementsEqual([], [{datasetIndex: 0, index: 1}])).toBeFalsy();
 			expect(helpers._elementsEqual([{datasetIndex: 0, index: 2}], [{datasetIndex: 0, index: 1}])).toBeFalsy();
 		});


### PR DESCRIPTION
Right now `Element` holds a few things that it doesn't really need to. This has a memory impact since an `Element` is created for every data point and held throughout the life of the chart. [Chart.js has relatively high memory requirements compared to some other libraries](https://github.com/leeoniya/uPlot#performance) and I think we can improve our standing on this front.

This alone probably doesn't have that large of an impact on performance, but there are additional performance improvements this will unblock that should be very impactful especially in the case that animations are disabled.

This is about 20-30 lines less code by making it easier to create `Element`. From a developer's point of view, the new APIs are purely more powerful since the interaction methods now return the `datasetIndex` and `index` as well. Previously these were private variables inside `Element`. It also makes `Element` easier to use as a developer because it removes a requirement that you reach inside the class to properly initialize these private variables