### PR TITLE
Remove helpers.where and unnecessary calls to helpers.each

### DIFF
--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -66,6 +66,7 @@ Chart.js 3.0 introduces a number of breaking changes. Chart.js 2.0 was released 
 * `helpers.removeEvent`
 * `helpers.roundedRect`
 * `helpers.scaleMerge`
+* `helpers.where`
 * `Chart.Controller`
 * `Chart.chart.chart`
 * `Chart.types`

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -221,7 +221,7 @@ module.exports = DatasetController.extend({
 		var meta = this._cachedMeta;
 		var count = 0;
 
-		helpers.each(meta.data, function(element, index) {
+		meta.data.forEach(function(element, index) {
 			if (!isNaN(dataset.data[index]) && !element.hidden) {
 				count++;
 			}

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -36,7 +36,7 @@ function listenArrayEvents(array, listener) {
 				var args = Array.prototype.slice.call(arguments);
 				var res = base.apply(this, args);
 
-				helpers.each(array._chartjs.listeners, function(object) {
+				array._chartjs.listeners.forEach(function(object) {
 					if (typeof object[method] === 'function') {
 						object[method].apply(object, args);
 					}

--- a/src/core/core.layouts.js
+++ b/src/core/core.layouts.js
@@ -8,11 +8,11 @@ var extend = helpers.extend;
 const STATIC_POSITIONS = ['left', 'top', 'right', 'bottom'];
 
 function filterByPosition(array, position) {
-	return helpers.where(array, v => v.pos === position);
+	return array.filter(v => v.pos === position);
 }
 
 function filterDynamicPositionByAxis(array, axis) {
-	return helpers.where(array, v => STATIC_POSITIONS.indexOf(v.pos) === -1 && v.box.axis === axis);
+	return array.filter(v => STATIC_POSITIONS.indexOf(v.pos) === -1 && v.box.axis === axis);
 }
 
 function sortByWeight(array, reverse) {

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -48,20 +48,6 @@ export default {
 	math,
 	rtl,
 
-	where: function(collection, filterCallback) {
-		if (coreHelpers.isArray(collection) && Array.prototype.filter) {
-			return collection.filter(filterCallback);
-		}
-		var filtered = [];
-
-		collection.forEach(function(item) {
-			if (filterCallback(item)) {
-				filtered.push(item);
-			}
-		});
-
-		return filtered;
-	},
 	findIndex: Array.prototype.findIndex ?
 		function(array, callback, scope) {
 			return array.findIndex(callback, scope);

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -54,7 +54,7 @@ export default {
 		}
 		var filtered = [];
 
-		coreHelpers.each(collection, function(item) {
+		collection.forEach(function(item) {
 			if (filterCallback(item)) {
 				filtered.push(item);
 			}

--- a/src/index.js
+++ b/src/index.js
@@ -22,8 +22,9 @@ Chart.Ticks = require('./core/core.ticks');
 Chart.Tooltip = require('./core/core.tooltip');
 
 // Register built-in scales
-var scales = require('./scales');
-Chart.helpers.each(scales, function(scale, type) {
+const scales = require('./scales');
+Object.keys(scales).forEach(function(type) {
+	const scale = scales[type];
 	Chart.scaleService.registerScaleType(type, scale, scale._defaults);
 });
 

--- a/src/platforms/platform.dom.js
+++ b/src/platforms/platform.dom.js
@@ -216,7 +216,7 @@ function watchForRender(node, handler) {
 		}
 	};
 
-	helpers.each(ANIMATION_START_EVENTS, function(type) {
+	ANIMATION_START_EVENTS.forEach(function(type) {
 		addListener(node, type, proxy);
 	});
 
@@ -235,7 +235,7 @@ function unwatchForRender(node) {
 	var proxy = expando.renderProxy;
 
 	if (proxy) {
-		helpers.each(ANIMATION_START_EVENTS, function(type) {
+		ANIMATION_START_EVENTS.forEach(function(type) {
 			removeListener(node, type, proxy);
 		});
 
@@ -382,14 +382,14 @@ module.exports = {
 	},
 
 	releaseContext: function(context) {
-		var canvas = context.canvas;
+		const canvas = context.canvas;
 		if (!canvas[EXPANDO_KEY]) {
 			return;
 		}
 
-		var initial = canvas[EXPANDO_KEY].initial;
+		const initial = canvas[EXPANDO_KEY].initial;
 		['height', 'width'].forEach(function(prop) {
-			var value = initial[prop];
+			const value = initial[prop];
 			if (helpers.isNullOrUndef(value)) {
 				canvas.removeAttribute(prop);
 			} else {
@@ -397,8 +397,9 @@ module.exports = {
 			}
 		});
 
-		helpers.each(initial.style || {}, function(value, key) {
-			canvas.style[key] = value;
+		const style = initial.style || {};
+		Object.keys(style).forEach(function(key) {
+			canvas.style[key] = style[key];
 		});
 
 		// The canvas render size might have been changed (and thus the state stack discarded),

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -274,7 +274,7 @@ class Legend extends Element {
 			ctx.textAlign = 'left';
 			ctx.textBaseline = 'middle';
 
-			helpers.each(me.legendItems, function(legendItem, i) {
+			me.legendItems.forEach(function(legendItem, i) {
 				var boxWidth = getBoxWidth(labelOpts, fontSize);
 				var width = boxWidth + (fontSize / 2) + ctx.measureText(legendItem.text).width;
 
@@ -304,7 +304,7 @@ class Legend extends Element {
 			var currentColWidth = 0;
 			var currentColHeight = 0;
 
-			helpers.each(me.legendItems, function(legendItem, i) {
+			me.legendItems.forEach(function(legendItem, i) {
 				var boxWidth = getBoxWidth(labelOpts, fontSize);
 				var itemWidth = boxWidth + (fontSize / 2) + ctx.measureText(legendItem.text).width;
 
@@ -471,7 +471,7 @@ class Legend extends Element {
 		helpers.rtl.overrideTextDirection(me.ctx, opts.textDirection);
 
 		var itemHeight = fontSize + labelOpts.padding;
-		helpers.each(me.legendItems, function(legendItem, i) {
+		me.legendItems.forEach(function(legendItem, i) {
 			var textWidth = ctx.measureText(legendItem.text).width;
 			var width = boxWidth + (fontSize / 2) + textWidth;
 			var x = cursor.x;

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -448,7 +448,7 @@ class RadialLinearScale extends LinearScaleBase {
 		}
 
 		if (gridLineOpts.display) {
-			helpers.each(me.ticks, function(tick, index) {
+			me.ticks.forEach(function(tick, index) {
 				if (index !== 0) {
 					offset = me.getDistanceFromCenterForValue(me._tickValues[index]);
 					drawRadiusLine(me, gridLineOpts, offset, index);
@@ -503,7 +503,7 @@ class RadialLinearScale extends LinearScaleBase {
 		ctx.textAlign = 'center';
 		ctx.textBaseline = 'middle';
 
-		helpers.each(me.ticks, function(tick, index) {
+		me.ticks.forEach(function(tick, index) {
 			if (index === 0 && !opts.reverse) {
 				return;
 			}

--- a/test/specs/core.helpers.tests.js
+++ b/test/specs/core.helpers.tests.js
@@ -11,7 +11,6 @@ describe('Core helper tests', function() {
 		var callback = function(item) {
 			return item > 2;
 		};
-		expect(helpers.where(data, callback)).toEqual([6, 7]);
 		expect(helpers.findNextWhere(data, callback)).toEqual(6);
 		expect(helpers.findNextWhere(data, callback, 2)).toBe(7);
 		expect(helpers.findNextWhere(data, callback, 4)).toBe(undefined);


### PR DESCRIPTION
We can generally call `forEach` instead of `helpers.each`. This replaces about half the calls to `helpers.each`. I hope we could eventually get rid of it entirely