### PR TITLE
Reduce object creation during parsing

### DIFF
--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -65,18 +65,19 @@ Chart.js 3.0 introduces a number of breaking changes. Chart.js 2.0 was released 
 * `helpers.removeEvent`
 * `helpers.roundedRect`
 * `helpers.scaleMerge`
-* `Scale.getRightValue`
-* `Scale.mergeTicksOptions`
-* `Scale.ticksAsNumbers`
 * `Chart.Controller`
 * `Chart.chart.chart`
 * `Chart.types`
-* `Line.calculatePointY`
+* `DatasetController.addElementAndReset`
 * `Element.getArea`
 * `Element.height`
 * `Element.inLabelRange`
-* Made `scale.handleDirectionalChanges` private
-* Made `scale.tickValues` private
+* `Line.calculatePointY`
+* `Scale.getRightValue`
+* `Scale.mergeTicksOptions`
+* `Scale.ticksAsNumbers`
+* `Scale.handleDirectionalChanges` is now private
+* `Scale.tickValues` is now private
 
 #### Removal of private APIs
 
@@ -95,6 +96,7 @@ Chart.js 3.0 introduces a number of breaking changes. Chart.js 2.0 was released 
 * `helpers.log10` was renamed to `helpers.math.log10`
 * `Chart.Animation.animationObject` was renamed to `Chart.Animation`
 * `Chart.Animation.chartInstance` was renamed to `Chart.Animation.chart`
+* `DatasetController.createMetaData` and `DatasetController.createMetaDataset` were replaced with `DatasetController.createMeta`
 * `TimeScale.getLabelCapacity` was renamed to `TimeScale._getLabelCapacity`
 * `TimeScale.tickFormatFunction` was renamed to `TimeScale._tickFormatFunction`
 * `TimeScale.getPixelForOffset` was renamed to `TimeScale._getPixelForOffset`

--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -96,7 +96,7 @@ Chart.js 3.0 introduces a number of breaking changes. Chart.js 2.0 was released 
 * `helpers.log10` was renamed to `helpers.math.log10`
 * `Chart.Animation.animationObject` was renamed to `Chart.Animation`
 * `Chart.Animation.chartInstance` was renamed to `Chart.Animation.chart`
-* `DatasetController.createMetaData` and `DatasetController.createMetaDataset` were replaced with `DatasetController.createMeta`
+* `DatasetController.createMetaData` and `DatasetController.createMetaDataset` were replaced with `DatasetController.createElement`
 * `TimeScale.getLabelCapacity` was renamed to `TimeScale._getLabelCapacity`
 * `TimeScale.tickFormatFunction` was renamed to `TimeScale._tickFormatFunction`
 * `TimeScale.getPixelForOffset` was renamed to `TimeScale._getPixelForOffset`

