### PR TITLE
feat(website): add DocSearch as recommended by docusaurus

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -14,7 +14,7 @@ module.exports = {
       apiKey: 'd7ee00a3cbaaf3c33e28ad1c274e7ba6',
       indexName: 'chartjs',
       algoliaOptions: {
-        facetFilters: [`version:${versions[0]}`],
+        facetFilters: [`version:VERSION`],
       }
     },
     googleAnalytics: {

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -10,6 +10,13 @@ module.exports = {
   plugins: ['@docusaurus/plugin-google-analytics'],
   scripts: ['https://www.chartjs.org/dist/VERSION/Chart.min.js'],
   themeConfig: {
+	algolia: {
+      apiKey: 'd7ee00a3cbaaf3c33e28ad1c274e7ba6',
+      indexName: 'chartjs',
+      algoliaOptions: {
+        facetFilters: [`version:${versions[0]}`],
+      }
+	},
     googleAnalytics: {
       trackingID: 'UA-28909194-3',
       // Optional fields.

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -10,13 +10,13 @@ module.exports = {
   plugins: ['@docusaurus/plugin-google-analytics'],
   scripts: ['https://www.chartjs.org/dist/VERSION/Chart.min.js'],
   themeConfig: {
-	algolia: {
+    algolia: {
       apiKey: 'd7ee00a3cbaaf3c33e28ad1c274e7ba6',
       indexName: 'chartjs',
       algoliaOptions: {
         facetFilters: [`version:${versions[0]}`],
       }
-	},
+    },
     googleAnalytics: {
       trackingID: 'UA-28909194-3',
       // Optional fields.


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.