### PR TITLE
Remove css from deploy scripts

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -41,7 +41,7 @@ cd $TARGET_DIR
 git checkout $TARGET_BRANCH
 
 # Copy dist files
-deploy_files '../dist/*.css ../dist/*.js' './dist'
+deploy_files '../dist/*.js' './dist'
 
 # Copy generated documentation
 deploy_files '../dist/docs/*' './docs'

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -21,7 +21,7 @@ git remote add auth-origin https://$GITHUB_AUTH_TOKEN@github.com/$TRAVIS_REPO_SL
 git config --global user.email "$GITHUB_AUTH_EMAIL"
 git config --global user.name "Chart.js"
 git checkout --detach --quiet
-git add -f dist/*.css dist/*.js bower.json
+git add -f dist/*.js bower.json
 git commit -m "Release $VERSION"
 git tag -a "v$VERSION" -m "Version $VERSION"
 git push -q auth-origin refs/tags/v$VERSION 2>/dev/null


### PR DESCRIPTION
From @kurkle on Slack:

```
cp: cannot stat '../dist/*.css': No such file or directory
Script failed with status 1
failed to deploy
```

We no longer have css since https://github.com/chartjs/Chart.js/pull/7104