### PR TITLE
Shorten imports

### DIFF
--- a/src/core/core.animations.js
+++ b/src/core/core.animations.js
@@ -1,6 +1,6 @@
 import Animator from './core.animator';
 import Animation from './core.animation';
-import defaults from '../core/core.defaults';
+import defaults from './core.defaults';
 import {noop, isObject} from '../helpers/helpers.core';
 
 const numbers = ['x', 'y', 'borderWidth', 'radius', 'tension'];

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -6,7 +6,7 @@ import Interaction from './core.interaction';
 import layouts from './core.layouts';
 import {BasicPlatform, DomPlatform} from '../platform/platforms';
 import plugins from './core.plugins';
-import scaleService from '../core/core.scaleService';
+import scaleService from './core.scaleService';
 import {getMaximumWidth, getMaximumHeight} from '../helpers/helpers.dom';
 // @ts-ignore
 import {version} from '../../package.json';

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -2,8 +2,8 @@ import helpers from '../helpers/index';
 import Animations from './core.animations';
 
 /**
- * @typedef { import("../core/core.controller").default } Chart
- * @typedef { import("../core/core.scale").default } Scale
+ * @typedef { import("./core.controller").default } Chart
+ * @typedef { import("./core.scale").default } Scale
  */
 
 const resolve = helpers.options.resolve;

--- a/src/core/core.interaction.js
+++ b/src/core/core.interaction.js
@@ -6,7 +6,7 @@ import {_lookupByKey, _rlookupByKey} from '../helpers/helpers.collection';
  * @typedef { import("./core.controller").default } Chart
  * @typedef { import("../platform/platform.base").IEvent } IEvent
  * @typedef {{axis?: string, intersect?: boolean}} InteractionOptions
- * @typedef {{datasetIndex: number, index: number, element: import("../core/core.element").default}} InteractionItem
+ * @typedef {{datasetIndex: number, index: number, element: import("./core.element").default}} InteractionItem
  */
 
 /**


### PR DESCRIPTION
@kurkle noticed someplace we'd made this mistake in https://github.com/chartjs/Chart.js/pull/7125, but it turns out there's a handful of them

It'd be cool if `eslint` could catch this for us