### PR TITLE
Update running animations

### DIFF
--- a/src/core/core.animation.js
+++ b/src/core/core.animation.js
@@ -42,6 +42,19 @@ export default class Animation {
 		return this._active;
 	}
 
+	update(cfg, to, date) {
+		const me = this;
+		if (me._active) {
+			const currentValue = me._target[me._prop];
+			const elapsed = date - me._start;
+			const remain = me._duration - elapsed;
+			me._start = date;
+			me._duration = Math.floor(Math.max(remain, cfg.duration));
+			me._to = resolve([cfg.to, to, currentValue, cfg.from]);
+			me._from = resolve([cfg.from, currentValue, to]);
+		}
+	}
+
 	cancel() {
 		const me = this;
 		if (me._active) {

--- a/src/core/core.animations.js
+++ b/src/core/core.animations.js
@@ -147,6 +147,7 @@ export default class Animations {
 		const animations = [];
 		const running = target.$animations || (target.$animations = {});
 		const props = Object.keys(values);
+		const date = Date.now();
 		let i;
 
 		for (i = props.length - 1; i >= 0; --i) {
@@ -161,11 +162,17 @@ export default class Animations {
 			}
 			const value = values[prop];
 			let animation = running[prop];
-			if (animation) {
-				animation.cancel();
-			}
-
 			const cfg = animatedProps.get(prop);
+
+			if (animation) {
+				if (cfg && animation.active()) {
+					// There is an existing active animation, let's update that
+					animation.update(cfg, value, date);
+					continue;
+				} else {
+					animation.cancel();
+				}
+			}
 			if (!cfg || !cfg.duration) {
 				// not animated, set directly to new value
 				target[prop] = value;

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -343,7 +343,6 @@ export default class Chart {
 				options.onResize(me, newSize);
 			}
 
-			me.stop();
 			me.update('resize');
 		}
 	}


### PR DESCRIPTION
This change is mainly for the initial animation that seems to get stopped by a resize quite often.

The issue can be observed in the samples, by loading with different window sizes. Sometimes it works sometimes it stops.

So the solution here is not to stop the animations on resize, but update them instead.

