### PR TITLE
Strip comments from ESM build otherwise the TS compiler breaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7827,6 +7827,17 @@
       "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
       "dev": true
     },
+    "js-cleanup": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/js-cleanup/-/js-cleanup-1.0.1.tgz",
+      "integrity": "sha512-wyHeWKqbcQV78/tiMJ6pgJrkG7p2u3b2xX9IJFvvurpJL9/++89dHfkUebhWvSMS84LG0uQ7BnG5GGyAzY21Ag==",
+      "dev": true,
+      "requires": {
+        "magic-string": "^0.25.1",
+        "perf-regexes": "^1.0.1",
+        "skip-regex": "^1.0.2"
+      }
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -13839,6 +13850,12 @@
         "through": "~2.3"
       }
     },
+    "perf-regexes": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/perf-regexes/-/perf-regexes-1.0.1.tgz",
+      "integrity": "sha512-L7MXxUDtqr4PUaLFCDCXBfGV/6KLIuSEccizDI7JxT+c9x1G1v04BQ4+4oag84SHaCdrBgQAIs/Cqn+flwFPng==",
+      "dev": true
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -14538,6 +14555,16 @@
         "rollup-pluginutils": "^2.8.1"
       }
     },
+    "rollup-plugin-cleanup": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-cleanup/-/rollup-plugin-cleanup-3.1.1.tgz",
+      "integrity": "sha512-wMS9JQm4ShvlMqno1pOfqvh0yYgNLO2ZgmzDsVvKuDt4XCn+9DcMoUwRQ5t9p9b113dR5FhPFFUHnvvQ/yuEtA==",
+      "dev": true,
+      "requires": {
+        "js-cleanup": "^1.0.1",
+        "rollup-pluginutils": "^2.3.3"
+      }
+    },
     "rollup-plugin-commonjs": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.1.0.tgz",
@@ -14769,6 +14796,12 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "skip-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/skip-regex/-/skip-regex-1.0.2.tgz",
+      "integrity": "sha512-pEjMUbwJ5Pl/6Vn6FsamXHXItJXSRftcibixDmNCWbWhic0hzHrwkMZo0IZ7fMRH9KxcWDFSkzhccB4285PutA==",
       "dev": true
     },
     "slice-ansi": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "pixelmatch": "^5.0.0",
     "rollup": "^1.31.0",
     "rollup-plugin-babel": "^4.3.3",
+    "rollup-plugin-cleanup": "^3.1.1",
     "rollup-plugin-commonjs": "^10.0.0",
     "rollup-plugin-istanbul": "^2.0.1",
     "rollup-plugin-node-resolve": "^5.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,7 @@
 const commonjs = require('rollup-plugin-commonjs');
 const resolve = require('rollup-plugin-node-resolve');
 const babel = require('rollup-plugin-babel');
+const cleanup = require('rollup-plugin-cleanup');
 const terser = require('rollup-plugin-terser').terser;
 const optional = require('./rollup.plugins').optional;
 const stylesheet = require('./rollup.plugins').stylesheet;
@@ -94,6 +95,7 @@ module.exports = [
 			stylesheet({
 				extract: true
 			}),
+			cleanup(),
 		],
 		output: {
 			name: 'Chart',

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -34,7 +34,8 @@ module.exports = [
 			}),
 			optional({
 				include: ['moment']
-			})
+			}),
+			cleanup(),
 		],
 		output: {
 			name: 'Chart',


### PR DESCRIPTION
The ESM build was left with TS comments in it. This caused problems when integrated into a typescript project because the referenced files could not be found.