### PR TITLE
Make update_latest work with alpha, beta, etc.

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -20,14 +20,20 @@ fi
 
 function update_latest {
     local out_path=$1
+
+    # The most recent directory whose name is a version number
     local latest=($(ls -v $out_path | egrep '^('$VERSION_REGEX')$' | tail -1))
+
+    # As soon as a single version is deployed this line is a no-op
     if [ "$latest" == "" ]; then latest='master'; fi
 
+    # Don't update "latest" on alpha or beta releases
     if [[ "$latest" =~ ^[^-]+$ ]]; then
         rm -f $out_path/latest
         ln -s $latest $out_path/latest
     fi
 
+    # Always update "next"
     rm -f $out_path/next
     ln -s $latest $out_path/next
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -22,8 +22,14 @@ function update_latest {
     local out_path=$1
     local latest=($(ls -v $out_path | egrep '^('$VERSION_REGEX')$' | tail -1))
     if [ "$latest" == "" ]; then latest='master'; fi
-    rm -f $out_path/latest
-    ln -s $latest $out_path/latest
+
+    if [[ "$latest" =~ ^[^-]+$ ]]; then
+        rm -f $out_path/latest
+        ln -s $latest $out_path/latest
+    fi
+
+    rm -f $out_path/next
+    ln -s $latest $out_path/next
 }
 
 function deploy_files {


### PR DESCRIPTION
Adds `next` which is updated with every release. Updates `latest` only if release does not contain `-` (e.g. `-alpha`, `-alpha.2`, `-beta`, , etc.)