### PR TITLE
Clean up after test

### DIFF
--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -728,6 +728,8 @@ describe('Chart', function() {
 				}
 			});
 
+			var wrapper = chart.canvas.parentNode;
+
 			waitForResize(chart, function() {
 				var canvas = chart.canvas;
 				expect(chart).toBeChartOfSize({
@@ -749,6 +751,8 @@ describe('Chart', function() {
 						rw: 455, rh: 455,
 					});
 
+					chart.destroy();
+					window.document.body.removeChild(wrapper);
 					done();
 				});
 				canvas.parentNode.style.width = '455px';

--- a/test/specs/plugin.tooltip.tests.js
+++ b/test/specs/plugin.tooltip.tests.js
@@ -148,7 +148,7 @@ describe('Core.Tooltip', function() {
 
 				done();
 			});
-			jasmine.triggerMouseEvent(chart, 'mousemove', {x: point.x, y: chart.chartArea.top});
+			jasmine.triggerMouseEvent(chart, 'mousemove', {x: point.x, y: chart.chartArea.top + 10});
 		});
 
 		it('Should only display if intersecting if intersect is set', function(done) {


### PR DESCRIPTION
This is the last one created with `new Chart` in tests, that was not cleaned up after.
Hoping that removing the trash from document.body would fix the interaction tests that occasionally fail.