### PR TITLE
Switch from chartjs-color to @kurkle/color

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -779,6 +779,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@kurkle/color": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.1.1.tgz",
+      "integrity": "sha512-rpgJFEVJQNwCLSPiBbSSzR3ujRFXuwTRJEzYEto5/L5hsvEzoEHq0M72A6GJC5tWO/CF+tlS5Ii9hUb+Geiu1A=="
+    },
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -2205,23 +2210,6 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
-    "chartjs-color": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.4.1.tgz",
-      "integrity": "sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==",
-      "requires": {
-        "chartjs-color-string": "^0.6.0",
-        "color-convert": "^1.9.3"
-      }
-    },
-    "chartjs-color-string": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz",
-      "integrity": "sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==",
-      "requires": {
-        "color-name": "^1.0.0"
-      }
-    },
     "chokidar": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
@@ -2445,6 +2433,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       },
@@ -2452,14 +2441,10 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
         }
       }
-    },
-    "color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "color-support": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,6 @@
     "yargs": "^14.0.0"
   },
   "dependencies": {
-    "chartjs-color": "^2.1.0"
+    "@kurkle/color": "^0.1.1"
   }
 }

--- a/src/core/core.animation.js
+++ b/src/core/core.animation.js
@@ -11,7 +11,7 @@ const interpolators = {
 		var c0 = helpers.color(from || transparent);
 		var c1 = c0.valid && helpers.color(to || transparent);
 		return c1 && c1.valid
-			? c1.mix(c0, factor).rgbaString()
+			? c1.mix(c0, factor).hexString()
 			: to;
 	}
 };

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import color from 'chartjs-color';
+import color from '@kurkle/color';
 
 import * as coreHelpers from './helpers.core';
 import * as canvas from './helpers.canvas';
@@ -49,6 +49,6 @@ export default {
 	getHoverColor: function(colorValue) {
 		return (colorValue instanceof CanvasPattern || colorValue instanceof CanvasGradient) ?
 			colorValue :
-			colorHelper(colorValue).saturate(0.5).darken(0.1).rgbString();
+			colorHelper(colorValue).saturate(0.5).darken(0.1).hexString();
 	}
 };

--- a/test/specs/controller.bar.tests.js
+++ b/test/specs/controller.bar.tests.js
@@ -1279,8 +1279,8 @@ describe('Chart.controllers.bar', function() {
 		var bar = meta.data[0];
 
 		meta.controller.setHoverStyle(bar, 1, 0);
-		expect(bar.options.backgroundColor).toBe('rgb(230, 0, 0)');
-		expect(bar.options.borderColor).toBe('rgb(0, 0, 230)');
+		expect(bar.options.backgroundColor).toBe('#E60000');
+		expect(bar.options.borderColor).toBe('#0000E6');
 		expect(bar.options.borderWidth).toBe(2);
 
 		// Set a dataset style

--- a/test/specs/controller.bubble.tests.js
+++ b/test/specs/controller.bubble.tests.js
@@ -293,8 +293,8 @@ describe('Chart.controllers.bubble', function() {
 			var point = chart.getDatasetMeta(0).data[0];
 
 			afterEvent(chart, 'mousemove', function() {
-				expect(point.options.backgroundColor).toBe('rgb(49, 135, 221)');
-				expect(point.options.borderColor).toBe('rgb(22, 89, 156)');
+				expect(point.options.backgroundColor).toBe('#3187DD');
+				expect(point.options.borderColor).toBe('#175A9D');
 				expect(point.options.borderWidth).toBe(1);
 				expect(point.options.radius).toBe(20 + 4);
 

--- a/test/specs/controller.doughnut.tests.js
+++ b/test/specs/controller.doughnut.tests.js
@@ -352,8 +352,8 @@ describe('Chart.controllers.doughnut', function() {
 			var arc = chart.getDatasetMeta(0).data[0];
 
 			afterEvent(chart, 'mousemove', function() {
-				expect(arc.options.backgroundColor).toBe('rgb(49, 135, 221)');
-				expect(arc.options.borderColor).toBe('rgb(22, 89, 156)');
+				expect(arc.options.backgroundColor).toBe('#3187DD');
+				expect(arc.options.borderColor).toBe('#175A9D');
 				expect(arc.options.borderWidth).toBe(2);
 
 				afterEvent(chart, 'mouseout', function() {

--- a/test/specs/controller.line.tests.js
+++ b/test/specs/controller.line.tests.js
@@ -795,8 +795,8 @@ describe('Chart.controllers.line', function() {
 			var point = chart.getDatasetMeta(0).data[0];
 
 			afterEvent(chart, 'mousemove', function() {
-				expect(point.options.backgroundColor).toBe('rgb(49, 135, 221)');
-				expect(point.options.borderColor).toBe('rgb(22, 89, 156)');
+				expect(point.options.backgroundColor).toBe('#3187DD');
+				expect(point.options.borderColor).toBe('#175A9D');
 				expect(point.options.borderWidth).toBe(1);
 				expect(point.options.radius).toBe(4);
 

--- a/test/specs/controller.polarArea.tests.js
+++ b/test/specs/controller.polarArea.tests.js
@@ -265,8 +265,8 @@ describe('Chart.controllers.polarArea', function() {
 			var arc = chart.getDatasetMeta(0).data[0];
 
 			afterEvent(chart, 'mousemove', function() {
-				expect(arc.options.backgroundColor).toBe('rgb(49, 135, 221)');
-				expect(arc.options.borderColor).toBe('rgb(22, 89, 156)');
+				expect(arc.options.backgroundColor).toBe('#3187DD');
+				expect(arc.options.borderColor).toBe('#175A9D');
 				expect(arc.options.borderWidth).toBe(2);
 
 				afterEvent(chart, 'mouseout', function() {

--- a/test/specs/controller.radar.tests.js
+++ b/test/specs/controller.radar.tests.js
@@ -257,8 +257,8 @@ describe('Chart.controllers.radar', function() {
 			var point = chart.getDatasetMeta(0).data[0];
 
 			afterEvent(chart, 'mousemove', function() {
-				expect(point.options.backgroundColor).toBe('rgb(49, 135, 221)');
-				expect(point.options.borderColor).toBe('rgb(22, 89, 156)');
+				expect(point.options.backgroundColor).toBe('#3187DD');
+				expect(point.options.borderColor).toBe('#175A9D');
 				expect(point.options.borderWidth).toBe(1);
 				expect(point.options.radius).toBe(4);
 

--- a/test/specs/core.helpers.tests.js
+++ b/test/specs/core.helpers.tests.js
@@ -16,7 +16,7 @@ describe('Core helper tests', function() {
 
 	describe('Color helper', function() {
 		function isColorInstance(obj) {
-			return typeof obj === 'object' && Object.prototype.hasOwnProperty.call(obj, 'values') && Object.prototype.hasOwnProperty.call(obj.values, 'rgb');
+			return typeof obj === 'object' && Object.prototype.hasOwnProperty.call(obj, 'valid');
 		}
 
 		it('should return a color when called with a color', function() {


### PR DESCRIPTION
* .min size reduced by **19 050** bytes (to 161kb)
* quite a lot faster
* use `hexString` instead of `rgbString` for additional speed