### PR TITLE
Update version in package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chart.js",
-  "version": "2.9.1",
+  "version": "3.0.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
`npm` does this automatically when running `npm install`. We maybe should have made this part of https://github.com/chartjs/Chart.js/pull/6965