### PR TITLE
Proper text alignment for multiline tick labels

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -1130,11 +1130,12 @@ class Scale extends Element {
 			if (isHorizontal) {
 				x = pixel;
 				if (position === 'top') {
-					textOffset = -1 * (!rotation ? (lineCount - 0.5) : (lineCount / 2)) * lineHeight;
+					textOffset = (Math.sin(rotation) * (lineCount / 2) + 0.5) * lineHeight;
+					textOffset -= (rotation === 0 ? (lineCount - 0.5) : Math.cos(rotation) * (lineCount / 2)) * lineHeight;
 				} else {
-					textOffset = (!rotation ? 0.5 : -(lineCount / 2) + 0.5) * lineHeight;
+					textOffset = Math.sin(rotation) * (lineCount / 2) * lineHeight;
+					textOffset += (rotation === 0 ? 0.5 : Math.cos(rotation) * (lineCount / 2)) * lineHeight;
 				}
-
 			} else {
 				y = pixel;
 				textOffset = (1 - lineCount) * lineHeight / 2;

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -1129,9 +1129,12 @@ class Scale extends Element {
 
 			if (isHorizontal) {
 				x = pixel;
-				textOffset = position === 'top'
-					? ((!rotation ? 0.5 : 1) - lineCount) * lineHeight
-					: (!rotation ? 0.5 : 0) * lineHeight;
+				if (position === 'top') {
+					textOffset = -1 * (!rotation ? (lineCount - 0.5) : (lineCount / 2)) * lineHeight;
+				} else {
+					textOffset = (!rotation ? 0.5 : -(lineCount / 2) + 0.5) * lineHeight;
+				}
+
 			} else {
 				y = pixel;
 				textOffset = (1 - lineCount) * lineHeight / 2;


### PR DESCRIPTION
Resolves #4057

## After Change

### Bottom Position
![multiline-rot-bottom](https://user-images.githubusercontent.com/6757853/72686554-0f205680-3ac4-11ea-9bf8-d6c21c97068e.PNG)
![multiline-bottom](https://user-images.githubusercontent.com/6757853/72686558-147da100-3ac4-11ea-854b-2e398a6fff9f.PNG)

### Top Position
![multiline-rot-top](https://user-images.githubusercontent.com/6757853/72686555-10ea1a00-3ac4-11ea-9d0f-3598b85696c7.PNG)
![multiline-top](https://user-images.githubusercontent.com/6757853/72686556-121b4700-3ac4-11ea-9950-873b7ff8d998.PNG)

