### PR TITLE
Store parsed data more similarly to provided data

### DIFF
--- a/src/controllers/controller.doughnut.js
+++ b/src/controllers/controller.doughnut.js
@@ -140,10 +140,10 @@ module.exports = DatasetController.extend({
 	 */
 	_parse: function(start, count) {
 		var data = this.getDataset().data;
-		var metaData = this._cachedMeta.data;
+		var meta = this._cachedMeta;
 		var i, ilen;
 		for (i = start, ilen = start + count; i < ilen; ++i) {
-			metaData[i]._parsed = +data[i];
+			meta._parsed[i] = +data[i];
 		}
 	},
 
@@ -232,7 +232,8 @@ module.exports = DatasetController.extend({
 		var centerY = (chartArea.top + chartArea.bottom) / 2;
 		var startAngle = opts.rotation; // non reset case handled later
 		var endAngle = opts.rotation; // non reset case handled later
-		var circumference = reset && animationOpts.animateRotate ? 0 : arc.hidden ? 0 : me.calculateCircumference(arc._parsed * opts.circumference / DOUBLE_PI);
+		var meta = me.getMeta();
+		var circumference = reset && animationOpts.animateRotate ? 0 : arc.hidden ? 0 : me.calculateCircumference(meta._parsed[index] * opts.circumference / DOUBLE_PI);
 		var innerRadius = reset && animationOpts.animateScale ? 0 : me.innerRadius;
 		var outerRadius = reset && animationOpts.animateScale ? 0 : me.outerRadius;
 		var options = arc._options || {};
@@ -271,16 +272,18 @@ module.exports = DatasetController.extend({
 	},
 
 	calculateTotal: function() {
-		var metaData = this._cachedMeta.data;
+		var meta = this._cachedMeta;
+		var metaData = meta.data;
 		var total = 0;
-		var value;
+		var i, ilen, arc, value;
 
-		helpers.each(metaData, function(arc) {
-			value = arc ? arc._parsed : NaN;
+		for (i = 0, ilen = metaData.length; i < ilen; i++) {
+			arc = metaData[i];
+			value = arc ? meta._parsed[i] : NaN;
 			if (!isNaN(value) && !arc.hidden) {
 				total += Math.abs(value);
 			}
-		});
+		}
 
 		/* if (total === 0) {
 			total = NaN;

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -874,7 +874,8 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 				xAxisID: null,
 				yAxisID: null,
 				order: dataset.order || 0,
-				index: datasetIndex
+				index: datasetIndex,
+				_parsed: []
 			};
 		}
 

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -504,7 +504,7 @@ helpers.extend(DatasetController.prototype, {
 		}
 
 		for (i = 0, ilen = parsed.length; i < ilen; ++i) {
-			meta.data[start + i]._parsed = parsed[i];
+			meta._parsed[start + i] = parsed[i];
 		}
 		if (stacked) {
 			updateStacks(me, parsed);
@@ -600,11 +600,11 @@ helpers.extend(DatasetController.prototype, {
 	 * @private
 	 */
 	_getParsed: function(index) {
-		const data = this._cachedMeta.data;
+		const data = this._cachedMeta._parsed;
 		if (index < 0 || index >= data.length) {
 			return;
 		}
-		return data[index]._parsed;
+		return data[index];
 	},
 
 	/**
@@ -640,7 +640,7 @@ helpers.extend(DatasetController.prototype, {
 
 		for (i = 0; i < ilen; ++i) {
 			item = metaData[i];
-			parsed = item._parsed;
+			parsed = meta._parsed[i];
 			value = parsed[scale.id];
 			otherValue = parsed[otherScale.id];
 			if (item.hidden || isNaN(value) ||
@@ -671,13 +671,12 @@ helpers.extend(DatasetController.prototype, {
 	 * @private
 	 */
 	_getAllParsedValues: function(scale) {
-		const meta = this._cachedMeta;
-		const metaData = meta.data;
+		const parsed = this._cachedMeta._parsed;
 		const values = [];
 		let i, ilen, value;
 
-		for (i = 0, ilen = metaData.length; i < ilen; ++i) {
-			value = metaData[i]._parsed[scale.id];
+		for (i = 0, ilen = parsed.length; i < ilen; ++i) {
+			value = parsed[i][scale.id];
 			if (!isNaN(value)) {
 				values.push(value);
 			}


### PR DESCRIPTION
This has some of the changes from https://github.com/chartjs/Chart.js/pull/6750, which we decided not to move forward with. I'm reopening for discussion purposes even if we decide to go in a different direction

I'd like to be able to skip all parsing if the user provides data in the correct format. Right now that format is essentially an array of objects. Other potential formats such as an array of arrays can be discussed in https://github.com/chartjs/Chart.js/issues/6696. Right now, it seems most likely that we'll be accepting data as an array with an entry for each row.

This implements about half the change required to simply utilize user data as passed in. The other half would be to change the keys that the user data is being stored under. Right now we have keys like "x-axis-0" and would need to change that to "x" or change from an object to an array

This is probably about a wash in terms of performance. E.g. `_getParsed` is probably slightly faster and `calculateTotal` is probably slightly slower. Overall I think these effects are fairly negligible though