### PR TITLE
Include Typedoc files on GitHub pages

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,2 @@
+include:
+  - "_*_.html"


### PR DESCRIPTION
Hopefully this will fix the Typedoc pages not showing up

E.g. 404 on https://www.chartjs.org/docs/master/typedoc/modules/_helpers_helpers_curve_.html