### PR TITLE
Update the legend object during beforeUpdate

### DIFF
--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -728,7 +728,7 @@ export default {
 		}
 	},
 
-	afterUpdate(chart) {
+	beforeUpdate(chart) {
 		const legendOpts = chart.options.legend;
 		const legend = chart.legend;
 

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -728,6 +728,9 @@ export default {
 		}
 	},
 
+	// During the beforeUpdate step, the layout configuration needs to run
+	// This ensures that if the legend position changes (via an option update)
+	// the layout system respects the change. See https://github.com/chartjs/Chart.js/issues/7527
 	beforeUpdate(chart) {
 		const legendOpts = chart.options.legend;
 		const legend = chart.legend;
@@ -747,6 +750,8 @@ export default {
 		}
 	},
 
+	// The labels need to be built after datasets are updated to ensure that colors
+	// and other styling are correct. See https://github.com/chartjs/Chart.js/issues/6968
 	afterUpdate(chart) {
 		if (chart.legend) {
 			chart.legend.buildLabels();

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -738,7 +738,6 @@ export default {
 			if (legend) {
 				layouts.configure(chart, legend, legendOpts);
 				legend.options = legendOpts;
-				legend.buildLabels();
 			} else {
 				createNewLegendAndAttach(chart, legendOpts);
 			}
@@ -747,6 +746,13 @@ export default {
 			delete chart.legend;
 		}
 	},
+
+	afterUpdate(chart) {
+		if (chart.legend) {
+			chart.legend.buildLabels();
+		}
+	},
+
 
 	afterEvent(chart, e) {
 		const legend = chart.legend;


### PR DESCRIPTION
When the legend is updated in afterUpdate, the position is not updated
before the layout system runs. When the event that the legend position
was changed, the legend would not move to the new position in the layout
system. This causes the chart to render incorrectly because the layout
system handled the layout as if the legend was still at the original position.

Resolves #7527 
