### PR TITLE
Move option resolution to helpers.options

### DIFF
--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -73,7 +73,6 @@ Chart.js 3.0 introduces a number of breaking changes. Chart.js 2.0 was released 
 * `scales.[x/y]Axes.time.max` was renamed to `scales[id].max`
 * `scales.[x/y]Axes.time.min` was renamed to `scales[id].min`
 * The dataset option `steppedLine` was removed. Use `stepped`
-* The dataset option `tension` was removed. Use `lineTension`
 * To override the platform class used in a chart instance, pass `platform: PlatformClass` in the config object. Note that the class should be passed, not an instance of the class.
 
 ### Animations

--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -181,6 +181,8 @@ function isFloatBar(custom) {
 
 export default class BarController extends DatasetController {
 
+	static dataElementType = Rectangle;
+
 	/**
 	 * Overriding primitive data parsing since we support mixed primitive/array
 	 * data for float bars
@@ -493,17 +495,3 @@ export default class BarController extends DatasetController {
 	}
 
 }
-
-BarController.prototype.dataElementType = Rectangle;
-
-BarController.prototype.dataElementOptions = [
-	'backgroundColor',
-	'borderColor',
-	'borderSkipped',
-	'borderWidth',
-	'barPercentage',
-	'barThickness',
-	'categoryPercentage',
-	'maxBarThickness',
-	'minBarLength'
-];

--- a/src/controllers/controller.doughnut.js
+++ b/src/controllers/controller.doughnut.js
@@ -130,6 +130,8 @@ function getRatioAndOffset(rotation, circumference, cutout) {
 
 export default class DoughnutController extends DatasetController {
 
+	static dataElementType = Arc;
+
 	constructor(chart, datasetIndex) {
 		super(chart, datasetIndex);
 
@@ -339,15 +341,3 @@ export default class DoughnutController extends DatasetController {
 		return this._getRingWeightOffset(this.chart.data.datasets.length) || 1;
 	}
 }
-
-DoughnutController.prototype.dataElementType = Arc;
-
-DoughnutController.prototype.dataElementOptions = [
-	'backgroundColor',
-	'borderColor',
-	'borderWidth',
-	'borderAlign',
-	'hoverBackgroundColor',
-	'hoverBorderColor',
-	'hoverBorderWidth',
-];

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -3,7 +3,6 @@ import defaults from '../core/core.defaults';
 import {Line, Point} from '../elements/index';
 import {valueOrDefault} from '../helpers/helpers.core';
 import {isNumber} from '../helpers/helpers.math';
-import {resolve} from '../helpers/helpers.options';
 
 defaults.set('line', {
 	showLines: true,
@@ -25,6 +24,9 @@ defaults.set('line', {
 
 export default class LineController extends DatasetController {
 
+	static datasetElementType = Line;
+	static dataElementType = Point;
+
 	constructor(chart, datasetIndex) {
 		super(chart, datasetIndex);
 
@@ -44,7 +46,7 @@ export default class LineController extends DatasetController {
 		if (showLine && mode !== 'resize') {
 			const properties = {
 				points,
-				options: me.resolveDatasetElementOptions()
+				options: me.resolveDatasetElementOptions(mode)
 			};
 
 			me.updateElement(line, undefined, properties, mode);
@@ -93,26 +95,6 @@ export default class LineController extends DatasetController {
 	/**
 	 * @protected
 	 */
-	resolveDatasetElementOptions(active) {
-		const me = this;
-		const config = me._config;
-		const options = me.chart.options;
-		const lineOptions = options.elements.line;
-		const values = super.resolveDatasetElementOptions(active);
-
-		// The default behavior of lines is to break at null values, according
-		// to https://github.com/chartjs/Chart.js/issues/2435#issuecomment-216718158
-		// This option gives lines the ability to span gaps
-		values.spanGaps = valueOrDefault(config.spanGaps, options.spanGaps);
-		values.tension = valueOrDefault(config.lineTension, lineOptions.tension);
-		values.stepped = resolve([config.stepped, lineOptions.stepped]);
-
-		return values;
-	}
-
-	/**
-	 * @protected
-	 */
 	getMaxOverflow() {
 		const me = this;
 		const meta = me._cachedMeta;
@@ -156,35 +138,3 @@ export default class LineController extends DatasetController {
 		}
 	}
 }
-
-LineController.prototype.datasetElementType = Line;
-
-LineController.prototype.dataElementType = Point;
-
-LineController.prototype.datasetElementOptions = [
-	'backgroundColor',
-	'borderCapStyle',
-	'borderColor',
-	'borderDash',
-	'borderDashOffset',
-	'borderJoinStyle',
-	'borderWidth',
-	'capBezierPoints',
-	'cubicInterpolationMode',
-	'fill'
-];
-
-LineController.prototype.dataElementOptions = {
-	backgroundColor: 'pointBackgroundColor',
-	borderColor: 'pointBorderColor',
-	borderWidth: 'pointBorderWidth',
-	hitRadius: 'pointHitRadius',
-	hoverHitRadius: 'pointHitRadius',
-	hoverBackgroundColor: 'pointHoverBackgroundColor',
-	hoverBorderColor: 'pointHoverBorderColor',
-	hoverBorderWidth: 'pointHoverBorderWidth',
-	hoverRadius: 'pointHoverRadius',
-	pointStyle: 'pointStyle',
-	radius: 'pointRadius',
-	rotation: 'pointRotation'
-};

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -90,6 +90,8 @@ function getStartAngleRadians(deg) {
 
 export default class PolarAreaController extends DatasetController {
 
+	static dataElementType = Arc;
+
 	constructor(chart, datasetIndex) {
 		super(chart, datasetIndex);
 
@@ -228,15 +230,3 @@ export default class PolarAreaController extends DatasetController {
 		], context, index);
 	}
 }
-
-PolarAreaController.prototype.dataElementType = Arc;
-
-PolarAreaController.prototype.dataElementOptions = [
-	'backgroundColor',
-	'borderColor',
-	'borderWidth',
-	'borderAlign',
-	'hoverBackgroundColor',
-	'hoverBorderColor',
-	'hoverBorderWidth'
-];

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -1,7 +1,6 @@
 import DatasetController from '../core/core.datasetController';
 import defaults from '../core/core.defaults';
 import {Line, Point} from '../elements/index';
-import {valueOrDefault} from '../helpers/helpers.core';
 
 defaults.set('radar', {
 	spanGaps: false,
@@ -18,6 +17,9 @@ defaults.set('radar', {
 });
 
 export default class RadarController extends DatasetController {
+
+	static datasetElementType = Line;
+	static dataElementType = Point;
 
 	/**
 	 * @protected
@@ -57,7 +59,7 @@ export default class RadarController extends DatasetController {
 			points,
 			_loop: true,
 			_fullLoop: labels.length === points.length,
-			options: me.resolveDatasetElementOptions()
+			options: me.resolveDatasetElementOptions(mode)
 		};
 
 		me.updateElement(line, undefined, properties, mode);
@@ -95,48 +97,4 @@ export default class RadarController extends DatasetController {
 			me.updateElement(point, index, properties, mode);
 		}
 	}
-
-	/**
-	 * @protected
-	 */
-	resolveDatasetElementOptions(active) {
-		const me = this;
-		const config = me._config;
-		const options = me.chart.options;
-		const values = super.resolveDatasetElementOptions(active);
-
-		values.spanGaps = valueOrDefault(config.spanGaps, options.spanGaps);
-		values.tension = valueOrDefault(config.lineTension, options.elements.line.tension);
-
-		return values;
-	}
 }
-
-RadarController.prototype.datasetElementType = Line;
-
-RadarController.prototype.dataElementType = Point;
-
-RadarController.prototype.datasetElementOptions = [
-	'backgroundColor',
-	'borderColor',
-	'borderCapStyle',
-	'borderDash',
-	'borderDashOffset',
-	'borderJoinStyle',
-	'borderWidth',
-	'fill'
-];
-
-RadarController.prototype.dataElementOptions = {
-	backgroundColor: 'pointBackgroundColor',
-	borderColor: 'pointBorderColor',
-	borderWidth: 'pointBorderWidth',
-	hitRadius: 'pointHitRadius',
-	hoverBackgroundColor: 'pointHoverBackgroundColor',
-	hoverBorderColor: 'pointHoverBorderColor',
-	hoverBorderWidth: 'pointHoverBorderWidth',
-	hoverRadius: 'pointHoverRadius',
-	pointStyle: 'pointStyle',
-	radius: 'pointRadius',
-	rotation: 'pointRotation'
-};

--- a/src/core/core.element.js
+++ b/src/core/core.element.js
@@ -3,8 +3,19 @@ import {isNumber} from '../helpers/helpers.math';
 
 export default class Element {
 
+	static _type = 'element';
+
 	static extend = inherits;
 
+	/**
+	 * Default options. Everything is looked up with `hover` prefix, so
+	 * only need to define those in case the default value is different.
+	 */
+	static _defaults = {};
+
+	/**
+	 * @param {object} [cfg] optional configuration
+	 */
 	constructor(cfg) {
 		this.x = undefined;
 		this.y = undefined;

--- a/src/elements/element.arc.js
+++ b/src/elements/element.arc.js
@@ -1,16 +1,8 @@
 import defaults from '../core/core.defaults';
 import Element from '../core/core.element';
 import {_angleBetween, getAngleFromPoint} from '../helpers/helpers.math';
-const TAU = Math.PI * 2;
 
-defaults.set('elements', {
-	arc: {
-		backgroundColor: defaults.color,
-		borderColor: '#fff',
-		borderWidth: 2,
-		borderAlign: 'center'
-	}
-});
+const TAU = Math.PI * 2;
 
 function clipArc(ctx, arc) {
 	const {startAngle, endAngle, pixelMargin, x, y} = arc;
@@ -87,6 +79,17 @@ function drawBorder(ctx, vm, arc) {
 export default class Arc extends Element {
 
 	static _type = 'arc';
+
+	/**
+	 * Default options. Everything is looked up with `hover` prefix, so
+	 * only need to define those in case the default value is different.
+	 */
+	static _defaults = {
+		backgroundColor: defaults.color,
+		borderColor: '#fff',
+		borderWidth: 2,
+		borderAlign: 'center'
+	};
 
 	constructor(cfg) {
 		super();
@@ -197,3 +200,5 @@ export default class Arc extends Element {
 		ctx.restore();
 	}
 }
+
+defaults.set('elements', {arc: Arc._defaults});

--- a/src/elements/element.line.js
+++ b/src/elements/element.line.js
@@ -11,21 +11,6 @@ import {_updateBezierControlPoints} from '../helpers/helpers.curve';
 
 const defaultColor = defaults.color;
 
-defaults.set('elements', {
-	line: {
-		tension: 0.4,
-		backgroundColor: defaultColor,
-		borderWidth: 3,
-		borderColor: defaultColor,
-		borderCapStyle: 'butt',
-		borderDash: [],
-		borderDashOffset: 0.0,
-		borderJoinStyle: 'miter',
-		capBezierPoints: true,
-		fill: true
-	}
-});
-
 function setStyle(ctx, vm) {
 	ctx.lineCap = vm.borderCapStyle;
 	ctx.setLineDash(vm.borderDash);
@@ -200,6 +185,26 @@ export default class Line extends Element {
 
 	static _type = 'line';
 
+	/**
+	 * Default options. Everything is looked up with `hover` prefix, so
+	 * only need to define those in case the default value is different.
+	 */
+	static _defaults = {
+		backgroundColor: defaultColor,
+		borderCapStyle: 'butt',
+		borderColor: defaultColor,
+		borderDash: [],
+		borderDashOffset: 0,
+		borderJoinStyle: 'miter',
+		borderWidth: 3,
+		capBezierPoints: true,
+		cubicInterpolationMode: '',
+		fill: true,
+		spanGaps: undefined,
+		stepped: false,
+		tension: 0.4
+	};
+
 	constructor(cfg) {
 		super();
 
@@ -357,3 +362,5 @@ export default class Line extends Element {
 		ctx.restore();
 	}
 }
+
+defaults.set('elements', {line: Line._defaults});

--- a/src/elements/element.point.js
+++ b/src/elements/element.point.js
@@ -4,23 +4,31 @@ import {_isPointInArea, drawPoint} from '../helpers/helpers.canvas';
 
 const defaultColor = defaults.color;
 
-defaults.set('elements', {
-	point: {
-		radius: 3,
-		pointStyle: 'circle',
-		backgroundColor: defaultColor,
-		borderColor: defaultColor,
-		borderWidth: 1,
-		// Hover
-		hitRadius: 1,
-		hoverRadius: 4,
-		hoverBorderWidth: 1
-	}
-});
-
 export default class Point extends Element {
 
 	static _type = 'point';
+
+	/**
+	 * Default options. Everything is looked up with `hover` prefix, so
+	 * only need to define those in case the default value is different.
+	 */
+	static _defaults = {
+		backgroundColor: defaultColor,
+		borderColor: defaultColor,
+		borderWidth: 1,
+		hitRadius: 1,
+		hoverBorderWidth: 1,
+		hoverRadius: 4,
+		pointStyle: 'circle',
+		radius: 3,
+		rotation: undefined
+	}
+
+	static size(options) {
+		const radius = Math.max(options.radius, options.hoverRadius) || 0;
+		const borderWidth = radius && options.borderWidth || 0;
+		return (radius + borderWidth) * 2;
+	}
 
 	constructor(cfg) {
 		super();
@@ -59,10 +67,7 @@ export default class Point extends Element {
 	}
 
 	size() {
-		const options = this.options || {};
-		const radius = Math.max(options.radius, options.hoverRadius) || 0;
-		const borderWidth = radius && options.borderWidth || 0;
-		return (radius + borderWidth) * 2;
+		return Point.size(this.options || {});
 	}
 
 	draw(ctx, chartArea) {
@@ -87,3 +92,5 @@ export default class Point extends Element {
 		return options.radius + options.hitRadius;
 	}
 }
+
+defaults.set('elements', {point: Point._defaults});

--- a/src/elements/element.rectangle.js
+++ b/src/elements/element.rectangle.js
@@ -4,15 +4,6 @@ import {isObject} from '../helpers/helpers.core';
 
 const defaultColor = defaults.color;
 
-defaults.set('elements', {
-	rectangle: {
-		backgroundColor: defaultColor,
-		borderColor: defaultColor,
-		borderSkipped: 'bottom',
-		borderWidth: 0
-	}
-});
-
 /**
  * Helper function to get the bounds of the bar regardless of the orientation
  * @param {Rectangle} bar the bar
@@ -128,6 +119,22 @@ export default class Rectangle extends Element {
 
 	static _type = 'rectangle';
 
+	/**
+	 * Default options. Everything is looked up with `hover` prefix, so
+	 * only need to define those in case the default value is different.
+	 */
+	static _defaults = {
+		backgroundColor: defaultColor,
+		barPercentage: 0.9,
+		barThickness: undefined,
+		borderColor: defaultColor,
+		borderSkipped: 'bottom',
+		borderWidth: 0,
+		categoryPercentage: 0.8,
+		maxBarThickness: undefined,
+		minBarLength: undefined,
+	};
+
 	constructor(cfg) {
 		super();
 
@@ -187,3 +194,5 @@ export default class Rectangle extends Element {
 		return axis === 'x' ? this.width / 2 : this.height / 2;
 	}
 }
+
+defaults.set('elements', {rectangle: Rectangle._defaults});

--- a/test/specs/controller.bar.tests.js
+++ b/test/specs/controller.bar.tests.js
@@ -1,3 +1,5 @@
+import {getHoverColor} from '../../src/helpers/helpers.color';
+
 describe('Chart.controllers.bar', function() {
 	describe('auto', jasmine.fixture.specs('controller.bar'));
 
@@ -1331,7 +1333,6 @@ describe('Chart.controllers.bar', function() {
 
 		var meta = chart.getDatasetMeta(1);
 		var bar = meta.data[0];
-		var helpers = window.Chart.helpers;
 
 		// Change default
 		chart.options.elements.rectangle.backgroundColor = 'rgb(128, 128, 128)';
@@ -1343,8 +1344,8 @@ describe('Chart.controllers.bar', function() {
 		expect(bar.options.borderColor).toBe('rgb(15, 15, 15)');
 		expect(bar.options.borderWidth).toBe(3.14);
 		meta.controller.setHoverStyle(bar, 1, 0);
-		expect(bar.options.backgroundColor).toBe(helpers.getHoverColor('rgb(128, 128, 128)'));
-		expect(bar.options.borderColor).toBe(helpers.getHoverColor('rgb(15, 15, 15)'));
+		expect(bar.options.backgroundColor).toBe(getHoverColor('rgb(128, 128, 128)'));
+		expect(bar.options.borderColor).toBe(getHoverColor('rgb(15, 15, 15)'));
 		expect(bar.options.borderWidth).toBe(3.14);
 		meta.controller.removeHoverStyle(bar);
 		expect(bar.options.backgroundColor).toBe('rgb(128, 128, 128)');
@@ -1361,8 +1362,8 @@ describe('Chart.controllers.bar', function() {
 		expect(bar.options.borderColor).toBe('rgb(9, 9, 9)');
 		expect(bar.options.borderWidth).toBe(2.5);
 		meta.controller.setHoverStyle(bar, 1, 0);
-		expect(bar.options.backgroundColor).toBe(helpers.getHoverColor('rgb(255, 255, 255)'));
-		expect(bar.options.borderColor).toBe(helpers.getHoverColor('rgb(9, 9, 9)'));
+		expect(bar.options.backgroundColor).toBe(getHoverColor('rgb(255, 255, 255)'));
+		expect(bar.options.borderColor).toBe(getHoverColor('rgb(9, 9, 9)'));
 		expect(bar.options.borderWidth).toBe(2.5);
 		meta.controller.removeHoverStyle(bar);
 		expect(bar.options.backgroundColor).toBe('rgb(255, 255, 255)');

--- a/test/specs/plugin.filler.tests.js
+++ b/test/specs/plugin.filler.tests.js
@@ -133,7 +133,6 @@ describe('Plugin.filler', function() {
 						{fill: NaN},
 						{fill: Infinity},
 						{fill: ''},
-						{fill: null},
 						{fill: []},
 					]
 				}
@@ -150,7 +149,6 @@ describe('Plugin.filler', function() {
 				false, // NaN
 				false, // !isFinite
 				false, // empty string
-				false, // null
 				false, // array
 			]);
 		});


### PR DESCRIPTION
* enforces consistent option fallback
* encourages consistent option naming (`steppedLine` = `stepped` or `lineStepped` (with type prefix))
* makes all options scriptable (most are already though)
* makes all options to be considered with `'hover'` prefix in `active` mode 
* makes all options prefixable by element type
  - borderColor -> arcBorderColor
  - hoverBorderColor -> arcHoverBorderColor
* enabled all element options to be specified in `chart.options` (because of `spanGaps`)
  - this needs to be discussed, but feels like it could make Chart.js simpler to use
* simplifies resolution customization in controller level
* makes adding new options to an element a bliss (only need to change the element)
* reduces size by 2259 bytes
```
this pr: 175 646 bytes
master: 177 905 bytes
```

downsides
* reduces control from dataset controllers (personally I do not consider this a downside)