### PR TITLE
Improve tick generation on time scale

### DIFF
--- a/samples/scales/time/line.html
+++ b/samples/scales/time/line.html
@@ -110,6 +110,10 @@
 							// round: 'day'
 							tooltipFormat: 'll HH:mm'
 						},
+						ticks: {
+							autoSkip: false,
+							maxTicksLimit: 10,
+						},
 						scaleLabel: {
 							display: true,
 							labelString: 'Date'

--- a/src/core/core.adapters.js
+++ b/src/core/core.adapters.js
@@ -24,7 +24,7 @@ function abstract() {
 
 /**
  * Currently supported unit string values.
- * @typedef {('millisecond'|'second'|'minute'|'hour'|'day'|'week'|'month'|'quarter'|'year')} Unit
+ * @typedef {('millisecond'|'second'|'minute'|'hour'|'day'|'week'|'isoWeek'|'month'|'quarter'|'year')} Unit
  * @memberof Chart._adapters._date
  */
 

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -457,6 +457,12 @@ class Scale extends Element {
 		me.determineDataLimits();
 		me.afterDataLimits();
 
+		// _configure is called twice, once here, once from core.controller.updateLayout.
+		// Here we haven't been positioned yet, but dimensions are correct.
+		// Variables set in _configure are needed for buildTicks and calculateLabelRotation.
+		// It's ok that coordinates are not correct yet, only dimensions matter.
+		me._configure();
+
 		me.beforeBuildTicks();
 
 		me.ticks = me.buildTicks() || [];
@@ -469,12 +475,6 @@ class Scale extends Element {
 		samplingEnabled = sampleSize < me.ticks.length;
 		me._convertTicksToLabels(samplingEnabled ? sample(me.ticks, sampleSize) : me.ticks);
 
-		// _configure is called twice, once here, once from core.controller.updateLayout.
-		// Here we haven't been positioned yet, but dimensions are correct.
-		// Variables set in _configure are needed for calculateLabelRotation, and
-		// it's ok that coordinates are not correct there, only dimensions matter.
-		me._configure();
-
 		// Tick Rotation
 		me.beforeCalculateLabelRotation();
 		me.calculateLabelRotation(); // Preconditions: number of ticks and sizes of largest labels must be calculated beforehand
@@ -485,7 +485,7 @@ class Scale extends Element {
 		me.afterFit();
 
 		// Auto-skip
-		me.ticks = tickOpts.display && (tickOpts.autoSkip || tickOpts.source === 'auto') ? me._autoSkip(me.ticks) : me.ticks;
+		me.ticks = tickOpts.display && tickOpts.autoSkip ? me._autoSkip(me.ticks) : me.ticks;
 
 		if (samplingEnabled) {
 			// Generate labels using all non-skipped ticks
@@ -1512,7 +1512,7 @@ class Scale extends Element {
 		const context = {
 			chart: me.chart,
 			scale: me,
-			tick: me.ticks[index],
+			tick: me.ticks && me.ticks[index],
 			index: index
 		};
 		return extend(_parseFont({

--- a/src/scales/scale.linearbase.js
+++ b/src/scales/scale.linearbase.js
@@ -269,7 +269,7 @@ class LinearScaleBase extends Scale {
 
 	_configure() {
 		const me = this;
-		const ticks = me.ticks;
+		const ticks = me.ticks || [];
 		let start = me.min;
 		let end = me.max;
 

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -901,9 +901,9 @@ describe('Linear Scale', function() {
 		var yScale = chart.scales.y;
 		expect(xScale.paddingTop).toBeCloseToPixel(0);
 		expect(xScale.paddingBottom).toBeCloseToPixel(0);
-		expect(xScale.paddingLeft).toBeCloseToPixel(12);
-		expect(xScale.paddingRight).toBeCloseToPixel(13.5);
-		expect(xScale.width).toBeCloseToPixel(468 - 6); // minus lineSpace
+		expect(xScale.paddingLeft).toBeCloseToPixel(50);
+		expect(xScale.paddingRight).toBeCloseToPixel(17);
+		expect(xScale.width).toBeCloseToPixel(443);
 		expect(xScale.height).toBeCloseToPixel(30);
 
 		expect(yScale.paddingTop).toBeCloseToPixel(7);
@@ -920,9 +920,9 @@ describe('Linear Scale', function() {
 
 		expect(xScale.paddingTop).toBeCloseToPixel(0);
 		expect(xScale.paddingBottom).toBeCloseToPixel(0);
-		expect(xScale.paddingLeft).toBeCloseToPixel(12);
-		expect(xScale.paddingRight).toBeCloseToPixel(13.5);
-		expect(xScale.width).toBeCloseToPixel(440);
+		expect(xScale.paddingLeft).toBeCloseToPixel(49);
+		expect(xScale.paddingRight).toBeCloseToPixel(17);
+		expect(xScale.width).toBeCloseToPixel(436);
 		expect(xScale.height).toBeCloseToPixel(53);
 
 		expect(yScale.paddingTop).toBeCloseToPixel(7);

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -6,7 +6,6 @@ describe('Time scale tests', function() {
 
 		options = options || {};
 		options.type = 'time';
-		options.id = 'xScale0';
 
 		var chart = window.acquireChart({
 			type: 'line',
@@ -127,7 +126,7 @@ describe('Time scale tests', function() {
 			var ticks = getLabels(scale);
 
 			// `bounds === 'data'`: first and last ticks removed since outside the data range
-			expect(ticks.length).toEqual(44);
+			expect(ticks.length).toEqual(9);
 		});
 
 		it('should accept labels as date objects', function() {
@@ -138,7 +137,7 @@ describe('Time scale tests', function() {
 			var ticks = getLabels(scale);
 
 			// `bounds === 'data'`: first and last ticks removed since outside the data range
-			expect(ticks.length).toEqual(44);
+			expect(ticks.length).toEqual(9);
 		});
 
 		it('should accept data as xy points', function() {
@@ -185,7 +184,7 @@ describe('Time scale tests', function() {
 			var ticks = getLabels(xScale);
 
 			// `bounds === 'data'`: first and last ticks removed since outside the data range
-			expect(ticks.length).toEqual(37);
+			expect(ticks.length).toEqual(9);
 		});
 
 		it('should accept data as ty points', function() {
@@ -232,7 +231,7 @@ describe('Time scale tests', function() {
 			var ticks = getLabels(tScale);
 
 			// `bounds === 'data'`: first and last ticks removed since outside the data range
-			expect(ticks.length).toEqual(37);
+			expect(ticks.length).toEqual(9);
 		});
 	});
 
@@ -588,7 +587,7 @@ describe('Time scale tests', function() {
 						},
 					}
 				}
-			}, {canvas: {width: 800, height: 200}});
+			}, {canvas: {width: 600, height: 200}});
 
 			this.scale = this.chart.scales.x;
 		});
@@ -697,7 +696,7 @@ describe('Time scale tests', function() {
 		it('should get the correct labels for ticks', function() {
 			var labels = getLabels(this.scale);
 
-			expect(labels.length).toEqual(21);
+			expect(labels.length).toEqual(13);
 			expect(labels[0]).toEqual('<8:00:00>');
 			expect(labels[labels.length - 1]).toEqual('<8:01:00>');
 		});
@@ -710,7 +709,7 @@ describe('Time scale tests', function() {
 			chart.update();
 
 			var labels = getLabels(this.scale);
-			expect(labels.length).toEqual(21);
+			expect(labels.length).toEqual(13);
 			expect(labels[0]).toEqual('{8:00:00}');
 			expect(labels[labels.length - 1]).toEqual('{8:01:00}');
 		});
@@ -949,8 +948,7 @@ describe('Time scale tests', function() {
 
 				expect(scale.min).toEqual(+moment('2017', 'YYYY'));
 				expect(scale.max).toEqual(+moment('2043', 'YYYY'));
-				expect(getLabels(scale)).toEqual([
-					'2017', '2018', '2019', '2020', '2025', '2042', '2043']);
+				expect(getLabels(scale)).toEqual(['2017', '2019', '2025', '2043']);
 			});
 			it ('should not add ticks for min and max if they extend the labels range', function() {
 				var chart = this.chart;
@@ -963,8 +961,7 @@ describe('Time scale tests', function() {
 
 				expect(scale.min).toEqual(+moment('2012', 'YYYY'));
 				expect(scale.max).toEqual(+moment('2051', 'YYYY'));
-				expect(getLabels(scale)).toEqual([
-					'2017', '2018', '2019', '2020', '2025', '2042', '2043']);
+				expect(getLabels(scale)).toEqual(['2017', '2020', '2025', '2042', '2051']);
 			});
 			it ('should not duplicate ticks if min and max are the labels limits', function() {
 				var chart = this.chart;
@@ -977,8 +974,7 @@ describe('Time scale tests', function() {
 
 				expect(scale.min).toEqual(+moment('2017', 'YYYY'));
 				expect(scale.max).toEqual(+moment('2043', 'YYYY'));
-				expect(getLabels(scale)).toEqual([
-					'2017', '2018', '2019', '2020', '2025', '2042', '2043']);
+				expect(getLabels(scale)).toEqual(['2017', '2019', '2025', '2043']);
 			});
 			it ('should correctly handle empty `data.labels` using "day" if `time.unit` is undefined`', function() {
 				var chart = this.chart;
@@ -989,8 +985,7 @@ describe('Time scale tests', function() {
 
 				expect(scale.min).toEqual(+moment('2018', 'YYYY'));
 				expect(scale.max).toEqual(+moment('2043', 'YYYY'));
-				expect(getLabels(scale)).toEqual([
-					'2018', '2020', '2043']);
+				expect(getLabels(scale)).toEqual(['2018', '2020', '2043']);
 			});
 			it ('should correctly handle empty `data.labels` and hidden datasets using `time.unit`', function() {
 				var chart = this.chart;
@@ -1005,7 +1000,7 @@ describe('Time scale tests', function() {
 
 				expect(scale.min).toEqual(+moment().startOf('year'));
 				expect(scale.max).toEqual(+moment().endOf('year') + 1);
-				expect(getLabels(scale)).toEqual([]);
+				expect(getLabels(scale)).toEqual(['2020', '2021']);
 			});
 		});
 	});
@@ -1186,8 +1181,7 @@ describe('Time scale tests', function() {
 				expect(scale.max).toEqual(+moment('02/23 11:00', 'MM/DD HH:mm'));
 				expect(scale.getPixelForValue(moment('02/20 08:00', 'MM/DD HH:mm').valueOf())).toBeCloseToPixel(scale.left);
 				expect(scale.getPixelForValue(moment('02/23 11:00', 'MM/DD HH:mm').valueOf())).toBeCloseToPixel(scale.left + scale.width);
-				expect(getLabels(scale)).toEqual([
-					'Feb 21', 'Feb 22', 'Feb 23']);
+				expect(getLabels(scale)).toEqual(['Feb 21', 'Feb 22', 'Feb 23']);
 			});
 		});
 
@@ -1736,6 +1730,11 @@ describe('Time scale tests', function() {
 							},
 							source: 'data',
 							autoSkip: true
+						},
+						time: {
+							displayFormats: {
+								quarter: 'MMM YYYY'
+							}
 						}
 					},
 				}


### PR DESCRIPTION
This brings back and improves the tick generation from earlier versions. It was simplified to generate all the ticks in 2.9, and to rely on autoSkip. It is quite expensive though and ticks can be generated with similar logic that is used by autoSkip to skip them.

IMO this works quite well in both series and linear modes.

### Logic
 *  determine the units to use. If `major` ticks are enabled, units all the way up to year can be used. So if the determined (or set) unit is `day`, major ticks can be `month` and `year`. Only `common` units are used by default.
 * determine maximum number of tick "slots". `scale._length / longest label format of the determined units`. Rotation options are considered when measuring the label. `maxTicksLimit` is used as upper bound (or 1000 if not defined)
 * determine `stepSize` for the smallest / base unit. use `time.stepSize` if specified.
 * if ticks.source is 'labels', convert labels to ticks. Else generate ticks. If source is `data`, align the generated ticks with data.

### Added config options:
 * `time.maxUnit`
 * `time.units` - array of acceptable units, smallest to largest
 * `ticks.spcacing` - number of pixels to space ticks apart, used to figure out the max number of "slots" (capacity)

### Tick generation
 * determine the first and last tick, aligned to unit and honoring bounds.
 * determine next value for each `major` unit available
 * generate ticks for every `stepSize` unit
   * check if that aligns with any marjor unit
     * if so make it a major tick and use the greatest major unit it aligns with
   * update `majors` object, so each major tick is > current tick
   * use `addTick` helper to add the ticks

`addTick`
* determine the slot index that this tick would belong.
* determine the relative offset to the slot center (optimal location)
* determine if the absolute position is `tooClose` to previously added tick. 
  * using a hard-coded 80% of the slot spacing at the moment. 
* if its shares the slot with previous tick or is too close, decide which one to keep
  1. keep the first tick
  2. keep the one with greater unit (level)
  3. keep the one that is placed more optimally to the slot
 * return false if the tick was not added

https://codepen.io/kurkle/pen/yLyrWXQ?editors=1010
https://plnkr.co/edit/M4W2Wx3WIrw0h1KlIe3w?p=preview

