### PR TITLE
Move location of dataset options

### DIFF
--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -37,7 +37,7 @@ var chartDifferentHoverMode = new Chart(ctx, {
 Options may be configured directly on the dataset. The dataset options can be changed at 3 different levels and are evaluated with the following priority:
 
 - per dataset: dataset.*
-- per chart: options.[type].datasets*
+- per chart: options[type].datasets.*
 - or globally: Chart.defaults[type].datasets.*
 
 where type corresponds to the dataset type.

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -37,8 +37,8 @@ var chartDifferentHoverMode = new Chart(ctx, {
 Options may be configured directly on the dataset. The dataset options can be changed at 3 different levels and are evaluated with the following priority:
 
 - per dataset: dataset.*
-- per chart: options.datasets[type].*
-- or globally: Chart.defaults.datasets[type].*
+- per chart: options.[type].datasets*
+- or globally: Chart.defaults[type].datasets.*
 
 where type corresponds to the dataset type.
 

--- a/docs/developers/charts.md
+++ b/docs/developers/charts.md
@@ -81,10 +81,6 @@ For example, to derive a new chart type that extends from a bubble chart, you wo
 // It looks like a bug exists when the defaults don't exist
 Chart.defaults.derivedBubble = Chart.defaults.bubble;
 
-// Sets the default dataset config for 'derivedBubble' to be the same as the bubble dataset defaults.
-// It looks like a bug exists when the dataset defaults don't exist
-Chart.defaults.datasets.derivedBubble = Chart.defaults.datasets.bubble;
-
 // I think the recommend using Chart.controllers.bubble.extend({ extensions here });
 var custom = Chart.controllers.bubble.extend({
     draw: function(ease) {

--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -44,6 +44,7 @@ Chart.js 3.0 introduces a number of breaking changes. Chart.js 2.0 was released 
 
 ### Options
 
+* Dataset options are now configured as `options[type].datasets` rather than `options.datasets[type]`
 * `Polar area` `startAngle` option is now consistent with `Radar`, 0 is at top and value is in degrees. Default is changed from `-½π` to  `0`.
 * `scales.[x/y]Axes` arrays were removed. Scales are now configured directly to `options.scales` object with the object key being the scale Id.
 * `scales.[x/y]Axes.barPercentage` was moved to dataset option `barPercentage`

--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -12,6 +12,17 @@ defaults._set('bar', {
 		mode: 'index'
 	},
 
+	datasets: {
+		categoryPercentage: 0.8,
+		barPercentage: 0.9,
+		animation: {
+			numbers: {
+				type: 'number',
+				properties: ['x', 'y', 'base', 'width', 'height']
+			}
+		}
+	},
+
 	scales: {
 		x: {
 			type: 'category',
@@ -23,19 +34,6 @@ defaults._set('bar', {
 		y: {
 			type: 'linear',
 			beginAtZero: true,
-		}
-	}
-});
-
-defaults._set('datasets', {
-	bar: {
-		categoryPercentage: 0.8,
-		barPercentage: 0.9,
-		animation: {
-			numbers: {
-				type: 'number',
-				properties: ['x', 'y', 'base', 'width', 'height']
-			}
 		}
 	}
 });

--- a/src/controllers/controller.horizontalBar.js
+++ b/src/controllers/controller.horizontalBar.js
@@ -25,6 +25,11 @@ defaults._set('horizontalBar', {
 		}
 	},
 
+	datasets: {
+		categoryPercentage: 0.8,
+		barPercentage: 0.9
+	},
+
 	elements: {
 		rectangle: {
 			borderSkipped: 'left'
@@ -34,13 +39,6 @@ defaults._set('horizontalBar', {
 	tooltips: {
 		mode: 'index',
 		axis: 'y'
-	}
-});
-
-defaults._set('datasets', {
-	horizontalBar: {
-		categoryPercentage: 0.8,
-		barPercentage: 0.9
 	}
 });
 

--- a/src/controllers/controller.scatter.js
+++ b/src/controllers/controller.scatter.js
@@ -15,6 +15,10 @@ defaults._set('scatter', {
 		}
 	},
 
+	datasets: {
+		showLine: false
+	},
+
 	tooltips: {
 		callbacks: {
 			title: function() {
@@ -24,12 +28,6 @@ defaults._set('scatter', {
 				return '(' + item.label + ', ' + item.value + ')';
 			}
 		}
-	}
-});
-
-defaults._set('datasets', {
-	scatter: {
-		showLine: false
 	}
 });
 

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -459,7 +459,7 @@ helpers.extend(DatasetController.prototype, {
 	_configure: function() {
 		const me = this;
 		me._config = helpers.merge({}, [
-			me.chart.options.datasets[me._type],
+			me.chart.options[me._type].datasets,
 			me.getDataset(),
 		], {
 			merger: function(key, target, source) {

--- a/test/fixtures/controller.bar/bar-thickness-multiple.json
+++ b/test/fixtures/controller.bar/bar-thickness-multiple.json
@@ -18,8 +18,8 @@
             "responsive": false,
             "legend": false,
             "title": false,
-            "datasets": {
-                "bar": {
+            "bar": {
+                "datasets": {
                     "barPercentage": 1,
                     "categoryPercentage": 1
                 }

--- a/test/fixtures/controller.bar/bar-thickness-no-overlap.json
+++ b/test/fixtures/controller.bar/bar-thickness-no-overlap.json
@@ -18,8 +18,8 @@
             "responsive": false,
             "legend": false,
             "title": false,
-            "datasets": {
-                "bar": {
+            "bar": {
+                "datasets": {
                     "barPercentage": 1,
                     "categoryPercentage": 1
                 }

--- a/test/fixtures/controller.bar/bar-thickness-offset.json
+++ b/test/fixtures/controller.bar/bar-thickness-offset.json
@@ -18,8 +18,8 @@
             "responsive": false,
             "legend": false,
             "title": false,
-            "datasets": {
-                "bar": {
+            "bar": {
+                "datasets": {
                     "barPercentage": 1,
                     "categoryPercentage": 1
                 }

--- a/test/fixtures/controller.bar/bar-thickness-reverse.json
+++ b/test/fixtures/controller.bar/bar-thickness-reverse.json
@@ -18,8 +18,8 @@
             "responsive": false,
             "legend": false,
             "title": false,
-            "datasets": {
-                "bar": {
+            "bar": {
+                "datasets": {
                     "barPercentage": 1,
                     "categoryPercentage": 1
                 }

--- a/test/fixtures/controller.bar/bar-thickness-stacked.json
+++ b/test/fixtures/controller.bar/bar-thickness-stacked.json
@@ -18,8 +18,8 @@
             "responsive": false,
             "legend": false,
             "title": false,
-            "datasets": {
-                "bar": {
+            "bar": {
+                "datasets": {
                     "barPercentage": 1,
                     "categoryPercentage": 1
                 }

--- a/test/fixtures/controller.bar/stacking/logarithmic-strings.js
+++ b/test/fixtures/controller.bar/stacking/logarithmic-strings.js
@@ -14,8 +14,8 @@ module.exports = {
 		options: {
 			legend: false,
 			title: false,
-			datasets: {
-				bar: {
+			bar: {
+				datasets: {
 					barPercentage: 1,
 				}
 			},

--- a/test/fixtures/controller.bar/stacking/logarithmic.js
+++ b/test/fixtures/controller.bar/stacking/logarithmic.js
@@ -14,8 +14,8 @@ module.exports = {
 		options: {
 			legend: false,
 			title: false,
-			datasets: {
-				bar: {
+			bar: {
+				datasets: {
 					barPercentage: 1,
 				}
 			},

--- a/test/fixtures/plugin.filler/fill-line-dataset-interpolated.js
+++ b/test/fixtures/plugin.filler/fill-line-dataset-interpolated.js
@@ -41,8 +41,8 @@ module.exports = {
 			responsive: false,
 			legend: false,
 			title: false,
-			datasets: {
-				line: {
+			line: {
+				datasets: {
 					lineTension: 0.4,
 					borderWidth: 1,
 					pointRadius: 1.5,

--- a/test/specs/controller.bar.tests.js
+++ b/test/specs/controller.bar.tests.js
@@ -1387,7 +1387,7 @@ describe('Chart.controllers.bar', function() {
 			var chart = window.acquireChart(this.config);
 			var meta = chart.getDatasetMeta(0);
 			var xScale = chart.scales[meta.xAxisID];
-			var options = Chart.defaults.datasets.bar;
+			var options = Chart.defaults.bar.datasets;
 
 			var categoryPercentage = options.categoryPercentage;
 			var barPercentage = options.barPercentage;
@@ -1535,8 +1535,8 @@ describe('Chart.controllers.bar', function() {
 						options: {
 							legend: false,
 							title: false,
-							datasets: {
-								bar: {
+							bar: {
+								datasets: {
 									barThickness: barThickness
 								}
 							},
@@ -1561,7 +1561,7 @@ describe('Chart.controllers.bar', function() {
 						expected = barThickness;
 					} else {
 						var scale = chart.scales.x;
-						var options = Chart.defaults.datasets.bar;
+						var options = Chart.defaults.bar.datasets;
 						var categoryPercentage = options.categoryPercentage;
 						var barPercentage = options.barPercentage;
 						var tickInterval = scale.getPixelForTick(1) - scale.getPixelForTick(0);

--- a/test/specs/controller.line.tests.js
+++ b/test/specs/controller.line.tests.js
@@ -559,18 +559,18 @@ describe('Chart.controllers.line', function() {
 
 	describe('dataset global defaults', function() {
 		beforeEach(function() {
-			this._defaults = Chart.helpers.clone(Chart.defaults.datasets.line);
+			this._defaults = Chart.helpers.clone(Chart.defaults.line.datasets);
 		});
 
 		afterEach(function() {
-			Chart.defaults.datasets.line = this._defaults;
+			Chart.defaults.line.datasets = this._defaults;
 			delete this._defaults;
 		});
 
 		it('should utilize the dataset global default options', function() {
-			Chart.defaults.datasets.line = Chart.defaults.datasets.line || {};
+			Chart.defaults.line.datasets = Chart.defaults.line.datasets || {};
 
-			Chart.helpers.merge(Chart.defaults.datasets.line, {
+			Chart.helpers.merge(Chart.defaults.line.datasets, {
 				spanGaps: true,
 				lineTension: 0.231,
 				backgroundColor: '#add',
@@ -611,9 +611,9 @@ describe('Chart.controllers.line', function() {
 		});
 
 		it('should be overriden by user-supplied values', function() {
-			Chart.defaults.datasets.line = Chart.defaults.datasets.line || {};
+			Chart.defaults.line.datasets = Chart.defaults.line.datasets || {};
 
-			Chart.helpers.merge(Chart.defaults.datasets.line, {
+			Chart.helpers.merge(Chart.defaults.line.datasets, {
 				spanGaps: true,
 				lineTension: 0.231
 			});
@@ -630,8 +630,8 @@ describe('Chart.controllers.line', function() {
 					labels: ['label1', 'label2']
 				},
 				options: {
-					datasets: {
-						line: {
+					line: {
+						datasets: {
 							lineTension: 0.345,
 							backgroundColor: '#add'
 						}
@@ -661,8 +661,8 @@ describe('Chart.controllers.line', function() {
 				labels: ['label1', 'label2']
 			},
 			options: {
-				datasets: {
-					line: {
+				line: {
+					datasets: {
 						spanGaps: true,
 						lineTension: 0.231,
 						backgroundColor: '#add',


### PR DESCRIPTION
As suggested by @stockiNail in https://github.com/chartjs/Chart.js/issues/6684

It has seemed to cause problems for several people who were extending charts that they needed to configure options in two places. This would fix that. See the change to docs/developers/charts.md