### PR TITLE
Make br tags self-closing

### DIFF
--- a/docs/charts/area.md
+++ b/docs/charts/area.md
@@ -13,9 +13,9 @@ Both [line](line.md) and [radar](radar.md) charts support a `fill` option on the
 | Boundary <sup>2</sup> | `string` | `'start'`, `'end'`, `'origin'` |
 | Disabled <sup>3</sup> | `boolean` | `false` |
 
-> <sup>1</sup> dataset filling modes have been introduced in version 2.6.0<br>
-> <sup>2</sup> prior version 2.6.0, boundary values was `'zero'`, `'top'`, `'bottom'` (deprecated)<br>
-> <sup>3</sup> for backward compatibility, `fill: true` (default) is equivalent to `fill: 'origin'`<br>
+> <sup>1</sup> dataset filling modes have been introduced in version 2.6.0<br/>
+> <sup>2</sup> prior version 2.6.0, boundary values was `'zero'`, `'top'`, `'bottom'` (deprecated)<br/>
+> <sup>3</sup> for backward compatibility, `fill: true` (default) is equivalent to `fill: 'origin'`<br/>
 
 **Example**
 ```javascript


### PR DESCRIPTION
This would be necessary to get the docs to build if we decided to migrate from GitBook to Docusaurus (https://github.com/chartjs/Chart.js/issues/7267). I figured it doesn't hurt and would make it easier to play around with Docusaurus so was worth doing