### PR TITLE
Convert the DateAdapter to ES6

### DIFF
--- a/src/core/core.adapters.js
+++ b/src/core/core.adapters.js
@@ -6,13 +6,13 @@
 
 'use strict';
 
-import helpers from '../helpers';
+import {extend} from '../helpers/helpers.core';
 
+/**
+ * @return {*}
+ */
 function abstract() {
-	throw new Error(
-		'This method is not implemented: either no adapter can ' +
-		'be found or an incomplete integration was provided.'
-	);
+	throw new Error('This method is not implemented: either no adapter can be found or an incomplete integration was provided.');
 }
 
 /**
@@ -24,43 +24,44 @@ function abstract() {
 
 /**
  * Currently supported unit string values.
- * @typedef {('millisecond'|'second'|'minute'|'hour'|'day'|'week'|'month'|'quarter'|'year')}
+ * @typedef {('millisecond'|'second'|'minute'|'hour'|'day'|'week'|'month'|'quarter'|'year')} Unit
  * @memberof Chart._adapters._date
- * @name Unit
  */
 
-/**
- * @class
- */
-function DateAdapter(options) {
-	this.options = options || {};
-}
+class DateAdapter {
 
-helpers.extend(DateAdapter.prototype, /** @lends DateAdapter */ {
+	constructor(options) {
+		this.options = options || {};
+	}
+
 	/**
 	 * Returns a map of time formats for the supported formatting units defined
 	 * in Unit as well as 'datetime' representing a detailed date/time string.
 	 * @returns {{string: string}}
 	 */
-	formats: abstract,
+	formats() {
+		return abstract();
+	}
 
 	/**
 	 * Parses the given `value` and return the associated timestamp.
 	 * @param {any} value - the value to parse (usually comes from the data)
 	 * @param {string} [format] - the expected data format
 	 * @returns {(number|null)}
-	 * @function
 	 */
-	parse: abstract,
+	parse(value, format) { // eslint-disable-line no-unused-vars
+		return abstract();
+	}
 
 	/**
 	 * Returns the formatted date in the specified `format` for a given `timestamp`.
 	 * @param {number} timestamp - the timestamp to format
 	 * @param {string} format - the date/time token
 	 * @return {string}
-	 * @function
 	 */
-	format: abstract,
+	format(timestamp, format) { // eslint-disable-line no-unused-vars
+		return abstract();
+	}
 
 	/**
 	 * Adds the specified `amount` of `unit` to the given `timestamp`.
@@ -68,19 +69,21 @@ helpers.extend(DateAdapter.prototype, /** @lends DateAdapter */ {
 	 * @param {number} amount - the amount to add
 	 * @param {Unit} unit - the unit as string
 	 * @return {number}
-	 * @function
 	 */
-	add: abstract,
+	add(timestamp, amount, unit) { // eslint-disable-line no-unused-vars
+		return abstract();
+	}
 
 	/**
 	 * Returns the number of `unit` between the given timestamps.
-	 * @param {number} max - the input timestamp (reference)
-	 * @param {number} min - the timestamp to substract
+	 * @param {number} a - the input timestamp (reference)
+	 * @param {number} b - the timestamp to subtract
 	 * @param {Unit} unit - the unit as string
 	 * @return {number}
-	 * @function
 	 */
-	diff: abstract,
+	diff(a, b, unit) { // eslint-disable-line no-unused-vars
+		return abstract();
+	}
 
 	/**
 	 * Returns start of `unit` for the given `timestamp`.
@@ -88,21 +91,26 @@ helpers.extend(DateAdapter.prototype, /** @lends DateAdapter */ {
 	 * @param {Unit} unit - the unit as string
 	 * @param {number} [weekday] - the ISO day of the week with 1 being Monday
 	 * and 7 being Sunday (only needed if param *unit* is `isoWeek`).
-	 * @function
+	 * @return {number}
 	 */
-	startOf: abstract,
+	startOf(timestamp, unit, weekday) { // eslint-disable-line no-unused-vars
+		return abstract();
+	}
 
 	/**
 	 * Returns end of `unit` for the given `timestamp`.
 	 * @param {number} timestamp - the input timestamp
 	 * @param {Unit} unit - the unit as string
-	 * @function
+	 * @return {number}
 	 */
-	endOf: abstract
-});
+	endOf(timestamp, unit) { // eslint-disable-line no-unused-vars
+		return abstract();
+	}
+
+}
 
 DateAdapter.override = function(members) {
-	helpers.extend(DateAdapter.prototype, members);
+	extend(DateAdapter.prototype, members);
 };
 
 export default {


### PR DESCRIPTION
Extracted from https://github.com/chartjs/Chart.js/pull/7030. Converts `DateAdapter` to an ES6 class, allows the `DateAdapter` to be used in TypeScript projects, and fixes a number of JSDoc errors.