### PR TITLE
Stacks readability improvements

### DIFF
--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -464,7 +464,7 @@ helpers.extend(DatasetController.prototype, {
 		const chart = me.chart;
 		const meta = me._cachedMeta;
 		const data = me._data;
-		const crossRef = chart._xref || (chart._xref = {});
+		const stacks = chart._stacks || (chart._stacks = {}); // map structure is {stackKey: {datasetIndex: value}}
 		const xScale = me._getIndexScale();
 		const yScale = me._getValueScale();
 		const xId = xScale.id;
@@ -487,7 +487,7 @@ helpers.extend(DatasetController.prototype, {
 		function storeStack(stackKey, indexValue, scaleId, value) {
 			stackKey += '.' + indexValue;
 			item._stackKeys[scaleId] = stackKey;
-			stack = crossRef[stackKey] || (crossRef[stackKey] = {});
+			stack = stacks[stackKey] || (stacks[stackKey] = {});
 			stack[meta.index] = value;
 		}
 
@@ -615,7 +615,7 @@ helpers.extend(DatasetController.prototype, {
 		var value = parsed[scale.id];
 		var stack = {
 			keys: getSortedDatasetIndices(chart, true),
-			values: chart._xref[parsed._stackKeys[scale.id]]
+			values: chart._stacks[parsed._stackKeys[scale.id]]
 		};
 		return applyStack(stack, value, meta.index);
 	},
@@ -628,7 +628,7 @@ helpers.extend(DatasetController.prototype, {
 		var meta = this._cachedMeta;
 		var metaData = meta.data;
 		var ilen = metaData.length;
-		var crossRef = chart._xref || (chart._xref = {});
+		var stacks = chart._stacks || (chart._stacks = {});
 		var max = Number.NEGATIVE_INFINITY;
 		var stacked = canStack && meta._stacked;
 		var indices = getSortedDatasetIndices(chart, true);
@@ -650,7 +650,7 @@ helpers.extend(DatasetController.prototype, {
 			if (stacked) {
 				stack = {
 					keys: indices,
-					values: crossRef[parsed._stackKeys[scale.id]]
+					values: stacks[parsed._stackKeys[scale.id]]
 				};
 				value = applyStack(stack, value, meta.index, true);
 			}

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -172,8 +172,8 @@ function isStacked(scale, meta) {
 	return stacked || (stacked === undefined && meta.stack !== undefined);
 }
 
-function getStackKey(xScale, yScale, meta) {
-	return isStacked(yScale, meta) && xScale.id + '.' + yScale.id + '.' + meta.stack + '.' + meta.type;
+function getStackKey(indexScale, valueScale, meta) {
+	return indexScale.id + '.' + valueScale.id + '.' + meta.stack + '.' + meta.type;
 }
 
 function getFirstScaleId(chart, axis) {
@@ -460,18 +460,20 @@ helpers.extend(DatasetController.prototype, {
 	 * @private
 	 */
 	_parse: function(start, count) {
-		var me = this;
-		var chart = me.chart;
-		var meta = me._cachedMeta;
-		var data = me._data;
-		var crossRef = chart._xref || (chart._xref = {});
-		var xScale = me._getIndexScale();
-		var yScale = me._getValueScale();
-		var xId = xScale.id;
-		var yId = yScale.id;
-		var xKey = getStackKey(xScale, yScale, meta);
-		var yKey = getStackKey(yScale, xScale, meta);
-		var stacks = xKey || yKey;
+		const me = this;
+		const chart = me.chart;
+		const meta = me._cachedMeta;
+		const data = me._data;
+		const crossRef = chart._xref || (chart._xref = {});
+		const xScale = me._getIndexScale();
+		const yScale = me._getValueScale();
+		const xId = xScale.id;
+		const yId = yScale.id;
+		const xStacked = isStacked(xScale, meta);
+		const yStacked = isStacked(yScale, meta);
+		const xKey = yStacked && getStackKey(xScale, yScale, meta);
+		const yKey = xStacked && getStackKey(yScale, xScale, meta);
+		const stacked = xStacked || yStacked;
 		var i, ilen, parsed, stack, item, x, y;
 
 		if (helpers.isArray(data[start])) {
@@ -483,25 +485,27 @@ helpers.extend(DatasetController.prototype, {
 		}
 
 		function storeStack(stackKey, indexValue, scaleId, value) {
-			if (stackKey) {
-				stackKey += '.' + indexValue;
-				item._stackKeys[scaleId] = stackKey;
-				stack = crossRef[stackKey] || (crossRef[stackKey] = {});
-				stack[meta.index] = value;
-			}
+			stackKey += '.' + indexValue;
+			item._stackKeys[scaleId] = stackKey;
+			stack = crossRef[stackKey] || (crossRef[stackKey] = {});
+			stack[meta.index] = value;
 		}
 
 		for (i = 0, ilen = parsed.length; i < ilen; ++i) {
 			item = parsed[i];
 			meta.data[start + i]._parsed = item;
 
-			if (stacks) {
+			if (stacked) {
 				item._stackKeys = {};
 				x = item[xId];
 				y = item[yId];
 
-				storeStack(xKey, x, yId, y);
-				storeStack(yKey, y, xId, x);
+				if (yStacked) {
+					storeStack(xKey, x, yId, y);
+				}
+				if (xStacked) {
+					storeStack(yKey, y, xId, x);
+				}
 			}
 		}
 


### PR DESCRIPTION
I was having a hard time figuring out this code, so made a few tweaks that let me better follow it.

We were sometimes passing `yScale` as the first parameter of `getStackKey` and the first parameter of `getStackKey` was called `xScale`

Also, we were using the stack keys for multiple purposes: both as an identifier and also a boolean to denote whether stacking is occurring. This was hard to follow because both setting it to a boolean and evaluating it as a boolean were done in other functions and so it was hard to follow the code across multiple functions to put the pieces together as to what exactly was happening.