### PR TITLE
Have scales and plugins register themselves

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ import elements from './elements';
 import Interaction from './core/core.interaction';
 import layouts from './core/core.layouts';
 import platform from './platforms/platform';
-import pluginsCore from './core/core.plugins';
+import plugins from './core/core.plugins';
 import Scale from './core/core.scale';
 import scaleService from './core/core.scaleService';
 import Ticks from './core/core.ticks';
@@ -35,29 +35,20 @@ Chart.elements = elements;
 Chart.Interaction = Interaction;
 Chart.layouts = layouts;
 Chart.platform = platform;
-Chart.plugins = pluginsCore;
+Chart.plugins = plugins;
 Chart.Scale = Scale;
 Chart.scaleService = scaleService;
 Chart.Ticks = Ticks;
 Chart.Tooltip = Tooltip;
 
 // Register built-in scales
-import scales from './scales';
-Object.keys(scales).forEach(function(type) {
-	const scale = scales[type];
-	Chart.scaleService.registerScaleType(type, scale, scale._defaults);
-});
+import './scales';
 
 // Load to register built-in adapters (as side effects)
 import './adapters';
 
 // Loading built-in plugins
-import plugins from './plugins';
-for (var k in plugins) {
-	if (Object.prototype.hasOwnProperty.call(plugins, k)) {
-		Chart.plugins.register(plugins[k]);
-	}
-}
+import './plugins';
 
 Chart.platform.initialize();
 

--- a/src/plugins/plugin.filler.js
+++ b/src/plugins/plugin.filler.js
@@ -8,6 +8,7 @@
 
 import defaults from '../core/core.defaults';
 import Line from '../elements/element.line';
+import plugins from '../core/core.plugins';
 import {_boundSegment, _boundSegments} from '../helpers/helpers.segment';
 import {clipArea, unclipArea} from '../helpers/helpers.canvas';
 import {valueOrDefault, isFinite, isArray, extend} from '../helpers/helpers.core';
@@ -372,7 +373,7 @@ function doFill(ctx, cfg) {
 	ctx.restore();
 }
 
