### PR TITLE
Make the build reproducible

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,7 +12,7 @@ const input = 'src/index.js';
 const banner = `/*!
  * Chart.js v${pkg.version}
  * ${pkg.homepage}
- * (c) ${new Date().getFullYear()} Chart.js Contributors
+ * (c) ${(new Date(process.env.SOURCE_DATE_EPOCH ? (process.env.SOURCE_DATE_EPOCH * 1000) : new Date().getTime())).getFullYear()} Chart.js Contributors
  * Released under the MIT License
  */`;
 


### PR DESCRIPTION
Whilst working on the [Reproducible Builds effort](https://reproducible-builds.org/) we noticed that Chart.js could not be built reproducibly.

This is because it was embedding another build date in a "banner" comment. This patch uses the value from [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/specs/source-date-epoch/) if present.

(This was originally filed in Debian as [#946333](https://bugs.debian.org/946333).)