### PR TITLE
Set the version to v3.0.0-dev for dev builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chart.js",
   "homepage": "https://www.chartjs.org",
   "description": "Simple HTML5 charts using the canvas element.",
-  "version": "2.9.1",
+  "version": "3.0.0-dev",
   "license": "MIT",
   "jsdelivr": "dist/Chart.min.js",
   "unpkg": "dist/Chart.min.js",


### PR DESCRIPTION
Right now dev builds appears as v2.9.1. This updates that to be more accurate
