### PR TITLE
Fix memory leak

### DIFF
--- a/src/core/core.animator.js
+++ b/src/core/core.animator.js
@@ -212,6 +212,14 @@ class Animator {
 		anims.items = [];
 		this._notify(chart, anims, Date.now(), 'complete');
 	}
+
+	/**
+	 * Remove chart from Animator
+	 * @param {Chart} chart
+	 */
+	remove(chart) {
+		return this._charts.delete(chart);
+	}
 }
 
 const instance = new Animator();

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -896,6 +896,7 @@ class Chart {
 		let i, ilen;
 
 		me.stop();
+		Animator.remove(me);
 
 		// dataset controllers need to cleanup associated data
 		for (i = 0, ilen = me.data.datasets.length; i < ilen; ++i) {


### PR DESCRIPTION
References to charts are kept in `Animator`, so destroyed charts keep on hanging around.

50 times uPlot bench results in 580 MB retained memory, this PR drops it to 19 MB
