### PR TITLE
Update horizontal bar chart default tooltip mode

### DIFF
--- a/docs/docs/getting-started/v3-migration.md
+++ b/docs/docs/getting-started/v3-migration.md
@@ -68,6 +68,7 @@ A number of changes were made to the configuration options passed to the `Chart`
 * `defaultFontSize` was renamed to `font.size`
 * `defaultFontStyle` was renamed to `font.style`
 * `defaultLineHeight` was renamed to `font.lineHeight`
+* Horizontal Bar default tooltip mode was changed from `'index'` to `'nearest'` to match vertical bar charts
 
 #### Scales
 

--- a/src/controllers/controller.horizontalBar.js
+++ b/src/controllers/controller.horizontalBar.js
@@ -33,7 +33,6 @@ defaults.set('horizontalBar', {
 	},
 
 	tooltips: {
-		mode: 'index',
 		axis: 'y'
 	}
 });


### PR DESCRIPTION
Ensures that vertical and horizontal bar charts behave the same way

Resolves #7487 
