### PR TITLE
fix drawPoint parameters

### DIFF
--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -389,12 +389,17 @@ class Legend extends Element {
 			if (labelOpts && labelOpts.usePointStyle) {
 				// Recalculate x and y for drawPoint() because its expecting
 				// x and y to be center of figure (instead of top left)
-				var radius = boxWidth * Math.SQRT2 / 2;
+				const drawOptions = {
+					radius: boxWidth * Math.SQRT2 / 2,
+					pointStyle: legendItem.pointStyle,
+					rotation: legendItem.rotation,
+					borderWidth: lineWidth
+				};
 				var centerX = rtlHelper.xPlus(x, boxWidth / 2);
 				var centerY = y + fontSize / 2;
 
 				// Draw pointStyle as legend symbol
-				helpers.canvas.drawPoint(ctx, legendItem.pointStyle, radius, centerX, centerY, legendItem.rotation);
+				helpers.canvas.drawPoint(ctx, drawOptions, centerX, centerY);
 			} else {
 				// Draw box as legend symbol
 				ctx.fillRect(rtlHelper.leftForLtr(x, boxWidth), y, boxWidth, fontSize);


### PR DESCRIPTION
Legend plugin was not using the latest method signature for drawPoint which is (context, options, x, y). This has been fixed here, so usePointStyle parameter is now working again for legend.