### PR TITLE
Remove helpers.previousItem/nextItem

### DIFF
--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -52,7 +52,9 @@ Chart.js is no longer providing the `Chart.bundle.js` and `Chart.bundle.min.js`.
 * `helpers.indexOf`
 * `helpers.min`
 * `helpers.max`
+* `helpers.nextItem`
 * `helpers.numberOfLabelLines`
+* `helpers.previousItem`
 * `helpers.removeEvent`
 * `helpers.scaleMerge`
 * `Scale.getRightValue`
@@ -120,7 +122,3 @@ Chart.js is no longer providing the `Chart.bundle.js` and `Chart.bundle.min.js`.
 #### Interactions
 
 * Interaction mode methods now return an array of objects containing the `element`, `datasetIndex`, and `index`
-
-#### helpers
-
-* Removed the last parameter of `helpers.previousItem` and `helpers.nextItem`. `loop` is always assumed to be false now

--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -120,3 +120,7 @@ Chart.js is no longer providing the `Chart.bundle.js` and `Chart.bundle.min.js`.
 #### Interactions
 
 * Interaction mode methods now return an array of objects containing the `element`, `datasetIndex`, and `index`
+
+#### helpers
+
+* Removed the last parameter of `helpers.previousItem` and `helpers.nextItem`. `loop` is always assumed to be false now

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -201,9 +201,9 @@ module.exports = DatasetController.extend({
 			for (i = 0, ilen = points.length; i < ilen; ++i) {
 				model = points[i]._model;
 				controlPoints = helpers.splineCurve(
-					helpers.previousItem(points, i)._model,
+					points[Math.max(0, i - 1)]._model,
 					model,
-					helpers.nextItem(points, i)._model,
+					points[Math.min(i + 1, ilen - 1)]._model,
 					lineModel.tension
 				);
 				model.controlPointPreviousX = controlPoints.previous.x;

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -19,6 +19,14 @@ defaults._set('radar', {
 	}
 });
 
+function nextItem(collection, index) {
+	return index >= collection.length - 1 ? collection[0] : collection[index + 1];
+}
+
+function previousItem(collection, index) {
+	return index <= 0 ? collection[collection.length - 1] : collection[index - 1];
+}
+
 module.exports = DatasetController.extend({
 	datasetElementType: elements.Line,
 
@@ -173,9 +181,9 @@ module.exports = DatasetController.extend({
 		for (i = 0, ilen = points.length; i < ilen; ++i) {
 			model = points[i]._model;
 			controlPoints = helpers.splineCurve(
-				helpers.previousItem(points, i, true)._model,
+				previousItem(points, i)._model,
 				model,
-				helpers.nextItem(points, i, true)._model,
+				nextItem(points, i)._model,
 				model.tension
 			);
 

--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -292,16 +292,10 @@ module.exports = function() {
 			}
 		}
 	};
-	helpers.nextItem = function(collection, index, loop) {
-		if (loop) {
-			return index >= collection.length - 1 ? collection[0] : collection[index + 1];
-		}
+	helpers.nextItem = function(collection, index) {
 		return index >= collection.length - 1 ? collection[collection.length - 1] : collection[index + 1];
 	};
-	helpers.previousItem = function(collection, index, loop) {
-		if (loop) {
-			return index <= 0 ? collection[collection.length - 1] : collection[index - 1];
-		}
+	helpers.previousItem = function(collection, index) {
 		return index <= 0 ? collection[0] : collection[index - 1];
 	};
 	// Implementation of the nice number algorithm used in determining where axis labels will go

--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -292,12 +292,6 @@ module.exports = function() {
 			}
 		}
 	};
-	helpers.nextItem = function(collection, index) {
-		return index >= collection.length - 1 ? collection[collection.length - 1] : collection[index + 1];
-	};
-	helpers.previousItem = function(collection, index) {
-		return index <= 0 ? collection[0] : collection[index - 1];
-	};
 	// Implementation of the nice number algorithm used in determining where axis labels will go
 	helpers.niceNum = function(range, round) {
 		var exponent = Math.floor(helpers.math.log10(range));

--- a/src/elements/element.line.js
+++ b/src/elements/element.line.js
@@ -49,7 +49,7 @@ class Line extends Element {
 
 		if (me._loop) {
 			for (index = 0; index < points.length; ++index) {
-				previous = helpers.previousItem(points, index);
+				previous = points[Math.max(0, index - 1)];
 				// If the line has an open path, shift the point array
 				if (!points[index]._view.skip && previous._view.skip) {
 					points = points.slice(index).concat(points.slice(0, index));
@@ -90,7 +90,7 @@ class Line extends Element {
 
 		for (index = 1; index < points.length; ++index) {
 			currentVM = points[index]._view;
-			previous = lastDrawnIndex === -1 ? helpers.previousItem(points, index) : points[lastDrawnIndex];
+			previous = lastDrawnIndex === -1 ? points[Math.max(0, index - 1)] : points[lastDrawnIndex];
 
 			if (!currentVM.skip) {
 				if ((lastDrawnIndex !== (index - 1) && !spanGaps) || lastDrawnIndex === -1) {

--- a/src/elements/element.line.js
+++ b/src/elements/element.line.js
@@ -81,7 +81,7 @@ class Line extends Element {
 		// Stroke Line
 		ctx.beginPath();
 
-		// First point moves to it's starting position no matter what
+		// First point moves to its starting position no matter what
 		currentVM = points[0]._view;
 		if (!currentVM.skip) {
 			ctx.moveTo(currentVM.x, currentVM.y);
@@ -90,7 +90,7 @@ class Line extends Element {
 
 		for (index = 1; index < points.length; ++index) {
 			currentVM = points[index]._view;
-			previous = lastDrawnIndex === -1 ? points[Math.max(0, index - 1)] : points[lastDrawnIndex];
+			previous = lastDrawnIndex === -1 ? points[index - 1] : points[lastDrawnIndex];
 
 			if (!currentVM.skip) {
 				if ((lastDrawnIndex !== (index - 1) && !spanGaps) || lastDrawnIndex === -1) {

--- a/test/specs/core.helpers.tests.js
+++ b/test/specs/core.helpers.tests.js
@@ -315,16 +315,12 @@ describe('Core helper tests', function() {
 	it('should get the next or previous item in an array', function() {
 		var testData = [0, 1, 2];
 
-		expect(helpers.nextItem(testData, 0, false)).toEqual(1);
-		expect(helpers.nextItem(testData, 2, false)).toEqual(2);
-		expect(helpers.nextItem(testData, 2, true)).toEqual(0);
-		expect(helpers.nextItem(testData, 1, true)).toEqual(2);
-		expect(helpers.nextItem(testData, -1, false)).toEqual(0);
+		expect(helpers.nextItem(testData, 0)).toEqual(1);
+		expect(helpers.nextItem(testData, 2)).toEqual(2);
+		expect(helpers.nextItem(testData, -1)).toEqual(0);
 
-		expect(helpers.previousItem(testData, 0, false)).toEqual(0);
-		expect(helpers.previousItem(testData, 0, true)).toEqual(2);
-		expect(helpers.previousItem(testData, 2, false)).toEqual(1);
-		expect(helpers.previousItem(testData, 1, true)).toEqual(0);
+		expect(helpers.previousItem(testData, 0)).toEqual(0);
+		expect(helpers.previousItem(testData, 2)).toEqual(1);
 	});
 
 	it('should return the width of the longest text in an Array and 2D Array', function() {

--- a/test/specs/core.helpers.tests.js
+++ b/test/specs/core.helpers.tests.js
@@ -312,17 +312,6 @@ describe('Core helper tests', function() {
 		}]);
 	});
 
-	it('should get the next or previous item in an array', function() {
-		var testData = [0, 1, 2];
-
-		expect(helpers.nextItem(testData, 0)).toEqual(1);
-		expect(helpers.nextItem(testData, 2)).toEqual(2);
-		expect(helpers.nextItem(testData, -1)).toEqual(0);
-
-		expect(helpers.previousItem(testData, 0)).toEqual(0);
-		expect(helpers.previousItem(testData, 2)).toEqual(1);
-	});
-
 	it('should return the width of the longest text in an Array and 2D Array', function() {
 		var context = window.createMockContext();
 		var font = "normal 12px 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif";


### PR DESCRIPTION
This removes a couple `if` checks per data point, which improves performance. It was always called with either hardcoded `true` or no third parameter, so there was little reason to combine these functionalities into a method that did two different things depending on `loop` parameter