### PR TITLE
Reduce scope of imports

### DIFF
--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -2,7 +2,7 @@
 
 import DatasetController from '../core/core.datasetController';
 import defaults from '../core/core.defaults';
-import elements from '../elements';
+import Rectangle from '../elements/element.rectangle';
 import helpers from '../helpers';
 
 const valueOrDefault = helpers.valueOrDefault;
@@ -184,7 +184,7 @@ function isFloatBar(custom) {
 
 export default DatasetController.extend({
 
-	dataElementType: elements.Rectangle,
+	dataElementType: Rectangle,
 
 	/**
 	 * @private

--- a/src/controllers/controller.bubble.js
+++ b/src/controllers/controller.bubble.js
@@ -2,7 +2,7 @@
 
 import DatasetController from '../core/core.datasetController';
 import defaults from '../core/core.defaults';
-import elements from '../elements';
+import Point from '../elements/element.point';
 import helpers from '../helpers';
 
 const resolve = helpers.options.resolve;
@@ -38,7 +38,7 @@ export default DatasetController.extend({
 	/**
 	 * @protected
 	 */
-	dataElementType: elements.Point,
+	dataElementType: Point,
 
 	/**
 	 * @private

--- a/src/controllers/controller.doughnut.js
+++ b/src/controllers/controller.doughnut.js
@@ -2,7 +2,7 @@
 
 import DatasetController from '../core/core.datasetController';
 import defaults from '../core/core.defaults';
-import elements from '../elements';
+import Arc from '../elements/element.arc';
 import helpers from '../helpers';
 
 const valueOrDefault = helpers.valueOrDefault;
@@ -100,7 +100,7 @@ defaults._set('doughnut', {
 
 export default DatasetController.extend({
 
-	dataElementType: elements.Arc,
+	dataElementType: Arc,
 
 	linkScales: helpers.noop,
 

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -2,7 +2,8 @@
 
 import DatasetController from '../core/core.datasetController';
 import defaults from '../core/core.defaults';
-import elements from '../elements';
+import Line from '../elements/element.line';
+import Point from '../elements/element.point';
 import helpers from '../helpers';
 
 const valueOrDefault = helpers.valueOrDefault;
@@ -28,9 +29,9 @@ defaults._set('line', {
 
 export default DatasetController.extend({
 
-	datasetElementType: elements.Line,
+	datasetElementType: Line,
 
-	dataElementType: elements.Point,
+	dataElementType: Point,
 
 	/**
 	 * @private

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -2,7 +2,7 @@
 
 import DatasetController from '../core/core.datasetController';
 import defaults from '../core/core.defaults';
-import elements from '../elements';
+import Arc from '../elements/element.arc';
 import helpers from '../helpers';
 
 const resolve = helpers.options.resolve;
@@ -93,7 +93,7 @@ function getStartAngleRadians(deg) {
 
 export default DatasetController.extend({
 
-	dataElementType: elements.Arc,
+	dataElementType: Arc,
 
 	/**
 	 * @private

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -2,7 +2,8 @@
 
 import DatasetController from '../core/core.datasetController';
 import defaults from '../core/core.defaults';
-import elements from '../elements';
+import Line from '../elements/element.line';
+import Point from '../elements/element.point';
 import helpers from '../helpers';
 
 const valueOrDefault = helpers.valueOrDefault;
@@ -22,9 +23,9 @@ defaults._set('radar', {
 });
 
 export default DatasetController.extend({
-	datasetElementType: elements.Line,
+	datasetElementType: Line,
 
-	dataElementType: elements.Point,
+	dataElementType: Point,
 
 	/**
 	 * @private

--- a/src/core/core.plugins.js
+++ b/src/core/core.plugins.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import defaults from './core.defaults';
-import helpers from '../helpers/';
+import {clone} from '../helpers/helpers.core';
 
 defaults._set('plugins', {});
 
@@ -142,7 +142,7 @@ export default {
 			}
 
 			if (opts === true) {
-				opts = helpers.clone(defaults.plugins[id]);
+				opts = clone(defaults.plugins[id]);
 			}
 
 			plugins.push(plugin);

--- a/src/core/core.scaleService.js
+++ b/src/core/core.scaleService.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import defaults from './core.defaults';
-import helpers from '../helpers';
+import {clone, each, extend, merge} from '../helpers/helpers.core';
 import layouts from './core.layouts';
 
 export default {
@@ -15,24 +15,24 @@ export default {
 	defaults: {},
 	registerScaleType: function(type, scaleConstructor, scaleDefaults) {
 		this.constructors[type] = scaleConstructor;
-		this.defaults[type] = helpers.clone(scaleDefaults);
+		this.defaults[type] = clone(scaleDefaults);
 	},
 	getScaleConstructor: function(type) {
 		return Object.prototype.hasOwnProperty.call(this.constructors, type) ? this.constructors[type] : undefined;
 	},
 	getScaleDefaults: function(type) {
 		// Return the scale defaults merged with the global settings so that we always use the latest ones
-		return Object.prototype.hasOwnProperty.call(this.defaults, type) ? helpers.merge({}, [defaults.scale, this.defaults[type]]) : {};
+		return Object.prototype.hasOwnProperty.call(this.defaults, type) ? merge({}, [defaults.scale, this.defaults[type]]) : {};
 	},
 	updateScaleDefaults: function(type, additions) {
 		var me = this;
 		if (Object.prototype.hasOwnProperty.call(me.defaults, type)) {
-			me.defaults[type] = helpers.extend(me.defaults[type], additions);
+			me.defaults[type] = extend(me.defaults[type], additions);
 		}
 	},
 	addScalesToLayout: function(chart) {
 		// Adds each scale to the chart.boxes array to be sized accordingly
-		helpers.each(chart.scales, function(scale) {
+		each(chart.scales, function(scale) {
 			// Set ILayoutItem parameters for backwards compatibility
 			scale.fullWidth = scale.options.fullWidth;
 			scale.position = scale.options.position;


### PR DESCRIPTION
This may allow unused elements to be tree shaken

I also did `helpers` for a couple of the core classes. That'll be a hard one to do, so isn't a priority for me, but I figured I'd start with core classes