### PR TITLE
(feature) Added separate top and bottom padding for title plugin.

### DIFF
--- a/docs/configuration/title.md
+++ b/docs/configuration/title.md
@@ -13,7 +13,7 @@ The title configuration is passed into the `options.title` namespace. The global
 | `fontFamily` | `string` | `"'Helvetica Neue', 'Helvetica', 'Arial', sans-serif"` | Font family for the title text.
 | `fontColor` | `Color` | `'#666'` | Font color.
 | `fontStyle` | `string` | `'bold'` | Font style.
-| `padding` | `number` | `10` | Number of pixels to add above and below the title text.
+| `padding` | <code>number&#124;{top: number, bottom: number}</code> | `10` | Adds padding above and below the title text if a single number is specified. It is also possible to change top and bottom padding separately.
 | `lineHeight` | <code>number&#124;string</code> | `1.2` | Height of an individual line of text. See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height).
 | `text` | <code>string&#124;string[]</code> | `''` | Title text to display. If specified as an array, text is rendered on multiple lines.
 
@@ -36,6 +36,25 @@ var chart = new Chart(ctx, {
         title: {
             display: true,
             text: 'Custom Chart Title'
+        }
+    }
+});
+```
+
+This example shows how to specify separate top and bottom title text padding:
+
+```javascript
+var chart = new Chart(ctx, {
+    type: 'line',
+    data: data,
+    options: {
+        title: {
+            display: true,
+            text: 'Custom Chart Title',
+            padding: {
+                top: 10,
+                bottom: 30
+            }
         }
     }
 });

