### PR TITLE
Remove requestAnimationFrame polyfill

### DIFF
--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -99,6 +99,7 @@ Animation system was completely rewritten in Chart.js v3. Each property can now 
 * `helpers.numberOfLabelLines`
 * `helpers.previousItem`
 * `helpers.removeEvent`
+* `helpers.requestAnimFrame`
 * `helpers.roundedRect`
 * `helpers.scaleMerge`
 * `helpers.where`

--- a/src/core/core.animator.js
+++ b/src/core/core.animator.js
@@ -1,7 +1,5 @@
 'use strict';
 
-import helpers from '../helpers';
-
 function drawFPS(chart, count, date, lastDate) {
 	const fps = (1000 / (date - lastDate)) | 0;
 	const ctx = chart.ctx;
@@ -48,7 +46,7 @@ class Animator {
 		}
 		me._running = true;
 
-		me._request = helpers.requestAnimFrame.call(window, function() {
+		me._request = window.requestAnimationFrame(function() {
 			me._update();
 			me._request = null;
 

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -113,22 +113,6 @@ export default {
 
 		return niceFraction * Math.pow(10, exponent);
 	},
-	// Request animation polyfill - https://www.paulirish.com/2011/requestanimationframe-for-smart-animating/
-	requestAnimFrame: (function() {
-		if (typeof window === 'undefined') {
-			return function(callback) {
-				callback();
-			};
-		}
-		return window.requestAnimationFrame ||
-			window.webkitRequestAnimationFrame ||
-			window.mozRequestAnimationFrame ||
-			window.oRequestAnimationFrame ||
-			window.msRequestAnimationFrame ||
-			function(callback) {
-				return window.setTimeout(callback, 1000 / 60);
-			};
-	}()),
 	// -- Canvas methods
 	fontString: function(pixelSize, fontStyle, fontFamily) {
 		return fontStyle + ' ' + pixelSize + 'px ' + fontFamily;

--- a/src/platform/platform.dom.js
+++ b/src/platform/platform.dom.js
@@ -162,7 +162,7 @@ function throttled(fn, thisArg) {
 
 		if (!ticking) {
 			ticking = true;
-			helpers.requestAnimFrame.call(window, function() {
+			window.requestAnimationFrame(function() {
 				ticking = false;
 				fn.apply(thisArg, args);
 			});


### PR DESCRIPTION
`requestAnimationFrame` appears to be supported on all supported browsers, so the polyfill no longer seems necessary. There is the chance that this breaks when `window` is not available, but I think in that case you'd just want to disable animations