### PR TITLE
Convert Tooltip to a plugin

### DIFF
--- a/docs/configuration/tooltip.md
+++ b/docs/configuration/tooltip.md
@@ -61,13 +61,14 @@ Example:
 ```javascript
 /**
  * Custom positioner
- * @function Chart.Tooltip.positioners.custom
+ * @function Tooltip.positioners.custom
  * @param elements {Chart.Element[]} the tooltip elements
  * @param eventPosition {Point} the position of the event in canvas coordinates
  * @returns {Point} the tooltip position
  */
-Chart.Tooltip.positioners.custom = function(elements, eventPosition) {
-    /** @type {Chart.Tooltip} */
+const tooltipPlugin = Chart.plugins.getAll().find(p => p.id === 'tooltip');
+tooltipPlugin.positioners.custom = function(elements, eventPosition) {
+    /** @type {Tooltip} */
     var tooltip = this;
 
     /* ... */
@@ -99,7 +100,7 @@ Allows filtering of [tooltip items](#tooltip-item-interface). Must implement at 
 
 ## Tooltip Callbacks
 
-The tooltip label configuration is nested below the tooltip configuration using the `callbacks` key. The tooltip has the following callbacks for providing text. For all functions, `this` will be the tooltip object created from the `Chart.Tooltip` constructor.
+The tooltip label configuration is nested below the tooltip configuration using the `callbacks` key. The tooltip has the following callbacks for providing text. For all functions, `this` will be the tooltip object created from the `Tooltip` constructor.
 
 All functions are called with the same arguments: a [tooltip item](#tooltip-item-interface) and the `data` object passed to the chart. All functions must return either a string or an array of strings. Arrays of strings are treated as multiple lines of text.
 

--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -79,6 +79,7 @@ Animation system was completely rewritten in Chart.js v3. Each property can now 
 * `Chart.Controller`
 * `Chart.prototype.generateLegend`
 * `Chart.types`
+* `Chart.Tooltip` is now provided by the tooltip plugin
 * `DatasetController.addElementAndReset`
 * `DatasetController.createMetaData`
 * `DatasetController.createMetaDataset`

--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -79,7 +79,7 @@ Animation system was completely rewritten in Chart.js v3. Each property can now 
 * `Chart.Controller`
 * `Chart.prototype.generateLegend`
 * `Chart.types`
-* `Chart.Tooltip` is now provided by the tooltip plugin
+* `Chart.Tooltip` is now provided by the tooltip plugin. The positioners can be accessed from `tooltipPlugin.positioners`
 * `DatasetController.addElementAndReset`
 * `DatasetController.createMetaData`
 * `DatasetController.createMetaDataset`

--- a/src/core/core.plugins.js
+++ b/src/core/core.plugins.js
@@ -201,6 +201,13 @@ export default {
  * @param {object} options - The plugin options.
  */
 /**
+ * @method IPlugin#reset
+ * @desc Called during chart reset
+ * @param {Chart.Controller} chart - The chart instance.
+ * @param {object} options - The plugin options.
+ * @since version 3.0.0
+ */
+/**
  * @method IPlugin#beforeDatasetsUpdate
  * @desc Called before updating the `chart` datasets. If any plugin returns `false`,
  * the datasets update is cancelled until another `update` is triggered.

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,6 @@ import pluginsCore from './core/core.plugins';
 import Scale from './core/core.scale';
 import scaleService from './core/core.scaleService';
 import Ticks from './core/core.ticks';
-import Tooltip from './core/core.tooltip';
 
 Chart.helpers = helpers;
 Chart._adapters = _adapters;
@@ -39,7 +38,6 @@ Chart.plugins = pluginsCore;
 Chart.Scale = Scale;
 Chart.scaleService = scaleService;
 Chart.Ticks = Ticks;
-Chart.Tooltip = Tooltip;
 
 // Register built-in scales
 import scales from './scales';

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -3,9 +3,11 @@
 import filler from './plugin.filler';
 import legend from './plugin.legend';
 import title from './plugin.title';
+import tooltip from './plugin.tooltip';
 
 export default {
 	filler,
 	legend,
-	title
+	title,
+	tooltip
 };

--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -1,9 +1,10 @@
 'use strict';
 
-import defaults from './core.defaults';
-import Element from './core.element';
+import Animations from '../core/core.animations';
+import defaults from '../core/core.defaults';
+import Element from '../core/core.element';
+import plugins from '../core/core.plugins';
 import helpers from '../helpers/index';
-import Animations from './core.animations';
 
 const valueOrDefault = helpers.valueOrDefault;
 const getRtlHelper = helpers.rtl.getRtlAdapter;
@@ -1001,4 +1002,48 @@ class Tooltip extends Element {
  */
 Tooltip.positioners = positioners;
 
-export default Tooltip;
+export default {
+	id: 'tooltip',
+	_element: Tooltip,
+
+	afterInit: function(chart) {
+		var tooltipOpts = chart.options.tooltips;
+
+		if (tooltipOpts) {
+			chart.tooltip = new Tooltip({_chart: chart});
+		}
+	},
+
+	beforeUpdate: function(chart) {
+		if (chart.tooltip) {
+			chart.tooltip.initialize();
+		}
+	},
+
+	reset: function(chart) {
+		if (chart.tooltip) {
+			chart.tooltip.initialize();
+		}
+	},
+
+	afterDraw: function(chart) {
+		const tooltip = chart.tooltip;
+		const args = {
+			tooltip
+		};
+
+		if (plugins.notify(chart, 'beforeTooltipDraw', [args]) === false) {
+			return;
+		}
+
+		tooltip.draw(chart.ctx);
+
+		plugins.notify(chart, 'afterTooltipDraw', [args]);
+	},
+
+	afterEvent: function(chart, e) {
+		if (chart.tooltip) {
+			chart.tooltip.handleEvent(e);
+		}
+	}
+};

--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -1005,6 +1005,7 @@ Tooltip.positioners = positioners;
 export default {
 	id: 'tooltip',
 	_element: Tooltip,
+	positioners,
 
 	afterInit: function(chart) {
 		const tooltipOpts = chart.options.tooltips;

--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -1007,7 +1007,7 @@ export default {
 	_element: Tooltip,
 
 	afterInit: function(chart) {
-		var tooltipOpts = chart.options.tooltips;
+		const tooltipOpts = chart.options.tooltips;
 
 		if (tooltipOpts) {
 			chart.tooltip = new Tooltip({_chart: chart});

--- a/test/specs/global.namespace.tests.js
+++ b/test/specs/global.namespace.tests.js
@@ -16,8 +16,6 @@ describe('Chart namespace', function() {
 			expect(Chart.Scale instanceof Object).toBeTruthy();
 			expect(Chart.scaleService instanceof Object).toBeTruthy();
 			expect(Chart.Ticks instanceof Object).toBeTruthy();
-			expect(Chart.Tooltip instanceof Object).toBeTruthy();
-			expect(Chart.Tooltip.positioners instanceof Object).toBeTruthy();
 		});
 	});
 

--- a/test/specs/plugin.tooltip.tests.js
+++ b/test/specs/plugin.tooltip.tests.js
@@ -1,5 +1,6 @@
 // Test the rectangle element
-const Tooltip = Chart.plugins.getAll().find(p => p.id === 'tooltip')._element;
+const tooltipPlugin = Chart.plugins.getAll().find(p => p.id === 'tooltip');
+const Tooltip = tooltipPlugin._element;
 
 describe('Core.Tooltip', function() {
 	describe('auto', jasmine.fixture.specs('core.tooltip'));
@@ -892,11 +893,11 @@ describe('Core.Tooltip', function() {
 	describe('positioners', function() {
 		it('Should call custom positioner with correct parameters and scope', function(done) {
 
-			Tooltip.positioners.test = function() {
+			tooltipPlugin.positioners.test = function() {
 				return {x: 0, y: 0};
 			};
 
-			spyOn(Tooltip.positioners, 'test').and.callThrough();
+			spyOn(tooltipPlugin.positioners, 'test').and.callThrough();
 
 			var chart = window.acquireChart({
 				type: 'line',
@@ -927,7 +928,7 @@ describe('Core.Tooltip', function() {
 			var datasetIndex = 0;
 			var meta = chart.getDatasetMeta(datasetIndex);
 			var point = meta.data[pointIndex];
-			var fn = Tooltip.positioners.test;
+			var fn = tooltipPlugin.positioners.test;
 
 			afterEvent(chart, 'mousemove', function() {
 				expect(fn.calls.count()).toBe(1);

--- a/test/specs/plugin.tooltip.tests.js
+++ b/test/specs/plugin.tooltip.tests.js
@@ -1,4 +1,6 @@
 // Test the rectangle element
+const Tooltip = Chart.plugins.getAll().find(p => p.id === 'tooltip')._element;
+
 describe('Core.Tooltip', function() {
 	describe('auto', jasmine.fixture.specs('core.tooltip'));
 
@@ -890,11 +892,11 @@ describe('Core.Tooltip', function() {
 	describe('positioners', function() {
 		it('Should call custom positioner with correct parameters and scope', function(done) {
 
-			Chart.Tooltip.positioners.test = function() {
+			Tooltip.positioners.test = function() {
 				return {x: 0, y: 0};
 			};
 
-			spyOn(Chart.Tooltip.positioners, 'test').and.callThrough();
+			spyOn(Tooltip.positioners, 'test').and.callThrough();
 
 			var chart = window.acquireChart({
 				type: 'line',
@@ -925,14 +927,14 @@ describe('Core.Tooltip', function() {
 			var datasetIndex = 0;
 			var meta = chart.getDatasetMeta(datasetIndex);
 			var point = meta.data[pointIndex];
-			var fn = Chart.Tooltip.positioners.test;
+			var fn = Tooltip.positioners.test;
 
 			afterEvent(chart, 'mousemove', function() {
 				expect(fn.calls.count()).toBe(1);
 				expect(fn.calls.first().args[0] instanceof Array).toBe(true);
 				expect(Object.prototype.hasOwnProperty.call(fn.calls.first().args[1], 'x')).toBe(true);
 				expect(Object.prototype.hasOwnProperty.call(fn.calls.first().args[1], 'y')).toBe(true);
-				expect(fn.calls.first().object instanceof Chart.Tooltip).toBe(true);
+				expect(fn.calls.first().object instanceof Tooltip).toBe(true);
 
 				done();
 			});
@@ -1261,7 +1263,7 @@ describe('Core.Tooltip', function() {
 		];
 
 		var mockContext = window.createMockContext();
-		var tooltip = new Chart.Tooltip({
+		var tooltip = new Tooltip({
 			_chart: {
 				options: {
 					tooltips: {


### PR DESCRIPTION
This eliminates special treatment of the tooltip from the core Chart class. It should be possible to eventually have the canvas tooltip replaced with an HTML tooltip simply by replacing the plugin.

# Changes

* New plugin event for `reset`
* Tooltip moved to `plugin.tooltip.js`

# Testing

* Unit tests passed
* Manually tested using sample files