### PR TITLE
When the container padding is an empty string, handle it as 0px

### DIFF
--- a/src/helpers/helpers.dom.js
+++ b/src/helpers/helpers.dom.js
@@ -80,6 +80,12 @@ function getConstraintHeight(domNode) {
 function _calculatePadding(container, padding, parentDimension) {
 	padding = getStyle(container, padding);
 
+	// If the padding is not set at all and the node is not in the DOM, this can be an empty string
+	// In that case, we need to handle it as no padding
+	if (padding === '') {
+		return 0;
+	}
+
 	return padding.indexOf('%') > -1 ? parentDimension * parseInt(padding, 10) / 100 : parseInt(padding, 10);
 }
 


### PR DESCRIPTION
This resolves #6876 

## Root Cause

The root cause was the silent `resize` that occurs during the initialization process. In this case, the container element's `currentStyle` was not defined, so we fell back to `document.defaultView.getComputedStyle(el, null)`. This has a `padding-left` style of `''`. We tried to parse that directly with `parseInt` which fails.

## Solution

This change special cases an empty string to return 0. An alternative implementation was to call `parseInt(padding || '0', 10)`.

## Testing

The codepen in #6876 was tested locally and confirmed to work after this change.