### PR TITLE
Make some variables private

### DIFF
--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -128,6 +128,13 @@ Animation system was completely rewritten in Chart.js v3. Each property can now 
 * `Scale.handleDirectionalChanges` is now private
 * `Scale.longestLabelWidth`
 * `Scale.longestTextCache` is now private
+* `Scale.margins` is now private
+* `Scale.maxHeight` is now private
+* `Scale.maxWidth` is now private
+* `Scale.paddingBottom` is now private
+* `Scale.paddingLeft` is now private
+* `Scale.paddingRight` is now private
+* `Scale.paddingTop` is now private
 * `Scale.mergeTicksOptions`
 * `Scale.ticksAsNumbers`
 * `Scale.tickValues` is now private
@@ -205,6 +212,7 @@ Animation system was completely rewritten in Chart.js v3. Each property can now 
 * `DatasetController.removeElements` was renamed to `DatasetController._removeElements`
 * `DatasetController.resyncElements` was renamed to `DatasetController._resyncElements`
 * `RadialLinearScale.setReductions` was renamed to `RadialLinearScale._setReductions`
+* `Scale.getPadding` was renamed to `Scale._getPadding`
 * `Scale.handleMargins` was renamed to `Scale._handleMargins`
 * `helpers._alignPixel` was renamed to `helpers.canvas._alignPixel`
 * `helpers._decimalPlaces` was renamed to `helpers.math._decimalPlaces`

