### PR TITLE
Fix padding for labels

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -779,8 +779,8 @@ export default class Scale extends Element {
 
 				minSize.width = Math.min(me.maxWidth, minSize.width + labelWidth);
 
-				me.paddingTop = firstLabelSize.height / 2;
-				me.paddingBottom = lastLabelSize.height / 2;
+				me.paddingTop = lastLabelSize.height / 2;
+				me.paddingBottom = firstLabelSize.height / 2;
 			}
 		}
 


### PR DESCRIPTION
Closes https://github.com/chartjs/Chart.js/issues/7571

This was broken for the linear scale by https://github.com/chartjs/Chart.js/pull/7559. Prior to that PR, it broken in some cases such as time scale on y-axis, but now it should always work