### PR TITLE
When `gridLines.display` is false, the axis border is still drawn

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -1161,11 +1161,6 @@ class Scale extends Element {
 	_drawGrid(chartArea) {
 		const me = this;
 		const gridLines = me.options.gridLines;
-
-		if (!gridLines.display) {
-			return;
-		}
-
 		const ctx = me.ctx;
 		const chart = me.chart;
 		let context = {
@@ -1176,34 +1171,36 @@ class Scale extends Element {
 		const items = me._gridLineItems || (me._gridLineItems = me._computeGridLineItems(chartArea));
 		let i, ilen;
 
-		for (i = 0, ilen = items.length; i < ilen; ++i) {
-			const item = items[i];
-			const width = item.width;
-			const color = item.color;
+		if (gridLines.display) {
+			for (i = 0, ilen = items.length; i < ilen; ++i) {
+				const item = items[i];
+				const width = item.width;
+				const color = item.color;
 
-			if (width && color) {
-				ctx.save();
-				ctx.lineWidth = width;
-				ctx.strokeStyle = color;
-				if (ctx.setLineDash) {
-					ctx.setLineDash(item.borderDash);
-					ctx.lineDashOffset = item.borderDashOffset;
+				if (width && color) {
+					ctx.save();
+					ctx.lineWidth = width;
+					ctx.strokeStyle = color;
+					if (ctx.setLineDash) {
+						ctx.setLineDash(item.borderDash);
+						ctx.lineDashOffset = item.borderDashOffset;
+					}
+
+					ctx.beginPath();
+
+					if (gridLines.drawTicks) {
+						ctx.moveTo(item.tx1, item.ty1);
+						ctx.lineTo(item.tx2, item.ty2);
+					}
+
+					if (gridLines.drawOnChartArea) {
+						ctx.moveTo(item.x1, item.y1);
+						ctx.lineTo(item.x2, item.y2);
+					}
+
+					ctx.stroke();
+					ctx.restore();
 				}
-
-				ctx.beginPath();
-
-				if (gridLines.drawTicks) {
-					ctx.moveTo(item.tx1, item.ty1);
-					ctx.lineTo(item.tx2, item.ty2);
-				}
-
-				if (gridLines.drawOnChartArea) {
-					ctx.moveTo(item.x1, item.y1);
-					ctx.lineTo(item.x2, item.y2);
-				}
-
-				ctx.stroke();
-				ctx.restore();
 			}
 		}
 


### PR DESCRIPTION
Resolves #6876 