### PR TITLE
Include src folder in release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ deploy:
   skip_cleanup: true
   file_glob: true
   file:
+  - ./src/**/*
   - ./dist/*.css
   - ./dist/*.js
   - ./dist/*.zip


### PR DESCRIPTION
This is necessary in order to import just the files you want for tree shaking as proposed in https://github.com/chartjs/Chart.js/issues/4461
