### PR TITLE
Remove outdated element tests

### DIFF
--- a/test/specs/element.arc.tests.js
+++ b/test/specs/element.arc.tests.js
@@ -1,17 +1,6 @@
 // Test the rectangle element
 
 describe('Arc element tests', function() {
-	it ('Should be constructed', function() {
-		var arc = new Chart.elements.Arc({
-			_datasetIndex: 2,
-			_index: 1
-		});
-
-		expect(arc).not.toBe(undefined);
-		expect(arc._datasetIndex).toBe(2);
-		expect(arc._index).toBe(1);
-	});
-
 	it ('should determine if in range', function() {
 		// Mock out the arc as if the controller put it there
 		var arc = new Chart.elements.Arc({

--- a/test/specs/element.point.tests.js
+++ b/test/specs/element.point.tests.js
@@ -1,17 +1,6 @@
 describe('Chart.elements.Point', function() {
 	describe('auto', jasmine.fixture.specs('element.point'));
 
-	it ('Should be constructed', function() {
-		var point = new Chart.elements.Point({
-			_datasetIndex: 2,
-			_index: 1
-		});
-
-		expect(point).not.toBe(undefined);
-		expect(point._datasetIndex).toBe(2);
-		expect(point._index).toBe(1);
-	});
-
 	it ('Should correctly identify as in range', function() {
 		// Mock out the point as if we were made by the controller
 		var point = new Chart.elements.Point({

--- a/test/specs/element.rectangle.tests.js
+++ b/test/specs/element.rectangle.tests.js
@@ -1,17 +1,6 @@
 // Test the rectangle element
 
 describe('Rectangle element tests', function() {
-	it('Should be constructed', function() {
-		var rectangle = new Chart.elements.Rectangle({
-			_datasetIndex: 2,
-			_index: 1
-		});
-
-		expect(rectangle).not.toBe(undefined);
-		expect(rectangle._datasetIndex).toBe(2);
-		expect(rectangle._index).toBe(1);
-	});
-
 	it('Should correctly identify as in range', function() {
 		var rectangle = new Chart.elements.Rectangle({
 			base: 0,


### PR DESCRIPTION
`_datasetIndex` and `_index` were removed, so these tests no longer make sense. Plus tons of other tests end up testing element construction indirectly