### PR TITLE
Title alignment options

### DIFF
--- a/docs/configuration/title.md
+++ b/docs/configuration/title.md
@@ -7,6 +7,7 @@ The title configuration is passed into the `options.title` namespace. The global
 
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
+| `align` | `string` | `'center'` | Alignment of the title. [more...](#align)
 | `display` | `boolean` | `false` | Is the title shown?
 | `position` | `string` | `'top'` | Position of title. [more...](#position)
 | `fontSize` | `number` | `12` | Font size.
@@ -23,6 +24,14 @@ Possible title position values are:
 * `'left'`
 * `'bottom'`
 * `'right'`
+
+## Align
+
+Alignment of the title. Options are:
+
+* `'start'`
+* `'center'`
+* `'end'`
 
 ## Example Usage
 

--- a/samples/samples.js
+++ b/samples/samples.js
@@ -168,6 +168,12 @@
 			path: 'legend/callbacks.html'
 		}]
 	}, {
+		title: 'Title',
+		items: [{
+			title: 'Alignment',
+			path: 'title/alignment.html'
+		}]
+	}, {
 		title: 'Tooltip',
 		items: [{
 			title: 'Positioning',

--- a/samples/title/alignment.html
+++ b/samples/title/alignment.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html>
+
+<head>
+	<title>Legend Positions</title>
+	<script src="../../dist/Chart.min.js"></script>
+	<script src="../utils.js"></script>
+	<style>
+		canvas {
+			-moz-user-select: none;
+			-webkit-user-select: none;
+			-ms-user-select: none;
+		}
+		.chart-container {
+			width: 500px;
+			margin-left: 40px;
+			margin-right: 40px;
+		}
+		.container {
+			display: flex;
+			flex-direction: row;
+			flex-wrap: wrap;
+			justify-content: center;
+		}
+	</style>
+</head>
+
+<body>
+	<div class="container">
+		<div class="chart-container">
+			<canvas id="chart-title-top-start"></canvas>
+		</div>
+		<div class="chart-container">
+			<canvas id="chart-title-top-center"></canvas>
+		</div>
+		<div class="chart-container">
+			<canvas id="chart-title-top-end"></canvas>
+		</div>
+		<div class="chart-container">
+			<canvas id="chart-title-left-start"></canvas>
+		</div>
+		<div class="chart-container">
+			<canvas id="chart-title-left-center"></canvas>
+		</div>
+		<div class="chart-container">
+			<canvas id="chart-title-left-end"></canvas>
+		</div>
+	</div>
+	<script>
+		var color = Chart.helpers.color;
+		function createConfig(titlePosition, titleAlignment, colorName) {
+			return {
+				type: 'line',
+				data: {
+					labels: ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
+					datasets: [{
+						label: 'My First dataset',
+						data: [
+							randomScalingFactor(),
+							randomScalingFactor(),
+							randomScalingFactor(),
+							randomScalingFactor(),
+							randomScalingFactor(),
+							randomScalingFactor(),
+							randomScalingFactor()
+						],
+						backgroundColor: color(window.chartColors[colorName]).alpha(0.5).rgbString(),
+						borderColor: window.chartColors[colorName],
+						borderWidth: 1
+					}]
+				},
+				options: {
+					responsive: true,
+					legend: {
+						display: false,
+					},
+					scales: {
+						x: {
+							display: true,
+							scaleLabel: {
+								display: true,
+								labelString: 'Month'
+							}
+						},
+						y: {
+							display: true,
+							scaleLabel: {
+								display: true,
+								labelString: 'Value'
+							}
+						}
+					},
+					title: {
+						align: titleAlignment,
+						display: true,
+						position: titlePosition,
+						text: 'Title Position: ' + titlePosition + ', Align: ' + titleAlignment
+					}
+				}
+			};
+		}
+
+		window.onload = function() {
+			[{
+				id: 'chart-title-top-start',
+				titleAlignment: 'start',
+				titlePosition: 'top',
+				color: 'red'
+			}, {
+				id: 'chart-title-top-center',
+				titleAlignment: 'center',
+				titlePosition: 'top',
+				color: 'orange'
+			}, {
+				id: 'chart-title-top-end',
+				titleAlignment: 'end',
+				titlePosition: 'top',
+				color: 'yellow'
+			}, {
+				id: 'chart-title-left-start',
+				titleAlignment: 'start',
+				titlePosition: 'left',
+				color: 'green'
+			}, {
+				id: 'chart-title-left-center',
+				titleAlignment: 'center',
+				titlePosition: 'left',
+				color: 'blue'
+			}, {
+				id: 'chart-title-left-end',
+				titleAlignment: 'end',
+				titlePosition: 'left',
+				color: 'purple'
+			}].forEach(function(details) {
+				var ctx = document.getElementById(details.id).getContext('2d');
+				var config = createConfig(details.titlePosition, details.titleAlignment, details.color);
+				new Chart(ctx, config);
+			});
+		};
+	</script>
+</body>
+
+</html>

--- a/samples/title/alignment.html
+++ b/samples/title/alignment.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-	<title>Legend Positions</title>
+	<title>Title Positions & Alignment</title>
 	<script src="../../dist/Chart.min.js"></script>
 	<script src="../utils.js"></script>
 	<style>

--- a/src/plugins/plugin.title.js
+++ b/src/plugins/plugin.title.js
@@ -6,6 +6,7 @@ const helpers = require('../helpers/index');
 const layouts = require('../core/core.layouts');
 
 defaults._set('title', {
+	align: 'center',
 	display: false,
 	fontStyle: 'bold',
 	fullWidth: true,
@@ -128,35 +129,64 @@ class Title extends Element {
 
 	// Actually draw the title block on the canvas
 	draw() {
-		var me = this;
-		var ctx = me.ctx;
-		var opts = me.options;
+		const me = this;
+		const ctx = me.ctx;
+		const opts = me.options;
 
 		if (!opts.display) {
 			return;
 		}
 
-		var fontOpts = helpers.options._parseFont(opts);
-		var lineHeight = fontOpts.lineHeight;
-		var offset = lineHeight / 2 + me._padding.top;
-		var rotation = 0;
-		var top = me.top;
-		var left = me.left;
-		var bottom = me.bottom;
-		var right = me.right;
-		var maxWidth, titleX, titleY;
+		const fontOpts = helpers.options._parseFont(opts);
+		const lineHeight = fontOpts.lineHeight;
+		const offset = lineHeight / 2 + me._padding.top;
+		let rotation = 0;
+		const top = me.top;
+		const left = me.left;
+		const bottom = me.bottom;
+		const right = me.right;
+		let maxWidth, titleX, titleY;
+		let align;
 
 		ctx.fillStyle = helpers.valueOrDefault(opts.fontColor, defaults.fontColor); // render in correct colour
 		ctx.font = fontOpts.string;
 
 		// Horizontal
 		if (me.isHorizontal()) {
-			titleX = left + ((right - left) / 2); // midpoint of the width
+			switch (opts.align) {
+			case 'start':
+				titleX = left;
+				align = 'left';
+				break;
+			case 'end':
+				titleX = right;
+				align = 'right';
+				break;
+			default:
+				titleX = left + ((right - left) / 2);
+				align = 'center';
+				break;
+			}
+
 			titleY = top + offset;
 			maxWidth = right - left;
 		} else {
 			titleX = opts.position === 'left' ? left + offset : right - offset;
-			titleY = top + ((bottom - top) / 2);
+
+			switch (opts.align) {
+			case 'start':
+				titleY = opts.position === 'left' ? bottom : top;
+				align = 'left';
+				break;
+			case 'end':
+				titleY = opts.position === 'left' ? top : bottom;
+				align = 'right';
+				break;
+			default:
+				titleY = top + ((bottom - top) / 2);
+				align = 'center';
+				break;
+			}
 			maxWidth = bottom - top;
 			rotation = Math.PI * (opts.position === 'left' ? -0.5 : 0.5);
 		}
@@ -164,7 +194,7 @@ class Title extends Element {
 		ctx.save();
 		ctx.translate(titleX, titleY);
 		ctx.rotate(rotation);
-		ctx.textAlign = 'center';
+		ctx.textAlign = align;
 		ctx.textBaseline = 'middle';
 
 		var text = opts.text;

--- a/test/specs/plugin.title.tests.js
+++ b/test/specs/plugin.title.tests.js
@@ -5,6 +5,7 @@ var Title = Chart.plugins.getAll().find(p => p.id === 'title')._element;
 describe('Title block tests', function() {
 	it('Should have the correct default config', function() {
 		expect(Chart.defaults.title).toEqual({
+			align: 'center',
 			display: false,
 			position: 'top',
 			fullWidth: true,


### PR DESCRIPTION
Allows the title to be aligned `'start'`, `'center'`, or `'end'`.

Resoves #5334

![title-alignment](https://user-images.githubusercontent.com/6757853/71774367-22b3b500-2f3b-11ea-855b-e6be92a359fb.PNG)

