### PR TITLE
Pre-allocate space for _parsed

### DIFF
--- a/src/core/core.element.js
+++ b/src/core/core.element.js
@@ -55,6 +55,8 @@ function interpolate(start, view, model, ease) {
 class Element {
 
 	constructor(configuration) {
+		this._parsed = null; // pre-allocate space for pointer to parsed data
+
 		helpers.extend(this, configuration);
 
 		// this.hidden = false; we assume Element has an attribute called hidden, but do not initialize to save memory


### PR DESCRIPTION
Alternative to #6814 
This is not as good, but just wanted to point this optimization out - it's probably usable in other situations.

Master:
![image](https://user-images.githubusercontent.com/27971921/70369978-f66c3080-18c9-11ea-9529-f63e5c0b5258.png)

PR:
![image](https://user-images.githubusercontent.com/27971921/70369982-113ea500-18ca-11ea-8e0e-4fdbb2462748.png)
