### PR TITLE
Fix filterBetween

### DIFF
--- a/src/helpers/helpers.collection.js
+++ b/src/helpers/helpers.collection.js
@@ -77,22 +77,16 @@ export function _rlookupByKey(table, key, value) {
  * @param {number} max - max value
  */
 export function _filterBetween(values, min, max) {
-	const maxIndex = values.length - 1;
 	let start = 0;
-	let end = maxIndex;
+	let end = values.length;
 
-	while (start < maxIndex && values[start] < min) {
+	while (start < end && values[start] < min) {
 		start++;
 	}
-	while (end > 0 && values[end] > max) {
+	while (end > start && values[end - 1] > max) {
 		end--;
 	}
 
-	if (start >= end) {
-		return [];
-	}
-
-	end++; // slice does not include last element
 	return start > 0 || end < values.length
 		? values.slice(start, end)
 		: values;

--- a/src/helpers/helpers.collection.js
+++ b/src/helpers/helpers.collection.js
@@ -68,3 +68,32 @@ export function _rlookupByKey(table, key, value) {
 
 	return {lo, hi};
 }
+
+/**
+ * Return subset of `values` between `min` and `max` inclusive.
+ * Values are assumed to be in sorted order.
+ * @param {number[]} values - sorted array of values
+ * @param {number} min - min value
+ * @param {number} max - max value
+ */
+export function _filterBetween(values, min, max) {
+	const maxIndex = values.length - 1;
+	let start = 0;
+	let end = maxIndex;
+
+	while (start < maxIndex && values[start] < min) {
+		start++;
+	}
+	while (end > 0 && values[end] > max) {
+		end--;
+	}
+
+	if (start >= end) {
+		return [];
+	}
+
+	end++; // slice does not include last element
+	return start > 0 || end < values.length
+		? values.slice(start, end)
+		: values;
+}

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -3,7 +3,7 @@ import defaults from '../core/core.defaults';
 import {isFinite, isNullOrUndef, mergeIf, valueOrDefault} from '../helpers/helpers.core';
 import {toRadians} from '../helpers/helpers.math';
 import Scale from '../core/core.scale';
-import {_lookup, _lookupByKey} from '../helpers/helpers.collection';
+import {_filterBetween, _lookup, _lookupByKey} from '../helpers/helpers.collection';
 
 /**
  * @typedef { import("../core/core.adapters").Unit } Unit
@@ -494,30 +494,6 @@ function getLabelBounds(scale) {
 	return {min, max};
 }
 
-/**
- * Return subset of `timestamps` between `min` and `max`.
- * Timestamps are assumend to be in sorted order.
- * @param {number[]} timestamps - array of timestamps
- * @param {number} min - min value (timestamp)
- * @param {number} max - max value (timestamp)
- */
-function filterBetween(timestamps, min, max) {
-	let start = 0;
-	let end = timestamps.length - 1;
-
-	while (start < end && timestamps[start] < min) {
-		start++;
-	}
-	while (end > start && timestamps[end] > max) {
-		end--;
-	}
-	end++; // slice does not include last element
-
-	return start > 0 || end < timestamps.length
-		? timestamps.slice(start, end)
-		: timestamps;
-}
-
 const defaultConfig = {
 	/**
 	 * Data distribution along the scale:
@@ -699,7 +675,7 @@ export default class TimeScale extends Scale {
 		const min = me.min;
 		const max = me.max;
 
-		const ticks = filterBetween(timestamps, min, max);
+		const ticks = _filterBetween(timestamps, min, max);
 
 		// PRIVATE
 		// determineUnitForFormatting relies on the number of ticks so we don't use it when

--- a/test/specs/helpers.collection.tests.js
+++ b/test/specs/helpers.collection.tests.js
@@ -30,6 +30,7 @@ describe('helpers.collection', function() {
 
 	it('Should filter a sorted array', function() {
 		expect(_filterBetween([1, 2, 3, 4, 5, 6, 7, 8, 9], 5, 8)).toEqual([5, 6, 7, 8]);
+		expect(_filterBetween([1], 1, 1)).toEqual([1]);
 		expect(_filterBetween([1583049600000], 1584816327553, 1585680327553)).toEqual([]);
 	});
 });

--- a/test/specs/helpers.collection.tests.js
+++ b/test/specs/helpers.collection.tests.js
@@ -1,6 +1,6 @@
-import {_lookup, _lookupByKey, _rlookupByKey} from '../../src/helpers/helpers.collection';
+import {_filterBetween, _lookup, _lookupByKey, _rlookupByKey} from '../../src/helpers/helpers.collection';
 
-describe('helpers.interpolation', function() {
+describe('helpers.collection', function() {
 	it('Should do binary search', function() {
 		const data = [0, 2, 6, 9];
 		expect(_lookup(data, 0)).toEqual({lo: 0, hi: 1});
@@ -26,5 +26,10 @@ describe('helpers.interpolation', function() {
 		expect(_rlookupByKey(data, 'x', 5)).toEqual({lo: 1, hi: 2});
 		expect(_rlookupByKey(data, 'x', 8)).toEqual({lo: 0, hi: 1});
 		expect(_rlookupByKey(data, 'x', 10)).toEqual({lo: 0, hi: 1});
+	});
+
+	it('Should filter a sorted array', function() {
+		expect(_filterBetween([1, 2, 3, 4, 5, 6, 7, 8, 9], 5, 8)).toEqual([5, 6, 7, 8]);
+		expect(_filterBetween([1583049600000], 1584816327553, 1585680327553)).toEqual([]);
 	});
 });


### PR DESCRIPTION
Closes https://github.com/chartjs/Chart.js/issues/7210

The method `filterBetween` is new in 3.0 and does not work correctly when all the timestamps are before `min`. I moved the method to `helpers.collection` so that I could add a unit test