### PR TITLE
Show color box only on the first line of the tooltip body

### DIFF
--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -788,12 +788,12 @@ class Tooltip extends Element {
 			helpers.each(bodyItem.before, fillLineOfText);
 
 			lines = bodyItem.lines;
-			for (j = 0, jlen = lines.length; j < jlen; ++j) {
-				// Draw Legend-like boxes if needed
-				if (displayColors && j === 0) {
-					me._drawColorBox(ctx, pt, i, rtlHelper);
-				}
+			// Draw Legend-like boxes if needed
+			if (displayColors && lines.length) {
+				me._drawColorBox(ctx, pt, i, rtlHelper);
+			}
 
+			for (j = 0, jlen = lines.length; j < jlen; ++j) {
 				fillLineOfText(lines[j]);
 			}
 

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -790,7 +790,7 @@ class Tooltip extends Element {
 			lines = bodyItem.lines;
 			for (j = 0, jlen = lines.length; j < jlen; ++j) {
 				// Draw Legend-like boxes if needed
-				if (displayColors) {
+				if (displayColors && j === 0) {
 					me._drawColorBox(ctx, pt, i, rtlHelper);
 				}
 


### PR DESCRIPTION
This makes multi line tooltips body much more usable.

## Before
![tooltip-before](https://user-images.githubusercontent.com/6757853/72670195-ec7d3780-3a08-11ea-80ee-8a038d0c87ff.PNG)

## After
![tooltip-after](https://user-images.githubusercontent.com/6757853/72670194-eab37400-3a08-11ea-8202-90d8c21c6d65.png)
