### PR TITLE
Resize on zoom

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -249,10 +249,6 @@ class Chart {
 		const newWidth = Math.max(0, Math.floor(helpers.dom.getMaximumWidth(canvas)));
 		const newHeight = Math.max(0, Math.floor(aspectRatio ? newWidth / aspectRatio : helpers.dom.getMaximumHeight(canvas)));
 
-		if (me.width === newWidth && me.height === newHeight) {
-			return;
-		}
-
 		canvas.width = me.width = newWidth;
 		canvas.height = me.height = newHeight;
 		canvas.style.width = newWidth + 'px';

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -547,6 +547,40 @@ describe('Chart', function() {
 			wrapper.style.display = 'block';
 		});
 
+		// https://github.com/chartjs/Chart.js/issues/5485
+		it('should resize the canvas when the devicePixelRatio changes', function(done) {
+			var chart = acquireChart({
+				options: {
+					responsive: true,
+					maintainAspectRatio: false,
+					devicePixelRatio: 1
+				}
+			}, {
+				canvas: {
+					style: ''
+				},
+				wrapper: {
+					style: 'width: 400px; height: 200px; position: relative'
+				}
+			});
+
+			expect(chart).toBeChartOfSize({
+				dw: 400, dh: 200,
+				rw: 400, rh: 200,
+			});
+
+			waitForResize(chart, function() {
+				expect(chart).toBeChartOfSize({
+					dw: 400, dh: 200,
+					rw: 800, rh: 400,
+				});
+
+				done();
+			});
+			chart.options.devicePixelRatio = 2;
+			chart.resize();
+		});
+
 		// https://github.com/chartjs/Chart.js/issues/3790
 		it('should resize the canvas if attached to the DOM after construction', function(done) {
 			var canvas = document.createElement('canvas');


### PR DESCRIPTION
When zooming, the dimensions stay the same, only devicePixelRatio changes.
Not sure what case this if was added originally for.

Fixes: #5485 