-export default {
+const FillerPlugin = {
 	id: 'filler',
 
 	afterDatasetsUpdate: function(chart, options) {
@@ -444,3 +445,7 @@ export default {
 		}
 	}
 };
+
+plugins.register(FillerPlugin);
+
+export default FillerPlugin;

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -4,6 +4,7 @@ import defaults from '../core/core.defaults';
 import Element from '../core/core.element';
 import helpers from '../helpers';
 import layouts from '../core/core.layouts';
+import plugins from '../core/core.plugins';
 
 const getRtlHelper = helpers.rtl.getRtlAdapter;
 const valueOrDefault = helpers.valueOrDefault;
@@ -668,7 +669,7 @@ function createNewLegendAndAttach(chart, legendOpts) {
 	chart.legend = legend;
 }
 
-export default {
+const LegendPlugin = {
 	id: 'legend',
 
 	/**
@@ -715,3 +716,7 @@ export default {
 		}
 	}
 };
+
+plugins.register(LegendPlugin);
+
+export default LegendPlugin;

--- a/src/plugins/plugin.title.js
+++ b/src/plugins/plugin.title.js
@@ -4,6 +4,7 @@ import defaults from '../core/core.defaults';
 import Element from '../core/core.element';
 import helpers from '../helpers/index';
 import layouts from '../core/core.layouts';
+import plugins from '../core/core.plugins';
 
 defaults._set('title', {
 	align: 'center',
@@ -216,7 +217,7 @@ function createNewTitleBlockAndAttach(chart, titleOpts) {
 	chart.titleBlock = title;
 }
 
-export default {
+const TitlePlugin = {
 	id: 'title',
 
 	/**
@@ -255,3 +256,7 @@ export default {
 		}
 	}
 };
+
+plugins.register(TitlePlugin);
+
+export default TitlePlugin;

--- a/src/scales/index.js
+++ b/src/scales/index.js
@@ -7,9 +7,9 @@ import radialLinear from './scale.radialLinear';
 import time from './scale.time';
 
 export default {
-	category: category,
-	linear: linear,
-	logarithmic: logarithmic,
-	radialLinear: radialLinear,
-	time: time
+	category,
+	linear,
+	logarithmic,
+	radialLinear,
+	time
 };

--- a/src/scales/scale.category.js
+++ b/src/scales/scale.category.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import Scale from '../core/core.scale';
+import scaleService from '../core/core.scaleService';
 
 const defaultConfig = {
 };
@@ -97,4 +98,7 @@ class CategoryScale extends Scale {
 
 // INTERNAL: static default options, registered in src/index.js
 CategoryScale._defaults = defaultConfig;
+
+scaleService.registerScaleType('category', CategoryScale, CategoryScale._defaults);
+
 export default CategoryScale;

--- a/src/scales/scale.linear.js
+++ b/src/scales/scale.linear.js
@@ -3,6 +3,7 @@
 import {isFinite, valueOrDefault} from '../helpers/helpers.core';
 import {_parseFont} from '../helpers/helpers.options';
 import LinearScaleBase from './scale.linearbase';
+import scaleService from '../core/core.scaleService';
 import Ticks from '../core/core.ticks';
 
 const defaultConfig = {
@@ -73,4 +74,7 @@ class LinearScale extends LinearScaleBase {
 
 // INTERNAL: static default options, registered in src/index.js
 LinearScale._defaults = defaultConfig;
+
+scaleService.registerScaleType('linear', LinearScale, LinearScale._defaults);
+
 export default LinearScale;

--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -3,6 +3,7 @@
 import {isFinite} from '../helpers/helpers.core';
 import {_setMinAndMaxByKey, log10} from '../helpers/helpers.math';
 import Scale from '../core/core.scale';
+import scaleService from '../core/core.scaleService';
 import LinearScaleBase from './scale.linearbase';
 import Ticks from '../core/core.ticks';
 
@@ -176,4 +177,7 @@ class LogarithmicScale extends Scale {
 
 // INTERNAL: static default options, registered in src/index.js
 LogarithmicScale._defaults = defaultConfig;
+
+scaleService.registerScaleType('logarithmic', LogarithmicScale, LogarithmicScale._defaults);
+
 export default LogarithmicScale;

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -4,6 +4,7 @@ import defaults from '../core/core.defaults';
 import helpers from '../helpers/index';
 import {isNumber, toDegrees, toRadians, _normalizeAngle} from '../helpers/helpers.math';
 import LinearScaleBase from './scale.linearbase';
+import scaleService from '../core/core.scaleService';
 import Ticks from '../core/core.ticks';
 
 const valueOrDefault = helpers.valueOrDefault;
@@ -527,4 +528,7 @@ class RadialLinearScale extends LinearScaleBase {
 
 // INTERNAL: static default options, registered in src/index.js
 RadialLinearScale._defaults = defaultConfig;
+
+scaleService.registerScaleType('radialLinear', RadialLinearScale, RadialLinearScale._defaults);
+
 export default RadialLinearScale;

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -5,6 +5,7 @@ import defaults from '../core/core.defaults';
 import helpers from '../helpers/index';
 import {toRadians} from '../helpers/helpers.math';
 import Scale from '../core/core.scale';
+import scaleService from '../core/core.scaleService';
 
 const resolve = helpers.options.resolve;
 const valueOrDefault = helpers.valueOrDefault;
@@ -764,4 +765,7 @@ class TimeScale extends Scale {
 
 // INTERNAL: static default options, registered in src/index.js
 TimeScale._defaults = defaultConfig;
+
+scaleService.registerScaleType('time', TimeScale, TimeScale._defaults);
+
 export default TimeScale;


### PR DESCRIPTION
This should hopefully allow users to import just the scales that they need and allow the others to be tree-shaken out

We will need to do one of two things to really make this work:
1. Create a controller registration service similar to the scale registration service instead of having users add to `Chart.controllers` as suggested in [the docs](https://www.chartjs.org/docs/latest/developers/charts.html)
2. Or stop using strings to specify chart and scale types and use the object types instead as suggested in https://github.com/chartjs/Chart.js/issues/4461. This would be more type safe and work better with tools like eslint, Typescript, etc. E.g. right now if you have a typo like you want to use the `'yime'` scale instead of `'time'` then you won't find out until runtime. But if instead you passed in `YimeScale` then that should be able to be caught at build time

These aren't necessarily mutually exclusive and we could possibly support them both, but I personally don't have time to do both and I think it would be potentially confusing to users to support multiple ways of creating charts (have to document everything twice, all the stackoverflow answers and docs look different, etc.). @etimberg @kurkle do you have a preference on approach here?