### PR TITLE
Simplify stacking even more, leverage more ES6 features

### DIFF
--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -218,8 +218,7 @@ module.exports = DatasetController.extend({
 	 * @private
 	 */
 	_parseObjectData: function(meta, data, start, count) {
-		const iScale = meta.iScale;
-		const vScale = meta.vScale;
+		const {iScale, vScale} = meta;
 		const vProp = vScale.axis;
 		const parsed = [];
 		let i, ilen, item, obj, value;
@@ -244,16 +243,15 @@ module.exports = DatasetController.extend({
 	_getLabelAndValue: function(index) {
 		const me = this;
 		const meta = me._cachedMeta;
-		const indexScale = meta.iScale;
-		const valueScale = meta.vScale;
+		const {iScale, vScale} = meta;
 		const parsed = me._getParsed(index);
 		const custom = parsed._custom;
 		const value = custom
 			? '[' + custom.start + ', ' + custom.end + ']'
-			: '' + valueScale.getLabelForValue(parsed[valueScale.id]);
+			: '' + vScale.getLabelForValue(parsed[vScale.id]);
 
 		return {
-			label: '' + indexScale.getLabelForValue(parsed[indexScale.id]),
+			label: '' + iScale.getLabelForValue(parsed[iScale.id]),
 			value: value
 		};
 	},

--- a/src/controllers/controller.bubble.js
+++ b/src/controllers/controller.bubble.js
@@ -57,17 +57,18 @@ module.exports = DatasetController.extend({
 	 * @private
 	 */
 	_parseObjectData: function(meta, data, start, count) {
-		const xScale = meta.xScale;
-		const yScale = meta.yScale;
+		const {xScale, yScale} = meta;
+		const xId = xScale.id;
+		const yId = yScale.id;
 		const parsed = [];
-		var i, ilen, item, obj;
+		let i, ilen, item;
 		for (i = start, ilen = start + count; i < ilen; ++i) {
-			obj = data[i];
-			item = {};
-			item[xScale.id] = xScale._parseObject(obj, 'x', i);
-			item[yScale.id] = yScale._parseObject(obj, 'y', i);
-			item._custom = obj && obj.r && +obj.r;
-			parsed.push(item);
+			item = data[i];
+			parsed.push({
+				[xId]: xScale._parseObject(item, 'x', i),
+				[yId]: yScale._parseObject(item, 'y', i),
+				_custom: item && item.r && +item.r
+			});
 		}
 		return parsed;
 	},
@@ -93,8 +94,7 @@ module.exports = DatasetController.extend({
 	_getLabelAndValue: function(index) {
 		const me = this;
 		const meta = me._cachedMeta;
-		const xScale = meta.xScale;
-		const yScale = meta.yScale;
+		const {xScale, yScale} = meta;
 		const parsed = me._getParsed(index);
 		const x = xScale.getLabelForValue(parsed[xScale.id]);
 		const y = yScale.getLabelForValue(parsed[yScale.id]);
@@ -122,9 +122,7 @@ module.exports = DatasetController.extend({
 	 */
 	updateElements: function(points, start, count, reset) {
 		const me = this;
-		const meta = me._cachedMeta;
-		const xScale = meta.xScale;
-		const yScale = meta.yScale;
+		const {xScale, yScale} = me._cachedMeta;
 		let i;
 
 		for (i = start; i < start + count; i++) {

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -100,10 +100,7 @@ module.exports = DatasetController.extend({
 
 	updateElements: function(points, start, count, reset) {
 		const me = this;
-		const meta = me._cachedMeta;
-		const xScale = meta.xScale;
-		const yScale = meta.yScale;
-		const stacked = meta._stacked;
+		const {xScale, yScale, _stacked} = me._cachedMeta;
 		var i;
 
 		for (i = start; i < start + count; ++i) {
@@ -111,7 +108,7 @@ module.exports = DatasetController.extend({
 			const parsed = me._getParsed(i);
 			const options = me._resolveDataElementOptions(i);
 			const x = xScale.getPixelForValue(parsed[xScale.id]);
-			const y = reset ? yScale.getBasePixel() : yScale.getPixelForValue(stacked ? me._applyStack(yScale, parsed) : parsed[yScale.id]);
+			const y = reset ? yScale.getBasePixel() : yScale.getPixelForValue(_stacked ? me._applyStack(yScale, parsed) : parsed[yScale.id]);
 
 			// Utility
 			point._options = options;

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -473,11 +473,8 @@ helpers.extend(DatasetController.prototype, {
 	 */
 	_parse: function(start, count) {
 		const me = this;
-		const meta = me._cachedMeta;
-		const data = me._data;
-		const iScale = meta.iScale;
-		const vScale = meta.vScale;
-		const stacked = isStacked(iScale, meta) || isStacked(vScale, meta);
+		const {_cachedMeta: meta, _data: data} = me;
+		const {iScale, vScale, _stacked} = meta;
 		let i, ilen, parsed;
 
 		if (helpers.isArray(data[start])) {
@@ -491,7 +488,8 @@ helpers.extend(DatasetController.prototype, {
 		for (i = 0, ilen = parsed.length; i < ilen; ++i) {
 			meta.data[start + i]._parsed = parsed[i];
 		}
-		if (stacked) {
+
+		if (_stacked) {
 			updateStacks(me, parsed);
 		}
 
@@ -513,8 +511,9 @@ helpers.extend(DatasetController.prototype, {
 	 * @private
 	 */
 	_parsePrimitiveData: function(meta, data, start, count) {
-		const iScale = meta.iScale;
-		const vScale = meta.vScale;
+		const {iScale, vScale} = meta;
+		const iId = iScale.id;
+		const vId = vScale.id;
 		const labels = iScale._getLabels();
 		const singleScale = iScale === vScale;
 		const parsed = [];
@@ -522,8 +521,8 @@ helpers.extend(DatasetController.prototype, {
 
 		for (i = start, ilen = start + count; i < ilen; ++i) {
 			item = {};
-			item[iScale.id] = singleScale || iScale._parse(labels[i], i);
-			item[vScale.id] = vScale._parse(data[i], i);
+			item[iId] = singleScale || iScale._parse(labels[i], i);
+			item[vId] = vScale._parse(data[i], i);
 			parsed.push(item);
 		}
 		return parsed;
@@ -541,16 +540,17 @@ helpers.extend(DatasetController.prototype, {
 	 * @private
 	 */
 	_parseArrayData: function(meta, data, start, count) {
-		const xScale = meta.xScale;
-		const yScale = meta.yScale;
+		const {xScale, yScale} = meta;
+		const xId = xScale.id;
+		const yId = yScale.id;
 		const parsed = [];
-		let i, ilen, item, arr;
+		let i, ilen, item;
 		for (i = start, ilen = start + count; i < ilen; ++i) {
-			arr = data[i];
-			item = {};
-			item[xScale.id] = xScale._parse(arr[0], i);
-			item[yScale.id] = yScale._parse(arr[1], i);
-			parsed.push(item);
+			item = data[i];
+			parsed.push({
+				[xId]: xScale._parse(item[0], i),
+				[yId]: yScale._parse(item[1], i)
+			});
 		}
 		return parsed;
 	},
@@ -567,16 +567,17 @@ helpers.extend(DatasetController.prototype, {
 	 * @private
 	 */
 	_parseObjectData: function(meta, data, start, count) {
-		const xScale = meta.xScale;
-		const yScale = meta.yScale;
+		const {xScale, yScale} = meta;
+		const xId = xScale.id;
+		const yId = yScale.id;
 		const parsed = [];
-		let i, ilen, item, obj;
+		let i, ilen, item;
 		for (i = start, ilen = start + count; i < ilen; ++i) {
-			obj = data[i];
-			item = {};
-			item[xScale.id] = xScale._parseObject(obj, 'x', i);
-			item[yScale.id] = yScale._parseObject(obj, 'y', i);
-			parsed.push(item);
+			item = data[i];
+			parsed.push({
+				[xId]: xScale._parseObject(item, 'x', i),
+				[yId]: yScale._parseObject(item, 'y', i)
+			});
 		}
 		return parsed;
 	},

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -189,35 +189,21 @@ function getOrCreateStack(stacks, stackKey, indexValue) {
 }
 
 function updateStacks(controller, parsed) {
-	const chart = controller.chart;
-	const meta = controller._cachedMeta;
+	const {chart, _cachedMeta: meta} = controller;
 	const stacks = chart._stacks || (chart._stacks = {}); // map structure is {stackKey: {datasetIndex: value}}
-	const xScale = meta.xScale;
-	const yScale = meta.yScale;
-	const xId = xScale.id;
-	const yId = yScale.id;
-	const xStacked = isStacked(xScale, meta);
-	const yStacked = isStacked(yScale, meta);
-	const xKey = yStacked && getStackKey(xScale, yScale, meta);
-	const yKey = xStacked && getStackKey(yScale, xScale, meta);
+	const {iScale, vScale, index: datasetIndex} = meta;
+	const iId = iScale.id;
+	const vId = vScale.id;
+	const key = getStackKey(iScale, vScale, meta);
 	const ilen = parsed.length;
-	const datasetIndex = meta.index;
 	let stack;
 
 	for (let i = 0; i < ilen; ++i) {
 		const item = parsed[i];
-		const x = item[xId];
-		const y = item[yId];
+		const {[iId]: index, [vId]: value} = item;
 		const itemStacks = item._stacks || (item._stacks = {});
-
-		if (yStacked) {
-			stack = itemStacks[yId] = getOrCreateStack(stacks, xKey, x);
-			stack[datasetIndex] = y;
-		}
-		if (xStacked) {
-			stack = itemStacks[xId] = getOrCreateStack(stacks, yKey, y);
-			stack[datasetIndex] = x;
-		}
+		stack = itemStacks[vId] = getOrCreateStack(stacks, key, index);
+		stack[datasetIndex] = value;
 	}
 }
 


### PR DESCRIPTION
We don't actually support a case where both scales values are stacked. Its always the value scale. Index scale can have stack groups, but its controlled by `stack` option of `dataset` and appended to the `stack key`.

[Destructuring assignment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) helps reduce lines.
[Computed property names](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer) in object initializer reduce the need for temporary variables.

```js
parsed.push({
	[xId]: xScale._parseObject(item, 'x', i),
	[yId]: yScale._parseObject(item, 'y', i),
});
```

translates to:
```js
parsed.push((_parsed$push4 = {}, _defineProperty(_parsed$push4, xId, xScale._parseObject(item, 'x', i)), _defineProperty(_parsed$push4, yId, yScale._parseObject(item, 'y', i)), _parsed$push4));
```

And that is faster (in Chrome)! (8.2 ms vs 12.4 ms, uPlot)

Force push: removed unintended inclusion of #6768 
