### PR TITLE
Remove ticksToTimestamps and change ticks to numbers

### DIFF
--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -172,9 +172,8 @@ Animation system was completely rewritten in Chart.js v3. Each property can now 
 ##### Ticks
 
 * `Scale.afterBuildTicks` now has no parameters like the other callbacks
-* `Scale.buildTicks` is now expected to return tick objects
-* `Scale.convertTicksToLabels` was renamed to `generateTickLabels`. It is now expected to set the label property on the ticks given as input
-* `Scale.ticks` now contains objects instead of strings
+* `Scale.ticks` now contains the tick values instead of labels, which are now available in `Scale.labels`
+* `TimeScale.buildTicks` is now expected to return `number`s like the other scales
 * When the `autoSkip` option is enabled, `Scale.ticks` now contains only the non-skipped ticks instead of all ticks.
 
 ##### Time Scale

--- a/src/core/core.ticks.js
+++ b/src/core/core.ticks.js
@@ -33,7 +33,7 @@ export default {
 		 */
 		linear: function(tickValue, index, ticks) {
 			// If we have lots of ticks, don't use the ones
-			var delta = ticks.length > 3 ? ticks[2].value - ticks[1].value : ticks[1].value - ticks[0].value;
+			var delta = ticks.length > 3 ? ticks[2] - ticks[1] : ticks[1] - ticks[0];
 
 			// If we have a number like 2.5 as the delta, figure out how many decimal places we need
 			if (Math.abs(delta) > 1) {
@@ -47,7 +47,7 @@ export default {
 			var tickString = '';
 
 			if (tickValue !== 0) {
-				var maxTick = Math.max(Math.abs(ticks[0].value), Math.abs(ticks[ticks.length - 1].value));
+				var maxTick = Math.max(Math.abs(ticks[0]), Math.abs(ticks[ticks.length - 1]));
 				if (maxTick < 1e-4) { // all ticks are small numbers; use scientific notation
 					var logTick = math.log10(Math.abs(tickValue));
 					var numExponential = Math.floor(logTick) - Math.floor(logDelta);

--- a/src/helpers/helpers.math.js
+++ b/src/helpers/helpers.math.js
@@ -58,11 +58,11 @@ export function almostWhole(x, epsilon) {
 	return ((rounded - epsilon) <= x) && ((rounded + epsilon) >= x);
 }
 
-export function _setMinAndMaxByKey(array, target, property) {
+export function _setMinAndMax(array, target) {
 	var i, ilen, value;
 
 	for (i = 0, ilen = array.length; i < ilen; i++) {
-		value = array[i][property];
+		value = array[i];
 		if (!isNaN(value)) {
 			target.min = Math.min(target.min, value);
 			target.max = Math.max(target.max, value);

--- a/src/scales/scale.category.js
+++ b/src/scales/scale.category.js
@@ -35,9 +35,7 @@ class CategoryScale extends Scale {
 		me._valueRange = Math.max(labels.length - (offset ? 0 : 1), 1);
 		me._startValue = me.min - (offset ? 0.5 : 0);
 
-		return labels.map(function(l) {
-			return {value: l};
-		});
+		return labels;
 	}
 
 	getLabelForValue(value) {

--- a/src/scales/scale.linear.js
+++ b/src/scales/scale.linear.js
@@ -67,7 +67,7 @@ class LinearScale extends LinearScaleBase {
 		if (index < 0 || index > ticks.length - 1) {
 			return null;
 		}
-		return this.getPixelForValue(ticks[index].value);
+		return this.getPixelForValue(ticks[index]);
 	}
 }
 

--- a/src/scales/scale.linearbase.js
+++ b/src/scales/scale.linearbase.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import helpers from '../helpers/index';
-import {almostEquals, almostWhole, _decimalPlaces, _setMinAndMaxByKey, sign} from '../helpers/helpers.math';
+import {almostEquals, almostWhole, _decimalPlaces, _setMinAndMax, sign} from '../helpers/helpers.math';
 import Scale from '../core/core.scale';
 
 const isNullOrUndef = helpers.isNullOrUndef;
@@ -33,7 +33,7 @@ function generateTicks(generationOptions, dataRange) {
 	// Beyond MIN_SPACING floating point numbers being to lose precision
 	// such that we can't do the math necessary to generate ticks
 	if (spacing < MIN_SPACING && isNullOrUndef(min) && isNullOrUndef(max)) {
-		return [{value: rmin}, {value: rmax}];
+		return [rmin, rmax];
 	}
 
 	numSpaces = Math.ceil(rmax / spacing) - Math.floor(rmin / spacing);
@@ -75,11 +75,11 @@ function generateTicks(generationOptions, dataRange) {
 
 	niceMin = Math.round(niceMin * factor) / factor;
 	niceMax = Math.round(niceMax * factor) / factor;
-	ticks.push({value: isNullOrUndef(min) ? niceMin : min});
+	ticks.push(isNullOrUndef(min) ? niceMin : min);
 	for (var j = 1; j < numSpaces; ++j) {
-		ticks.push({value: Math.round((niceMin + j * spacing) * factor) / factor});
+		ticks.push(Math.round((niceMin + j * spacing) * factor) / factor);
 	}
-	ticks.push({value: isNullOrUndef(max) ? niceMax : max});
+	ticks.push(isNullOrUndef(max) ? niceMax : max);
 
 	return ticks;
 }
@@ -216,7 +216,7 @@ class LinearScaleBase extends Scale {
 
 		// At this point, we need to update our max and min given the tick values since we have expanded the
 		// range of the scale
-		_setMinAndMaxByKey(ticks, me, 'value');
+		_setMinAndMax(ticks, me);
 
 		if (opts.reverse) {
 			ticks.reverse();

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -322,16 +322,17 @@ class RadialLinearScale extends LinearScaleBase {
 		return Math.ceil(this.drawingArea / getTickBackdropHeight(this.options));
 	}
 
-	generateTickLabels(ticks) {
+	convertTicksToLabels(ticks) {
 		var me = this;
-
-		LinearScaleBase.prototype.generateTickLabels.call(me, ticks);
+		var labels = LinearScaleBase.prototype.convertTicksToLabels.call(me, ticks);
 
 		// Point labels
 		me.pointLabels = me.chart.data.labels.map(function() {
 			var label = helpers.callback(me.options.pointLabels.callback, arguments, me);
 			return label || label === 0 ? label : '';
 		});
+
+		return labels;
 	}
 
 	fit() {
@@ -440,7 +441,7 @@ class RadialLinearScale extends LinearScaleBase {
 		if (gridLineOpts.display) {
 			me.ticks.forEach(function(tick, index) {
 				if (index !== 0) {
-					offset = me.getDistanceFromCenterForValue(me.ticks[index].value);
+					offset = me.getDistanceFromCenterForValue(me.ticks[index]);
 					drawRadiusLine(me, gridLineOpts, offset, index);
 				}
 			});
@@ -498,7 +499,7 @@ class RadialLinearScale extends LinearScaleBase {
 				return;
 			}
 
-			offset = me.getDistanceFromCenterForValue(me.ticks[index].value);
+			offset = me.getDistanceFromCenterForValue(me.ticks[index]);
 
 			if (tickOpts.showLabelBackdrop) {
 				width = ctx.measureText(tick.label).width;

--- a/test/specs/core.layouts.tests.js
+++ b/test/specs/core.layouts.tests.js
@@ -1,7 +1,3 @@
-function getLabels(scale) {
-	return scale.ticks.map(t => t.label);
-}
-
 describe('Chart.layouts', function() {
 	it('should be exposed through Chart.layouts', function() {
 		expect(Chart.layouts).toBeDefined();
@@ -635,7 +631,7 @@ describe('Chart.layouts', function() {
 			// issue #4441: y-axis labels partially hidden.
 			// minimum horizontal space required to fit labels
 			expect(yAxis.width).toBeCloseToPixel(33);
-			expect(getLabels(yAxis)).toEqual(['2.5', '2.0', '1.5', '1.0', '0.5', '0']);
+			expect(yAxis.labels).toEqual(['2.5', '2.0', '1.5', '1.0', '0.5', '0']);
 		});
 	});
 });

--- a/test/specs/core.scale.tests.js
+++ b/test/specs/core.scale.tests.js
@@ -1,7 +1,3 @@
-function getLabels(scale) {
-	return scale.ticks.map(t => t.label);
-}
-
 describe('Core.scale', function() {
 	describe('auto', jasmine.fixture.specs('core.scale'));
 
@@ -38,10 +34,10 @@ describe('Core.scale', function() {
 			});
 		}
 
-		function lastTick(chart) {
+		function lastLabel(chart) {
 			var xAxis = chart.scales.x;
-			var ticks = xAxis.getTicks();
-			return ticks[ticks.length - 1];
+			var labels = xAxis.labels;
+			return labels[labels.length - 1];
 		}
 
 		it('should display the last tick if it fits evenly with other ticks', function() {
@@ -56,7 +52,7 @@ describe('Core.scale', function() {
 				}]
 			});
 
-			expect(lastTick(chart).label).toEqual('September 2018');
+			expect(lastLabel(chart)).toEqual('September 2018');
 		});
 
 		it('should not display the last tick if it does not fit evenly', function() {
@@ -75,7 +71,7 @@ describe('Core.scale', function() {
 				}]
 			});
 
-			expect(lastTick(chart).label).toEqual('January 2020');
+			expect(lastLabel(chart)).toEqual('January 2020');
 		});
 	});
 
@@ -392,7 +388,7 @@ describe('Core.scale', function() {
 			});
 
 			var scale = chart.scales.x;
-			expect(getLabels(scale)).toEqual(labels.slice(1));
+			expect(scale.labels).toEqual(labels.slice(1));
 		});
 
 		it('should allow no return value from callback', function() {
@@ -411,7 +407,7 @@ describe('Core.scale', function() {
 			});
 
 			var scale = chart.scales.x;
-			expect(getLabels(scale)).toEqual(labels);
+			expect(scale.labels).toEqual(labels);
 		});
 
 		it('should allow empty ticks', function() {

--- a/test/specs/core.ticks.tests.js
+++ b/test/specs/core.ticks.tests.js
@@ -1,5 +1,5 @@
 function getLabels(scale) {
-	return scale.ticks.map(t => t.label);
+	return scale.labels;
 }
 
 describe('Test tick generators', function() {

--- a/test/specs/scale.category.tests.js
+++ b/test/specs/scale.category.tests.js
@@ -1,11 +1,11 @@
 // Test the category scale
 
 function getLabels(scale) {
-	return scale.ticks.map(t => t.label);
+	return scale.labels;
 }
 
 function getValues(scale) {
-	return scale.ticks.map(t => t.value);
+	return scale.ticks;
 }
 
 describe('Category scale tests', function() {

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -1,5 +1,5 @@
 function getLabels(scale) {
-	return scale.ticks.map(t => t.label);
+	return scale.labels;
 }
 
 describe('Linear Scale', function() {

--- a/test/specs/scale.logarithmic.tests.js
+++ b/test/specs/scale.logarithmic.tests.js
@@ -1,5 +1,5 @@
 function getLabels(scale) {
-	return scale.ticks.map(t => t.label);
+	return scale.labels;
 }
 
 describe('Logarithmic Scale tests', function() {
@@ -476,8 +476,8 @@ describe('Logarithmic Scale tests', function() {
 		var tickCount = yScale.ticks.length;
 		expect(yScale.min).toBe(10);
 		expect(yScale.max).toBe(1010);
-		expect(yScale.ticks[0].value).toBe(1010);
-		expect(yScale.ticks[tickCount - 1].value).toBe(10);
+		expect(yScale.ticks[0]).toBe(1010);
+		expect(yScale.ticks[tickCount - 1]).toBe(10);
 	});
 
 	it('should ignore negative min and max options', function() {

--- a/test/specs/scale.radialLinear.tests.js
+++ b/test/specs/scale.radialLinear.tests.js
@@ -1,5 +1,5 @@
 function getLabels(scale) {
-	return scale.ticks.map(t => t.label);
+	return scale.labels;
 }
 
 // Tests for the radial linear scale used by the polar area and radar charts

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -23,7 +23,7 @@ describe('Time scale tests', function() {
 	}
 
 	function getLabels(scale) {
-		return scale.ticks.map(t => t.label);
+		return scale.labels;
 	}
 
 	beforeEach(function() {
@@ -596,7 +596,7 @@ describe('Time scale tests', function() {
 		it('should be bounded by nearest step\'s year start and end', function() {
 			var scale = this.scale;
 			var ticks = scale.getTicks();
-			var step = ticks[1].value - ticks[0].value;
+			var step = ticks[1] - ticks[0];
 			var stepsAmount = Math.floor((scale.max - scale.min) / step);
 
 			expect(scale.getValueForPixel(scale.left)).toBeCloseToTime({
@@ -623,7 +623,7 @@ describe('Time scale tests', function() {
 			for (var i = 0; i < ticks.length - 1; i++) {
 				var offset = pixelsPerTick * i;
 				expect(scale.getValueForPixel(scale.left + offset)).toBeCloseToTime({
-					value: moment(ticks[i].label + '-01-01'),
+					value: moment(scale.labels[i] + '-01-01'),
 					unit: 'day',
 					threshold: 1,
 				});
@@ -1301,8 +1301,8 @@ describe('Time scale tests', function() {
 				var scale = chart.scales.x;
 				var ticks = scale.getTicks();
 
-				expect(scale.min).toEqual(ticks[0].value);
-				expect(scale.max).toEqual(ticks[ticks.length - 1].value);
+				expect(scale.min).toEqual(ticks[0]);
+				expect(scale.max).toEqual(ticks[ticks.length - 1]);
 				expect(scale.getPixelForValue(moment('02/20 08:00', 'MM/DD HH:mm').valueOf())).toBeCloseToPixel(60);
 				expect(scale.getPixelForValue(moment('02/23 11:00', 'MM/DD HH:mm').valueOf())).toBeCloseToPixel(426);
 				expect(getLabels(scale)).toEqual([
@@ -1361,8 +1361,8 @@ describe('Time scale tests', function() {
 						expect(scale.getPixelForValue(minMillis)).toBeCloseToPixel(scale.left);
 						expect(scale.getPixelForValue(maxMillis)).toBeCloseToPixel(scale.left + scale.width);
 						scale.getTicks().forEach(function(tick) {
-							expect(tick.value >= minMillis).toBeTruthy();
-							expect(tick.value <= maxMillis).toBeTruthy();
+							expect(tick >= minMillis).toBeTruthy();
+							expect(tick <= maxMillis).toBeTruthy();
 						});
 					});
 					it ('should shrink scale to the min/max range', function() {
@@ -1383,8 +1383,8 @@ describe('Time scale tests', function() {
 						expect(scale.getPixelForValue(minMillis)).toBeCloseToPixel(scale.left);
 						expect(scale.getPixelForValue(maxMillis)).toBeCloseToPixel(scale.left + scale.width);
 						scale.getTicks().forEach(function(tick) {
-							expect(tick.value >= minMillis).toBeTruthy();
-							expect(tick.value <= maxMillis).toBeTruthy();
+							expect(tick >= minMillis).toBeTruthy();
+							expect(tick <= maxMillis).toBeTruthy();
 						});
 					});
 				});
@@ -1826,10 +1826,7 @@ describe('Time scale tests', function() {
 
 		var scale = chart.scales.x;
 
-		var labels = scale.ticks.map(function(t) {
-			return t.label;
-		});
-		expect(labels).toEqual([
+		expect(scale.labels).toEqual([
 			'1990', 'Apr 1990', 'Jul 1990', 'Oct 1990',
 			'1991', 'Apr 1991', 'Jul 1991', 'Oct 1991',
 			'1992', 'Apr 1992', 'Jul 1992', 'Oct 1992',


### PR DESCRIPTION
`ticksFromTimestamps` is pretty expensive in the uPlot benchmark since it creates an object for every tick. Leaving ticks as primitives is much more performant and will be one less thing for the user to migrate since that's how it is in 2.9 for all scales other than the time scale. This now stores the `major` attribute in a separate `_tickMeta` array of objects, which is much cheaper since an object only needs to be created when `major: true`

**`buildTicks` timing**
Before: 73.05 ms
After: 19.23 ms

This makes the total render time for the Chart about 10% faster