### PR TITLE
Small chores

### DIFF
--- a/docs/configuration/tooltip.md
+++ b/docs/configuration/tooltip.md
@@ -136,7 +136,7 @@ var chart = new Chart(ctx, {
                     if (label) {
                         label += ': ';
                     }
-                    label += Math.round(tooltipItem.yLabel * 100) / 100;
+                    label += Math.round(tooltipItem.value * 100) / 100;
                     return label;
                 }
             }

--- a/samples/tooltips/custom-points.html
+++ b/samples/tooltips/custom-points.html
@@ -57,7 +57,7 @@
 
 			if (tooltip.dataPoints.length > 0) {
 				tooltip.dataPoints.forEach(function(dataPoint) {
-					var content = [dataPoint.xLabel, dataPoint.yLabel].join(': ');
+					var content = [dataPoint.label, dataPoint.value].join(': ');
 					var $tooltip = $('#tooltip-' + dataPoint.datasetIndex);
 
 					$tooltip.html(content);

--- a/src/scales/scale.category.js
+++ b/src/scales/scale.category.js
@@ -15,13 +15,6 @@ module.exports = Scale.extend({
 		return first === -1 || first !== last ? index : first;
 	},
 
-	_parseObject: function(obj, axis, index) {
-		if (obj[axis] !== undefined) {
-			return this._parse(obj[axis], index);
-		}
-		return null;
-	},
-
 	determineDataLimits: function() {
 		var me = this;
 		var max = me._getLabels().length - 1;


### PR DESCRIPTION
* `CategoryScale` overrides `_parseObject` with exact same code that already comes from `Scale`.
* Tooltip `xLabel` and `yLabel` migrations