### PR TITLE
Remove Element.initialize

### DIFF
--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -71,6 +71,7 @@ Chart.js 3.0 introduces a number of breaking changes. Chart.js 2.0 was released 
 * `DatasetController.addElementAndReset`
 * `Element.getArea`
 * `Element.height`
+* `Element.initialize`
 * `Element.inLabelRange`
 * `IPlugin.afterScaleUpdate`. Use `afterLayout` instead
 * `Line.calculatePointY`

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -952,7 +952,7 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 			_chart: me,
 			_data: me.data,
 			_options: me.options.tooltips
-		}, me);
+		});
 	},
 
 	/**

--- a/src/core/core.element.js
+++ b/src/core/core.element.js
@@ -58,11 +58,7 @@ class Element {
 		helpers.extend(this, configuration);
 
 		// this.hidden = false; we assume Element has an attribute called hidden, but do not initialize to save memory
-
-		this.initialize.apply(this, arguments);
 	}
-
-	initialize() {}
 
 	pivot(animationsDisabled) {
 		var me = this;

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -485,6 +485,12 @@ function getBeforeAfterBodyLines(callback) {
 }
 
 class Tooltip extends Element {
+	constructor(config) {
+		super(config);
+
+		this.initialize();
+	}
+
 	initialize() {
 		var me = this;
 		me._model = getBaseModel(me._options);

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -113,8 +113,10 @@ function getBoxWidth(labelOpts, fontSize) {
  */
 class Legend extends Element {
 
-	initialize(config) {
-		var me = this;
+	constructor(config) {
+		super();
+
+		const me = this;
 		helpers.extend(me, config);
 
 		// Contains hit boxes for each dataset (in dataset order)

--- a/src/plugins/plugin.title.js
+++ b/src/plugins/plugin.title.js
@@ -21,7 +21,9 @@ defaults._set('global', {
  * IMPORTANT: this class is exposed publicly as Chart.Legend, backward compatibility required!
  */
 class Title extends Element {
-	initialize(config) {
+	constructor(config) {
+		super();
+
 		var me = this;
 		helpers.extend(me, config);
 


### PR DESCRIPTION
I'm not sure why `Element`'s constructor must call `helpers.extend` and feel that could probably be removed as well in a follow up PR if someone can figure out why it's there