### PR TITLE
Add a scale.init method

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -403,9 +403,6 @@ export default class Chart {
 			let scale = null;
 			if (id in scales && scales[id].type === scaleType) {
 				scale = scales[id];
-				scale.options = scaleOptions;
-				scale.ctx = me.ctx;
-				scale.chart = me;
 			} else {
 				const scaleClass = scaleService.getScaleConstructor(scaleType);
 				if (!scaleClass) {
@@ -414,18 +411,13 @@ export default class Chart {
 				scale = new scaleClass({
 					id,
 					type: scaleType,
-					options: scaleOptions,
 					ctx: me.ctx,
 					chart: me
 				});
 				scales[scale.id] = scale;
 			}
 
-			scale.axis = scale.options.position === 'chartArea' ? 'r' : scale.isHorizontal() ? 'x' : 'y';
-
-			// parse min/max value, so we can properly determine min/max for other scales
-			scale._userMin = scale.parse(scale.options.min);
-			scale._userMax = scale.parse(scale.options.max);
+			scale.init(scaleOptions);
 
 			// TODO(SB): I think we should be able to remove this custom case (options.scale)
 			// and consider it as a regular scale part of the "scales"" map only! This would

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -278,7 +278,7 @@ export default class Scale extends Element {
 		/** @type {string} */
 		this.type = cfg.type;
 		/** @type {object} */
-		this.options = cfg.options;
+		this.options = undefined;
 		/** @type {CanvasRenderingContext2D} */
 		this.ctx = cfg.ctx;
 		/** @type {Chart} */
@@ -345,9 +345,24 @@ export default class Scale extends Element {
 	}
 
 	/**
+	 * @param {object} options
+	 * @since 3.0
+	 */
+	init(options) {
+		const me = this;
+		me.options = options;
+
+		me.axis = me.isHorizontal() ? 'x' : 'y';
+
+		// parse min/max value, so we can properly determine min/max for other scales
+		me._userMin = me.parse(options.min);
+		me._userMax = me.parse(options.max);
+	}
+
+	/**
 	 * Parse a supported input value to internal representation.
 	 * @param {*} raw
-	 * @param {number} index
+	 * @param {number} [index]
 	 * @since 3.0
 	 */
 	parse(raw, index) { // eslint-disable-line no-unused-vars

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -309,6 +309,11 @@ export default class RadialLinearScale extends LinearScaleBase {
 		this.pointLabels = [];
 	}
 
+	init(options) {
+		super.init(options);
+		this.axis = 'r';
+	}
+
 	setDimensions() {
 		const me = this;
 

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -555,10 +555,6 @@ export default class TimeScale extends Scale {
 	constructor(props) {
 		super(props);
 
-		const options = this.options;
-		const time = options.time || (options.time = {});
-		const adapter = this._adapter = new adapters._date(options.adapters.date);
-
 		/** @type {{data: number[], labels: number[], all: number[]}} */
 		this._cache = {
 			data: [],
@@ -574,12 +570,19 @@ export default class TimeScale extends Scale {
 		this._offsets = {};
 		/** @type {object[]} */
 		this._table = [];
+	}
+
+	init(options) {
+		const time = options.time || (options.time = {});
+		const adapter = this._adapter = new adapters._date(options.adapters.date);
 
 		// Backward compatibility: before introducing adapter, `displayFormats` was
 		// supposed to contain *all* unit/string pairs but this can't be resolved
 		// when loading the scale (adapters are loaded afterward), so let's populate
 		// missing formats on update
 		mergeIf(time.displayFormats, adapter.formats());
+
+		super.init(options);
 	}
 
 	/**

--- a/test/specs/scale.category.tests.js
+++ b/test/specs/scale.category.tests.js
@@ -76,13 +76,13 @@ describe('Category scale tests', function() {
 		var Constructor = Chart.scaleService.getScaleConstructor('category');
 		var scale = new Constructor({
 			ctx: {},
-			options: config,
 			chart: {
 				data: mockData
 			},
 			id: scaleID
 		});
 
+		scale.init(config);
 		scale.determineDataLimits();
 		scale.ticks = scale.buildTicks();
 		expect(getValues(scale)).toEqual(mockData.xLabels);
@@ -104,13 +104,13 @@ describe('Category scale tests', function() {
 		var Constructor = Chart.scaleService.getScaleConstructor('category');
 		var scale = new Constructor({
 			ctx: {},
-			options: config,
 			chart: {
 				data: mockData
 			},
 			id: scaleID
 		});
 
+		scale.init(config);
 		scale.determineDataLimits();
 		scale.ticks = scale.buildTicks();
 		expect(getValues(scale)).toEqual(mockData.yLabels);


### PR DESCRIPTION
Closes https://github.com/chartjs/Chart.js/issues/7342

This is cleaner than the current code, which has the core controller reaching into the internals of the scale