### PR TITLE
Generate types

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,6 +18,7 @@ const typedoc = require('gulp-typedoc');
 
 const pkg = require('./package.json');
 const tsProject = typescript.createProject('./tsconfig.json');
+const tsBuild = typescript.createProject('./tsconfig.build.json');
 
 const argv = yargs
 	.option('verbose', {default: false})
@@ -27,7 +28,9 @@ const srcDir = './src/';
 const outDir = './dist/';
 
 gulp.task('bower', bowerTask);
-gulp.task('build', buildTask);
+gulp.task('buildjs', buildTask);
+gulp.task('buildts', typescriptDefinitionsTask);
+gulp.task('build', gulp.parallel('buildjs', 'buildts'));
 gulp.task('package', packageTask);
 gulp.task('lint-html', lintHtmlTask);
 gulp.task('lint-js', lintJsTask);
@@ -132,6 +135,12 @@ function lintJsTask() {
 function typescriptTask() {
 	return tsProject.src()
 		.pipe(tsProject())
+		.js.pipe(gulp.dest('dist'));
+}
+
+function typescriptDefinitionsTask() {
+	return tsBuild.src()
+		.pipe(tsBuild())
 		.js.pipe(gulp.dest('dist'));
 }
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "bower.json",
     "composer.json",
     "dist/*.css",
-    "dist/*.js"
+    "dist/*.js",
+    "dist/types/**/*.d.ts"
   ],
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/src/core/core.adapters.js
+++ b/src/core/core.adapters.js
@@ -28,7 +28,7 @@ function abstract() {
  * @memberof Chart._adapters._date
  */
 
-class DateAdapter {
+export class DateAdapter {
 
 	constructor(options) {
 		this.options = options || {};

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -208,6 +208,7 @@ class Chart {
 		this._updating = false;
 		this.scales = {};
 		this.scale = undefined;
+		this.$plugins = undefined;
 
 		// Add the chart instance to the global namespace
 		Chart.instances[me.id] = me;

--- a/src/core/core.plugins.js
+++ b/src/core/core.plugins.js
@@ -131,6 +131,7 @@ class PluginService {
 	 * Returns descriptors of enabled plugins for the given chart.
 	 * @returns {object[]} [{ plugin, options }]
 	 * @private
+	 * @param {Chart} chart
 	 */
 	descriptors(chart) {
 		var cache = chart.$plugins || (chart.$plugins = {});
@@ -176,6 +177,7 @@ class PluginService {
 	 * but in some cases, this reference can be changed by the user when updating options.
 	 * https://github.com/chartjs/Chart.js/issues/5111#issuecomment-355934167
 	 * @private
+	 * @param {Chart} chart
 	 */
 	_invalidate(chart) {
 		delete chart.$plugins;

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+	  "target": "ES6",
+	  "moduleResolution": "Node",
+	  "allowSyntheticDefaultImports": true,
+	  "allowJs": true,
+	  "checkJs": true,
+	  "noEmit": false,
+	  "declaration": true,
+	  "declarationDir": "dist/types",
+	  "emitDeclarationOnly": true
+	},
+	"include": [
+	  "./src/**/*.js"
+	]
+  }


### PR DESCRIPTION
On top of #7030, add type generation. 

It produced initially 3 errors, that are resolved by changing `defaults` and `pluginService` to class declarations, making singleton instance and exporting that, changing `defaults._set` to `defaults.set` and exporting `DateAdapter`.

Also fixed the formatting of gulpfile.js