### PR TITLE
Remove extra font parsing in Scale.fit

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -623,13 +623,12 @@ class Scale extends Element {
 
 		// Don't bother fitting the ticks if we are not showing the labels
 		if (tickOpts.display && display) {
-			const tickFonts = parseTickFontOptions(tickOpts);
 			const labelSizes = me._getLabelSizes();
 			const firstLabelSize = labelSizes.first;
 			const lastLabelSize = labelSizes.last;
 			const widestLabelSize = labelSizes.widest;
 			const highestLabelSize = labelSizes.highest;
-			const lineSpace = tickFonts.minor.lineHeight * 0.4;
+			const lineSpace = highestLabelSize.offset * 0.8;
 			const tickPadding = tickOpts.padding;
 
 			if (isHorizontal) {


### PR DESCRIPTION
This is more accurate and more performant. The `lineSpace` should be determined based on the tallest label. `offset` is `0.5 * lineHeight`, so I took the previous `0.4` and divided by `0.5`, which is why I'm multiplying by `0.8`. It's mainly stylistic, but without it a bunch of tests start failing, so I'd rather not remove it

This will make it possible to implement scriptable options for tick formatting (https://github.com/chartjs/Chart.js/issues/2442) because after this PR we call `parseTickFontOptions` in only two places which could be converted into per-tick `resolve` calls. It's be hard to replace `parseTickFontOptions` here because it's being used generally and not specific to a tick, but by removing it we eliminate that obstacle