### PR TITLE
Output ES6 from babel

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,12 +1,33 @@
 {
-  "presets": ["@babel/preset-env"],
+  "presets": [
+    "@babel/preset-env"
+  ],
   "plugins": [
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-transform-object-assign"
   ],
   "env": {
+    "es6": {
+      "presets": [
+        [
+          "@babel/preset-env",
+          {
+            "targets": {
+              "esmodules": true
+            },
+            "modules": false,
+            "useBuiltIns": false
+          }
+        ]
+      ],
+      "plugins": [
+        "@babel/plugin-proposal-class-properties"
+      ]
+    },
     "test": {
-      "plugins": ["istanbul"]
+      "plugins": [
+        "istanbul"
+      ]
     }
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -162,7 +162,6 @@ function docsTask(done) {
 }
 
 function unittestTask(done) {
-	process.env.NODE_ENV = 'test';
 	new karma.Server({
 		configFile: path.join(__dirname, 'karma.conf.js'),
 		singleRun: !argv.watch,

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -67,7 +67,7 @@ module.exports = function(karma) {
 		rollupPreprocessor: {
 			plugins: [
 				resolve(),
-				babel({exclude: 'node_modules/**'}), // use babel since we have ES proposal features
+				babel({envName: 'test', exclude: 'node_modules/**'}), // use babel since we have ES proposal features
 				commonjs()
 			],
 			output: {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -86,7 +86,7 @@ module.exports = [
 		plugins: [
 			json(),
 			resolve(),
-			babel(),
+			babel({envName: 'es6'}),
 			cleanup({
 				sourcemap: true
 			})
@@ -110,7 +110,7 @@ module.exports = [
 		plugins: [
 			json(),
 			resolve(),
-			babel(),
+			babel({envName: 'es6'}),
 			terser({
 				output: {
 					preamble: banner


### PR DESCRIPTION
Babel for some reason seems to transpile to ES5 despite being used through `rollup-plugin-babel`
This is probably fine when we are targeting browsers, but the `Chart.esm.js` build should be ES6.

Skipping the `Object.assign` polyfill from there too.

The `ResizeObserver polyfill` is injecting some unneeded shims still (Map for example), that should be stripped out. I think best way would be to fork that repo and remove anything we don't need.