### PR TITLE
Determine if data is sorted

### DIFF
--- a/docs/general/data-structures.md
+++ b/docs/general/data-structures.md
@@ -25,7 +25,7 @@ data: [{x:'2016-12-25', y:20}, {x:'2016-12-26', y:10}]
 data: [{x:'Sales', y:20}, {x:'Revenue', y:10}]
 ```
 
-This is also the internal format used for parsed data. Property names are matched to scale-id. In this mode, parsing can be disabled by specifying `parsing: false` at chart options or dataset. If parsing is disabled, data must be in the formats the associated chart type and scales use internally.
+This is also the internal format used for parsed data. Property names are matched to scale-id. In this mode, parsing can be disabled by specifying `parsing: false` at chart options or dataset. If parsing is disabled, data must be sorted and in the formats the associated chart type and scales use internally.
 
 ## Object
 

--- a/docs/general/performance.md
+++ b/docs/general/performance.md
@@ -28,6 +28,10 @@ new Chart(ctx, {
 });
 ```
 
+## Provide ordered data
+
+If the data is unordered, Chart.js needs to sort it. This can be slow in some cases, so its always a good idea to provide ordered data.
+
 ## Specify `min` and `max` for scales
 
 If you specify the `min` and `max`, the scale does not have to compute the range from the data.

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -817,7 +817,8 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 				order: dataset.order || 0,
 				index: datasetIndex,
 				_dataset: dataset,
-				_parsed: []
+				_parsed: [],
+				_sorted: true
 			};
 		}
 

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -818,7 +818,7 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 				index: datasetIndex,
 				_dataset: dataset,
 				_parsed: [],
-				_sorted: true
+				_sorted: false
 			};
 		}
 

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -478,8 +478,10 @@ helpers.extend(DatasetController.prototype, {
 		const me = this;
 		const {_cachedMeta: meta, _data: data} = me;
 		const {iScale, vScale, _stacked} = meta;
+		const iScaleId = iScale.id;
+		let sorted = meta._sorted;
 		let offset = 0;
-		let i, parsed;
+		let i, parsed, cur, prev;
 
 		if (me._parsing === false) {
 			meta._parsed = data;
@@ -493,8 +495,15 @@ helpers.extend(DatasetController.prototype, {
 			}
 
 			for (i = 0; i < count; ++i) {
-				meta._parsed[i + start] = parsed[i + offset];
+				meta._parsed[i + start] = cur = parsed[i + offset];
+				if (sorted) {
+					if (i > 0 && cur[iScaleId] < prev[iScaleId]) {
+						sorted = false;
+					}
+					prev = cur;
+				}
 			}
+			meta._sorted = sorted;
 		}
 
 		if (_stacked) {

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -479,12 +479,17 @@ helpers.extend(DatasetController.prototype, {
 		const {_cachedMeta: meta, _data: data} = me;
 		const {iScale, vScale, _stacked} = meta;
 		const iScaleId = iScale.id;
-		let sorted = meta._sorted;
-		let offset = 0;
+		let sorted = true;
 		let i, parsed, cur, prev;
+
+		if (start > 0) {
+			sorted = meta._sorted;
+			prev = meta._parsed[start - 1];
+		}
 
 		if (me._parsing === false) {
 			meta._parsed = data;
+			meta._sorted = true;
 		} else {
 			if (helpers.isArray(data[start])) {
 				parsed = me._parseArrayData(meta, data, start, count);
@@ -494,10 +499,11 @@ helpers.extend(DatasetController.prototype, {
 				parsed = me._parsePrimitiveData(meta, data, start, count);
 			}
 
+
 			for (i = 0; i < count; ++i) {
-				meta._parsed[i + start] = cur = parsed[i + offset];
+				meta._parsed[i + start] = cur = parsed[i];
 				if (sorted) {
-					if (i > 0 && cur[iScaleId] < prev[iScaleId]) {
+					if (prev && cur[iScaleId] < prev[iScaleId]) {
 						sorted = false;
 					}
 					prev = cur;
@@ -511,9 +517,7 @@ helpers.extend(DatasetController.prototype, {
 		}
 
 		iScale._invalidateCaches();
-		if (vScale !== iScale) {
-			vScale._invalidateCaches();
-		}
+		vScale._invalidateCaches();
 	},
 
 	/**


### PR DESCRIPTION
Add a `_sorted` boolean to dataset meta, indicating if the data is sorted by index scale. This can be used to skip sorting of timestamps, for example.

We are assuming `true` when parsing is disabled.

Did not want to go further, before checking opinions on this.