### PR TITLE
Fix broken config in log scatter sample

### DIFF
--- a/samples/scales/logarithmic/scatter.html
+++ b/samples/scales/logarithmic/scatter.html
@@ -137,7 +137,7 @@
 						type: 'logarithmic',
 						position: 'bottom',
 						ticks: {
-							userCallback: function(tick) {
+							callback: function(tick) {
 								var remain = tick / (Math.pow(10, Math.floor(Chart.helpers.math.log10(tick))));
 								if (remain === 1 || remain === 2 || remain === 5) {
 									return tick.toString() + 'Hz';
@@ -153,7 +153,7 @@
 					y: {
 						type: 'linear',
 						ticks: {
-							userCallback: function(tick) {
+							callback: function(tick) {
 								return tick.toString() + 'dB';
 							}
 						},


### PR DESCRIPTION
From the migration guide:
* `options.ticks.userCallback` was renamed to `options.ticks.callback`