### PR TITLE
Resize on zoom, retry

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -241,6 +241,7 @@ class Chart {
 		const options = me.options;
 		const canvas = me.canvas;
 		const aspectRatio = (options.maintainAspectRatio && me.aspectRatio) || null;
+		const oldRatio = me.currentDevicePixelRatio;
 
 		// the canvas render width and height will be casted to integers so make sure that
 		// the canvas display style uses the same integer values to avoid blurring effect.
@@ -248,13 +249,18 @@ class Chart {
 		// Set to 0 instead of canvas.size because the size defaults to 300x150 if the element is collapsed
 		const newWidth = Math.max(0, Math.floor(helpers.dom.getMaximumWidth(canvas)));
 		const newHeight = Math.max(0, Math.floor(aspectRatio ? newWidth / aspectRatio : helpers.dom.getMaximumHeight(canvas)));
+		const newRatio = options.devicePixelRatio || platform.getDevicePixelRatio();
+
+		if (me.width === newWidth && me.height === newHeight && oldRatio === newRatio) {
+			return;
+		}
 
 		canvas.width = me.width = newWidth;
 		canvas.height = me.height = newHeight;
 		canvas.style.width = newWidth + 'px';
 		canvas.style.height = newHeight + 'px';
 
-		helpers.dom.retinaScale(me, options.devicePixelRatio);
+		helpers.dom.retinaScale(me, newRatio);
 
 		if (!silent) {
 			// Notify any plugins about the resize

--- a/src/platforms/platform.dom.js
+++ b/src/platforms/platform.dom.js
@@ -445,5 +445,9 @@ export default {
 		}
 
 		removeListener(canvas, type, proxy);
+	},
+
+	getDevicePixelRatio: function() {
+		return window.devicePixelRatio;
 	}
 };

--- a/src/platforms/platform.js
+++ b/src/platforms/platform.js
@@ -50,7 +50,14 @@ export default helpers.extend({
 	 * @param {string} type - The ({@link IEvent}) type to remove
 	 * @param {function} listener - The listener function to remove from the event target.
 	 */
-	removeEventListener: function() {}
+	removeEventListener: function() {},
+
+	/**
+	 * Returs current devicePixelRatio of the device this platform is connected to.
+	 */
+	getDevicePixelRatio: function() {
+		return 1;
+	}
 
 }, implementation);
 


### PR DESCRIPTION
Fixes: #6986 

Also a proposal to add `getDevicePixelRatio` to `platform`, so we don't need to be checking the existence of `window`. Ideally all `dom` specific stuff should be routed through platform.