### PR TITLE
Simplify scale registration

### DIFF
--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -169,6 +169,7 @@ Animation system was completely rewritten in Chart.js v3. Each property can now 
 
 * `Scale.getLabelForIndex` was replaced by `scale.getLabelForValue`
 * `Scale.getPixelForValue` now has only one parameter. For the `TimeScale` that parameter must be millis since the epoch
+* `ScaleService.registerScaleType` was renamed to `ScaleService.registerScales` and now takes a variable number of scale constructors which are expected to have `id` and `defaults` properties.
 
 ##### Ticks
 

--- a/src/core/core.scaleService.js
+++ b/src/core/core.scaleService.js
@@ -13,9 +13,10 @@ export default {
 
 	// Scale config defaults
 	defaults: {},
-	registerScaleType: function(type, scaleConstructor, scaleDefaults) {
+	registerScaleType: function(scaleConstructor) {
+		const type = scaleConstructor.id;
 		this.constructors[type] = scaleConstructor;
-		this.defaults[type] = clone(scaleDefaults);
+		this.defaults[type] = clone(scaleConstructor.defaults);
 	},
 	getScaleConstructor: function(type) {
 		return Object.prototype.hasOwnProperty.call(this.constructors, type) ? this.constructors[type] : undefined;

--- a/src/core/core.scaleService.js
+++ b/src/core/core.scaleService.js
@@ -13,10 +13,14 @@ export default {
 
 	// Scale config defaults
 	defaults: {},
-	registerScaleType: function(scaleConstructor) {
-		const type = scaleConstructor.id;
-		this.constructors[type] = scaleConstructor;
-		this.defaults[type] = clone(scaleConstructor.defaults);
+	registerScales: function(...scaleConstructors) {
+		const me = this;
+		for (let i = 0; i < scaleConstructors.length; i++) {
+			const scaleConstructor = scaleConstructors[i];
+			const type = scaleConstructor.id;
+			me.constructors[type] = scaleConstructor;
+			me.defaults[type] = clone(scaleConstructor.defaults);
+		}
 	},
 	getScaleConstructor: function(type) {
 		return Object.prototype.hasOwnProperty.call(this.constructors, type) ? this.constructors[type] : undefined;

--- a/src/index.js
+++ b/src/index.js
@@ -41,17 +41,18 @@ Chart.Ticks = Ticks;
 
 // Register built-in scales
 import scales from './scales';
-Object.keys(scales).forEach(function(type) {
-	const scale = scales[type];
-	Chart.scaleService.registerScaleType(type, scale, scale._defaults);
-});
+for (let k in scales) {
+	if (Object.prototype.hasOwnProperty.call(scales, k)) {
+		Chart.scaleService.registerScaleType(scales[k]);
+	}
+}
 
 // Load to register built-in adapters (as side effects)
 import './adapters';
 
 // Loading built-in plugins
 import plugins from './plugins';
-for (var k in plugins) {
+for (let k in plugins) {
 	if (Object.prototype.hasOwnProperty.call(plugins, k)) {
 		Chart.plugins.register(plugins[k]);
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -41,11 +41,7 @@ Chart.Ticks = Ticks;
 
 // Register built-in scales
 import scales from './scales';
-for (let k in scales) {
-	if (Object.prototype.hasOwnProperty.call(scales, k)) {
-		Chart.scaleService.registerScaleType(scales[k]);
-	}
-}
+Chart.scaleService.registerScales(...Object.keys(scales).map(key => scales[key]));
 
 // Load to register built-in adapters (as side effects)
 import './adapters';

--- a/src/scales/index.js
+++ b/src/scales/index.js
@@ -1,15 +1,15 @@
 'use strict';
 
-import category from './scale.category';
-import linear from './scale.linear';
-import logarithmic from './scale.logarithmic';
-import radialLinear from './scale.radialLinear';
-import time from './scale.time';
+import CategoryScale from './scale.category';
+import LinearScale from './scale.linear';
+import LogarithmicScale from './scale.logarithmic';
+import RadialLinearScale from './scale.radialLinear';
+import TimeScale from './scale.time';
 
 export default {
-	category: category,
-	linear: linear,
-	logarithmic: logarithmic,
-	radialLinear: radialLinear,
-	time: time
+	CategoryScale,
+	LinearScale,
+	LogarithmicScale,
+	RadialLinearScale,
+	TimeScale
 };

--- a/src/scales/scale.category.js
+++ b/src/scales/scale.category.js
@@ -95,6 +95,6 @@ class CategoryScale extends Scale {
 	}
 }
 
-// INTERNAL: static default options, registered in src/index.js
-CategoryScale._defaults = defaultConfig;
+CategoryScale.id = 'category';
+CategoryScale.defaults = defaultConfig;
 export default CategoryScale;

--- a/src/scales/scale.linear.js
+++ b/src/scales/scale.linear.js
@@ -71,6 +71,7 @@ class LinearScale extends LinearScaleBase {
 	}
 }
 
-// INTERNAL: static default options, registered in src/index.js
-LinearScale._defaults = defaultConfig;
+LinearScale.id = 'linear';
+LinearScale.defaults = defaultConfig;
+
 export default LinearScale;

--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -174,6 +174,6 @@ class LogarithmicScale extends Scale {
 	}
 }
 
-// INTERNAL: static default options, registered in src/index.js
-LogarithmicScale._defaults = defaultConfig;
+LogarithmicScale.id = 'logarithmic';
+LogarithmicScale.defaults = defaultConfig;
 export default LogarithmicScale;

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -525,6 +525,6 @@ class RadialLinearScale extends LinearScaleBase {
 	_drawTitle() {}
 }
 
-// INTERNAL: static default options, registered in src/index.js
-RadialLinearScale._defaults = defaultConfig;
+RadialLinearScale.id = 'radialLinear';
+RadialLinearScale.defaults = defaultConfig;
 export default RadialLinearScale;

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -727,6 +727,6 @@ class TimeScale extends Scale {
 	}
 }
 
-// INTERNAL: static default options, registered in src/index.js
-TimeScale._defaults = defaultConfig;
+TimeScale.id = 'time';
+TimeScale.defaults = defaultConfig;
 export default TimeScale;

--- a/test/specs/core.scale.tests.js
+++ b/test/specs/core.scale.tests.js
@@ -462,7 +462,7 @@ describe('Core.scale', function() {
 			});
 			customScale.id = 'customScale';
 			customScale.defaults = {};
-			Chart.scaleService.registerScaleType(customScale);
+			Chart.scaleService.registerScales(customScale);
 
 			var chart = window.acquireChart({
 				type: 'line',

--- a/test/specs/core.scale.tests.js
+++ b/test/specs/core.scale.tests.js
@@ -460,7 +460,9 @@ describe('Core.scale', function() {
 					return ['tick'];
 				}
 			});
-			Chart.scaleService.registerScaleType('customScale', customScale, {});
+			customScale.id = 'customScale';
+			customScale.defaults = {};
+			Chart.scaleService.registerScaleType(customScale);
 
 			var chart = window.acquireChart({
 				type: 'line',

--- a/test/specs/core.scaleService.tests.js
+++ b/test/specs/core.scaleService.tests.js
@@ -2,14 +2,15 @@
 describe('Test the scale service', function() {
 
 	it('should update scale defaults', function() {
-		var defaults = {
-			testProp: true
-		};
 		var type = 'my_test_type';
 		var Constructor = function() {
 			this.initialized = true;
 		};
-		Chart.scaleService.registerScaleType(type, Constructor, defaults);
+		Constructor.id = type;
+		Constructor.defaults = {
+			testProp: true
+		};
+		Chart.scaleService.registerScaleType(Constructor);
 
 		// Should equal defaults but not be an identical object
 		expect(Chart.scaleService.getScaleDefaults(type)).toEqual(jasmine.objectContaining({

--- a/test/specs/core.scaleService.tests.js
+++ b/test/specs/core.scaleService.tests.js
@@ -10,7 +10,7 @@ describe('Test the scale service', function() {
 		Constructor.defaults = {
 			testProp: true
 		};
-		Chart.scaleService.registerScaleType(Constructor);
+		Chart.scaleService.registerScales(Constructor);
 
 		// Should equal defaults but not be an identical object
 		expect(Chart.scaleService.getScaleDefaults(type)).toEqual(jasmine.objectContaining({


### PR DESCRIPTION
This would make it much easier to register a scale. You only need to pass the scale and can pass multiple at once if you want

@kurkle had suggested over Slack that as an alternative to https://github.com/chartjs/Chart.js/pull/6979 to support tree shaking we create a separate entry point for npm such as `index.es6.js` and don't do the auto-registration.

We might be able to use this register controllers as well, which would also be needed for tree shaking. I'm imagining you'd want to do something like:
```
import {registrationService, TimeScale, LinearScale, LineController} from 'chart.js';
registrationService.register(TimeScale, LinearScale, LineController);
```

If you have auto-registration you wouldn't want to have an entry point that imports everything, so you'd want to import the modules, but wouldn't need to register, so it'd end up looking like:
```
import TimeScale from 'chart.js/scale.time';
import LinearScale from 'chart.js/scale.linear';
import LineController from 'chart.js/controller.line';
```

I still think I prefer the auto-registration route, but thought this would be helpful for visualizing the differences between the two approaches