--- a/src/core/core.layouts.js
+++ b/src/core/core.layouts.js
@@ -89,8 +89,8 @@ function updateDims(chartArea, params, layout) {
 	layout.size = layout.horizontal ? box.height : box.width;
 	chartArea[layout.pos] += layout.size;
 
-	if (box.getPadding) {
-		const boxPadding = box.getPadding();
+	if (box._getPadding) {
+		const boxPadding = box._getPadding();
 		maxPadding.top = Math.max(maxPadding.top, boxPadding.top);
 		maxPadding.left = Math.max(maxPadding.left, boxPadding.left);
 		maxPadding.bottom = Math.max(maxPadding.bottom, boxPadding.bottom);
@@ -217,7 +217,7 @@ defaults.set('layout', {
  * @prop {function} isHorizontal - returns true if the layout item is horizontal (ie. top or bottom)
  * @prop {function} update - Takes two parameters: width and height. Returns size of item
  * @prop {function} draw - Draws the element
- * @prop {function} [getPadding] -  Returns an object with padding on the edges
+ * @prop {function} [_getPadding] -  Returns an object with padding on the edges
  * @prop {number} width - Width of item. Must be valid after update()
  * @prop {number} height - Height of item. Must be valid after update()
  * @prop {number} left - Left edge of the item. Set by layout system and cannot be used in update

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -140,7 +140,7 @@ function fitWithPointLabels(scale) {
 		l: 0,
 		r: scale.width,
 		t: 0,
-		b: scale.height - scale.paddingTop
+		b: scale.height - scale._paddingTop
 	};
 	const furthestAngles = {};
 	let i, textSize, pointPosition;
@@ -309,12 +309,12 @@ class RadialLinearScale extends LinearScaleBase {
 		const me = this;
 
 		// Set the unconstrained dimension before label rotation
-		me.width = me.maxWidth;
-		me.height = me.maxHeight;
-		me.paddingTop = getTickBackdropHeight(me.options) / 2;
+		me.width = me._maxWidth;
+		me.height = me._maxHeight;
+		me._paddingTop = getTickBackdropHeight(me.options) / 2;
 		me.xCenter = Math.floor(me.width / 2);
-		me.yCenter = Math.floor((me.height - me.paddingTop) / 2);
-		me.drawingArea = Math.min(me.height - me.paddingTop, me.width) / 2;
+		me.yCenter = Math.floor((me.height - me._paddingTop) / 2);
+		me.drawingArea = Math.min(me.height - me._paddingTop, me.width) / 2;
 	}
 
 	determineDataLimits() {
@@ -370,7 +370,7 @@ class RadialLinearScale extends LinearScaleBase {
 		let radiusReductionLeft = furthestLimits.l / Math.sin(furthestAngles.l);
 		let radiusReductionRight = Math.max(furthestLimits.r - me.width, 0) / Math.sin(furthestAngles.r);
 		let radiusReductionTop = -furthestLimits.t / Math.cos(furthestAngles.t);
-		let radiusReductionBottom = -Math.max(furthestLimits.b - (me.height - me.paddingTop), 0) / Math.cos(furthestAngles.b);
+		let radiusReductionBottom = -Math.max(furthestLimits.b - (me.height - me._paddingTop), 0) / Math.cos(furthestAngles.b);
 
 		radiusReductionLeft = numberOrZero(radiusReductionLeft);
 		radiusReductionRight = numberOrZero(radiusReductionRight);
@@ -388,10 +388,10 @@ class RadialLinearScale extends LinearScaleBase {
 		const maxRight = me.width - rightMovement - me.drawingArea;
 		const maxLeft = leftMovement + me.drawingArea;
 		const maxTop = topMovement + me.drawingArea;
-		const maxBottom = (me.height - me.paddingTop) - bottomMovement - me.drawingArea;
+		const maxBottom = (me.height - me._paddingTop) - bottomMovement - me.drawingArea;
 
 		me.xCenter = Math.floor(((maxLeft + maxRight) / 2) + me.left);
-		me.yCenter = Math.floor(((maxTop + maxBottom) / 2) + me.top + me.paddingTop);
+		me.yCenter = Math.floor(((maxTop + maxBottom) / 2) + me.top + me._paddingTop);
 	}
 
 	getIndexAngle(index) {

--- a/test/specs/core.layouts.tests.js
+++ b/test/specs/core.layouts.tests.js
@@ -144,10 +144,10 @@ describe('Chart.layouts', function() {
 		expect(chart.scales.x.labelRotation).toBeCloseTo(0);
 
 		expect(chart.scales.x.height).toBeCloseToPixel(30);
-		expect(chart.scales.x.paddingLeft).toBeCloseToPixel(60);
-		expect(chart.scales.x.paddingTop).toBeCloseToPixel(0);
-		expect(chart.scales.x.paddingRight).toBeCloseToPixel(60);
-		expect(chart.scales.x.paddingBottom).toBeCloseToPixel(0);
+		expect(chart.scales.x._paddingLeft).toBeCloseToPixel(60);
+		expect(chart.scales.x._paddingTop).toBeCloseToPixel(0);
+		expect(chart.scales.x._paddingRight).toBeCloseToPixel(60);
+		expect(chart.scales.x._paddingBottom).toBeCloseToPixel(0);
 
 		// Is yScale at the right spot
 		expect(chart.scales.y.bottom).toBeCloseToPixel(120);
@@ -157,10 +157,10 @@ describe('Chart.layouts', function() {
 		expect(chart.scales.y.labelRotation).toBeCloseTo(0);
 
 		expect(chart.scales.y.width).toBeCloseToPixel(34);
-		expect(chart.scales.y.paddingLeft).toBeCloseToPixel(0);
-		expect(chart.scales.y.paddingTop).toBeCloseToPixel(7);
-		expect(chart.scales.y.paddingRight).toBeCloseToPixel(0);
-		expect(chart.scales.y.paddingBottom).toBeCloseToPixel(7);
+		expect(chart.scales.y._paddingLeft).toBeCloseToPixel(0);
+		expect(chart.scales.y._paddingTop).toBeCloseToPixel(7);
+		expect(chart.scales.y._paddingRight).toBeCloseToPixel(0);
+		expect(chart.scales.y._paddingBottom).toBeCloseToPixel(7);
 	});
 
 	it('should fit scales that overlap the chart area', function() {

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -899,17 +899,17 @@ describe('Linear Scale', function() {
 
 		var xScale = chart.scales.x;
 		var yScale = chart.scales.y;
-		expect(xScale.paddingTop).toBeCloseToPixel(0);
-		expect(xScale.paddingBottom).toBeCloseToPixel(0);
-		expect(xScale.paddingLeft).toBeCloseToPixel(12);
-		expect(xScale.paddingRight).toBeCloseToPixel(13.5);
+		expect(xScale._paddingTop).toBeCloseToPixel(0);
+		expect(xScale._paddingBottom).toBeCloseToPixel(0);
+		expect(xScale._paddingLeft).toBeCloseToPixel(12);
+		expect(xScale._paddingRight).toBeCloseToPixel(13.5);
 		expect(xScale.width).toBeCloseToPixel(468 - 6); // minus lineSpace
 		expect(xScale.height).toBeCloseToPixel(30);
 
-		expect(yScale.paddingTop).toBeCloseToPixel(7);
-		expect(yScale.paddingBottom).toBeCloseToPixel(7);
-		expect(yScale.paddingLeft).toBeCloseToPixel(0);
-		expect(yScale.paddingRight).toBeCloseToPixel(0);
+		expect(yScale._paddingTop).toBeCloseToPixel(7);
+		expect(yScale._paddingBottom).toBeCloseToPixel(7);
+		expect(yScale._paddingLeft).toBeCloseToPixel(0);
+		expect(yScale._paddingRight).toBeCloseToPixel(0);
 		expect(yScale.width).toBeCloseToPixel(30 + 6); // plus lineSpace
 		expect(yScale.height).toBeCloseToPixel(450);
 
@@ -918,17 +918,17 @@ describe('Linear Scale', function() {
 		yScale.options.scaleLabel.display = true;
 		chart.update();
 
-		expect(xScale.paddingTop).toBeCloseToPixel(0);
-		expect(xScale.paddingBottom).toBeCloseToPixel(0);
-		expect(xScale.paddingLeft).toBeCloseToPixel(12);
-		expect(xScale.paddingRight).toBeCloseToPixel(13.5);
+		expect(xScale._paddingTop).toBeCloseToPixel(0);
+		expect(xScale._paddingBottom).toBeCloseToPixel(0);
+		expect(xScale._paddingLeft).toBeCloseToPixel(12);
+		expect(xScale._paddingRight).toBeCloseToPixel(13.5);
 		expect(xScale.width).toBeCloseToPixel(440);
 		expect(xScale.height).toBeCloseToPixel(53);
 
-		expect(yScale.paddingTop).toBeCloseToPixel(7);
-		expect(yScale.paddingBottom).toBeCloseToPixel(7);
-		expect(yScale.paddingLeft).toBeCloseToPixel(0);
-		expect(yScale.paddingRight).toBeCloseToPixel(0);
+		expect(yScale._paddingTop).toBeCloseToPixel(7);
+		expect(yScale._paddingBottom).toBeCloseToPixel(7);
+		expect(yScale._paddingLeft).toBeCloseToPixel(0);
+		expect(yScale._paddingRight).toBeCloseToPixel(0);
 		expect(yScale.width).toBeCloseToPixel(58);
 		expect(yScale.height).toBeCloseToPixel(427);
 	});

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -822,7 +822,7 @@ describe('Time scale tests', function() {
 			},
 		});
 		expect(chart.scales.y.width).toEqual(0);
-		expect(chart.scales.y.maxWidth).toEqual(0);
+		expect(chart.scales.y._maxWidth).toEqual(0);
 		expect(chart.width).toEqual(0);
 	});
 


### PR DESCRIPTION
This fixes a TODO and also renames a few other variables that were only used internally

Also, I renamed `getPadding` to `_getPadding` since it was marked `@private`. We may want to consider exposing it, but it really wasn't clear to me if it was actually margin or padding and I'd want to make sure it was named appropriately before making it part of the public API