### PR TITLE
Reduce object creation in parsing

### DIFF
--- a/src/controllers/controller.doughnut.js
+++ b/src/controllers/controller.doughnut.js
@@ -139,11 +139,11 @@ module.exports = DatasetController.extend({
 	 * @private
 	 */
 	_parse: function(start, count) {
-		var data = this.getDataset().data;
-		var metaData = this.getMeta().data;
+		const data = this.getDataset().data;
+		const meta = this.getMeta();
 		var i, ilen;
 		for (i = start, ilen = start + count; i < ilen; ++i) {
-			metaData[i]._val = +data[i];
+			meta._parsed[i] = +data[i];
 		}
 	},
 
@@ -232,7 +232,8 @@ module.exports = DatasetController.extend({
 		var centerY = (chartArea.top + chartArea.bottom) / 2;
 		var startAngle = opts.rotation; // non reset case handled later
 		var endAngle = opts.rotation; // non reset case handled later
-		var circumference = reset && animationOpts.animateRotate ? 0 : arc.hidden ? 0 : me.calculateCircumference(arc._val * opts.circumference / DOUBLE_PI);
+		var meta = me.getMeta();
+		var circumference = reset && animationOpts.animateRotate ? 0 : arc.hidden ? 0 : me.calculateCircumference(meta._parsed[index] * opts.circumference / DOUBLE_PI);
 		var innerRadius = reset && animationOpts.animateScale ? 0 : me.innerRadius;
 		var outerRadius = reset && animationOpts.animateScale ? 0 : me.outerRadius;
 		var options = arc._options || {};
@@ -271,16 +272,18 @@ module.exports = DatasetController.extend({
 	},
 
 	calculateTotal: function() {
-		var metaData = this.getMeta().data;
+		var meta = this.getMeta();
+		var metaData = meta.data;
 		var total = 0;
-		var value;
+		var i, ilen, arc, value;
 
-		helpers.each(metaData, function(arc) {
-			value = arc ? arc._val : NaN;
+		for (i = 0, ilen = metaData.length; i < ilen; i++) {
+			arc = metaData[i];
+			value = arc ? meta._parsed[i] : NaN;
 			if (!isNaN(value) && !arc.hidden) {
 				total += Math.abs(value);
 			}
-		});
+		}
 
 		/* if (total === 0) {
 			total = NaN;

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -874,7 +874,8 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 				xAxisID: null,
 				yAxisID: null,
 				order: dataset.order || 0,
-				index: datasetIndex
+				index: datasetIndex,
+				_parsed: []
 			};
 		}
 

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -339,8 +339,7 @@ helpers.extend(DatasetController.prototype, {
 		var me = this;
 		var type = me.dataElementType;
 		return type && new type({
-			_ctx: me.chart.ctx,
-			_parsed: {}
+			_ctx: me.chart.ctx
 		});
 	},
 
@@ -493,7 +492,7 @@ helpers.extend(DatasetController.prototype, {
 
 		for (i = 0, ilen = parsed.length; i < ilen; ++i) {
 			item = parsed[i];
-			meta.data[start + i]._parsed = item;
+			meta._parsed[start + i] = item;
 
 			if (stacks) {
 				item._stackKeys = {};
@@ -595,11 +594,11 @@ helpers.extend(DatasetController.prototype, {
 	 * @private
 	 */
 	_getParsed: function(index) {
-		var data = this._cachedMeta.data;
+		var data = this._cachedMeta._parsed;
 		if (index < 0 || index >= data.length) {
 			return;
 		}
-		return data[index]._parsed;
+		return data[index];
 	},
 
 	/**
@@ -636,7 +635,7 @@ helpers.extend(DatasetController.prototype, {
 
 		for (i = 0; i < ilen; ++i) {
 			item = metaData[i];
-			parsed = item._parsed;
+			parsed = meta._parsed[i];
 			value = parsed[scale.id];
 			otherValue = parsed[otherScale.id];
 			if (item.hidden || isNaN(value) ||
@@ -667,13 +666,12 @@ helpers.extend(DatasetController.prototype, {
 	 * @private
 	 */
 	_getAllParsedValues: function(scale) {
-		var meta = this._cachedMeta;
-		var metaData = meta.data;
-		var values = [];
+		const parsed = this._cachedMeta._parsed;
+		const values = [];
 		var i, ilen, value;
 
-		for (i = 0, ilen = metaData.length; i < ilen; ++i) {
-			value = metaData[i]._parsed[scale.id];
+		for (i = 0, ilen = parsed.length; i < ilen; ++i) {
+			value = parsed[i][scale.id];
 			if (!isNaN(value)) {
 				values.push(value);
 			}
@@ -969,10 +967,10 @@ helpers.extend(DatasetController.prototype, {
 	 * @private
 	 */
 	insertElements: function(start, count) {
+		this._parse(start, count);
 		for (var i = 0; i < count; ++i) {
 			this.addElementAndReset(start + i);
 		}
-		this._parse(start, count);
 	},
 
 	/**


### PR DESCRIPTION
There was a line (`_parsed: {}`) that created a new object for each index, which I think caused extra garbage collection since that object was never used and ended up getting replaced

There seemed to be a bug in `insertElements`. `addElementsAndReset` called `updateElement` which depended on parsing already having happened. It seems like it was able to complete before because it had the empty object to reference, but it was uncovered when I got rid of that

I'm not sure why doughnut was using `_val` instead of `_parsed`. This changes that for consistency