### PR TITLE
Docs: fix z-index default

### DIFF
--- a/docs/docs/axes/styling.md
+++ b/docs/docs/axes/styling.md
@@ -46,7 +46,7 @@ The tick configuration is nested under the scale configuration in the `ticks` ke
 | `major` | `object` | | `{}` | Major ticks configuration.
 | `padding` | `number` | | `0` | Sets the offset of the tick labels from the axis
 | `reverse` | `boolean` | | `false` | Reverses order of tick labels.
-| `z` | `number` | `0` | | z-index of tick layer. Useful when ticks are drawn on chart area. Values &lt;= 0 are drawn under datasets, &gt; 0 on top.
+| `z` | `number` | | `0` | z-index of tick layer. Useful when ticks are drawn on chart area. Values &lt;= 0 are drawn under datasets, &gt; 0 on top.
 
 ## Major Tick Configuration
 


### PR DESCRIPTION
The 0 was showing up in the "scriptable" column