### PR TITLE
Fix updating retinaScale

### DIFF
--- a/src/helpers/helpers.dom.js
+++ b/src/helpers/helpers.dom.js
@@ -152,24 +152,20 @@ export function getMaximumHeight(domNode) {
 }
 
 export function retinaScale(chart, forceRatio) {
-	var pixelRatio = chart.currentDevicePixelRatio = forceRatio || (typeof window !== 'undefined' && window.devicePixelRatio) || 1;
-	if (pixelRatio === 1) {
-		return;
-	}
+	const pixelRatio = chart.currentDevicePixelRatio = forceRatio || (typeof window !== 'undefined' && window.devicePixelRatio) || 1;
+	const canvas = chart.canvas;
+	const height = chart.height;
+	const width = chart.width;
 
-	var canvasElement = chart.canvas;
-	var height = chart.height;
-	var width = chart.width;
-
-	canvasElement.height = height * pixelRatio;
-	canvasElement.width = width * pixelRatio;
-	chart.ctx.scale(pixelRatio, pixelRatio);
+	canvas.height = height * pixelRatio;
+	canvas.width = width * pixelRatio;
+	chart.ctx.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
 
 	// If no style has been set on the canvas, the render size is used as display size,
 	// making the chart visually bigger, so let's enforce it to the "correct" values.
 	// See https://github.com/chartjs/Chart.js/issues/3575
-	if (!canvasElement.style.height && !canvasElement.style.width) {
-		canvasElement.style.height = height + 'px';
-		canvasElement.style.width = width + 'px';
+	if (!canvas.style.height && !canvas.style.width) {
+		canvas.style.height = height + 'px';
+		canvas.style.width = width + 'px';
 	}
 }

--- a/src/helpers/helpers.dom.js
+++ b/src/helpers/helpers.dom.js
@@ -153,9 +153,7 @@ export function getMaximumHeight(domNode) {
 
 export function retinaScale(chart, forceRatio) {
 	const pixelRatio = chart.currentDevicePixelRatio = forceRatio || (typeof window !== 'undefined' && window.devicePixelRatio) || 1;
-	const canvas = chart.canvas;
-	const height = chart.height;
-	const width = chart.width;
+	const {canvas, width, height} = chart;
 
 	canvas.height = height * pixelRatio;
 	canvas.width = width * pixelRatio;


### PR DESCRIPTION
`ctx.scale` applies on top of previous scaling. 

Using `ctx.setTransform` instead.
Not bailing out if `pixelRatio === 1`, because it could have been different previously. Also makes the behavior consistent.
