### PR TITLE
Filler fix

### DIFF
--- a/src/plugins/plugin.filler.js
+++ b/src/plugins/plugin.filler.js
@@ -184,6 +184,7 @@ function getTarget(source) {
 	const boundary = computeBoundary(source);
 	let points = [];
 	let _loop = false;
+	let _refPoints = false;
 
 	if (boundary instanceof simpleArc) {
 		return boundary;
@@ -194,8 +195,15 @@ function getTarget(source) {
 		points = boundary;
 	} else {
 		points = pointsFromSegments(boundary, line);
+		_refPoints = true;
 	}
-	return points.length ? new Line({points, options: {tension: 0}, _loop, _fullLoop: _loop}) : null;
+	return points.length ? new Line({
+		points,
+		options: {tension: 0},
+		_loop,
+		_fullLoop: _loop,
+		_refPoints
+	}) : null;
 }
 
 function resolveTarget(sources, index, propagate) {
@@ -264,7 +272,7 @@ function _segments(line, target, property) {
 	const tpoints = target.points;
 	const parts = [];
 
-	if (target.segments) {
+	if (target._refPoints) {
 		// Update properties from reference points. (In case those points are animating)
 		for (let i = 0, ilen = tpoints.length; i < ilen; ++i) {
 			const point = tpoints[i];

--- a/src/plugins/plugin.filler.js
+++ b/src/plugins/plugin.filler.js
@@ -164,11 +164,11 @@ function pointsFromSegments(boundary, line) {
 		const first = linePoints[segment.start];
 		const last = linePoints[segment.end];
 		if (y !== null) {
-			points.push({x: first.x, y});
-			points.push({x: last.x, y});
+			points.push({x: first.x, y, _prop: 'x', _ref: first});
+			points.push({x: last.x, y, _prop: 'x', _ref: last});
 		} else if (x !== null) {
-			points.push({x, y: first.y});
-			points.push({x, y: last.y});
+			points.push({x, y: first.y, _prop: 'y', _ref: first});
+			points.push({x, y: last.y, _prop: 'y', _ref: last});
 		}
 	});
 	return points;
@@ -263,6 +263,17 @@ function _segments(line, target, property) {
 	const points = line.points;
 	const tpoints = target.points;
 	const parts = [];
+
+	if (target.segments) {
+		// Update properties from reference points. (In case those points are animating)
+		for (let i = 0, ilen = tpoints.length; i < ilen; ++i) {
+			const point = tpoints[i];
+			const prop = point._prop;
+			if (prop) {
+				point[prop] = point._ref[prop];
+			}
+		}
+	}
 
 	for (let segment of line.segments) {
 		const bounds = getBounds(property, points[segment.start], points[segment.end], segment.loop);


### PR DESCRIPTION
Fixes: #6985 

The target boundary is built using the line points after update.
Those values are the `view` values, not the `model` values. This causes the bug when element is moved in the `indexScale` direction.

This PR adds reference to the points from where the boundary property is gotten from and updates those values before filling.

[Fiddle](https://jsfiddle.net/7ntxu8L4/)
