### PR TITLE
Use round when setting new chart size

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -313,8 +313,8 @@ export default class Chart {
 		// the canvas display style uses the same integer values to avoid blurring effect.
 
 		// Set to 0 instead of canvas.size because the size defaults to 300x150 if the element is collapsed
-		const newWidth = Math.max(0, Math.floor(width));
-		const newHeight = Math.max(0, Math.floor(aspectRatio ? newWidth / aspectRatio : height));
+		const newWidth = Math.max(0, Math.round(width));
+		const newHeight = Math.max(0, Math.round(aspectRatio ? newWidth / aspectRatio : height));
 
 		// detect devicePixelRation changes
 		const oldRatio = me.currentDevicePixelRatio;


### PR DESCRIPTION
This fixes a missing 1px in chart width on my hidpi screen, that was due to usage of floor when the chart is resized:

![Screenshot_20200325_210501](https://user-images.githubusercontent.com/42184090/77581711-7c929e00-6ede-11ea-8659-6d67e8465879.png)