--- a/src/helpers/helpers.options.js
+++ b/src/helpers/helpers.options.js
@@ -56,7 +56,7 @@ export function toLineHeight(value, size) {
 /**
  * Converts the given value into a padding object with pre-computed width/height.
  * @param {number|object} value - If a number, set the value to all TRBL component,
- *  else, if and object, use defined properties and sets undefined ones to 0.
+ *  else, if an object, use defined properties and sets undefined ones to 0.
  * @returns {object} The padding values (top, right, bottom, left, width, height)
  * @since 2.7.0
  */

--- a/src/plugins/plugin.title.js
+++ b/src/plugins/plugin.title.js
@@ -108,7 +108,6 @@ class Title extends Element {
 	fit() {
 		var me = this;
 		var opts = me.options;
-		var padding = 0;
 		var minSize = me.minSize = {};
 		var isHorizontal = me.isHorizontal();
 		var lineCount, textSize;
@@ -119,12 +118,8 @@ class Title extends Element {
 		}
 
 		lineCount = helpers.isArray(opts.text) ? opts.text.length : 1;
-		if (me._isPaddingObj()) {
-			padding = opts.padding.bottom + opts.padding.top;
-		} else {
-			padding = opts.padding * 2;
-		}
-		textSize = lineCount * helpers.options._parseFont(opts).lineHeight + padding;
+		opts.padding = helpers.options.toPadding(opts.padding);
+		textSize = lineCount * helpers.options._parseFont(opts).lineHeight + (opts.padding.top + opts.padding.bottom);
 		me.width = minSize.width = isHorizontal ? me.maxWidth : textSize;
 		me.height = minSize.height = isHorizontal ? textSize : me.maxHeight;
 	}
@@ -134,14 +129,6 @@ class Title extends Element {
 	isHorizontal() {
 		var pos = this.options.position;
 		return pos === 'top' || pos === 'bottom';
-	}
-
-	/**
-	 * @private
-	 * @returns A boolean, true if the options.padding is an object, or false when it's a number.
-	 */
-	_isPaddingObj() {
-		return (typeof this.options.padding.top !== 'undefined' && typeof this.options.padding.bottom !== 'undefined');
 	}
 
 	// Actually draw the title block on the canvas
@@ -156,13 +143,7 @@ class Title extends Element {
 
 		var fontOpts = helpers.options._parseFont(opts);
 		var lineHeight = fontOpts.lineHeight;
-		var padding = 0;
-		if (me._isPaddingObj()) {
-			padding = opts.padding.top;
-		} else {
-			padding = opts.padding;
-		}
-		var offset = lineHeight / 2 + padding;
+		var offset = lineHeight / 2 + opts.padding.top;
 		var rotation = 0;
 		var top = me.top;
 		var left = me.left;

--- a/src/plugins/plugin.title.js
+++ b/src/plugins/plugin.title.js
@@ -10,10 +10,7 @@ defaults._set('global', {
 		display: false,
 		fontStyle: 'bold',
 		fullWidth: true,
-		padding: 10 || {
-			top: 10,
-			bottom: 10
-		},
+		padding: 10,
 		position: 'top',
 		text: '',
 		weight: 2000         // by default greater than legend (1000) to be above
@@ -36,7 +33,7 @@ class Title extends Element {
 
 	// These methods are ordered by lifecycle. Utilities then follow.
 
-	beforeUpdate() { }
+	beforeUpdate() {}
 	update(maxWidth, maxHeight, margins) {
 		var me = this;
 
@@ -67,11 +64,11 @@ class Title extends Element {
 		return me.minSize;
 
 	}
-	afterUpdate() { }
+	afterUpdate() {}
 
 	//
 
-	beforeSetDimensions() { }
+	beforeSetDimensions() {}
 	setDimensions() {
 		var me = this;
 		// Set the unconstrained dimension before label rotation
@@ -94,17 +91,17 @@ class Title extends Element {
 			height: 0
 		};
 	}
-	afterSetDimensions() { }
+	afterSetDimensions() {}
 
 	//
 
-	beforeBuildLabels() { }
-	buildLabels() { }
-	afterBuildLabels() { }
+	beforeBuildLabels() {}
+	buildLabels() {}
+	afterBuildLabels() {}
 
 	//
 
-	beforeFit() { }
+	beforeFit() {}
 	fit() {
 		var me = this;
 		var opts = me.options;
@@ -118,12 +115,12 @@ class Title extends Element {
 		}
 
 		lineCount = helpers.isArray(opts.text) ? opts.text.length : 1;
-		opts.padding = helpers.options.toPadding(opts.padding);
-		textSize = lineCount * helpers.options._parseFont(opts).lineHeight + (opts.padding.top + opts.padding.bottom);
+		me._padding = helpers.options.toPadding(opts.padding);
+		textSize = lineCount * helpers.options._parseFont(opts).lineHeight + me._padding.height;
 		me.width = minSize.width = isHorizontal ? me.maxWidth : textSize;
 		me.height = minSize.height = isHorizontal ? textSize : me.maxHeight;
 	}
-	afterFit() { }
+	afterFit() {}
 
 	// Shared Methods
 	isHorizontal() {
@@ -143,7 +140,7 @@ class Title extends Element {
 
 		var fontOpts = helpers.options._parseFont(opts);
 		var lineHeight = fontOpts.lineHeight;
-		var offset = lineHeight / 2 + opts.padding.top;
+		var offset = lineHeight / 2 + me._padding.top;
 		var rotation = 0;
 		var top = me.top;
 		var left = me.left;

--- a/src/plugins/plugin.title.js
+++ b/src/plugins/plugin.title.js
@@ -10,7 +10,10 @@ defaults._set('global', {
 		display: false,
 		fontStyle: 'bold',
 		fullWidth: true,
-		padding: 10,
+		padding: 10 || {
+			top: 10,
+			bottom: 10
+		},
 		position: 'top',
 		text: '',
 		weight: 2000         // by default greater than legend (1000) to be above
@@ -18,7 +21,7 @@ defaults._set('global', {
 });
 
 /**
- * IMPORTANT: this class is exposed publicly as Chart.Legend, backward compatibility required!
+ * IMPORTANT: this class is exposed publicly as Chart.Title, backward compatibility required!
  */
 class Title extends Element {
 	constructor(config) {
@@ -33,7 +36,7 @@ class Title extends Element {
 
 	// These methods are ordered by lifecycle. Utilities then follow.
 
-	beforeUpdate() {}
+	beforeUpdate() { }
 	update(maxWidth, maxHeight, margins) {
 		var me = this;
 
@@ -64,11 +67,11 @@ class Title extends Element {
 		return me.minSize;
 
 	}
-	afterUpdate() {}
+	afterUpdate() { }
 
 	//
 
-	beforeSetDimensions() {}
+	beforeSetDimensions() { }
 	setDimensions() {
 		var me = this;
 		// Set the unconstrained dimension before label rotation
@@ -85,32 +88,27 @@ class Title extends Element {
 			me.bottom = me.height;
 		}
 
-		// Reset padding
-		me.paddingLeft = 0;
-		me.paddingTop = 0;
-		me.paddingRight = 0;
-		me.paddingBottom = 0;
-
 		// Reset minSize
 		me.minSize = {
 			width: 0,
 			height: 0
 		};
 	}
-	afterSetDimensions() {}
+	afterSetDimensions() { }
 
 	//
 
-	beforeBuildLabels() {}
-	buildLabels() {}
-	afterBuildLabels() {}
+	beforeBuildLabels() { }
+	buildLabels() { }
+	afterBuildLabels() { }
 
 	//
 
-	beforeFit() {}
+	beforeFit() { }
 	fit() {
 		var me = this;
 		var opts = me.options;
+		var padding = 0;
 		var minSize = me.minSize = {};
 		var isHorizontal = me.isHorizontal();
 		var lineCount, textSize;
@@ -121,17 +119,29 @@ class Title extends Element {
 		}
 
 		lineCount = helpers.isArray(opts.text) ? opts.text.length : 1;
-		textSize = lineCount * helpers.options._parseFont(opts).lineHeight + opts.padding * 2;
-
+		if (me._isPaddingObj()) {
+			padding = opts.padding.bottom + opts.padding.top;
+		} else {
+			padding = opts.padding;
+		}
+		textSize = lineCount * helpers.options._parseFont(opts).lineHeight + padding;
 		me.width = minSize.width = isHorizontal ? me.maxWidth : textSize;
 		me.height = minSize.height = isHorizontal ? textSize : me.maxHeight;
 	}
-	afterFit() {}
+	afterFit() { }
 
 	// Shared Methods
 	isHorizontal() {
 		var pos = this.options.position;
 		return pos === 'top' || pos === 'bottom';
+	}
+
+	/**
+	 * @private
+	 * @returns A boolean, true if the options.padding is an object, or false when it's a number.
+	 */
+	_isPaddingObj() {
+		return (typeof this.options.padding.top !== 'undefined' && typeof this.options.padding.bottom !== 'undefined');
 	}
 
 	// Actually draw the title block on the canvas
@@ -146,7 +156,13 @@ class Title extends Element {
 
 		var fontOpts = helpers.options._parseFont(opts);
 		var lineHeight = fontOpts.lineHeight;
-		var offset = lineHeight / 2 + opts.padding;
+		var padding = 0;
+		if (me._isPaddingObj()) {
+			padding = opts.padding.top;
+		} else {
+			padding = opts.padding;
+		}
+		var offset = lineHeight / 2 + padding;
 		var rotation = 0;
 		var top = me.top;
 		var left = me.left;

--- a/src/plugins/plugin.title.js
+++ b/src/plugins/plugin.title.js
@@ -122,7 +122,7 @@ class Title extends Element {
 		if (me._isPaddingObj()) {
 			padding = opts.padding.bottom + opts.padding.top;
 		} else {
-			padding = opts.padding;
+			padding = opts.padding * 2;
 		}
 		textSize = lineCount * helpers.options._parseFont(opts).lineHeight + padding;
 		me.width = minSize.width = isHorizontal ? me.maxWidth : textSize;


### PR DESCRIPTION
<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->

Added feature to specify separate padding top and bottom.
Issue #6842 

**Old:**
```
...
options: {
    title: {
        display: true,
        text: "Title",
        padding: 20 // Padding for above and below the title text
    }
},
...
```

**New:**
```
...
options: {
    title: {
        display: true,
        text: "Title",
        padding: {top: 10, bottom: 30}
    }
},
...
```

- [X] More flexible
- [X] Backwards compatible / non-breaking change
- [X] Modified docs
- [X] Consistent with padding behavior in other places in the library
- [X] New method is private