### PR TITLE
fastline controller

### DIFF
--- a/src/controllers/controller.fastline.js
+++ b/src/controllers/controller.fastline.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const LineController = require('./controller.line');
+const defaults = require('../core/core.defaults');
+
+defaults._set('fastline', {
+	hover: {
+		mode: 'index'
+	},
+
+	scales: {
+		x: {
+			type: 'category',
+		},
+		y: {
+			type: 'linear',
+		},
+	}
+});
+
+// TODO: expose from elements.Line
+function setStyle(ctx, vm) {
+	ctx.lineCap = vm.borderCapStyle;
+	ctx.setLineDash(vm.borderDash);
+	ctx.lineDashOffset = vm.borderDashOffset;
+	ctx.lineJoin = vm.borderJoinStyle;
+	ctx.lineWidth = vm.borderWidth;
+	ctx.strokeStyle = vm.borderColor;
+}
+
+module.exports = LineController.extend({
+
+	addElements: function() {},
+
+	insertElements: function(start, count) {
+		this._parse(start, count);
+	},
+
+	update: function() {
+		const me = this;
+		me._cachedMeta._options = me._resolveDatasetElementOptions();
+	},
+
+	updateElements: function() {
+	},
+
+	/**
+	 * @private
+	 */
+	_getMaxOverflow: function() {
+		return this._cachedMeta._options.borderWidth;
+	},
+
+	draw: function() {
+		const me = this;
+		const ctx = me._ctx;
+		const meta = me._cachedMeta;
+		const {xScale, yScale, _stacked} = meta;
+		const options = meta._options;
+		let i = 0;
+
+		ctx.save();
+		setStyle(ctx, options);
+		ctx.beginPath();
+
+		for (i = 0; i < meta._parsed.length; ++i) {
+			const parsed = me._getParsed(i);
+			const x = xScale.getPixelForValue(parsed[xScale.id]);
+			const y = yScale.getPixelForValue(_stacked ? me._applyStack(yScale, parsed) : parsed[yScale.id]);
+
+			ctx.lineTo(x, y);
+		}
+
+		ctx.stroke();
+		ctx.restore();
+	}
+});

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -5,6 +5,7 @@ var bubble = require('./controller.bubble');
 var doughnut = require('./controller.doughnut');
 var horizontalBar = require('./controller.horizontalBar');
 var line = require('./controller.line');
+var fastline = require('./controller.fastline');
 var polarArea = require('./controller.polarArea');
 var pie = require('./controller.pie');
 var radar = require('./controller.radar');
@@ -19,6 +20,7 @@ module.exports = {
 	bubble: bubble,
 	doughnut: doughnut,
 	horizontalBar: horizontalBar,
+	fastline: fastline,
 	line: line,
 	polarArea: polarArea,
 	pie: pie,


### PR DESCRIPTION
This is an idea I wanted to run past you guys.

It's a far faster controller for drawing a line graph because it doesn't create any elements.

I made it a separate controller for experimenting, but I wonder if it should be combined with the main one. Also, it doesn't use the new `fastpath` code, so could probably be made faster still.

Features it disables:
- animation
- bezier and stepped lines and `spanGaps: false`
- drawing points (could be added back, but I didn't plan on it)
- tooltips (I'd like to add this back)