### PR TITLE
Only polyfill ResizeObserver for UMD builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14921,6 +14921,15 @@
         "rollup-pluginutils": "^2.3.3"
       }
     },
+    "rollup-plugin-polyfill": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-polyfill/-/rollup-plugin-polyfill-3.0.0.tgz",
+      "integrity": "sha512-LfJ1OR/wJrJdNDVNrdhVm7CgENfaNoQlFYMaQ0vlQH3zO+BMVrBMWDX9k6HVcr9gHsKbthrkiBzWRfFU9fr0hQ==",
+      "dev": true,
+      "requires": {
+        "magic-string": "^0.25.3"
+      }
+    },
     "rollup-plugin-terser": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "rollup": "^1.31.1",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-cleanup": "^3.1.1",
+    "rollup-plugin-polyfill": "^3.0.0",
     "rollup-plugin-terser": "^5.2.0",
     "typedoc": "^0.16.10",
     "typescript": "^3.8.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,6 +3,7 @@
 
 const babel = require('rollup-plugin-babel');
 const cleanup = require('rollup-plugin-cleanup');
+const polyfill = require('rollup-plugin-polyfill')
 const json = require('@rollup/plugin-json');
 const resolve = require('@rollup/plugin-node-resolve');
 const terser = require('rollup-plugin-terser').terser;
@@ -24,6 +25,7 @@ module.exports = [
 	{
 		input,
 		plugins: [
+			polyfill(['resize-observer-polyfill', './platform/platform.dom.js']),
 			json(),
 			resolve(),
 			babel(),
@@ -42,6 +44,7 @@ module.exports = [
 	{
 		input,
 		plugins: [
+			polyfill(['resize-observer-polyfill', './platform/platform.dom.js']),
 			json(),
 			resolve(),
 			babel(),

--- a/src/platform/platform.dom.js
+++ b/src/platform/platform.dom.js
@@ -5,7 +5,6 @@
 import helpers from '../helpers/index';
 import BasePlatform from './platform.base';
 import {_getParentNode} from '../helpers/helpers.dom';
-import ResizeObserver from 'resize-observer-polyfill';
 
 /**
  * @typedef { import("../core/core.controller").default } Chart
@@ -178,7 +177,6 @@ function throttled(fn, thisArg) {
  * Calling `fn` is limited to once per animation frame
  * @param {Element} element - The element to monitor
  * @param {function} fn - Callback function to call when resized
- * @return {ResizeObserver}
  */
 function watchForResize(element, fn) {
 	const resize = throttled((width, height) => {
@@ -196,6 +194,7 @@ function watchForResize(element, fn) {
 		}
 	}, window);
 
+	// @ts-ignore until https://github.com/Microsoft/TypeScript/issues/28502 implemented
 	const observer = new ResizeObserver(entries => {
 		const entry = entries[0];
 		resize(entry.contentRect.width, entry.contentRect.height);


### PR DESCRIPTION
Closes https://github.com/chartjs/Chart.js/issues/7204

RemovesObserver for people who are using npm and have their own build pipeline. This allows them to use a different polyfill if they choose or not polyfill if they don't need to support IE11

Chart.esm.min.js goes from 158K to 150K with this PR.