### PR TITLE
Default aspectRatio to 1 for square charts

### DIFF
--- a/docs/docs/getting-started/v3-migration.md
+++ b/docs/docs/getting-started/v3-migration.md
@@ -49,6 +49,7 @@ A number of changes were made to the configuration options passed to the `Chart`
 * The dataset option `tension` was removed. Use `lineTension`
 * Dataset options are now configured as `options[type].datasets` rather than `options.datasets[type]`
 * To override the platform class used in a chart instance, pass `platform: PlatformClass` in the config object. Note that the class should be passed, not an instance of the class.
+* `aspectRatio` defaults to 1 for doughnut, pie, polarArea, and radar charts
 
 #### Defaults
 

--- a/src/controllers/controller.doughnut.js
+++ b/src/controllers/controller.doughnut.js
@@ -22,6 +22,7 @@ defaults.set('doughnut', {
 		// Boolean - Whether we animate scaling the Doughnut from the centre
 		animateScale: false
 	},
+	aspectRatio: 1,
 	legend: {
 		labels: {
 			generateLabels(chart) {

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -13,6 +13,7 @@ defaults.set('polarArea', {
 		animateRotate: true,
 		animateScale: true
 	},
+	aspectRatio: 1,
 	scales: {
 		r: {
 			type: 'radialLinear',

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -4,6 +4,7 @@ import {Line, Point} from '../elements/index';
 import {valueOrDefault} from '../helpers/helpers.core';
 
 defaults.set('radar', {
+	aspectRatio: 1,
 	spanGaps: false,
 	scales: {
 		r: {


### PR DESCRIPTION
We initially added this in ~v2.4.0 and then removed in the v2.7 timeframe as it was a breaking change for existing v2 users. Now is the time to add it back as this significantly improves these charts IMO.