### PR TITLE
Convert Scale to TypeScript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "allowSyntheticDefaultImports": true,
     "allowJs": true,
     "checkJs": true,
-    "noEmit": true
+    "outDir": "./dist/js"
   },
   "typedocOptions": {
     "name": "Chart.js",


### PR DESCRIPTION
I know we don't necessarily want to go this way, but just wanted to experiment for my own knowledge and thought I'd share since it might be interesting to compare this approach to creating and maintaining type declarations.

I started from https://github.com/chartjs/Chart.js/pull/7085. Most of these changes aren't necessary unless we want to enable those additional checks. The one thing you really need to do is move the field declarations out of the constructor and for some reason it made me update `_draw`. It ends up being a lot less code since you don't need all the JSDoc type declarations. It'll let you just leave the types as `any` if you don't want to declare them though, so theoretically you could do that for all of them. I think there are even tools that will do this basic conversion for you and then you can add types over time.

The one thing I didn't do here that we would need to do is update the gulp file. This just checks that the file is valid, but doesn't convert it back to JS. I don't think that'd be hard, but really I just wanted to see what the syntax differences would be. I think the extra time spent building the library would be the main downside. It takes about 7s on my machine (which is fairly old). This happens right now when we run the tests, but can be done in parallel. If we went full-on TypeScript then it'd have to happen first

I just made all the fields public. I'm not sure what happens if I make them private. E.g. would it actually stop you from accessing them? I like being able to be a little naught and access private members in my personal-use plugins because I'm okay knowing that the API might change and am comfortable needing to update my own code.