### PR TITLE
Preserve object prototypes when cloning (v2)

### DIFF
--- a/src/helpers/helpers.core.js
+++ b/src/helpers/helpers.core.js
@@ -175,7 +175,7 @@ var helpers = {
 		}
 
 		if (helpers.isObject(source)) {
-			var target = {};
+			var target = Object.create(source);
 			var keys = Object.keys(source);
 			var klen = keys.length;
 			var k = 0;

--- a/test/specs/helpers.core.tests.js
+++ b/test/specs/helpers.core.tests.js
@@ -301,6 +301,25 @@ describe('Chart.helpers.core', function() {
 			expect(output.o.a).not.toBe(a1);
 			expect(output.a).not.toBe(a0);
 		});
+		it('should preserve prototype of objects', function() {
+			// https://github.com/chartjs/Chart.js/issues/7340
+			function MyConfigObject(s) {
+				this._s = s;
+			}
+			MyConfigObject.prototype.func = function() {
+				return 10;
+			};
+			var original = new MyConfigObject('something');
+			var output = helpers.merge({}, {
+				plugins: [{
+					test: original
+				}]
+			});
+			var clone = output.plugins[0].test;
+			expect(clone).toBeInstanceOf(MyConfigObject);
+			expect(clone).toEqual(original);
+			expect(clone === original).toBeFalse();
+		});
 	});
 
 	describe('merge', function() {


### PR DESCRIPTION
This is a backport of #7381, fixing #7340 for v2. Test was modified to support ES5.
