### PR TITLE
Remove moment from dependencies

### DIFF
--- a/docs/axes/cartesian/time.md
+++ b/docs/axes/cartesian/time.md
@@ -4,7 +4,7 @@ The time scale is used to display times and dates. When building its ticks, it w
 
 ## Date Adapters
 
-The time scale requires both a date library and corresponding adapter to be present. By default, Chart.js includes an adapter for Moment.js. You may wish to [exclude moment](../../getting-started/integration.md) and choose from [other available adapters](https://github.com/chartjs/awesome#adapters) instead.
+The time scale requires both a date library and corresponding adapter to be present. By default, Chart.js includes an adapter for Moment.js. You may wish to choose from [other available adapters](https://github.com/chartjs/awesome#adapters) instead.
 
 ## Data Sets
 

--- a/docs/getting-started/integration.md
+++ b/docs/getting-started/integration.md
@@ -25,26 +25,6 @@ import Chart from 'chart.js';
 var myChart = new Chart(ctx, {...});
 ```
 
-**Note:** Moment.js is installed along Chart.js as dependency. If you don't want to use Moment.js (either because you use a different date adapter or simply because don't need time functionalities), you will have to configure your bundler to exclude this dependency (e.g. using [`externals` for Webpack](https://webpack.js.org/configuration/externals/) or [`external` for Rollup](https://rollupjs.org/guide/en#peer-dependencies)).
-
-```javascript
-// Webpack
-{
-    externals: {
-        moment: 'moment'
-    }
-}
-```
-
-```javascript
-// Rollup
-{
-    external: {
-        ['moment']
-    }
-}
-```
-
 ## Require JS
 
 **Important:** RequireJS [can **not** load CommonJS module as is](https://requirejs.org/docs/commonjs.html#intro), so be sure to require one of the UMD builds instead (i.e. `dist/Chart.js`, `dist/Chart.min.js`, etc.).
@@ -55,7 +35,7 @@ require(['path/to/chartjs/dist/Chart.min.js'], function(Chart){
 });
 ```
 
-**Note:** starting v2.8, Moment.js is an optional dependency for `Chart.js` and `Chart.min.js`. In order to use the time scale with Moment.js, you need to make sure Moment.js is fully loaded **before** requiring Chart.js. You can either use a shim:
+**Note:** starting v2.8, in order to use the time scale, you need to make sure [one of the available date adapters](https://github.com/chartjs/awesome#adapters) and corresponding date library are fully loaded **before** requiring Chart.js. The date adapter for Moment.js is included with Chart.js, but you still need to include Moment.js itself if this is the date adapter you choose to use. You can either use a shim:
 
 ```javascript
 require.config({

--- a/docs/getting-started/integration.md
+++ b/docs/getting-started/integration.md
@@ -35,7 +35,7 @@ require(['path/to/chartjs/dist/Chart.min.js'], function(Chart){
 });
 ```
 
-**Note:** starting v2.8, in order to use the time scale, you need to make sure [one of the available date adapters](https://github.com/chartjs/awesome#adapters) and corresponding date library are fully loaded **before** requiring Chart.js. The date adapter for Moment.js is included with Chart.js, but you still need to include Moment.js itself if this is the date adapter you choose to use. You can either use a shim:
+**Note:** in order to use the time scale, you need to make sure [one of the available date adapters](https://github.com/chartjs/awesome#adapters) and corresponding date library are fully loaded **before** requiring Chart.js. The date adapter for Moment.js is included with Chart.js, but you still need to include Moment.js itself if this is the date adapter you choose to use. You can either use a shim:
 
 ```javascript
 require.config({

--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -2,11 +2,12 @@
 
 Chart.js 3.0 introduces a number of breaking changes. Chart.js 2.0 was released in April 2016. In the years since then, as Chart.js has grown in popularity and feature set, we've learned some lessons about how to better create a charting library. In order to improve performance, offer new features, and improve maintainability it was necessary to break backwards compatibility, but we aimed to do so only when necessary.
 
-## Setup
-
-Chart.js is no longer providing the `Chart.bundle.js` and `Chart.bundle.min.js`. Please see the [installation](installation.md) and [integration](integration.md) docs for details on the recommended way to setup Chart.js if you were using these builds.
-
 ## End user migration
+
+### Setup and installation
+
+* Chart.js is no longer providing the `Chart.bundle.js` and `Chart.bundle.min.js`. Please see the [installation](installation.md) and [integration](integration.md) docs for details on the recommended way to setup Chart.js if you were using these builds.
+* `moment` is no longer specified as an npm dependency. If you are using the time scale, you must include one of [the available adapters](https://github.com/chartjs/awesome#adapters) and corresponding date library. If you are using a date library other than moment, you no longer need to exclude moment from your build.
 
 ### Ticks
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6843,7 +6843,8 @@
     "moment": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "karma-rollup-preprocessor": "^7.0.0",
     "karma-safari-private-launcher": "^1.0.0",
     "merge-stream": "^1.0.1",
+    "moment": "^2.10.2",
     "pixelmatch": "^5.0.0",
     "rollup": "^1.0.0",
     "rollup-plugin-babel": "^4.3.3",
@@ -71,7 +72,6 @@
     "yargs": "^14.0.0"
   },
   "dependencies": {
-    "chartjs-color": "^2.1.0",
-    "moment": "^2.10.2"
+    "chartjs-color": "^2.1.0"
   }
 }


### PR DESCRIPTION
We should probably also move the moment adapter to be in an external repo, but this is a good first step