### PR TITLE
Improve calculation for number of ticks that can fit

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -884,7 +884,7 @@ class Scale extends Element {
 		const me = this;
 		const tickOpts = me.options.ticks;
 		const axisLength = me._length;
-		const ticksLimit = tickOpts.maxTicksLimit || axisLength / me._tickSize() + 1;
+		const ticksLimit = tickOpts.maxTicksLimit || axisLength / me._tickSize();
 		const majorIndices = tickOpts.major.enabled ? getMajorIndices(ticks) : [];
 		const numMajorIndices = majorIndices.length;
 		const first = majorIndices[0];

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -755,12 +755,9 @@ class TimeScale extends Scale {
 		const format = displayFormats[timeOpts.unit] || displayFormats.millisecond;
 		const exampleLabel = me._tickFormatFunction(exampleTime, 0, ticksFromTimestamps(me, [exampleTime], me._majorUnit), format);
 		const size = me._getLabelSize(exampleLabel);
-		let capacity = Math.floor(me.isHorizontal() ? me.width / size.w : me.height / size.h);
-
-		if (me.options.offset) {
-			capacity--;
-		}
-
+		// subtract 1 - if offset then there's one less label than tick
+		// if not offset then one half label padding is added to each end leaving room for one less label
+		const capacity = Math.floor(me.isHorizontal() ? me.width / size.w : me.height / size.h) - 1;
 		return capacity > 0 ? capacity : 1;
 	}
 }

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -1397,8 +1397,8 @@ describe('Time scale tests', function() {
 					this.chart = window.acquireChart({
 						type: 'line',
 						data: {
-							labels: ['2017', '2019', '2020', '2025', '2042'],
-							datasets: [{data: [0, 1, 2, 3, 4, 5]}]
+							labels: ['2017', '2019', '2020', '2025'],
+							datasets: [{data: [0, 1, 2, 3, 4]}]
 						},
 						options: {
 							scales: {
@@ -1421,7 +1421,7 @@ describe('Time scale tests', function() {
 					var scale = this.chart.scales.x;
 
 					expect(scale.getPixelForValue(moment('2017').valueOf())).toBeCloseToPixel(scale.left);
-					expect(scale.getPixelForValue(moment('2042').valueOf())).toBeCloseToPixel(scale.left + scale.width);
+					expect(scale.getPixelForValue(moment('2025').valueOf())).toBeCloseToPixel(scale.left + scale.width);
 				});
 
 				it ('should add offset from the edges if offset is true', function() {
@@ -1437,7 +1437,7 @@ describe('Time scale tests', function() {
 					var lastTickInterval = scale.getPixelForTick(numTicks - 1) - scale.getPixelForTick(numTicks - 2);
 
 					expect(scale.getPixelForValue(moment('2017').valueOf())).toBeCloseToPixel(scale.left + firstTickInterval / 2);
-					expect(scale.getPixelForValue(moment('2042').valueOf())).toBeCloseToPixel(scale.left + scale.width - lastTickInterval / 2);
+					expect(scale.getPixelForValue(moment('2025').valueOf())).toBeCloseToPixel(scale.left + scale.width - lastTickInterval / 2);
 				});
 
 				it ('should not add offset if min and max extend the labels range', function() {


### PR DESCRIPTION
`master`: https://codepen.io/kurkle/pen/GRgyGRx
This PR:  https://codepen.io/benmccann/pen/QWwaoGK

Adding 1 to `ticksLimit` in `_autoSkip` is wrong. The reason it was done was that the ticks may extend past the scale edge. However, what was not taken into account was that the ticks may not align perfectly with the scale edges. Look at "Sep 2014" on https://codepen.io/kurkle/pen/GRgyGRx. It's not right at the chart edge. So we should subtract one tick to make up for this and these effects cancel each other out.