### PR TITLE
Use correct dataset index in parseVisibleItems

### DIFF
--- a/src/core/core.interaction.js
+++ b/src/core/core.interaction.js
@@ -25,15 +25,14 @@ function getRelativePosition(e, chart) {
  * @param {function} handler - the callback to execute for each visible item
  */
 function parseVisibleItems(chart, handler) {
-	var metasets = chart._getSortedVisibleDatasetMetas();
-	var metadata, i, j, ilen, jlen, element;
+	const metasets = chart._getSortedVisibleDatasetMetas();
 
-	for (i = 0, ilen = metasets.length; i < ilen; ++i) {
-		metadata = metasets[i].data;
-		for (j = 0, jlen = metadata.length; j < jlen; ++j) {
-			element = metadata[j];
-			if (!element._view.skip) {
-				handler(element, i, j);
+	for (let i = 0, ilen = metasets.length; i < ilen; ++i) {
+		const {index, data} = metasets[i];
+		for (let j = 0, jlen = data.length; j < jlen; ++j) {
+			const element = data[j];
+			if (!element.skip) {
+				handler(element, index, j);
 			}
 		}
 	}

--- a/src/core/core.interaction.js
+++ b/src/core/core.interaction.js
@@ -26,12 +26,13 @@ function getRelativePosition(e, chart) {
  */
 function parseVisibleItems(chart, handler) {
 	const metasets = chart._getSortedVisibleDatasetMetas();
+	let index, data, element;
 
 	for (let i = 0, ilen = metasets.length; i < ilen; ++i) {
-		const {index, data} = metasets[i];
+		({index, data} = metasets[i]);
 		for (let j = 0, jlen = data.length; j < jlen; ++j) {
-			const element = data[j];
-			if (!element.skip) {
+			element = data[j];
+			if (!element._view.skip) {
 				handler(element, index, j);
 			}
 		}


### PR DESCRIPTION
When some datasets are hidden, `visible index` and `dataset index` are different things.

So here the `index` supplied to `handler` is fetched from the `metaset` instead of using the zero based `i`.