### PR TITLE
fix resizeObserver Polyfill #7341

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,7 +25,7 @@ module.exports = [
 	{
 		input,
 		plugins: [
-			polyfill(['resize-observer-polyfill', './platform/platform.dom.js']),
+			polyfill(['./platform/platform.dom.js']),
 			json(),
 			resolve(),
 			babel(),

--- a/src/platform/platform.dom.js
+++ b/src/platform/platform.dom.js
@@ -2,6 +2,8 @@
  * Chart.Platform implementation for targeting a web browser
  */
 
+import ResizeObserver from 'resize-observer-polyfill';
+
 import helpers from '../helpers/index';
 import BasePlatform from './platform.base';
 import {_getParentNode} from '../helpers/helpers.dom';


### PR DESCRIPTION
Hi.
This PR is related to issue #7341 .

rollup-plugin-polyfill [seems to not include correctly resize-observer-polyfill](https://github.com/JRJurman/rollup-plugin-polyfill/issues/7), it changes the name `ResizeObserver` to `ResizeObserver$1` . So I change to Import the ResizeObserver Polyfill directly in the code.

Could you verify if it's OK? =]

Thanks.
