### PR TITLE
Only draw the tooltip if it is defined

### DIFF
--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -1076,6 +1076,7 @@ export default {
 
 	afterDraw(chart) {
 		const tooltip = chart.tooltip;
+
 		const args = {
 			tooltip
 		};
@@ -1084,7 +1085,9 @@ export default {
 			return;
 		}
 
-		tooltip.draw(chart.ctx);
+		if (tooltip) {
+			tooltip.draw(chart.ctx);
+		}
 
 		plugins.notify(chart, 'afterTooltipDraw', [args]);
 	},


### PR DESCRIPTION
Fixes an issue I noticed when testing locally

## Reproduce

```javascript
Chart.defaults.tooltips = false;
const ci = new Chart(ctx, {
  data,
});
```

This will crash when trying to draw the tooltip because `chart.tooltip` is never created when the options are falsy

Closes: #7423
