### PR TITLE
Remove unused layouts.defaults

### DIFF
--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -221,6 +221,10 @@ The following properties and methods were removed:
 * `helpers.scaleMerge`
 * `helpers.where`
 
+#### Layout
+
+* `Layout.defaults`
+
 #### Scales
 
 * `LogarithmicScale.minNotZero`

--- a/src/core/core.layouts.js
+++ b/src/core/core.layouts.js
@@ -230,7 +230,6 @@ defaults.set('layout', {
 // Scales, Legends and Plugins all rely on the layout service and can easily register to be placed anywhere they need
 // It is this service's responsibility of carrying out that layout.
 export default {
-	defaults: {},
 
 	/**
 	 * Register a box to a chart.

--- a/test/specs/core.layouts.tests.js
+++ b/test/specs/core.layouts.tests.js
@@ -6,7 +6,6 @@ describe('Chart.layouts', function() {
 	it('should be exposed through Chart.layouts', function() {
 		expect(Chart.layouts).toBeDefined();
 		expect(typeof Chart.layouts).toBe('object');
-		expect(Chart.layouts.defaults).toBeDefined();
 		expect(Chart.layouts.addBox).toBeDefined();
 		expect(Chart.layouts.removeBox).toBeDefined();
 		expect(Chart.layouts.configure).toBeDefined();


### PR DESCRIPTION
As far as I can tell, this is unused. There are default options set higher up in the file, but this is unrelated and doesn't seem to serve any purpose