### PR TITLE
Format numbers in tooltip

### DIFF
--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -84,7 +84,7 @@ defaults._set('tooltips', {
 			}
 			const value = tooltipItem.value;
 			if (!helpers.isNullOrUndef(value)) {
-				label += isNaN(value) ? value : new Intl.NumberFormat().format(value);
+				label += !helpers.isFinite(value) ? value : new Intl.NumberFormat().format(value);
 			}
 			return label;
 		},

--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -77,13 +77,14 @@ defaults._set('tooltips', {
 		// Args are: (tooltipItem, data)
 		beforeLabel: helpers.noop,
 		label: function(tooltipItem, data) {
-			var label = data.datasets[tooltipItem.datasetIndex].label || '';
+			let label = data.datasets[tooltipItem.datasetIndex].label || '';
 
 			if (label) {
 				label += ': ';
 			}
-			if (!helpers.isNullOrUndef(tooltipItem.value)) {
-				label += tooltipItem.value;
+			const value = tooltipItem.value;
+			if (!helpers.isNullOrUndef(value)) {
+				label += isNaN(value) ? value : new Intl.NumberFormat().format(value);
 			}
 			return label;
 		},

--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -84,7 +84,7 @@ defaults._set('tooltips', {
 			}
 			const value = tooltipItem.value;
 			if (!helpers.isNullOrUndef(value)) {
-				label += !helpers.isFinite(value) ? value : new Intl.NumberFormat().format(value);
+				label += value;
 			}
 			return label;
 		},

--- a/src/scales/scale.linearbase.js
+++ b/src/scales/scale.linearbase.js
@@ -242,6 +242,10 @@ class LinearScaleBase extends Scale {
 		me._endValue = end;
 		me._valueRange = end - start;
 	}
+
+	getLabelForValue(value) {
+		return new Intl.NumberFormat().format(value);
+	}
 }
 
 export default LinearScaleBase;

--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -136,7 +136,7 @@ class LogarithmicScale extends Scale {
 	}
 
 	getLabelForValue(value) {
-		return value === undefined ? 0 : value;
+		return value === undefined ? 0 : new Intl.NumberFormat().format(value);
 	}
 
 	getPixelForTick(index) {

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -332,7 +332,7 @@ describe('Linear Scale', function() {
 		});
 		chart.update();
 
-		expect(chart.scales.y.getLabelForValue(7)).toBe(7);
+		expect(chart.scales.y.getLabelForValue(7)).toBe('7');
 	});
 
 	it('Should correctly determine the min and max data values when stacked mode is turned on', function() {

--- a/test/specs/scale.logarithmic.tests.js
+++ b/test/specs/scale.logarithmic.tests.js
@@ -738,7 +738,7 @@ describe('Logarithmic Scale tests', function() {
 			}
 		});
 
-		expect(chart.scales.y.getLabelForValue(150)).toBe(150);
+		expect(chart.scales.y.getLabelForValue(150)).toBe('150');
 	});
 
 	describe('when', function() {

--- a/test/specs/scale.radialLinear.tests.js
+++ b/test/specs/scale.radialLinear.tests.js
@@ -414,7 +414,7 @@ describe('Test the radial linear scale', function() {
 				}
 			}
 		});
-		expect(chart.scales.r.getLabelForValue(5)).toBe(5);
+		expect(chart.scales.r.getLabelForValue(5)).toBe('5');
 	});
 
 	it('should get the correct distance from the center point', function() {


### PR DESCRIPTION
I have a dataset with numbers in the millions and it's impossible to read at the moment. This fixes it. Pictures below for the logarithmic sample

**Before**

![before](https://user-images.githubusercontent.com/322311/72958850-4c534580-3d5d-11ea-80c5-9d831cdfc4c7.png)

**After**

![after](https://user-images.githubusercontent.com/322311/72958855-4f4e3600-3d5d-11ea-9d88-4703d817f0af.png)