### PR TITLE
Internal data by axis instead of scale id

### DIFF
--- a/docs/general/data-structures.md
+++ b/docs/general/data-structures.md
@@ -25,7 +25,7 @@ data: [{x:'2016-12-25', y:20}, {x:'2016-12-26', y:10}]
 data: [{x:'Sales', y:20}, {x:'Revenue', y:10}]
 ```
 
-This is also the internal format used for parsed data. Property names are matched to scale-id. In this mode, parsing can be disabled by specifying `parsing: false` at chart options or dataset. If parsing is disabled, data must be sorted and in the formats the associated chart type and scales use internally.
+This is also the internal format used for parsed data. In this mode, parsing can be disabled by specifying `parsing: false` at chart options or dataset. If parsing is disabled, data must be sorted and in the formats the associated chart type and scales use internally.
 
 ## Object
 

--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -143,7 +143,7 @@ function parseFloatBar(arr, item, vScale, i) {
 
 	// Store `barEnd` (furthest away from origin) as parsed value,
 	// to make stacking straight forward
-	item[vScale.id] = barEnd;
+	item[vScale.axis] = barEnd;
 
 	item._custom = {
 		barStart: barStart,
@@ -166,12 +166,12 @@ function parseArrayOrPrimitive(meta, data, start, count) {
 	for (i = start, ilen = start + count; i < ilen; ++i) {
 		entry = data[i];
 		item = {};
-		item[iScale.id] = singleScale || iScale._parse(labels[i], i);
+		item[iScale.axis] = singleScale || iScale._parse(labels[i], i);
 
 		if (helpers.isArray(entry)) {
 			parseFloatBar(entry, item, vScale, i);
 		} else {
-			item[vScale.id] = vScale._parse(entry, i);
+			item[vScale.axis] = vScale._parse(entry, i);
 		}
 
 		parsed.push(item);
@@ -229,12 +229,12 @@ module.exports = DatasetController.extend({
 		for (i = start, ilen = start + count; i < ilen; ++i) {
 			obj = data[i];
 			item = {};
-			item[iScale.id] = iScale._parseObject(obj, iScale.axis, i);
+			item[iScale.axis] = iScale._parseObject(obj, iScale.axis, i);
 			value = obj[vProp];
 			if (helpers.isArray(value)) {
 				parseFloatBar(value, item, vScale, i);
 			} else {
-				item[vScale.id] = vScale._parseObject(obj, vProp, i);
+				item[vScale.axis] = vScale._parseObject(obj, vProp, i);
 			}
 			parsed.push(item);
 		}
@@ -252,10 +252,10 @@ module.exports = DatasetController.extend({
 		const custom = parsed._custom;
 		const value = custom
 			? '[' + custom.start + ', ' + custom.end + ']'
-			: '' + vScale.getLabelForValue(parsed[vScale.id]);
+			: '' + vScale.getLabelForValue(parsed[vScale.axis]);
 
 		return {
-			label: '' + iScale.getLabelForValue(parsed[iScale.id]),
+			label: '' + iScale.getLabelForValue(parsed[iScale.axis]),
 			value: value
 		};
 	},
@@ -393,7 +393,7 @@ module.exports = DatasetController.extend({
 		let i, ilen;
 
 		for (i = 0, ilen = meta.data.length; i < ilen; ++i) {
-			pixels.push(iScale.getPixelForValue(me._getParsed(i)[iScale.id]));
+			pixels.push(iScale.getPixelForValue(me._getParsed(i)[iScale.axis]));
 		}
 
 		return {
@@ -416,9 +416,9 @@ module.exports = DatasetController.extend({
 		const minBarLength = options.minBarLength;
 		const parsed = me._getParsed(index);
 		const custom = parsed._custom;
-		let value = parsed[vScale.id];
+		let value = parsed[vScale.axis];
 		let start = 0;
-		let length = meta._stacked ? me._applyStack(vScale, parsed) : parsed[vScale.id];
+		let length = meta._stacked ? me._applyStack(vScale, parsed) : parsed[vScale.axis];
 		let base, head, size;
 
 		if (length !== value) {
@@ -488,7 +488,7 @@ module.exports = DatasetController.extend({
 		helpers.canvas.clipArea(chart.ctx, chart.chartArea);
 
 		for (; i < ilen; ++i) {
-			if (!isNaN(me._getParsed(i)[vScale.id])) {
+			if (!isNaN(me._getParsed(i)[vScale.axis])) {
 				rects[i].draw(me._ctx);
 			}
 		}

--- a/src/controllers/controller.bubble.js
+++ b/src/controllers/controller.bubble.js
@@ -59,15 +59,13 @@ module.exports = DatasetController.extend({
 	 */
 	_parseObjectData: function(meta, data, start, count) {
 		const {xScale, yScale} = meta;
-		const xId = xScale.id;
-		const yId = yScale.id;
 		const parsed = [];
 		let i, ilen, item;
 		for (i = start, ilen = start + count; i < ilen; ++i) {
 			item = data[i];
 			parsed.push({
-				[xId]: xScale._parseObject(item, 'x', i),
-				[yId]: yScale._parseObject(item, 'y', i),
+				x: xScale._parseObject(item, 'x', i),
+				y: yScale._parseObject(item, 'y', i),
 				_custom: item && item.r && +item.r
 			});
 		}
@@ -96,8 +94,8 @@ module.exports = DatasetController.extend({
 		const meta = me._cachedMeta;
 		const {xScale, yScale} = meta;
 		const parsed = me._getParsed(index);
-		const x = xScale.getLabelForValue(parsed[xScale.id]);
-		const y = yScale.getLabelForValue(parsed[yScale.id]);
+		const x = xScale.getLabelForValue(parsed.x);
+		const y = yScale.getLabelForValue(parsed.y);
 		const r = parsed._custom;
 
 		return {
@@ -133,8 +131,8 @@ module.exports = DatasetController.extend({
 			const point = points[i];
 			const index = start + i;
 			const parsed = !reset && me._getParsed(index);
-			const x = reset ? xScale.getPixelForDecimal(0.5) : xScale.getPixelForValue(parsed[xScale.id]);
-			const y = reset ? yScale.getBasePixel() : yScale.getPixelForValue(parsed[yScale.id]);
+			const x = reset ? xScale.getPixelForDecimal(0.5) : xScale.getPixelForValue(parsed.x);
+			const y = reset ? yScale.getBasePixel() : yScale.getPixelForValue(parsed.y);
 			const properties = {
 				x,
 				y,

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -104,8 +104,8 @@ module.exports = DatasetController.extend({
 			const index = start + i;
 			const point = points[i];
 			const parsed = me._getParsed(index);
-			const x = xScale.getPixelForValue(parsed[xScale.id]);
-			const y = reset ? yScale.getBasePixel() : yScale.getPixelForValue(_stacked ? me._applyStack(yScale, parsed) : parsed[yScale.id]);
+			const x = xScale.getPixelForValue(parsed.x);
+			const y = reset ? yScale.getBasePixel() : yScale.getPixelForValue(_stacked ? me._applyStack(yScale, parsed) : parsed.y);
 			const properties = {
 				x,
 				y,

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -81,7 +81,7 @@ module.exports = DatasetController.extend({
 
 		return {
 			label: vScale._getLabels()[index],
-			value: '' + vScale.getLabelForValue(parsed[vScale.id])
+			value: '' + vScale.getLabelForValue(parsed[vScale.axis])
 		};
 	},
 

--- a/test/specs/core.datasetController.tests.js
+++ b/test/specs/core.datasetController.tests.js
@@ -118,6 +118,42 @@ describe('Chart.DatasetController', function() {
 		});
 	});
 
+	it('should parse data using correct scales', function() {
+		const data1 = [0, 1, 2, 3, 4, 5];
+		const data2 = ['a', 'b', 'c', 'd', 'a'];
+		const chart = acquireChart({
+			type: 'line',
+			data: {
+				datasets: [
+					{data: data1},
+					{data: data2, yAxisID: 'y2'}
+				]
+			},
+			options: {
+				scales: {
+					y: {
+						type: 'linear'
+					},
+					y2: {
+						type: 'category',
+						labels: ['a', 'b', 'c', 'd', 'e']
+					}
+				}
+			}
+		});
+
+		const meta1 = chart.getDatasetMeta(0);
+		const parsedYValues1 = meta1._parsed.map(p => p.y);
+		const meta2 = chart.getDatasetMeta(1);
+		const parsedYValues2 = meta2._parsed.map(p => p.y);
+
+		expect(meta1.data.length).toBe(6);
+		expect(parsedYValues1).toEqual(data1);
+
+		expect(meta2.data.length).toBe(5);
+		expect(parsedYValues2).toEqual([0, 1, 2, 3, 0]); // label indices
+	});
+
 	it('should synchronize metadata when data are inserted or removed and parsing is on', function() {
 		const data = [0, 1, 2, 3, 4, 5];
 		const chart = acquireChart({

--- a/test/specs/core.datasetController.tests.js
+++ b/test/specs/core.datasetController.tests.js
@@ -126,11 +126,19 @@ describe('Chart.DatasetController', function() {
 			data: {
 				datasets: [
 					{data: data1},
-					{data: data2, yAxisID: 'y2'}
+					{data: data2, xAxisID: 'x2', yAxisID: 'y2'}
 				]
 			},
 			options: {
 				scales: {
+					x: {
+						type: 'category',
+						labels: ['one', 'two', 'three', 'four', 'five', 'six']
+					},
+					x2: {
+						type: 'logarithmic',
+						labels: ['1', '10', '100', '1000', '2000']
+					},
 					y: {
 						type: 'linear'
 					},
@@ -143,14 +151,19 @@ describe('Chart.DatasetController', function() {
 		});
 
 		const meta1 = chart.getDatasetMeta(0);
+		const parsedXValues1 = meta1._parsed.map(p => p.x);
 		const parsedYValues1 = meta1._parsed.map(p => p.y);
-		const meta2 = chart.getDatasetMeta(1);
-		const parsedYValues2 = meta2._parsed.map(p => p.y);
 
 		expect(meta1.data.length).toBe(6);
+		expect(parsedXValues1).toEqual([0, 1, 2, 3, 4, 5]); // label indices
 		expect(parsedYValues1).toEqual(data1);
 
+		const meta2 = chart.getDatasetMeta(1);
+		const parsedXValues2 = meta2._parsed.map(p => p.x);
+		const parsedYValues2 = meta2._parsed.map(p => p.y);
+
 		expect(meta2.data.length).toBe(5);
+		expect(parsedXValues2).toEqual([1, 10, 100, 1000, 2000]); // logarithmic scale labels
 		expect(parsedYValues2).toEqual([0, 1, 2, 3, 0]); // label indices
 	});
 


### PR DESCRIPTION
Relevant part of `parseObjectData` after `babel`:
**pr**
```js
    for (i = 0, ilen = count; i < ilen; ++i) {
      index = i + start;
      item = data[index];
      parsed[i] = {
        x: xScale._parseObject(item, 'x', index),
        y: yScale._parseObject(item, 'y', index)
      };
    }
