### PR TITLE
Remove "for bugs" from bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.md
+++ b/.github/ISSUE_TEMPLATE/BUG.md
@@ -26,7 +26,7 @@ labels: 'type: bug'
   or ideas how to implement the addition or change
 -->
 
-## Steps to Reproduce (for bugs)
+## Steps to Reproduce
 <!--
   Provide a link to a live example. Bug reports MUST be submitted with an
   interactive example (https://codepen.io/pen?template=JXVYzq).


### PR DESCRIPTION
It's a bit redundant and doesn't add much

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
