### PR TITLE
Radial Linear Scale: Compute Value based on distance from center

### DIFF
--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -429,14 +429,7 @@ class RadialLinearScale extends LinearScaleBase {
 
 		const me = this;
 		const scaledDistance = distance / (me.drawingArea / (me.max - me.min));
-		let value;
-		if (me.options.reverse) {
-			value = me.max - scaledDistance;
-		} else {
-			value = me.min + scaledDistance;
-		}
-
-		return value;
+		return me.options.reverse ? me.max - scaledDistance : me.min + scaledDistance;
 	}
 
 	getPointPosition(index, distanceFromCenter) {

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -422,6 +422,23 @@ class RadialLinearScale extends LinearScaleBase {
 		return (value - me.min) * scalingFactor;
 	}
 
+	getValueForDistanceFromCenter(distance) {
+		if (isNullOrUndef(distance)) {
+			return NaN;
+		}
+
+		const me = this;
+		const scaledDistance = distance / (me.drawingArea / (me.max - me.min));
+		let value;
+		if (me.options.reverse) {
+			value = me.max - scaledDistance;
+		} else {
+			value = me.min + scaledDistance;
+		}
+
+		return value;
+	}
+
 	getPointPosition(index, distanceFromCenter) {
 		const me = this;
 		const angle = me.getIndexAngle(index) - (Math.PI / 2);

--- a/test/specs/scale.radialLinear.tests.js
+++ b/test/specs/scale.radialLinear.tests.js
@@ -453,6 +453,39 @@ describe('Test the radial linear scale', function() {
 		expect(chart.scales.r.getDistanceFromCenterForValue(chart.scales.r.max)).toBe(0);
 	});
 
+	it('should get the correct value for a distance from the center point', function() {
+		var chart = window.acquireChart({
+			type: 'radar',
+			data: {
+				datasets: [{
+					data: [10, 5, 0, 25, 78]
+				}],
+				labels: ['label1', 'label2', 'label3', 'label4', 'label5']
+			},
+			options: {
+				scale: {
+					pointLabels: {
+						callback: function(value, index) {
+							return index.toString();
+						}
+					}
+				}
+			}
+		});
+
+		expect(chart.scales.r.getValueForDistanceFromCenter(0)).toBe(chart.scales.r.min);
+		expect(chart.scales.r.getValueForDistanceFromCenter(227)).toBe(chart.scales.r.max);
+
+		var dist = chart.scales.r.getDistanceFromCenterForValue(5);
+		expect(chart.scales.r.getValueForDistanceFromCenter(dist)).toBe(5);
+
+		chart.scales.r.options.reverse = true;
+		chart.update();
+
+		expect(chart.scales.r.getValueForDistanceFromCenter(0)).toBe(chart.scales.r.max);
+		expect(chart.scales.r.getValueForDistanceFromCenter(227)).toBe(chart.scales.r.min);
+	});
+
 	it('should correctly get angles for all points', function() {
 		var chart = window.acquireChart({
 			type: 'radar',


### PR DESCRIPTION
Resolves #5931 

Adds a new method to the radial linear scale: `getValueForDistanceFromCenter` which does the inverse of the existing `getDistanceFromCenterForValue`
