### PR TITLE
Cleanup private methods on Scales

### DIFF
--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -201,6 +201,8 @@ Animation system was completely rewritten in Chart.js v3. Each property can now 
 * `DatasetController.onDataUnshift` was renamed to `DatasetController._onDataUnshift`
 * `DatasetController.removeElements` was renamed to `DatasetController._removeElements`
 * `DatasetController.resyncElements` was renamed to `DatasetController._resyncElements`
+* `RadialLinearScale.setReductions` was renamed to `RadialLinearScale._setReductions`
+* `Scale.handleMargins` was renamed to `Scale._handleMargins`
 * `helpers._alignPixel` was renamed to `helpers.canvas._alignPixel`
 * `helpers._decimalPlaces` was renamed to `helpers.math._decimalPlaces`
 

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -379,7 +379,7 @@ class Scale extends Element {
 
 	/**
 	 * Get the padding needed for the scale
-	 * @return {{top: number, left: number, bottom: number, right: number}}
+	 * @return {{top: number, left: number, bottom: number, right: number}} the necessary padding
 	 * @private
 	 */
 	getPadding() {
@@ -746,7 +746,7 @@ class Scale extends Element {
 			}
 		}
 
-		me.handleMargins();
+		me._handleMargins();
 
 		if (isHorizontal) {
 			me.width = me._length = chart.width - me.margins.left - me.margins.right;
@@ -761,7 +761,7 @@ class Scale extends Element {
 	 * Handle margins and padding interactions
 	 * @private
 	 */
-	handleMargins() {
+	_handleMargins() {
 		const me = this;
 		if (me.margins) {
 			me.margins.left = Math.max(me.paddingLeft, me.margins.left);
@@ -792,6 +792,7 @@ class Scale extends Element {
 
 	/**
 	 * @param {object[]} ticks
+	 * @private
 	 */
 	_convertTicksToLabels(ticks) {
 		const me = this;

--- a/src/helpers/helpers.segment.js
+++ b/src/helpers/helpers.segment.js
@@ -71,6 +71,7 @@ function getSegment(segment, points, bounds) {
  * @param {string} bounds.property - the property of a `Point` we are bounding. `x`, `y` or `angle`.
  * @param {number} bounds.start - start value of the property
  * @param {number} bounds.end - end value of the property
+ * @private
  **/
 export function _boundSegment(segment, points, bounds) {
 	if (!bounds) {
@@ -121,6 +122,7 @@ export function _boundSegment(segment, points, bounds) {
  * @param {string} bounds.property - the property we are bounding with. `x`, `y` or `angle`.
  * @param {number} bounds.start - start value of the `property`
  * @param {number} bounds.end - end value of the `property`
+ * @private
  */
 export function _boundSegments(line, bounds) {
 	const result = [];
@@ -213,6 +215,7 @@ function solidSegments(points, start, max, loop) {
  * Compute the continuous segments that define the whole line
  * There can be skipped points within a segment, if spanGaps is true.
  * @param {Line} line
+ * @private
  */
 export function _computeSegments(line) {
 	const points = line.points;

--- a/src/platform/platform.dom.js
+++ b/src/platform/platform.dom.js
@@ -45,8 +45,8 @@ const EVENT_TYPES = {
  * @returns {number} Size in pixels or undefined if unknown.
  */
 function readUsedSize(element, property) {
-	var value = helpers.dom.getStyle(element, property);
-	var matches = value && value.match(/^(\d+)(\.\d+)?px$/);
+	const value = helpers.dom.getStyle(element, property);
+	const matches = value && value.match(/^(\d+)(\.\d+)?px$/);
 	return matches ? Number(matches[1]) : undefined;
 }
 
@@ -110,7 +110,7 @@ function initCanvas(canvas, config) {
  * https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Safely_detecting_option_support
  * @private
  */
-var supportsEventListenerOptions = (function() {
+const supportsEventListenerOptions = (function() {
 	let supports = false;
 	try {
 		const options = Object.defineProperty({}, 'passive', {
@@ -128,7 +128,7 @@ var supportsEventListenerOptions = (function() {
 
 // Default passive to true as expected by Chrome for 'touchstart' and 'touchend' events.
 // https://github.com/chartjs/Chart.js/issues/4287
-var eventListenerOptions = supportsEventListenerOptions ? {passive: true} : false;
+const eventListenerOptions = supportsEventListenerOptions ? {passive: true} : false;
 
 function addListener(node, type, listener) {
 	node.addEventListener(type, listener, eventListenerOptions);

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -530,6 +530,9 @@ class Legend extends Element {
 		restoreTextDirection(me.ctx, opts.textDirection);
 	}
 
+	/**
+	 * @private
+	 */
 	_drawTitle() {
 		const me = this;
 		const opts = me.options;
@@ -612,6 +615,9 @@ class Legend extends Element {
 		ctx.fillText(titleOpts.text, x, y);
 	}
 
+	/**
+	 * @private
+	 */
 	_computeTitleHeight() {
 		const titleOpts = this.options.title;
 		const titleFont = _parseFont(titleOpts);
@@ -645,7 +651,6 @@ class Legend extends Element {
 	/**
 	 * Handle an event
 	 * @param {IEvent} e - The event to handle
-	 * @private
 	 */
 	handleEvent(e) {
 		var me = this;

--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -751,6 +751,9 @@ class Tooltip extends Element {
 		}
 	}
 
+	/**
+	 * @private
+	 */
 	_drawColorBox(ctx, pt, i, rtlHelper) {
 		const me = this;
 		const options = me.options;
@@ -983,7 +986,6 @@ class Tooltip extends Element {
 
 	/**
 	 * Handle an event
-	 * @private
 	 * @param {IEvent} e - The event to handle
 	 * @returns {boolean} true if the tooltip changed
 	 */

--- a/src/scales/scale.category.js
+++ b/src/scales/scale.category.js
@@ -18,6 +18,9 @@ class CategoryScale extends Scale {
 		this._valueRange = undefined;
 	}
 
+	/**
+	 * @private
+	 */
 	_parse(raw, index) {
 		const labels = this._getLabels();
 		if (labels[index] === raw) {
@@ -65,6 +68,9 @@ class CategoryScale extends Scale {
 		return value;
 	}
 
+	/**
+	 * @private
+	 */
 	_configure() {
 		const me = this;
 

--- a/src/scales/scale.linearbase.js
+++ b/src/scales/scale.linearbase.js
@@ -122,6 +122,9 @@ class LinearScaleBase extends Scale {
 		this._valueRange = undefined;
 	}
 
+	/**
+	 * @private
+	 */
 	_parse(raw, index) { // eslint-disable-line no-unused-vars
 		if (isNullOrUndef(raw)) {
 			return NaN;
@@ -219,10 +222,16 @@ class LinearScaleBase extends Scale {
 		return maxTicks;
 	}
 
+	/**
+	 * @private
+	 */
 	_computeTickLimit() {
 		return Number.POSITIVE_INFINITY;
 	}
 
+	/**
+	 * @private
+	 */
 	_handleDirectionalChanges(ticks) {
 		return ticks;
 	}
@@ -267,6 +276,9 @@ class LinearScaleBase extends Scale {
 		return ticks;
 	}
 
+	/**
+	 * @private
+	 */
 	_configure() {
 		const me = this;
 		const ticks = me.ticks;

--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -74,6 +74,9 @@ class LogarithmicScale extends Scale {
 		this._valueRange = undefined;
 	}
 
+	/**
+	 * @private
+	 */
 	_parse(raw, index) { // eslint-disable-line no-unused-vars
 		const value = LinearScaleBase.prototype._parse.apply(this, arguments);
 		if (value === 0) {
@@ -165,6 +168,9 @@ class LogarithmicScale extends Scale {
 		return this.getPixelForValue(ticks[index].value);
 	}
 
+	/**
+	 * @private
+	 */
 	_configure() {
 		const me = this;
 		let start = me.min;

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -183,7 +183,7 @@ function fitWithPointLabels(scale) {
 		}
 	}
 
-	scale.setReductions(scale.drawingArea, furthestLimits, furthestAngles);
+	scale._setReductions(scale.drawingArea, furthestLimits, furthestAngles);
 }
 
 function getTextAlignForAngle(angle) {
@@ -332,7 +332,10 @@ class RadialLinearScale extends LinearScaleBase {
 		me.handleTickRangeOptions();
 	}
 
-	// Returns the maximum number of ticks based on the scale dimension
+	/**
+	 * Returns the maximum number of ticks based on the scale dimension
+	 * @private
+	 */
 	_computeTickLimit() {
 		return Math.ceil(this.drawingArea / getTickBackdropHeight(this.options));
 	}
@@ -364,7 +367,7 @@ class RadialLinearScale extends LinearScaleBase {
 	 * Set radius reductions and determine new radius and center point
 	 * @private
 	 */
-	setReductions(largestPossibleRadius, furthestLimits, furthestAngles) {
+	_setReductions(largestPossibleRadius, furthestLimits, furthestAngles) {
 		var me = this;
 		var radiusReductionLeft = furthestLimits.l / Math.sin(furthestAngles.l);
 		var radiusReductionRight = Math.max(furthestLimits.r - me.width, 0) / Math.sin(furthestAngles.r);

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -605,6 +605,7 @@ class TimeScale extends Scale {
 	 * @param {*} raw
 	 * @param {number} index
 	 * @return {number}
+	 * @private
 	 */
 	_parse(raw, index) { // eslint-disable-line no-unused-vars
 		if (raw === undefined) {
@@ -618,6 +619,7 @@ class TimeScale extends Scale {
 	 * @param {string} axis
 	 * @param {number} index
 	 * @return {number}
+	 * @private
 	 */
 	_parseObject(obj, axis, index) {
 		if (obj && obj.t) {
@@ -629,6 +631,9 @@ class TimeScale extends Scale {
 		return null;
 	}
 
+	/**
+	 * @private
+	 */
 	_invalidateCaches() {
 		this._cache = {
 			data: [],


### PR DESCRIPTION
I made `getPadding` and `handleEvent` public since they were being called from outside the classes. The others I either prefixed with underscore or added `@private` tag to