### PR TITLE
Linear scale with min/max/stepSize set should use all 3 if the range fit

### DIFF
--- a/src/scales/scale.linearbase.js
+++ b/src/scales/scale.linearbase.js
@@ -13,22 +13,18 @@ const isNullOrUndef = helpers.isNullOrUndef;
  * @returns {number[]} array of tick values
  */
 function generateTicks(generationOptions, dataRange) {
-	var ticks = [];
+	const ticks = [];
 	// To get a "nice" value for the tick spacing, we will use the appropriately named
 	// "nice number" algorithm. See https://stackoverflow.com/questions/8506881/nice-label-algorithm-for-charts-with-minimum-ticks
 	// for details.
 
-	var MIN_SPACING = 1e-14;
-	var stepSize = generationOptions.stepSize;
-	var unit = stepSize || 1;
-	var maxNumSpaces = generationOptions.maxTicks - 1;
-	var min = generationOptions.min;
-	var max = generationOptions.max;
-	var precision = generationOptions.precision;
-	var rmin = dataRange.min;
-	var rmax = dataRange.max;
-	var spacing = helpers.niceNum((rmax - rmin) / maxNumSpaces / unit) * unit;
-	var factor, niceMin, niceMax, numSpaces;
+	const MIN_SPACING = 1e-14;
+	const {stepSize, min, max, precision} = generationOptions;
+	const unit = stepSize || 1;
+	const maxNumSpaces = generationOptions.maxTicks - 1;
+	const {min: rmin, max: rmax} = dataRange;
+	let spacing = helpers.niceNum((rmax - rmin) / maxNumSpaces / unit) * unit;
+	let factor, niceMin, niceMax, numSpaces;
 
 	// Beyond MIN_SPACING floating point numbers being to lose precision
 	// such that we can't do the math necessary to generate ticks
@@ -55,12 +51,10 @@ function generateTicks(generationOptions, dataRange) {
 	niceMax = Math.ceil(rmax / spacing) * spacing;
 
 	// If min, max and stepSize is set and they make an evenly spaced scale use it.
-	if (stepSize) {
+	if (stepSize && !isNullOrUndef(min) && !isNullOrUndef(max)) {
 		// If very close to our whole number, use it.
-		if (!isNullOrUndef(min) && almostWhole(min / spacing, spacing / 1000)) {
+		if (almostWhole((max - min) / stepSize, spacing / 1000)) {
 			niceMin = min;
-		}
-		if (!isNullOrUndef(max) && almostWhole(max / spacing, spacing / 1000)) {
 			niceMax = max;
 		}
 	}
@@ -163,11 +157,10 @@ class LinearScaleBase extends Scale {
 	}
 
 	getTickLimit() {
-		var me = this;
-		var tickOpts = me.options.ticks;
-		var stepSize = tickOpts.stepSize;
-		var maxTicksLimit = tickOpts.maxTicksLimit;
-		var maxTicks;
+		const me = this;
+		const tickOpts = me.options.ticks;
+		let {maxTicksLimit, stepSize} = tickOpts;
+		let maxTicks;
 
 		if (stepSize) {
 			maxTicks = Math.ceil(me.max / stepSize) - Math.floor(me.min / stepSize) + 1;

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -572,7 +572,7 @@ describe('Linear Scale', function() {
 		expect(chart.scales.y).not.toEqual(undefined); // must construct
 		expect(chart.scales.y.min).toBe(1);
 		expect(chart.scales.y.max).toBe(11);
-		expect(getLabels(chart.scales.y)).toEqual(['11', '10', '8', '6', '4', '2', '1']);
+		expect(getLabels(chart.scales.y)).toEqual(['11', '9', '7', '5', '3', '1']);
 	});
 
 	it('Should create decimal steps if stepSize is a decimal number', function() {
@@ -788,7 +788,7 @@ describe('Linear Scale', function() {
 		chart.options.scales.y.max = 2.8;
 		chart.update();
 
-		expect(getLabels(chart.scales.y)).toEqual(['2.8', '2.5', '2.0', '1.5', '1.0', '0.5', '0.3']);
+		expect(getLabels(chart.scales.y)).toEqual(['2.8', '2.3', '1.8', '1.3', '0.8', '0.3']);
 	});
 
 	it('Should build labels using the user supplied callback', function() {

--- a/test/specs/scale.radialLinear.tests.js
+++ b/test/specs/scale.radialLinear.tests.js
@@ -306,7 +306,7 @@ describe('Test the radial linear scale', function() {
 		chart.options.scales.r.max = 2.8;
 		chart.update();
 
-		expect(getLabels(chart.scales.r)).toEqual(['0.3', '0.5', '1.0', '1.5', '2.0', '2.5', '2.8']);
+		expect(getLabels(chart.scales.r)).toEqual(['0.3', '0.8', '1.3', '1.8', '2.3', '2.8']);
 	});
 
 	it('Should build labels using the user supplied callback', function() {


### PR DESCRIPTION
When `(max - min) / stepSize` is an integer, we can do a very simple tick generation method.

Resolves #5644 and ensures that @kurkle's workaround in https://github.com/chartjs/Chart.js/issues/4234#issuecomment-571999141 will always work.
