### PR TITLE
Make margins private

### DIFF
--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -122,15 +122,18 @@ Animation system was completely rewritten in Chart.js v3. Each property can now 
 * `helpers.where`
 * `ILayoutItem.minSize`
 * `IPlugin.afterScaleUpdate`. Use `afterLayout` instead
+* `Legend.margins` is now private
 * `Line.calculatePointY`
 * `LogarithmicScale.minNotZero`
 * `Scale.getRightValue`
 * `Scale.handleDirectionalChanges` is now private
 * `Scale.longestLabelWidth`
 * `Scale.longestTextCache` is now private
+* `Scale.margins` is now private
 * `Scale.mergeTicksOptions`
 * `Scale.ticksAsNumbers`
 * `Scale.tickValues` is now private
+* `Title.margins` is now private
 * The tooltip item's `x` and `y` attributes were removed. Use `datasetIndex` and `index` to get the element and any corresponding data from it
 
 #### Removal of private APIs

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -246,13 +246,12 @@ class Scale extends Element {
 		this.width = undefined;
 		/** @type {number} */
 		this.height = undefined;
-		this.margins = {
+		this._margins = {
 			left: 0,
 			right: 0,
 			top: 0,
 			bottom: 0
 		};
-		// TODO: make maxWidth, maxHeight private
 		/** @type {number} */
 		this.maxWidth = undefined;
 		/** @type {number} */
@@ -434,7 +433,7 @@ class Scale extends Element {
 		// Absorb the master measurements
 		me.maxWidth = maxWidth;
 		me.maxHeight = maxHeight;
-		me.margins = Object.assign({
+		me._margins = Object.assign({
 			left: 0,
 			right: 0,
 			top: 0,
@@ -744,11 +743,11 @@ class Scale extends Element {
 		me._handleMargins();
 
 		if (isHorizontal) {
-			me.width = me._length = chart.width - me.margins.left - me.margins.right;
+			me.width = me._length = chart.width - me._margins.left - me._margins.right;
 			me.height = minSize.height;
 		} else {
 			me.width = minSize.width;
-			me.height = me._length = chart.height - me.margins.top - me.margins.bottom;
+			me.height = me._length = chart.height - me._margins.top - me._margins.bottom;
 		}
 	}
 
@@ -758,11 +757,11 @@ class Scale extends Element {
 	 */
 	_handleMargins() {
 		const me = this;
-		if (me.margins) {
-			me.margins.left = Math.max(me.paddingLeft, me.margins.left);
-			me.margins.top = Math.max(me.paddingTop, me.margins.top);
-			me.margins.right = Math.max(me.paddingRight, me.margins.right);
-			me.margins.bottom = Math.max(me.paddingBottom, me.margins.bottom);
+		if (me._margins) {
+			me._margins.left = Math.max(me.paddingLeft, me._margins.left);
+			me._margins.top = Math.max(me.paddingTop, me._margins.top);
+			me._margins.right = Math.max(me.paddingRight, me._margins.right);
+			me._margins.bottom = Math.max(me.paddingBottom, me._margins.bottom);
 		}
 	}
 

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -132,7 +132,7 @@ class Legend extends Element {
 		this.right = undefined;
 		this.height = undefined;
 		this.width = undefined;
-		this.margins = undefined;
+		this._margins = undefined;
 		this.paddingTop = undefined;
 		this.paddingBottom = undefined;
 		this.paddingLeft = undefined;
@@ -157,7 +157,7 @@ class Legend extends Element {
 		// Absorb the master measurements
 		me.maxWidth = maxWidth;
 		me.maxHeight = maxHeight;
-		me.margins = margins;
+		me._margins = margins;
 
 		// Dimensions
 		me.beforeSetDimensions();

--- a/src/plugins/plugin.title.js
+++ b/src/plugins/plugin.title.js
@@ -26,7 +26,7 @@ class Title extends Element {
 		this.chart = config.chart;
 		this.options = config.options;
 		this.ctx = config.ctx;
-		this.margins = undefined;
+		this._margins = undefined;
 		this._padding = undefined;
 		this.legendHitBoxes = []; // Contains hit boxes for each dataset (in dataset order)
 		this.top = undefined;
@@ -56,7 +56,7 @@ class Title extends Element {
 		// Absorb the master measurements
 		me.maxWidth = maxWidth;
 		me.maxHeight = maxHeight;
-		me.margins = margins;
+		me._margins = margins;
 
 		// Dimensions
 		me.beforeSetDimensions();


### PR DESCRIPTION
`_handleMargins` has always seemed really weird to me. I'm not sure why it combines margins and padding. To me these are two separate concepts. By making `margins` private I hope that it will make it easier to possibly address any issues in the future