### PR TITLE
Optimize category parse for usual use case

### DIFF
--- a/src/scales/scale.category.js
+++ b/src/scales/scale.category.js
@@ -8,6 +8,9 @@ const defaultConfig = {
 class CategoryScale extends Scale {
 	_parse(raw, index) {
 		const labels = this._getLabels();
+		if (labels[index] === raw) {
+			return index;
+		}
 		const first = labels.indexOf(raw);
 		const last = labels.lastIndexOf(raw);
 		return first === -1 || first !== last ? index : first;


### PR DESCRIPTION
When labels array contains item for each data point, the label is going to be at the same index.
So check there first, before going for `indexOf`.

With this chart:
```js
function generateFakeData() {
	var res = [];
	var i = 0;
	for (i = 0; i < 50000; ++i) {
		res.push(i);
	}

	return res;
}

var chart = new Chart(ctx, {
	type: 'line',
	data: {
		labels: generateFakeData(),
		datasets: [
			{
				label: '# of Votes',
				data: generateFakeData()
			}
		]
	},
	options: {
		animation: false,
		tooltips: {
			intersect: false
		},
		scales: {
			y: {
				beginAtZero: true
			}
		}
	}
});
```

master:
![image](https://user-images.githubusercontent.com/27971921/72349026-64372380-36e4-11ea-8ed8-f0860c58820a.png)

pr:
![image](https://user-images.githubusercontent.com/27971921/72349050-731dd600-36e4-11ea-9481-e2ee59a45afd.png)
