### PR TITLE
No need to use rollup commonjs plugin

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,6 @@
 /* eslint-disable import/no-commonjs */
 /* eslint-env es6 */
 
-const commonjs = require('rollup-plugin-commonjs');
 const resolve = require('rollup-plugin-node-resolve');
 const babel = require('rollup-plugin-babel');
 const cleanup = require('rollup-plugin-cleanup');
@@ -26,7 +25,6 @@ module.exports = [
 		input,
 		plugins: [
 			resolve(),
-			commonjs(),
 			babel(),
 			optional({
 				include: ['moment']
@@ -53,7 +51,6 @@ module.exports = [
 		input,
 		plugins: [
 			resolve(),
-			commonjs(),
 			babel(),
 			optional({
 				include: ['moment']
@@ -85,7 +82,6 @@ module.exports = [
 		input,
 		plugins: [
 			resolve(),
-			commonjs(),
 			babel(),
 			cleanup({
 				sourcemap: true
@@ -109,7 +105,6 @@ module.exports = [
 		input,
 		plugins: [
 			resolve(),
-			commonjs(),
 			babel(),
 			terser({
 				output: {


### PR DESCRIPTION
This plugin was causing issues since it gets called before babel and didn't understand some new syntax I introduced

Breaking it off of https://github.com/chartjs/Chart.js/pull/7121 to try to understand why the tests are failing on that one