### PR TITLE
Enable custom legend box heights

### DIFF
--- a/docs/docs/configuration/legend.md
+++ b/docs/docs/configuration/legend.md
@@ -49,6 +49,7 @@ The legend label configuration is nested below the legend configuration using th
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
 | `boxWidth` | `number` | `40` | Width of coloured box.
+| `boxHeight` | `number` | fontSize | Height of the coloured box.
 | `font` | `Font` | `defaults.font` | See [Fonts](fonts.md)
 | `padding` | `number` | `10` | Padding between rows of colored boxes.
 | `generateLabels` | `function` | | Generates legend items for each thing in the legend. Default implementation returns the text + styling for the color box. See [Legend Item](#legend-item-interface) for details.

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -2,7 +2,7 @@ import defaults from '../core/core.defaults';
 import Element from '../core/core.element';
 import layouts from '../core/core.layouts';
 import {drawPoint} from '../helpers/helpers.canvas';
-import {callback as call, mergeIf, valueOrDefault} from '../helpers/helpers.core';
+import {callback as call, mergeIf, valueOrDefault, isNullOrUndef} from '../helpers/helpers.core';
 import {toFont, toPadding} from '../helpers/helpers.options';
 import {getRtlAdapter, overrideTextDirection, restoreTextDirection} from '../helpers/helpers.rtl';
 
@@ -102,7 +102,8 @@ function getBoxWidth(labelOpts, fontSize) {
  * @return {number} height of the color box area
  */
 function getBoxHeight(labelOpts, fontSize) {
-	return labelOpts.usePointStyle && labelOpts.boxHeight > fontSize ?
+	const {boxHeight} = labelOpts;
+	return (labelOpts.usePointStyle && boxHeight) || isNullOrUndef(boxHeight) > fontSize ?
 		fontSize :
 		labelOpts.boxHeight;
 }

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -103,7 +103,7 @@ function getBoxWidth(labelOpts, fontSize) {
  */
 function getBoxHeight(labelOpts, fontSize) {
 	const {boxHeight} = labelOpts;
-	return (labelOpts.usePointStyle && boxHeight) || isNullOrUndef(boxHeight) > fontSize ?
+	return (labelOpts.usePointStyle && boxHeight > fontSize) || isNullOrUndef(boxHeight) ?
 		fontSize :
 		labelOpts.boxHeight;
 }

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -2,7 +2,7 @@ import defaults from '../core/core.defaults';
 import Element from '../core/core.element';
 import layouts from '../core/core.layouts';
 import {drawPoint} from '../helpers/helpers.canvas';
-import {callback as call, mergeIf, valueOrDefault, isNullOrUndef} from '../helpers/helpers.core';
+import {callback as call, mergeIf, valueOrDefault} from '../helpers/helpers.core';
 import {toFont, toPadding} from '../helpers/helpers.options';
 import {getRtlAdapter, overrideTextDirection, restoreTextDirection} from '../helpers/helpers.rtl';
 
@@ -251,6 +251,9 @@ export class Legend extends Element {
 		const ctx = me.ctx;
 		const labelFont = toFont(labelOpts.font);
 		const fontSize = labelFont.size;
+		const boxWidth = getBoxWidth(labelOpts, fontSize);
+		const boxHeight = getBoxHeight(labelOpts, fontSize);
+		const itemHeight = Math.max(boxHeight, fontSize);
 
 		// Reset hit boxes
 		const hitboxes = me.legendHitBoxes = [];
@@ -283,10 +286,7 @@ export class Legend extends Element {
 			ctx.textBaseline = 'middle';
 
 			me.legendItems.forEach((legendItem, i) => {
-				const boxWidth = getBoxWidth(labelOpts, fontSize);
-				const boxHeight = getBoxHeight(labelOpts, fontSize);
 				const width = boxWidth + (fontSize / 2) + ctx.measureText(legendItem.text).width;
-				const itemHeight = Math.max(boxHeight, fontSize);
 
 				if (i === 0 || lineWidths[lineWidths.length - 1] + width + 2 * labelOpts.padding > minSize.width) {
 					totalHeight += itemHeight + labelOpts.padding;
@@ -316,8 +316,6 @@ export class Legend extends Element {
 
 			const heightLimit = minSize.height - titleHeight;
 			me.legendItems.forEach((legendItem, i) => {
-				const boxWidth = getBoxWidth(labelOpts, fontSize);
-				const boxHeight = getBoxHeight(labelOpts, fontSize);
 				const itemWidth = boxWidth + (fontSize / 2) + ctx.measureText(legendItem.text).width;
 
 				// If too tall, go to new column
@@ -338,7 +336,7 @@ export class Legend extends Element {
 					left: 0,
 					top: 0,
 					width: itemWidth,
-					height: Math.max(fontSize, boxHeight)
+					height: itemHeight,
 				};
 			});
 

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -102,7 +102,7 @@ function getBoxWidth(labelOpts, fontSize) {
  * @return {number} height of the color box area
  */
 function getBoxHeight(labelOpts, fontSize) {
-	return labelOpts.usePointStyle && labelOpts.boxHeight ?
+	return labelOpts.usePointStyle && labelOpts.boxHeight > fontSize ?
 		fontSize :
 		labelOpts.boxHeight;
 }

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -90,9 +90,10 @@ defaults.set('legend', {
  * @return {number} width of the color box area
  */
 function getBoxWidth(labelOpts, fontSize) {
-	return labelOpts.usePointStyle && labelOpts.boxWidth > fontSize ?
+	const {boxWidth} = labelOpts;
+	return (labelOpts.usePointStyle && boxWidth > fontSize) || isNullOrUndef(boxWidth) ?
 		fontSize :
-		labelOpts.boxWidth;
+		boxWidth;
 }
 
 /**
@@ -105,7 +106,7 @@ function getBoxHeight(labelOpts, fontSize) {
 	const {boxHeight} = labelOpts;
 	return (labelOpts.usePointStyle && boxHeight > fontSize) || isNullOrUndef(boxHeight) ?
 		fontSize :
-		labelOpts.boxHeight;
+		boxHeight;
 }
 
 export class Legend extends Element {

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -102,7 +102,7 @@ function getBoxWidth(labelOpts, fontSize) {
  * @return {number} height of the color box area
  */
 function getBoxHeight(labelOpts, fontSize) {
-	return labelOpts.usePointStyle || isNullOrUndef(labelOpts.boxHeight) ?
+	return labelOpts.usePointStyle && labelOpts.boxHeight ?
 		fontSize :
 		labelOpts.boxHeight;
 }
@@ -393,6 +393,7 @@ export class Legend extends Element {
 
 		const boxWidth = getBoxWidth(labelOpts, fontSize);
 		const boxHeight = getBoxHeight(labelOpts, fontSize);
+		const height = Math.max(fontSize, boxHeight);
 		const hitboxes = me.legendHitBoxes;
 
 		// current position
@@ -448,7 +449,7 @@ export class Legend extends Element {
 		const fillText = function(x, y, legendItem, textWidth) {
 			const halfFontSize = fontSize / 2;
 			const xLeft = rtlHelper.xPlus(x, boxWidth + halfFontSize);
-			const yMiddle = y + (Math.max(fontSize, boxHeight) / 2);
+			const yMiddle = y + (height / 2);
 			ctx.fillText(legendItem.text, xLeft, yMiddle);
 
 			if (legendItem.hidden) {
@@ -491,7 +492,7 @@ export class Legend extends Element {
 
 		overrideTextDirection(me.ctx, opts.textDirection);
 
-		const itemHeight = Math.max(fontSize, boxHeight) + labelOpts.padding;
+		const itemHeight = height + labelOpts.padding;
 		me.legendItems.forEach((legendItem, i) => {
 			const textWidth = ctx.measureText(legendItem.text).width;
 			const width = boxWidth + (fontSize / 2) + textWidth;

--- a/test/specs/plugin.legend.tests.js
+++ b/test/specs/plugin.legend.tests.js
@@ -373,6 +373,37 @@ describe('Legend block tests', function() {
 		});
 	});
 
+	it('should draw items with a custom boxHeight', function() {
+		var chart = window.acquireChart(
+			{
+				type: 'line',
+				data: {
+					datasets: [{
+						label: 'dataset1',
+						data: []
+					}],
+					labels: []
+				},
+				options: {
+					legend: {
+						position: 'right',
+						labels: {
+							boxHeight: 40
+						}
+					}
+				}
+			},
+			{
+				canvas: {
+					width: 512,
+					height: 105
+				}
+			}
+		);
+		const hitBox = chart.legend.legendHitBoxes[0];
+		expect(hitBox.height).toBe(40);
+	});
+
 	it('should pick up the first item when the property is an array', function() {
 		var chart = window.acquireChart({
 			type: 'bar',


### PR DESCRIPTION
Adds a new option `options.legend.labels.boxHeight` which can be used to set the legend box height. Resolves #2051 

This could lead to some alignment options in the future to control where low height boxes are drawn (currently this is in the center) or where text is drawn when the box is taller than the font size (this is also the center).

## Large Height

`options.legend.labels.boxHeight == 100`

![tall box](https://user-images.githubusercontent.com/6757853/83700344-93d3c300-a5d4-11ea-8328-b5499cf0a506.PNG)

## Small Height

`options.legend.labels.boxHeight == 5`

![short box](https://user-images.githubusercontent.com/6757853/83700321-7bfc3f00-a5d4-11ea-960a-c36e223a5681.png)


## Line Appearance

`options.legend.labels.boxHeight == 1`

![line style](https://user-images.githubusercontent.com/6757853/83700298-7141aa00-a5d4-11ea-81cb-6c42f9448a9f.PNG)
