### PR TITLE
Re-parse existing elements when data is replaced

### DIFF
--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -1058,6 +1058,10 @@ helpers.extend(DatasetController.prototype, {
 
 		if (numData > numMeta) {
 			me.insertElements(numMeta, numData - numMeta);
+			if (changed && numMeta) {
+				// insertElements parses the new elements. The old ones might need parsing too.
+				me._parse(0, numMeta);
+			}
 		} else if (numData < numMeta) {
 			meta.data.splice(numData, numMeta - numData);
 			meta._parsed.splice(numData, numMeta - numData);

--- a/test/specs/core.datasetController.tests.js
+++ b/test/specs/core.datasetController.tests.js
@@ -250,14 +250,22 @@ describe('Chart.DatasetController', function() {
 		var meta = chart.getDatasetMeta(0);
 
 		expect(meta.data.length).toBe(6);
+		expect(meta._parsed.map(p => p.y)).toEqual(data0);
 
 		chart.data.datasets[0].data = data1;
 		chart.update();
 
 		expect(meta.data.length).toBe(3);
+		expect(meta._parsed.map(p => p.y)).toEqual(data1);
 
-		data1.push(9, 10, 11);
+		data1.push(9);
+		expect(meta.data.length).toBe(4);
+
+		chart.data.datasets[0].data = data0;
+		chart.update();
+
 		expect(meta.data.length).toBe(6);
+		expect(meta._parsed.map(p => p.y)).toEqual(data0);
 	});
 
 	it('should re-synchronize metadata when data are unusually altered', function() {


### PR DESCRIPTION
Fix for a error I found while playing with financial sample, switching from year to second.

Todo:
- [x] regression test
