### PR TITLE
Tooltip: Provide argument for custom callback

### DIFF
--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -669,7 +669,7 @@ export class Tooltip extends Element {
 		}
 
 		if (changed && options.custom) {
-			options.custom.call(me);
+			options.custom.call(me, [me]);
 		}
 	}
 


### PR DESCRIPTION
Resolves: #7515 

Note: The model was removed when animation logic was rewritten. The properties are available through the Tooltip itself now, which is provided instead of the old `_model`.