```
Locally run tests:
> 100 runs done in 15430ms. Average: 154ms, min: 92ms, max: 516ms, variation: 424ms
100 runs done in 16681ms. Average: 166ms, min: 87ms, max: 867ms, variation: 780ms

In plunker:
> 50 runs done in 6431ms. Average: 128ms, min: 87ms, max: 441ms, variation: 354ms

**master**
```js
    for (i = 0, ilen = count; i < ilen; ++i) {
      var _parsed$i3;

      index = i + start;
      item = data[index];
      parsed[i] = (_parsed$i3 = {}, _defineProperty(_parsed$i3, xId, xScale._parseObject(item, 'x', index)), _defineProperty(_parsed$i3, yId, yScale._parseObject(item, 'y', index)), _parsed$i3);
    }
```

Locally run tests:
> 100 runs done in 19970ms. Average: 199ms, min: 118ms, max: 539ms, variation: 421ms
100 runs done in 22556ms. Average: 225ms, min: 109ms, max: 863ms, variation: 754ms

In plunker:
> 50 runs done in 8775ms. Average: 175ms, min: 118ms, max: 461ms, variation: 343ms

[plunker](http://plnkr.co/edit/aBodGRLXczwwwixhJO52?preview&p=preview)

(all tests run on chrome 79)