### PR TITLE
Remove unnecessary check for color library

### DIFF
--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -11,11 +11,7 @@ import * as options from './helpers.options';
 import * as math from './helpers.math';
 import * as rtl from './helpers.rtl';
 
-const colorHelper = !color ?
-	function(value) {
-		console.error('Color.js not found!');
-		return value;
-	} :
+const colorHelper =
 	function(value) {
 		if (value instanceof CanvasGradient || value instanceof CanvasPattern) {
 			// TODO: figure out what this should be. Previously returned


### PR DESCRIPTION
The color library gets compiled into the bundle by rollup, so I don't see how it could ever be missing.