### PR TITLE
Enable autoSkip for time scale to match others

### DIFF
--- a/docs/docs/getting-started/v3-migration.md
+++ b/docs/docs/getting-started/v3-migration.md
@@ -156,7 +156,8 @@ options: {
 }
 ```
 
-Also, the time scale option `distribution: 'series'` was removed and a new scale type `timeseries` was introduced in its place.
+* The time scale option `distribution: 'series'` was removed and a new scale type `timeseries` was introduced in its place
+* In the time scale, `autoSkip` is now enabled by default for consistency with the other scales
 
 #### Animations
 

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -219,8 +219,6 @@ const defaultConfig = {
 		displayFormats: {}
 	},
 	ticks: {
-		autoSkip: false,
-
 		/**
 		 * Ticks generation input values:
 		 * - 'auto': generates "optimal" ticks based on scale size and time options.

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -88,7 +88,7 @@ describe('Time scale tests', function() {
 				padding: 0,
 				display: true,
 				callback: defaultConfig.ticks.callback, // make this nicer, then check explicitly below,
-				autoSkip: false,
+				autoSkip: true,
 				autoSkipPadding: 0,
 				labelOffset: 0,
 				minor: {},


### PR DESCRIPTION
`autoSkip` is on by default for all other scales. Make them match

The time scale docs didn't say anything about having a different default, so I just updated the migration guide