### PR TITLE
Use ticks consistently

### DIFF
--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -53,7 +53,7 @@ function computeMinSampleSize(scale, pixels) {
 		min = Math.min(min, Math.abs(pixels[i] - pixels[i - 1]));
 	}
 
-	for (i = 0, ilen = scale.getTicks().length; i < ilen; ++i) {
+	for (i = 0, ilen = scale.ticks.length; i < ilen; ++i) {
 		curr = scale.getPixelForTick(i);
 		min = i > 0 ? Math.min(min, Math.abs(curr - prev)) : min;
 		prev = curr;

--- a/src/scales/scale.category.js
+++ b/src/scales/scale.category.js
@@ -78,7 +78,7 @@ class CategoryScale extends Scale {
 		if (index < 0 || index > ticks.length - 1) {
 			return null;
 		}
-		return this.getPixelForValue(index * me._numLabels / ticks.length + this.min);
+		return me.getPixelForValue(index * me._numLabels / ticks.length + me.min);
 	}
 
 	getValueForPixel(pixel) {

--- a/src/scales/scale.linear.js
+++ b/src/scales/scale.linear.js
@@ -63,11 +63,11 @@ class LinearScale extends LinearScaleBase {
 	}
 
 	getPixelForTick(index) {
-		var ticks = this._tickValues;
+		const ticks = this.ticks;
 		if (index < 0 || index > ticks.length - 1) {
 			return null;
 		}
-		return this.getPixelForValue(ticks[index]);
+		return this.getPixelForValue(ticks[index].value);
 	}
 }
 

--- a/src/scales/scale.linearbase.js
+++ b/src/scales/scale.linearbase.js
@@ -231,15 +231,9 @@ class LinearScaleBase extends Scale {
 		return ticks;
 	}
 
-	generateTickLabels(ticks) {
-		var me = this;
-		me._tickValues = ticks.map(t => t.value);
-		Scale.prototype.generateTickLabels.call(me, ticks);
-	}
-
 	_configure() {
 		var me = this;
-		var ticks = me.getTicks();
+		var ticks = me.ticks;
 		var start = me.min;
 		var end = me.max;
 		var offset;

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -450,7 +450,7 @@ class RadialLinearScale extends LinearScaleBase {
 		if (gridLineOpts.display) {
 			me.ticks.forEach(function(tick, index) {
 				if (index !== 0) {
-					offset = me.getDistanceFromCenterForValue(me._tickValues[index]);
+					offset = me.getDistanceFromCenterForValue(me.ticks[index].value);
 					drawRadiusLine(me, gridLineOpts, offset, index);
 				}
 			});
@@ -508,7 +508,7 @@ class RadialLinearScale extends LinearScaleBase {
 				return;
 			}
 
-			offset = me.getDistanceFromCenterForValue(me._tickValues[index]);
+			offset = me.getDistanceFromCenterForValue(me.ticks[index].value);
 
 			if (tickOpts.showLabelBackdrop) {
 				width = ctx.measureText(tick.label).width;

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -703,10 +703,11 @@ class TimeScale extends Scale {
 	}
 
 	getPixelForTick(index) {
-		const ticks = this.getTicks();
-		return index >= 0 && index < ticks.length ?
-			this.getPixelForValue(ticks[index].value) :
-			null;
+		const ticks = this.ticks;
+		if (index < 0 || index > ticks.length - 1) {
+			return null;
+		}
+		return this.getPixelForValue(ticks[index].value);
 	}
 
 	getValueForPixel(pixel) {


### PR DESCRIPTION
This fixes a similar bug in `linear` that was already fixed for `category`.

When `autoSkip` does its job (need to make the window quite small to get the effect):
![image](https://user-images.githubusercontent.com/27971921/71583066-8db55400-2b15-11ea-9c6e-a9fd2040331b.png)
