### PR TITLE
Remove _ctx from Element

### DIFF
--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -84,6 +84,7 @@ Chart.js 3.0 introduces a number of breaking changes. Chart.js 2.0 was released 
 
 * `Element._model.datasetLabel`
 * `Element._model.label`
+* `Element._ctx`
 * `Point._model.tension`
 * `Point._model.steppedLine`
 * `TimeScale._getPixelForOffset`

--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -82,9 +82,9 @@ Chart.js 3.0 introduces a number of breaking changes. Chart.js 2.0 was released 
 
 #### Removal of private APIs
 
+* `Element._ctx`
 * `Element._model.datasetLabel`
 * `Element._model.label`
-* `Element._ctx`
 * `Point._model.tension`
 * `Point._model.steppedLine`
 * `TimeScale._getPixelForOffset`

--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -484,7 +484,7 @@ module.exports = DatasetController.extend({
 
 		for (; i < ilen; ++i) {
 			if (!isNaN(me._getParsed(i)[vScale.id])) {
-				rects[i].draw();
+				rects[i].draw(me._ctx);
 			}
 		}
 

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -229,6 +229,7 @@ module.exports = DatasetController.extend({
 
 	draw: function() {
 		var me = this;
+		var ctx = me._ctx;
 		var chart = me.chart;
 		var meta = me._cachedMeta;
 		var points = meta.data || [];
@@ -237,12 +238,12 @@ module.exports = DatasetController.extend({
 		var ilen = points.length;
 
 		if (me._showLine) {
-			meta.dataset.draw();
+			meta.dataset.draw(ctx);
 		}
 
 		// Draw the points
 		for (; i < ilen; ++i) {
-			points[i].draw(area);
+			points[i].draw(ctx, area);
 		}
 	},
 

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -282,6 +282,7 @@ helpers.extend(DatasetController.prototype, {
 		const me = this;
 		let meta;
 		me.chart = chart;
+		me._ctx = chart.ctx;
 		me.index = datasetIndex;
 		me._cachedMeta = meta = me.getMeta();
 		me._type = meta.type;
@@ -371,9 +372,7 @@ helpers.extend(DatasetController.prototype, {
 	},
 
 	createElement: function(type) {
-		return type && new type({
-			_ctx: this.chart.ctx
-		});
+		return type && new type();
 	},
 
 	/**
@@ -768,17 +767,18 @@ helpers.extend(DatasetController.prototype, {
 	},
 
 	draw: function() {
+		const ctx = this._ctx;
 		const meta = this._cachedMeta;
 		const elements = meta.data || [];
 		const ilen = elements.length;
 		let i = 0;
 
 		if (meta.dataset) {
-			meta.dataset.draw();
+			meta.dataset.draw(ctx);
 		}
 
 		for (; i < ilen; ++i) {
-			elements[i].draw();
+			elements[i].draw(ctx);
 		}
 	},
 

--- a/src/elements/element.arc.js
+++ b/src/elements/element.arc.js
@@ -148,8 +148,7 @@ class Arc extends Element {
 		};
 	}
 
-	draw() {
-		var ctx = this._ctx;
+	draw(ctx) {
 		var vm = this._view;
 		var pixelMargin = (vm.borderAlign === 'inner') ? 0.33 : 0;
 		var arc = {

--- a/src/elements/element.line.js
+++ b/src/elements/element.line.js
@@ -145,10 +145,9 @@ class Line extends Element {
 		super(props);
 	}
 
-	draw() {
+	draw(ctx) {
 		const me = this;
 		const vm = me._view;
-		const ctx = me._ctx;
 		const spanGaps = vm.spanGaps;
 		let closePath = me._loop;
 		let points = me._children;

--- a/src/elements/element.point.js
+++ b/src/elements/element.point.js
@@ -67,9 +67,8 @@ class Point extends Element {
 		};
 	}
 
-	draw(chartArea) {
+	draw(ctx, chartArea) {
 		const vm = this._view;
-		const ctx = this._ctx;
 		const pointStyle = vm.pointStyle;
 		const rotation = vm.rotation;
 		const radius = vm.radius;

--- a/src/elements/element.rectangle.js
+++ b/src/elements/element.rectangle.js
@@ -136,8 +136,7 @@ class Rectangle extends Element {
 		super(props);
 	}
 
-	draw() {
-		var ctx = this._ctx;
+	draw(ctx) {
 		var vm = this._view;
 		var rects = boundingRects(vm);
 		var outer = rects.outer;

--- a/test/specs/element.point.tests.js
+++ b/test/specs/element.point.tests.js
@@ -74,11 +74,7 @@ describe('Chart.elements.Point', function() {
 
 	it ('should not draw if skipped', function() {
 		var mockContext = window.createMockContext();
-		var point = new Chart.elements.Point({
-			_datasetIndex: 2,
-			_index: 1,
-			_ctx: mockContext
-		});
+		var point = new Chart.elements.Point();
 
 		// Attach a view object as if we were the controller
 		point._view = {
@@ -90,7 +86,7 @@ describe('Chart.elements.Point', function() {
 			skip: true
 		};
 
-		point.draw();
+		point.draw(mockContext);
 
 		expect(mockContext.getCalls()).toEqual([]);
 	});


### PR DESCRIPTION
Reduces memory footprint by 8 bytes / Element (on 64 bit machines).