### PR TITLE
Remove zeroLineIndex functionality

### DIFF
--- a/docs/axes/styling.md
+++ b/docs/axes/styling.md
@@ -18,10 +18,6 @@ The grid line configuration is nested under the scale configuration in the `grid
 | `drawOnChartArea` | `boolean` | `true` | If true, draw lines on the chart area inside the axis lines. This is useful when there are multiple axes and you need to control which grid lines are drawn.
 | `drawTicks` | `boolean` | `true` | If true, draw lines beside the ticks in the axis area beside the chart.
 | `tickMarkLength` | `number` | `10` | Length in pixels that the grid lines will draw into the axis area.
-| `zeroLineWidth` | `number` | `1` | Stroke width of the grid line for the first index (index 0).
-| `zeroLineColor` | `Color` | `'rgba(0, 0, 0, 0.25)'` | Stroke color of the grid line for the first index (index 0).
-| `zeroLineBorderDash` | `number[]` | `[]` | Length and spacing of dashes of the grid line for the first index (index 0). See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash).
-| `zeroLineBorderDashOffset` | `number` | `0.0` | Offset for line dashes of the grid line for the first index (index 0). See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineDashOffset).
 | `offsetGridLines` | `boolean` | `false` | If true, grid lines will be shifted to be between labels. This is set to `true` for a bar chart by default.
 | `z` | `number` | `0` | z-index of gridline layer. Values &lt;= 0 are drawn under datasets, &gt; 0 on top.
 

--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -26,6 +26,7 @@ Chart.js is no longer providing the `Chart.bundle.js` and `Chart.bundle.min.js`.
 ### Customizability
 
 * `custom` attribute of elements was removed. Please use scriptable options
+* The `zeroLine*` features of axes were removed.
 
 ### Options
 

--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -26,7 +26,7 @@ Chart.js is no longer providing the `Chart.bundle.js` and `Chart.bundle.min.js`.
 ### Customizability
 
 * `custom` attribute of elements was removed. Please use scriptable options
-* The `zeroLine*` features of axes were removed.
+* The `zeroLine*` options of axes were removed.
 
 ### Options
 

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -24,10 +24,6 @@ defaults._set('scale', {
 		drawOnChartArea: true,
 		drawTicks: true,
 		tickMarkLength: 10,
-		zeroLineWidth: 1,
-		zeroLineColor: 'rgba(0,0,0,0.25)',
-		zeroLineBorderDash: [],
-		zeroLineBorderDashOffset: 0.0,
 		offsetGridLines: false,
 		borderDash: [],
 		borderDashOffset: 0.0
@@ -324,9 +320,6 @@ function skip(ticks, spacing, majorStart, majorEnd) {
 }
 
 var Scale = Element.extend({
-
-	zeroLineIndex: 0,
-
 	/**
 	 * Parse a supported input value to internal representation.
 	 * @param {*} raw
@@ -1012,18 +1005,10 @@ var Scale = Element.extend({
 		for (i = 0; i < ticksLength; ++i) {
 			tick = ticks[i] || {};
 
-			if (i === me.zeroLineIndex && options.offset === offsetGridLines) {
-				// Draw the first index specially
-				lineWidth = gridLines.zeroLineWidth;
-				lineColor = gridLines.zeroLineColor;
-				borderDash = gridLines.zeroLineBorderDash || [];
-				borderDashOffset = gridLines.zeroLineBorderDashOffset || 0.0;
-			} else {
-				lineWidth = valueAtIndexOrDefault(gridLines.lineWidth, i, 1);
-				lineColor = valueAtIndexOrDefault(gridLines.color, i, 'rgba(0,0,0,0.1)');
-				borderDash = gridLines.borderDash || [];
-				borderDashOffset = gridLines.borderDashOffset || 0.0;
-			}
+			lineWidth = valueAtIndexOrDefault(gridLines.lineWidth, i, 1);
+			lineColor = valueAtIndexOrDefault(gridLines.color, i, 'rgba(0,0,0,0.1)');
+			borderDash = gridLines.borderDash || [];
+			borderDashOffset = gridLines.borderDashOffset || 0.0;
 
 			lineValue = getPixelForGridLine(me, tick._index || i, offsetGridLines);
 

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -974,7 +974,7 @@ var Scale = Element.extend({
 			return alignPixel(chart, pixel, axisWidth);
 		};
 		var borderValue, i, tick, lineValue, alignedLineValue;
-		var tx1, ty1, tx2, ty2, x1, y1, x2, y2, lineWidth, lineColor, borderDash, borderDashOffset;
+		var tx1, ty1, tx2, ty2, x1, y1, x2, y2;
 
 		if (position === 'top') {
 			borderValue = alignBorderValue(me.bottom);
@@ -1005,10 +1005,10 @@ var Scale = Element.extend({
 		for (i = 0; i < ticksLength; ++i) {
 			tick = ticks[i] || {};
 
-			lineWidth = valueAtIndexOrDefault(gridLines.lineWidth, i, 1);
-			lineColor = valueAtIndexOrDefault(gridLines.color, i, 'rgba(0,0,0,0.1)');
-			borderDash = gridLines.borderDash || [];
-			borderDashOffset = gridLines.borderDashOffset || 0.0;
+			const lineWidth = valueAtIndexOrDefault(gridLines.lineWidth, i, 1);
+			const lineColor = valueAtIndexOrDefault(gridLines.color, i, 'rgba(0,0,0,0.1)');
+			const borderDash = gridLines.borderDash || [];
+			const borderDashOffset = gridLines.borderDashOffset || 0.0;
 
 			lineValue = getPixelForGridLine(me, tick._index || i, offsetGridLines);
 

--- a/src/scales/scale.linearbase.js
+++ b/src/scales/scale.linearbase.js
@@ -234,8 +234,6 @@ module.exports = Scale.extend({
 	generateTickLabels: function(ticks) {
 		var me = this;
 		me._tickValues = ticks.map(t => t.value);
-		me.zeroLineIndex = me._tickValues.indexOf(0);
-
 		Scale.prototype.generateTickLabels.call(me, ticks);
 	},
 

--- a/test/fixtures/core.scale/tick-drawing.json
+++ b/test/fixtures/core.scale/tick-drawing.json
@@ -19,8 +19,7 @@
                     "gridLines":{
                         "drawOnChartArea": false,
                         "drawBorder": false,
-                        "color": "rgba(0, 0, 0, 1)",
-                        "zeroLineColor": "rgba(0, 0, 0, 1)"
+                        "color": "rgba(0, 0, 0, 1)"
                     }
                 }, {
                     "type": "category",
@@ -32,8 +31,7 @@
                     "gridLines":{
                         "drawOnChartArea": false,
                         "drawBorder": false,
-                        "color": "rgba(0, 0, 0, 1)",
-                        "zeroLineColor": "rgba(0, 0, 0, 1)"
+                        "color": "rgba(0, 0, 0, 1)"
                     }
                 }],
                 "yAxes": [{

--- a/test/specs/scale.category.tests.js
+++ b/test/specs/scale.category.tests.js
@@ -29,10 +29,6 @@ describe('Category scale tests', function() {
 				lineWidth: 1,
 				offsetGridLines: false,
 				display: true,
-				zeroLineColor: 'rgba(0,0,0,0.25)',
-				zeroLineWidth: 1,
-				zeroLineBorderDash: [],
-				zeroLineBorderDashOffset: 0.0,
 				borderDash: [],
 				borderDashOffset: 0.0
 			},

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -23,10 +23,6 @@ describe('Linear Scale', function() {
 				lineWidth: 1,
 				offsetGridLines: false,
 				display: true,
-				zeroLineColor: 'rgba(0,0,0,0.25)',
-				zeroLineWidth: 1,
-				zeroLineBorderDash: [],
-				zeroLineBorderDashOffset: 0.0,
 				borderDash: [],
 				borderDashOffset: 0.0
 			},

--- a/test/specs/scale.logarithmic.tests.js
+++ b/test/specs/scale.logarithmic.tests.js
@@ -22,10 +22,6 @@ describe('Logarithmic Scale tests', function() {
 				lineWidth: 1,
 				offsetGridLines: false,
 				display: true,
-				zeroLineColor: 'rgba(0,0,0,0.25)',
-				zeroLineWidth: 1,
-				zeroLineBorderDash: [],
-				zeroLineBorderDashOffset: 0.0,
 				borderDash: [],
 				borderDashOffset: 0.0
 			},

--- a/test/specs/scale.radialLinear.tests.js
+++ b/test/specs/scale.radialLinear.tests.js
@@ -34,10 +34,6 @@ describe('Test the radial linear scale', function() {
 				lineWidth: 1,
 				offsetGridLines: false,
 				display: true,
-				zeroLineColor: 'rgba(0,0,0,0.25)',
-				zeroLineWidth: 1,
-				zeroLineBorderDash: [],
-				zeroLineBorderDashOffset: 0.0,
 				borderDash: [],
 				borderDashOffset: 0.0
 			},

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -69,10 +69,6 @@ describe('Time scale tests', function() {
 				lineWidth: 1,
 				offsetGridLines: false,
 				display: true,
-				zeroLineColor: 'rgba(0,0,0,0.25)',
-				zeroLineWidth: 1,
-				zeroLineBorderDash: [],
-				zeroLineBorderDashOffset: 0.0,
 				borderDash: [],
 				borderDashOffset: 0.0
 			},


### PR DESCRIPTION
Removes the `zeroLineIndex` feature. It's not well understood and a pain to use. My plan to replace it was to allow functions to be specified as the options with a `context` that provided the tick value. That would let users control the scale grid lines easily.