### PR TITLE
Reduce requestAnimationFrame polyfill

### DIFF
--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -120,10 +120,7 @@ export default {
 				callback();
 			};
 		}
-		return window.requestAnimationFrame ||
-			function(callback) {
-				return window.setTimeout(callback, 1000 / 60);
-			};
+		return window.requestAnimationFrame;
 	}()),
 	// -- Canvas methods
 	fontString: function(pixelSize, fontStyle, fontFamily) {

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -113,7 +113,7 @@ export default {
 
 		return niceFraction * Math.pow(10, exponent);
 	},
-	// Request animation polyfill - https://www.paulirish.com/2011/requestanimationframe-for-smart-animating/
+	// Request animation polyfill
 	requestAnimFrame: (function() {
 		if (typeof window === 'undefined') {
 			return function(callback) {
@@ -121,10 +121,6 @@ export default {
 			};
 		}
 		return window.requestAnimationFrame ||
-			window.webkitRequestAnimationFrame ||
-			window.mozRequestAnimationFrame ||
-			window.oRequestAnimationFrame ||
-			window.msRequestAnimationFrame ||
 			function(callback) {
 				return window.setTimeout(callback, 1000 / 60);
 			};


### PR DESCRIPTION
`requestAnimationFrame` appears to be supported on all supported browsers, so the polyfill no longer seems necessary