### PR TITLE
Remove unnecessary method argument

### DIFF
--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -106,7 +106,6 @@ Animation system was completely rewritten in Chart.js v3. Each property can now 
 
 * `Chart.Animation.animationObject` was renamed to `Chart.Animation`
 * `Chart.Animation.chartInstance` was renamed to `Chart.Animation.chart`
-* `DatasetController.updateElement` was renamed to `DatasetController.updateElements`
 * `helpers._decimalPlaces` was renamed to `helpers.math._decimalPlaces`
 * `helpers.almostEquals` was renamed to `helpers.math.almostEquals`
 * `helpers.almostWhole` was renamed to `helpers.math.almostWhole`
@@ -168,6 +167,7 @@ Animation system was completely rewritten in Chart.js v3. Each property can now 
 
 ##### Dataset Controllers
 
+* `updateElement` was replaced with `updateElements` now taking the elements to update, the `start` index, and `mode`
 * `setHoverStyle` and `removeHoverStyle` now additionally take the `datasetIndex` and `index`
 
 #### Interactions

--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -277,10 +277,10 @@ module.exports = DatasetController.extend({
 		const me = this;
 		const rects = me._cachedMeta.data;
 
-		me.updateElements(rects, 0, rects.length, mode);
+		me.updateElements(rects, 0, mode);
 	},
 
-	updateElements: function(rectangles, start, count, mode) {
+	updateElements: function(rectangles, start, mode) {
 		const me = this;
 		const reset = mode === 'reset';
 		const vscale = me._cachedMeta.vScale;
@@ -293,10 +293,11 @@ module.exports = DatasetController.extend({
 
 		let i;
 
-		for (i = 0; i < start + count; i++) {
-			const options = me._resolveDataElementOptions(i, mode);
-			const vpixels = me.calculateBarValuePixels(i, options);
-			const ipixels = me.calculateBarIndexPixels(i, ruler, options);
+		for (i = 0; i < rectangles.length; i++) {
+			const index = start + i;
+			const options = me._resolveDataElementOptions(index, mode);
+			const vpixels = me.calculateBarValuePixels(index, options);
+			const ipixels = me.calculateBarIndexPixels(index, ruler, options);
 
 			const properties = {
 				horizontal,
@@ -316,7 +317,7 @@ module.exports = DatasetController.extend({
 			if (includeOptions) {
 				properties.options = options;
 			}
-			me._updateElement(rectangles[i], i, properties, mode);
+			me._updateElement(rectangles[i], index, properties, mode);
 		}
 
 		me._updateSharedOptions(sharedOptions, mode);

--- a/src/controllers/controller.bubble.js
+++ b/src/controllers/controller.bubble.js
@@ -114,13 +114,13 @@ module.exports = DatasetController.extend({
 		const points = me._cachedMeta.data;
 
 		// Update Points
-		me.updateElements(points, 0, points.length, mode);
+		me.updateElements(points, 0, mode);
 	},
 
 	/**
 	 * @protected
 	 */
-	updateElements: function(points, start, count, mode) {
+	updateElements: function(points, start, mode) {
 		const me = this;
 		const reset = mode === 'reset';
 		const {xScale, yScale} = me._cachedMeta;
@@ -129,9 +129,10 @@ module.exports = DatasetController.extend({
 		const includeOptions = me._includeOptions(mode, sharedOptions);
 		let i;
 
-		for (i = start; i < start + count; i++) {
+		for (i = 0; i < points.length; i++) {
 			const point = points[i];
-			const parsed = !reset && me._getParsed(i);
+			const index = start + i;
+			const parsed = !reset && me._getParsed(index);
 			const x = reset ? xScale.getPixelForDecimal(0.5) : xScale.getPixelForValue(parsed[xScale.id]);
 			const y = reset ? yScale.getBasePixel() : yScale.getPixelForValue(parsed[yScale.id]);
 			const properties = {
@@ -141,7 +142,7 @@ module.exports = DatasetController.extend({
 			};
 
 			if (includeOptions) {
-				properties.options = i === start ? firstOpts
+				properties.options = i === 0 ? firstOpts
 					: me._resolveDataElementOptions(i, mode);
 
 				if (reset) {
@@ -149,7 +150,7 @@ module.exports = DatasetController.extend({
 				}
 			}
 
-			me._updateElement(point, i, properties, mode);
+			me._updateElement(point, index, properties, mode);
 		}
 
 		me._updateSharedOptions(sharedOptions, mode);

--- a/src/controllers/controller.doughnut.js
+++ b/src/controllers/controller.doughnut.js
@@ -224,6 +224,16 @@ module.exports = DatasetController.extend({
 		me.updateElements(arcs, 0, mode);
 	},
 
+	/**
+	 * @private
+	 */
+	_circumference: function(i, reset) {
+		const me = this;
+		const opts = me.chart.options;
+		const meta = me._cachedMeta;
+		return reset && opts.animation.animateRotate ? 0 : meta.data[i].hidden ? 0 : me.calculateCircumference(meta._parsed[i] * opts.circumference / DOUBLE_PI);
+	},
+
 	updateElements: function(arcs, start, mode) {
 		const me = this;
 		const reset = mode === 'reset';
@@ -233,20 +243,20 @@ module.exports = DatasetController.extend({
 		const animationOpts = opts.animation;
 		const centerX = (chartArea.left + chartArea.right) / 2;
 		const centerY = (chartArea.top + chartArea.bottom) / 2;
-		const meta = me.getMeta();
 		const innerRadius = reset && animationOpts.animateScale ? 0 : me.innerRadius;
 		const outerRadius = reset && animationOpts.animateScale ? 0 : me.outerRadius;
 		let startAngle = opts.rotation;
 		let i;
 
-		for (i = 0; i < start + arcs.length; ++i) {
-			const arc = this._cachedMeta.data[i];
-			const circumference = reset && animationOpts.animateRotate ? 0 : arc.hidden ? 0 : me.calculateCircumference(meta._parsed[i] * opts.circumference / DOUBLE_PI);
+		for (i = 0; i < start; ++i) {
+			startAngle += me._circumference(i, reset);
+		}
+
+		for (i = 0; i < arcs.length; ++i) {
+			const index = start + i;
+			const circumference = me._circumference(index, reset);
+			const arc = arcs[i];
 			const options = arc._options || {};
-			if (i < start) {
-				startAngle += circumference;
-				continue;
-			}
 			const properties = {
 				x: centerX + chart.offsetX,
 				y: centerY + chart.offsetY,
@@ -259,7 +269,7 @@ module.exports = DatasetController.extend({
 			};
 			startAngle += circumference;
 
-			me._updateElement(arc, i, properties, mode);
+			me._updateElement(arc, index, properties, mode);
 		}
 	},
 

--- a/src/controllers/controller.doughnut.js
+++ b/src/controllers/controller.doughnut.js
@@ -221,10 +221,10 @@ module.exports = DatasetController.extend({
 		me.outerRadius = chart.outerRadius - chart.radiusLength * me._getRingWeightOffset(me.index);
 		me.innerRadius = Math.max(me.outerRadius - chart.radiusLength * chartWeight, 0);
 
-		me.updateElements(arcs, 0, arcs.length, mode);
+		me.updateElements(arcs, 0, mode);
 	},
 
-	updateElements: function(arcs, start, count, mode) {
+	updateElements: function(arcs, start, mode) {
 		const me = this;
 		const reset = mode === 'reset';
 		const chart = me.chart;
@@ -239,8 +239,8 @@ module.exports = DatasetController.extend({
 		let startAngle = opts.rotation;
 		let i;
 
-		for (i = 0; i < start + count; ++i) {
-			const arc = arcs[i];
+		for (i = 0; i < start + arcs.length; ++i) {
+			const arc = this._cachedMeta.data[i];
 			const circumference = reset && animationOpts.animateRotate ? 0 : arc.hidden ? 0 : me.calculateCircumference(meta._parsed[i] * opts.circumference / DOUBLE_PI);
 			const options = arc._options || {};
 			if (i < start) {

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -88,11 +88,11 @@ module.exports = DatasetController.extend({
 
 		// Update Points
 		if (meta.visible) {
-			me.updateElements(points, 0, points.length, mode);
+			me.updateElements(points, 0, mode);
 		}
 	},
 
-	updateElements: function(points, start, count, mode) {
+	updateElements: function(points, start, mode) {
 		const me = this;
 		const reset = mode === 'reset';
 		const {xScale, yScale, _stacked} = me._cachedMeta;
@@ -101,9 +101,10 @@ module.exports = DatasetController.extend({
 		const includeOptions = me._includeOptions(mode, sharedOptions);
 		let i;
 
-		for (i = start; i < start + count; ++i) {
+		for (i = 0; i < points.length; ++i) {
+			const index = start + i;
 			const point = points[i];
-			const parsed = me._getParsed(i);
+			const parsed = me._getParsed(index);
 			const x = xScale.getPixelForValue(parsed[xScale.id]);
 			const y = reset ? yScale.getBasePixel() : yScale.getPixelForValue(_stacked ? me._applyStack(yScale, parsed) : parsed[yScale.id]);
 			const properties = {
@@ -113,11 +114,11 @@ module.exports = DatasetController.extend({
 			};
 
 			if (includeOptions) {
-				properties.options = i === start ? firstOpts
-					: me._resolveDataElementOptions(i, mode);
+				properties.options = i === 0 ? firstOpts
+					: me._resolveDataElementOptions(index, mode);
 			}
 
-			me._updateElement(point, i, properties, mode);
+			me._updateElement(point, index, properties, mode);
 		}
 
 		me._updateSharedOptions(sharedOptions, mode);

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -144,7 +144,7 @@ module.exports = DatasetController.extend({
 
 		me._updateRadius();
 
-		me.updateElements(arcs, 0, arcs.length, mode);
+		me.updateElements(arcs, 0, mode);
 	},
 
 	/**
@@ -165,7 +165,7 @@ module.exports = DatasetController.extend({
 		me.innerRadius = me.outerRadius - chart.radiusLength;
 	},
 
-	updateElements: function(arcs, start, count, mode) {
+	updateElements: function(arcs, start, mode) {
 		const me = this;
 		const reset = mode === 'reset';
 		const chart = me.chart;
@@ -184,11 +184,12 @@ module.exports = DatasetController.extend({
 		for (i = 0; i < start; ++i) {
 			angle += me._computeAngle(i);
 		}
-		for (; i < start + count; i++) {
+		for (i = 0; i < arcs.length; i++) {
 			const arc = arcs[i];
+			const index = start + i;
 			let startAngle = angle;
-			let endAngle = angle + me._computeAngle(i);
-			let outerRadius = arc.hidden ? 0 : scale.getDistanceFromCenterForValue(dataset.data[i]);
+			let endAngle = angle + me._computeAngle(index);
+			let outerRadius = arc.hidden ? 0 : scale.getDistanceFromCenterForValue(dataset.data[index]);
 			angle = endAngle;
 
 			if (reset) {
@@ -208,10 +209,10 @@ module.exports = DatasetController.extend({
 				outerRadius,
 				startAngle,
 				endAngle,
-				options: me._resolveDataElementOptions(i)
+				options: me._resolveDataElementOptions(index)
 			};
 
-			me._updateElement(arc, i, properties, mode);
+			me._updateElement(arc, index, properties, mode);
 		}
 	},
 

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -86,10 +86,10 @@ module.exports = DatasetController.extend({
 	},
 
 	update: function(mode) {
-		var me = this;
-		var meta = me._cachedMeta;
-		var line = meta.dataset;
-		var points = meta.data || [];
+		const me = this;
+		const meta = me._cachedMeta;
+		const line = meta.dataset;
+		const points = meta.data || [];
 
 		const properties = {
 			_children: points,
@@ -100,22 +100,23 @@ module.exports = DatasetController.extend({
 		me._updateElement(line, undefined, properties, mode);
 
 		// Update Points
-		me.updateElements(points, 0, points.length, mode);
+		me.updateElements(points, 0, mode);
 
 		line.updateControlPoints(me.chart.chartArea);
 	},
 
-	updateElements: function(points, start, count, mode) {
+	updateElements: function(points, start, mode) {
 		const me = this;
 		const dataset = me.getDataset();
 		const scale = me.chart.scales.r;
 		const reset = mode === 'reset';
-		var i;
+		let i;
 
-		for (i = start; i < start + count; i++) {
+		for (i = 0; i < points.length; i++) {
 			const point = points[i];
-			const options = me._resolveDataElementOptions(i);
-			const pointPosition = scale.getPointPositionForValue(i, dataset.data[i]);
+			const index = start + i;
+			const options = me._resolveDataElementOptions(index);
+			const pointPosition = scale.getPointPositionForValue(index, dataset.data[index]);
 
 			const x = reset ? scale.xCenter : pointPosition.x;
 			const y = reset ? scale.yCenter : pointPosition.y;
@@ -127,7 +128,7 @@ module.exports = DatasetController.extend({
 				options,
 			};
 
-			me._updateElement(point, i, properties, mode);
+			me._updateElement(point, index, properties, mode);
 		}
 	},
 
@@ -135,10 +136,10 @@ module.exports = DatasetController.extend({
 	 * @private
 	 */
 	_resolveDatasetElementOptions: function() {
-		var me = this;
-		var config = me._config;
-		var options = me.chart.options;
-		var values = DatasetController.prototype._resolveDatasetElementOptions.apply(me, arguments);
+		const me = this;
+		const config = me._config;
+		const options = me.chart.options;
+		const values = DatasetController.prototype._resolveDatasetElementOptions.apply(me, arguments);
 
 		values.spanGaps = valueOrDefault(config.spanGaps, options.spanGaps);
 		values.tension = valueOrDefault(config.lineTension, options.elements.line.tension);

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -1063,7 +1063,7 @@ helpers.extend(DatasetController.prototype, {
 		}
 		me._parse(start, count);
 
-		me.updateElements(data, start, count, 'reset');
+		me.updateElements(elements, start, 'reset');
 	},
 
 	/**


### PR DESCRIPTION
Pass in just the elements to be updated rather than all elements, so `count` is no longer required

This allows me to make tooltips work for `fastline` by creating just the element needed for the tooltip at that time