### PR TITLE
Remove duplicate tests

### DIFF
--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -187,47 +187,6 @@ describe('Time scale tests', function() {
 		});
 	});
 
-	describe('when specifying limits in a deprecated fashion', function() {
-		var mockData = {
-			labels: ['2015-01-01T20:00:00', '2015-01-02T20:00:00', '2015-01-03T20:00:00'],
-		};
-
-		var config;
-		beforeEach(function() {
-			config = Chart.helpers.clone(Chart.scaleService.getScaleDefaults('time'));
-			config.ticks.source = 'labels';
-			config.time.unit = 'day';
-		});
-
-		it('should use the min option when less than first label for building ticks', function() {
-			config.min = '2014-12-29T04:00:00';
-
-			var labels = getLabels(createScale(mockData, config));
-			expect(labels[0]).toEqual('Jan 1');
-		});
-
-		it('should use the min option when greater than first label for building ticks', function() {
-			config.min = '2015-01-02T04:00:00';
-
-			var labels = getLabels(createScale(mockData, config));
-			expect(labels[0]).toEqual('Jan 2');
-		});
-
-		it('should use the max option when greater than last label for building ticks', function() {
-			config.max = '2015-01-05T06:00:00';
-
-			var labels = getLabels(createScale(mockData, config));
-			expect(labels[labels.length - 1]).toEqual('Jan 3');
-		});
-
-		it('should use the max option when less than last label for building ticks', function() {
-			config.max = '2015-01-02T23:00:00';
-
-			var labels = getLabels(createScale(mockData, config));
-			expect(labels[labels.length - 1]).toEqual('Jan 2');
-		});
-	});
-
 	it('should use the isoWeekday option', function() {
 		var mockData = {
 			labels: [


### PR DESCRIPTION
The code block above is exactly the same. I guess when we removed the deprecated code we updated these tests and didn't notice that this was specifically testing the deprecated path and we already had tests for the non-deprecated path