### PR TITLE
Remove unnecessary parsing and getPixelForOffset

### DIFF
--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -71,6 +71,7 @@ Chart.js is no longer providing the `Chart.bundle.js` and `Chart.bundle.min.js`.
 
 * `_model.datasetLabel`
 * `_model.label`
+* `TimeScale.getPixelForOffset`
 
 ### Renamed
 

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -653,31 +653,19 @@ module.exports = Scale.extend({
 	},
 
 	/**
-	 * @private
+	 * @param {number} value - milliseconds since epoch (1 January 1970 00:00:00 UTC)
 	 */
-	getPixelForOffset: function(time) {
-		var me = this;
-		var offsets = me._offsets;
-		var pos = interpolate(me._table, 'time', time, 'pos');
-		return me.getPixelForDecimal((offsets.start + pos) * offsets.factor);
-	},
-
 	getPixelForValue: function(value) {
 		var me = this;
-
-		if (typeof value !== 'number') {
-			value = parse(me, value);
-		}
-
-		if (value !== null) {
-			return me.getPixelForOffset(value);
-		}
+		var offsets = me._offsets;
+		var pos = interpolate(me._table, 'time', value, 'pos');
+		return me.getPixelForDecimal((offsets.start + pos) * offsets.factor);
 	},
 
 	getPixelForTick: function(index) {
 		var ticks = this.getTicks();
 		return index >= 0 && index < ticks.length ?
-			this.getPixelForOffset(ticks[index].value) :
+			this.getPixelForValue(ticks[index].value) :
 			null;
 	},
 


### PR DESCRIPTION
The only place this function is called is from the function in core.scale:
```
	getBasePixel() {
		return this.getPixelForValue(this.getBaseValue());
	}
```

Since it can never receive a non-numeric value it's overkill to do parsing on the input

Once the unnecessary parsing is removed `getPixelForOffset` and `getPixelForValue` are the same, so I removed the duplicate method