### PR TITLE
docs: Fix simple typo, layed -> laid

### DIFF
--- a/src/core/core.layouts.js
+++ b/src/core/core.layouts.js
@@ -236,7 +236,7 @@ export default {
 	 * Register a box to a chart.
 	 * A box is simply a reference to an object that requires layout. eg. Scales, Legend, Title.
 	 * @param {Chart} chart - the chart to use
-	 * @param {ILayoutItem} item - the item to add to be layed out
+	 * @param {ILayoutItem} item - the item to add to be laid out
 	 */
 	addBox(chart, item) {
 		if (!chart.boxes) {

--- a/src/core/core.plugins.js
+++ b/src/core/core.plugins.js
@@ -266,7 +266,7 @@ export default new PluginService();
  */
 /**
  * @method IPlugin#afterLayout
- * @desc Called after the `chart` has been layed out. Note that this hook will not
+ * @desc Called after the `chart` has been laid out. Note that this hook will not
  * be called if the layout update has been previously cancelled.
  * @param {Chart} chart - The chart instance.
  * @param {object} options - The plugin options.


### PR DESCRIPTION
There is a small typo in src/core/core.layouts.js, src/core/core.plugins.js.

Should read `laid` rather than `layed`.