--- a/src/controllers/controller.doughnut.js
+++ b/src/controllers/controller.doughnut.js
@@ -143,7 +143,7 @@ module.exports = DatasetController.extend({
 		var metaData = this.getMeta().data;
 		var i, ilen;
 		for (i = start, ilen = start + count; i < ilen; ++i) {
-			metaData[i]._val = +data[i];
+			metaData[i]._parsed = +data[i];
 		}
 	},
 
@@ -232,7 +232,7 @@ module.exports = DatasetController.extend({
 		var centerY = (chartArea.top + chartArea.bottom) / 2;
 		var startAngle = opts.rotation; // non reset case handled later
 		var endAngle = opts.rotation; // non reset case handled later
-		var circumference = reset && animationOpts.animateRotate ? 0 : arc.hidden ? 0 : me.calculateCircumference(arc._val * opts.circumference / DOUBLE_PI);
+		var circumference = reset && animationOpts.animateRotate ? 0 : arc.hidden ? 0 : me.calculateCircumference(arc._parsed * opts.circumference / DOUBLE_PI);
 		var innerRadius = reset && animationOpts.animateScale ? 0 : me.innerRadius;
 		var outerRadius = reset && animationOpts.animateScale ? 0 : me.outerRadius;
 		var options = arc._options || {};
@@ -276,7 +276,7 @@ module.exports = DatasetController.extend({
 		var value;
 
 		helpers.each(metaData, function(arc) {
-			value = arc ? arc._val : NaN;
+			value = arc ? arc._parsed : NaN;
 			if (!isNaN(value) && !arc.hidden) {
 				total += Math.abs(value);
 			}

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -957,12 +957,15 @@ helpers.extend(DatasetController.prototype, {
 	 */
 	insertElements: function(start, count) {
 		const me = this;
+		const elements = [];
 		var i;
 		for (i = start; i < start + count; ++i) {
-			const element = me.createElement(me.dataElementType);
-			me._cachedMeta.data.splice(i, 0, element);
-			me._parse(i, 1);
-			me.updateElement(element, i, true);
+			elements.push(me.createElement(me.dataElementType));
+		}
+		me._cachedMeta.data.splice(start, 0, ...elements);
+		me._parse(start, count);
+		for (i = 0; i < count; ++i) {
+			me.updateElement(elements[i], start + i, true);
 		}
 	},
 

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -327,7 +327,7 @@ helpers.extend(DatasetController.prototype, {
 		}
 	},
 
-	createMeta: function(type) {
+	createElement: function(type) {
 		return type && new type({
 			_ctx: this.chart.ctx
 		});
@@ -400,10 +400,10 @@ helpers.extend(DatasetController.prototype, {
 		data = me._data;
 
 		for (i = 0, ilen = data.length; i < ilen; ++i) {
-			metaData[i] = metaData[i] || me.createMeta(me.dataElementType);
+			metaData[i] = metaData[i] || me.createElement(me.dataElementType);
 		}
 
-		meta.dataset = meta.dataset || me.createMeta(me.datasetElementType);
+		meta.dataset = meta.dataset || me.createElement(me.datasetElementType);
 	},
 
 	buildOrUpdateElements: function() {
@@ -959,7 +959,7 @@ helpers.extend(DatasetController.prototype, {
 		const me = this;
 		var i;
 		for (i = start; i < start + count; ++i) {
-			const element = me.createMeta(me.dataElementType);
+			const element = me.createElement(me.dataElementType);
 			me._cachedMeta.data.splice(i, 0, element);
 			me._parse(i, 1);
 			me.updateElement(element, i, true);

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -327,20 +327,9 @@ helpers.extend(DatasetController.prototype, {
 		}
 	},
 
-	createMetaDataset: function() {
-		var me = this;
-		var type = me.datasetElementType;
+	createMeta: function(type) {
 		return type && new type({
-			_ctx: me.chart.ctx
-		});
-	},
-
-	createMetaData: function() {
-		var me = this;
-		var type = me.dataElementType;
-		return type && new type({
-			_ctx: me.chart.ctx,
-			_parsed: {}
+			_ctx: this.chart.ctx
 		});
 	},
 
@@ -411,16 +400,10 @@ helpers.extend(DatasetController.prototype, {
 		data = me._data;
 
 		for (i = 0, ilen = data.length; i < ilen; ++i) {
-			metaData[i] = metaData[i] || me.createMetaData();
+			metaData[i] = metaData[i] || me.createMeta(me.dataElementType);
 		}
 
-		meta.dataset = meta.dataset || me.createMetaDataset();
-	},
-
-	addElementAndReset: function(index) {
-		var element = this.createMetaData();
-		this._cachedMeta.data.splice(index, 0, element);
-		this.updateElement(element, index, true);
+		meta.dataset = meta.dataset || me.createMeta(me.datasetElementType);
 	},
 
 	buildOrUpdateElements: function() {
@@ -973,10 +956,14 @@ helpers.extend(DatasetController.prototype, {
 	 * @private
 	 */
 	insertElements: function(start, count) {
-		for (var i = 0; i < count; ++i) {
-			this.addElementAndReset(start + i);
+		const me = this;
+		var i;
+		for (i = start; i < start + count; ++i) {
+			const element = me.createMeta(me.dataElementType);
+			me._cachedMeta.data.splice(i, 0, element);
+			me._parse(i, 1);
+			me.updateElement(element, i, true);
 		}
-		this._parse(start, count);
 	},
 
 	/**


### PR DESCRIPTION
This is an alternative to https://github.com/chartjs/Chart.js/pull/6750, which does not move `_parsed` out of `metaData`

Removed `addElementAndReset` because of a bug. `insertElements` was calling `updateElement` via `addElementAndReset` and then calling `_parse`. However, `updateElement` assumes that the parsing has already happened, so these were happening in the wrong order. Also, `_parse` assumes the `metaData` is already created and stored, so there was no possible way to call `addElementAndReset` without causing issues. The code now calls these methods in the correct order

It also renames `_val` to `_parsed` in doughnut.