### PR TITLE
Fix category scale autoSkip

### DIFF
--- a/src/scales/scale.category.js
+++ b/src/scales/scale.category.js
@@ -7,36 +7,42 @@ const defaultConfig = {
 
 class CategoryScale extends Scale {
 	_parse(raw, index) {
-		var labels = this._getLabels();
-		var first = labels.indexOf(raw);
-		var last = labels.lastIndexOf(raw);
+		const labels = this._getLabels();
+		const first = labels.indexOf(raw);
+		const last = labels.lastIndexOf(raw);
 		return first === -1 || first !== last ? index : first;
 	}
 
 	determineDataLimits() {
-		var me = this;
-		var max = me._getLabels().length - 1;
+		const me = this;
+		const max = me._getLabels().length - 1;
 
 		me.min = Math.max(me._userMin || 0, 0);
 		me.max = Math.min(me._userMax || max, max);
 	}
 
 	buildTicks() {
-		var me = this;
-		var labels = me._getLabels();
-		var min = me.min;
-		var max = me.max;
+		const me = this;
+		const min = me.min;
+		const max = me.max;
+		const offset = me.options.offset;
+		let labels = me._getLabels();
 
 		// If we are viewing some subset of labels, slice the original array
 		labels = (min === 0 && max === labels.length - 1) ? labels : labels.slice(min, max + 1);
+
+		me._numLabels = labels.length;
+		me._valueRange = Math.max(labels.length - (offset ? 0 : 1), 1);
+		me._startValue = me.min - (offset ? 0.5 : 0);
+
 		return labels.map(function(l) {
 			return {value: l};
 		});
 	}
 
 	getLabelForValue(value) {
-		var me = this;
-		var labels = me._getLabels();
+		const me = this;
+		const labels = me._getLabels();
 
 		if (value >= 0 && value < labels.length) {
 			return labels[value];
@@ -45,9 +51,7 @@ class CategoryScale extends Scale {
 	}
 
 	_configure() {
-		var me = this;
-		var offset = me.options.offset;
-		var ticks = me.ticks;
+		const me = this;
 
 		Scale.prototype._configure.call(me);
 
@@ -55,16 +59,9 @@ class CategoryScale extends Scale {
 			// For backward compatibility, vertical category scale reverse is inverted.
 			me._reversePixels = !me._reversePixels;
 		}
-
-		if (!ticks) {
-			return;
-		}
-
-		me._startValue = me.min - (offset ? 0.5 : 0);
-		me._valueRange = Math.max(ticks.length - (offset ? 0 : 1), 1);
 	}
 
-	// Used to get data value locations.  Value can either be an index or a numerical value
+	// Used to get data value locations. Value can either be an index or a numerical value
 	getPixelForValue(value) {
 		var me = this;
 
@@ -76,15 +73,17 @@ class CategoryScale extends Scale {
 	}
 
 	getPixelForTick(index) {
-		var ticks = this.ticks;
-		return index < 0 || index > ticks.length - 1
-			? null
-			: this.getPixelForValue(index + this.min);
+		const me = this;
+		const ticks = me.ticks;
+		if (index < 0 || index > ticks.length - 1) {
+			return null;
+		}
+		return this.getPixelForValue(index * me._numLabels / ticks.length + this.min);
 	}
 
 	getValueForPixel(pixel) {
-		var me = this;
-		var value = Math.round(me._startValue + me.getDecimalForPixel(pixel) * me._valueRange);
+		const me = this;
+		const value = Math.round(me._startValue + me.getDecimalForPixel(pixel) * me._valueRange);
 		return Math.min(Math.max(value, 0), me.ticks.length - 1);
 	}
 


### PR DESCRIPTION
Thanks to @kurkle for the bug report over Slack

The main issue on `master` at least was `_valueRange` using `ticks.length` in `_configure` after auto-skip. I moved the variables to be set in `buildTicks`, which seemed better. `_configure` is called multiple times, so I'd rather set those variables just once and then we don't need to worry about autoSkip