### PR TITLE
Fix time scale computeOffsets

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -358,23 +358,23 @@ function generate(scale) {
  * They add extra margins on the both sides by scaling down the original scale.
  * Offsets are added when the `offset` option is true.
  */
-function computeOffsets(table, ticks, min, max, options) {
+function computeOffsets(table, timestamps, min, max, options) {
 	let start = 0;
 	let end = 0;
 	let first, last;
 
-	if (options.offset && ticks.length) {
-		first = interpolate(table, 'time', ticks[0], 'pos');
-		if (ticks.length === 1) {
+	if (options.offset && timestamps.length) {
+		first = interpolate(table, 'time', timestamps[0], 'pos');
+		if (timestamps.length === 1) {
 			start = 1 - first;
 		} else {
-			start = (interpolate(table, 'time', ticks[1], 'pos') - first) / 2;
+			start = (interpolate(table, 'time', timestamps[1], 'pos') - first) / 2;
 		}
-		last = interpolate(table, 'time', ticks[ticks.length - 1], 'pos');
-		if (ticks.length === 1) {
+		last = interpolate(table, 'time', timestamps[timestamps.length - 1], 'pos');
+		if (timestamps.length === 1) {
 			end = last;
 		} else {
-			end = (last - interpolate(table, 'time', ticks[ticks.length - 2], 'pos')) / 2;
+			end = (last - interpolate(table, 'time', timestamps[timestamps.length - 2], 'pos')) / 2;
 		}
 	}
 
@@ -626,7 +626,7 @@ class TimeScale extends Scale {
 		me._majorUnit = !tickOpts.major.enabled || me._unit === 'year' ? undefined
 			: determineMajorUnit(me._unit);
 		me._table = buildLookupTable(getTimestampsForTable(me), min, max, distribution);
-		me._offsets = computeOffsets(me._table, ticks, min, max, options);
+		me._offsets = computeOffsets(me._table, getDataTimestamps(me), min, max, options);
 
 		if (options.reverse) {
 			ticks.reverse();

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -1317,7 +1317,7 @@ describe('Time scale tests', function() {
 					this.chart = window.acquireChart({
 						type: 'line',
 						data: {
-							labels: ['2017', '2019', '2020', '2025'],
+							labels: ['2017', '2018', '2019', '2020', '2021'],
 							datasets: [{data: [0, 1, 2, 3, 4]}]
 						},
 						options: {
@@ -1325,7 +1325,8 @@ describe('Time scale tests', function() {
 								x: {
 									type: 'time',
 									time: {
-										parser: 'YYYY'
+										parser: 'YYYY',
+										unit: 'year'
 									},
 									ticks: {
 										source: source
@@ -1341,7 +1342,7 @@ describe('Time scale tests', function() {
 					var scale = this.chart.scales.x;
 
 					expect(scale.getPixelForValue(moment('2017').valueOf())).toBeCloseToPixel(scale.left);
-					expect(scale.getPixelForValue(moment('2025').valueOf())).toBeCloseToPixel(scale.left + scale.width);
+					expect(scale.getPixelForValue(moment('2021').valueOf())).toBeCloseToPixel(scale.left + scale.width);
 				});
 
 				it ('should add offset from the edges if offset is true', function() {
@@ -1357,7 +1358,7 @@ describe('Time scale tests', function() {
 					var lastTickInterval = scale.getPixelForTick(numTicks - 1) - scale.getPixelForTick(numTicks - 2);
 
 					expect(scale.getPixelForValue(moment('2017').valueOf())).toBeCloseToPixel(scale.left + firstTickInterval / 2);
-					expect(scale.getPixelForValue(moment('2025').valueOf())).toBeCloseToPixel(scale.left + scale.width - lastTickInterval / 2);
+					expect(scale.getPixelForValue(moment('2021').valueOf())).toBeCloseToPixel(scale.left + scale.width - lastTickInterval / 2);
 				});
 
 				it ('should not add offset if min and max extend the labels range', function() {
@@ -1430,8 +1431,8 @@ describe('Time scale tests', function() {
 				this.chart = window.acquireChart({
 					type: 'line',
 					data: {
-						labels: ['2017', '2019', '2020', '2025', '2042'],
-						datasets: [{data: [0, 1, 2, 3, 4, 5]}]
+						labels: ['2017', '2018', '2019', '2020', '2021'],
+						datasets: [{data: [0, 1, 2, 3, 4]}]
 					},
 					options: {
 						scales: {
@@ -1440,6 +1441,7 @@ describe('Time scale tests', function() {
 								reverse: true,
 								time: {
 									parser: 'YYYY',
+									unit: 'year'
 								},
 								ticks: {
 									source: 'labels',
@@ -1456,13 +1458,13 @@ describe('Time scale tests', function() {
 			it ('should reverse the labels', function() {
 				var scale = this.chart.scales.x;
 				expect(scale.getPixelForValue(moment('2017').valueOf())).toBeCloseToPixel(scale.left + scale.width);
-				expect(scale.getPixelForValue(moment('2042').valueOf())).toBeCloseToPixel(scale.left);
+				expect(scale.getPixelForValue(moment('2021').valueOf())).toBeCloseToPixel(scale.left);
 			});
 
 			it ('should reverse the values for pixels', function() {
 				var scale = this.chart.scales.x;
 				expect(scale.getValueForPixel(scale.left)).toBeCloseToTime({
-					value: moment('2042-01-01T00:00:00'),
+					value: moment('2021-01-01T00:00:00'),
 					unit: 'hour',
 				});
 				expect(scale.getValueForPixel(scale.left + scale.width)).toBeCloseToTime({
@@ -1480,11 +1482,11 @@ describe('Time scale tests', function() {
 				chart.update();
 
 				var numTicks = scale.ticks.length;
-				var firstTickInterval = scale.getPixelForTick(1) - scale.getPixelForTick(0);
-				var lastTickInterval = scale.getPixelForTick(numTicks - 1) - scale.getPixelForTick(numTicks - 2);
+				var firstTickInterval = scale.getPixelForTick(numTicks - 2) - scale.getPixelForTick(numTicks - 1);
+				var lastTickInterval = scale.getPixelForTick(0) - scale.getPixelForTick(1);
 
 				expect(scale.getPixelForValue(moment('2017').valueOf())).toBeCloseToPixel(scale.left + scale.width - lastTickInterval / 2);
-				expect(scale.getPixelForValue(moment('2042').valueOf())).toBeCloseToPixel(scale.left + firstTickInterval / 2);
+				expect(scale.getPixelForValue(moment('2021').valueOf())).toBeCloseToPixel(scale.left + firstTickInterval / 2);
 			});
 
 			it ('should reverse the values for pixels if offset is true', function() {
@@ -1496,12 +1498,12 @@ describe('Time scale tests', function() {
 				chart.update();
 
 				var numTicks = scale.ticks.length;
-				var firstTickInterval = scale.getPixelForTick(1) - scale.getPixelForTick(0);
-				var lastTickInterval = scale.getPixelForTick(numTicks - 1) - scale.getPixelForTick(numTicks - 2);
+				var firstTickInterval = scale.getPixelForTick(numTicks - 2) - scale.getPixelForTick(numTicks - 1);
+				var lastTickInterval = scale.getPixelForTick(0) - scale.getPixelForTick(1);
 
 				expect(scale.getValueForPixel(scale.left + lastTickInterval / 2)).toBeCloseToTime({
-					value: moment('2042-01-01T00:00:00'),
-					unit: 'hour',
+					value: moment('2021-01-01T00:00:00'),
+					unit: 'year',
 				});
 				expect(scale.getValueForPixel(scale.left + scale.width - firstTickInterval / 2)).toBeCloseToTime({
 					value: moment('2017-01-01T00:00:00'),


### PR DESCRIPTION
Closes https://github.com/chartjs/Chart.js/issues/7071

The `offset` option is meant to give a little extra room to be able to show a whole bar. It should be based on the bar/data width. Basing it on the space between ticks can add way too much whitespace

**master**

![Screenshot from 2020-02-08 09-09-13](https://user-images.githubusercontent.com/322311/74089160-2b743b00-4a53-11ea-8dd4-5bee71024fe4.png)

**PR**

![Screenshot from 2020-02-08 09-11-23](https://user-images.githubusercontent.com/322311/74089161-2f07c200-4a53-11ea-8822-4e040902da69.png)