### PR TITLE
Upgrade Ubuntu on Travis to match GitHub Actions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
   - cat ./coverage/lcov.info | ./node_modules/.bin/coveralls || true
 
 sudo: required
+dist: bionic
 
 addons:
   chrome: stable


### PR DESCRIPTION
It looks like upgrading from 14.04 to 16.04 didn't fix it: https://travis-ci.org/chartjs/Chart.js/builds/633968698?utm_source=github_status&utm_medium=notification

Let's try 18.04 since that's what GitHub Actions is using