### PR TITLE
Tests and fixes for data watching

### DIFF
--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -270,6 +270,7 @@ helpers.extend(DatasetController.prototype, {
 		me.index = datasetIndex;
 		me._cachedMeta = meta = me.getMeta();
 		me._type = meta.type;
+		me._configure();
 		me.linkScales();
 		meta._stacked = isStacked(meta.vScale, meta);
 		me.addElements();
@@ -464,6 +465,7 @@ helpers.extend(DatasetController.prototype, {
 				}
 			}
 		});
+		me._parsing = resolve([me._config.parsing, me.chart.options.parsing, true]);
 	},
 
 	/**
@@ -473,11 +475,10 @@ helpers.extend(DatasetController.prototype, {
 		const me = this;
 		const {_cachedMeta: meta, _data: data} = me;
 		const {iScale, vScale, _stacked} = meta;
-		const parsing = resolve([me.getDataset().parsing, me.chart.options.parsing, true]);
 		let offset = 0;
 		let i, parsed;
 
-		if (parsing === false) {
+		if (me._parsing === false) {
 			meta._parsed = data;
 		} else {
 			if (helpers.isArray(data[start])) {
@@ -968,7 +969,8 @@ helpers.extend(DatasetController.prototype, {
 	insertElements: function(start, count) {
 		const me = this;
 		const elements = new Array(count);
-		const data = me._cachedMeta.data;
+		const meta = me._cachedMeta;
+		const data = meta.data;
 		let i;
 
 		for (i = 0; i < count; ++i) {
@@ -976,9 +978,25 @@ helpers.extend(DatasetController.prototype, {
 		}
 		data.splice(start, 0, ...elements);
 
+		if (me._parsing) {
+			meta._parsed.splice(start, 0, ...new Array(count));
+		}
 		me._parse(start, count);
+
 		me.updateElements(data, start, count);
 	},
+
+	/**
+	 * @private
+	 */
+	removeElements: function(start, count) {
+		const me = this;
+		if (me._parsing) {
+			me._cachedMeta._parsed.splice(start, count);
+		}
+		me._cachedMeta.data.splice(start, count);
+	},
+
 
 	/**
 	 * @private
@@ -992,21 +1010,21 @@ helpers.extend(DatasetController.prototype, {
 	 * @private
 	 */
 	onDataPop: function() {
-		this._cachedMeta.data.pop();
+		this.removeElements(this._cachedMeta.data.length - 1, 1);
 	},
 
 	/**
 	 * @private
 	 */
 	onDataShift: function() {
-		this._cachedMeta.data.shift();
+		this.removeElements(0, 1);
 	},
 
 	/**
 	 * @private
 	 */
 	onDataSplice: function(start, count) {
-		this._cachedMeta.data.splice(start, count);
+		this.removeElements(start, count);
 		this.insertElements(start, arguments.length - 2);
 	},
 

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -791,7 +791,6 @@ helpers.extend(DatasetController.prototype, {
 		const dataset = meta.dataset;
 		let style;
 
-		me._configure();
 		if (dataset && index === undefined) {
 			style = me._resolveDatasetElementOptions();
 		} else {

--- a/test/specs/core.datasetController.tests.js
+++ b/test/specs/core.datasetController.tests.js
@@ -118,9 +118,9 @@ describe('Chart.DatasetController', function() {
 		});
 	});
 
-	it('should synchronize metadata when data are inserted or removed', function() {
-		var data = [0, 1, 2, 3, 4, 5];
-		var chart = acquireChart({
+	it('should synchronize metadata when data are inserted or removed and parsing is on', function() {
+		const data = [0, 1, 2, 3, 4, 5];
+		const chart = acquireChart({
 			type: 'line',
 			data: {
 				datasets: [{
@@ -129,8 +129,9 @@ describe('Chart.DatasetController', function() {
 			}
 		});
 
-		var meta = chart.getDatasetMeta(0);
-		var first, second, last;
+		const meta = chart.getDatasetMeta(0);
+		const parsedYValues = () => meta._parsed.map(p => p.y);
+		let first, second, last;
 
 		first = meta.data[0];
 		last = meta.data[5];
@@ -139,12 +140,14 @@ describe('Chart.DatasetController', function() {
 		expect(meta.data.length).toBe(10);
 		expect(meta.data[0]).toBe(first);
 		expect(meta.data[5]).toBe(last);
+		expect(parsedYValues()).toEqual(data);
 
 		last = meta.data[9];
 		data.pop();
 		expect(meta.data.length).toBe(9);
 		expect(meta.data[0]).toBe(first);
 		expect(meta.data.indexOf(last)).toBe(-1);
+		expect(parsedYValues()).toEqual(data);
 
 		last = meta.data[8];
 		data.shift();
@@ -153,6 +156,7 @@ describe('Chart.DatasetController', function() {
 		expect(meta.data.length).toBe(6);
 		expect(meta.data.indexOf(first)).toBe(-1);
 		expect(meta.data[5]).toBe(last);
+		expect(parsedYValues()).toEqual(data);
 
 		first = meta.data[0];
 		second = meta.data[1];
@@ -162,12 +166,14 @@ describe('Chart.DatasetController', function() {
 		expect(meta.data[0]).toBe(first);
 		expect(meta.data[3]).toBe(last);
 		expect(meta.data.indexOf(second)).toBe(-1);
+		expect(parsedYValues()).toEqual(data);
 
 		data.unshift(12, 13, 14, 15);
 		data.unshift(16, 17);
 		expect(meta.data.length).toBe(10);
 		expect(meta.data[6]).toBe(first);
 		expect(meta.data[9]).toBe(last);
+		expect(parsedYValues()).toEqual(data);
 	});
 
 	it('should synchronize metadata when data are inserted or removed and parsing is off', function() {


### PR DESCRIPTION
@kurkle hopefully this addresses your concerns. It does seem you were right there were some issues still. This encapsulates everything in `insert` and `remove` so it's pretty well contained. I still strongly prefer storing `_parsed` separately since it performs so much better, but the prior implementation wasn't great as I think you were suggesting. I wasn't very familiar with this data watching functionality previously

This data watching functionality seems a bit problematic to me:
- It's undocumented
- Doesn't `resyncElements` also try to handle just the new elements on update? I'm not sure why we need both of these functionalities. Though just from looking at the code, I'm not sure `resyncElements` works correctly, so that might be the better one to simplify. E.g. if you add the data at the beginning or the middle of the array I'm not sure `resyncElements` will handle it properly.
- It potentially could be moved to a plugin. E.g. maybe it should live in the streaming plugin instead
- Could we support `concat`? It looks like the streaming plugin might use this functionality and that seems possibly the most useful (right now it looks like it does `push` once per element passed in, but that seems not the most performant and it should maybe use `concat` or `slice`)

Even if we decide to move to a plugin, I think this PR would be helpful because it provides the new `remove` functionality that I think a plugin would want to call