### PR TITLE
Cleaner handling of fitting no ticks

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -726,7 +726,7 @@ export default class Scale extends Element {
 		}
 
 		// Don't bother fitting the ticks if we are not showing the labels
-		if (tickOpts.display && display) {
+		if (tickOpts.display && display && me.ticks.length) {
 			const labelSizes = me._getLabelSizes();
 			const firstLabelSize = labelSizes.first;
 			const lastLabelSize = labelSizes.last;


### PR DESCRIPTION
The code works today because `me.getPixelForTick(0)` returns `null` which is treated as `0`, but that's a little hacky to rely upon, so I think this is a bit cleaner