### PR TITLE
Shrink _parsed to match if dataset shrinks

### DIFF
--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -955,6 +955,7 @@ helpers.extend(DatasetController.prototype, {
 			me.insertElements(numMeta, numData - numMeta);
 		} else if (numData < numMeta) {
 			meta.data.splice(numData, numMeta - numData);
+			meta._parsed.splice(numData, numMeta - numData);
 			me._parse(0, numData);
 		} else if (changed) {
 			me._parse(0, numData);

--- a/test/specs/controller.bar.tests.js
+++ b/test/specs/controller.bar.tests.js
@@ -722,6 +722,7 @@ describe('Chart.controllers.bar', function() {
 		chart.update();
 
 		expect(meta.data.length).toBe(2);
+		expect(meta._parsed.length).toBe(2);
 
 		[
 			{x: 89, y: 512},

--- a/test/specs/controller.line.tests.js
+++ b/test/specs/controller.line.tests.js
@@ -197,7 +197,7 @@ describe('Chart.controllers.line', function() {
 		chart.update();
 
 		expect(meta.data.length).toBe(2);
-
+		expect(meta._parsed.length).toBe(2);
 
 		[
 			{x: 0, y: 512},


### PR DESCRIPTION
This should fix the failing tests in https://github.com/chartjs/Chart.js/pull/6822. Sending this as a separate PR since it's easily separable and a good change regardless of the direction we go in that one