### PR TITLE
Fix helper._calculatePadding return NaN causes Maximum Call Stack Size Exceeded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ bower.json
 *.log
 *.swp
 *.stackdump
+
+chart.js-*.tgz

--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -454,7 +454,7 @@ module.exports = function() {
 	 * @private
  	 */
 	helpers._calculatePadding = function(container, padding, parentDimension) {
-		padding = helpers.getStyle(container, padding);
+		padding = helpers.getStyle(container, padding) || '0';
 
 		return padding.indexOf('%') > -1 ? parentDimension * parseInt(padding, 10) / 100 : parseInt(padding, 10);
 	};


### PR DESCRIPTION
I encounter an issue that causes maximum call stack size exceeded in Chrome by using *ng2-charts*, found out that was in issue from this library.

The root cause from `helpers.getStyle()` inside `helpers._calculatePadding()` return an empty string, so `parseInt()` will result **NaN** that cause `fitBoxes()` recursive called infinitively.