### PR TITLE
Reduce iterations through all points

### DIFF
--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -92,18 +92,15 @@ module.exports = DatasetController.extend({
 			line.pivot();
 		}
 
+		me._bezierEnabled = showLine && line._model.tension !== 0;
+
 		// Update Points
 		for (i = 0, ilen = points.length; i < ilen; ++i) {
 			me.updateElement(points[i], i, reset);
 		}
 
-		if (showLine && line._model.tension !== 0) {
+		if (me._bezierEnabled) {
 			me.updateBezierControlPoints();
-		}
-
-		// Now pivot the point for animation
-		for (i = 0, ilen = points.length; i < ilen; ++i) {
-			points[i].pivot(me.chart._animationsDisabled);
 		}
 	},
 
@@ -142,6 +139,10 @@ module.exports = DatasetController.extend({
 			// Tooltip
 			hitRadius: options.hitRadius
 		};
+
+		if (!me._bezierEnabled) {
+			point.pivot(me.chart._animationsDisabled);
+		}
 	},
 
 	/**
@@ -216,6 +217,10 @@ module.exports = DatasetController.extend({
 					}
 				}
 			}
+		}
+
+		for (i = 0, ilen = points.length; i < ilen; ++i) {
+			points[i].pivot(me.chart._animationsDisabled);
 		}
 	},
 


### PR DESCRIPTION
Calling `pivot` in a separate loop is relatively expensive. It costs about an extra 20 ms or so on my computer on the uPlot benchmark

I don't call `pivot` in `updateElement` as a performance optimization if bezier is enabled since we'll be doing it later in that case though we could just do it twice if we don't care about the cost and would rather save a couple lines of code.