### PR TITLE
Pass context parameter to custom tooltip

### DIFF
--- a/docs/docs/configuration/tooltip.md
+++ b/docs/docs/configuration/tooltip.md
@@ -194,7 +194,7 @@ The tooltip items passed to the tooltip callbacks implement the following interf
 
 ## External (Custom) Tooltips
 
-Custom tooltips allow you to hook into the tooltip rendering process so that you can render the tooltip in your own custom way. Generally this is used to create an HTML tooltip instead of an oncanvas one. You can enable custom tooltips in the global or chart configuration like so:
+Custom tooltips allow you to hook into the tooltip rendering process so that you can render the tooltip in your own custom way. Generally this is used to create an HTML tooltip instead of an on-canvas tooltip. The `custom` option takes a function which is passed a context parameter containing the `chart` and `tooltip`. You can enable custom tooltips in the global or chart configuration like so:
 
 ```javascript
 var myPieChart = new Chart(ctx, {
@@ -205,7 +205,7 @@ var myPieChart = new Chart(ctx, {
             // Disable the on-canvas tooltip
             enabled: false,
 
-            custom: function(tooltipModel) {
+            custom: function(context) {
                 // Tooltip Element
                 var tooltipEl = document.getElementById('chartjs-tooltip');
 
@@ -218,6 +218,7 @@ var myPieChart = new Chart(ctx, {
                 }
 
                 // Hide if no tooltip
+                var tooltipModel = context.tooltip;
                 if (tooltipModel.opacity === 0) {
                     tooltipEl.style.opacity = 0;
                     return;

--- a/docs/docs/getting-started/v3-migration.md
+++ b/docs/docs/getting-started/v3-migration.md
@@ -186,6 +186,7 @@ Animation system was completely rewritten in Chart.js v3. Each property can now 
 
 * `xLabel` and `yLabel` were removed. Please use `index` and `value`
 * The `filter` option will now be passed additional parameters when called and should have the method signature `function(tooltipItem, index, tooltipItems, data)`
+* The `custom` callback now takes a context object that has `tooltip` and `chart` properties
 
 ## Developer migration
 

--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -669,7 +669,7 @@ export class Tooltip extends Element {
 		}
 
 		if (changed && options.custom) {
-			options.custom.call(me, [me]);
+			options.custom.call(me, {chart: me._chart, tooltip: me});
 		}
 	}
 


### PR DESCRIPTION
Closes https://github.com/chartjs/Chart.js/issues/7541 https://github.com/chartjs/Chart.js/pull/7240 https://github.com/chartjs/Chart.js/issues/7239

It doesn't make sense that we passed an array of tooltip models when there was only ever a single model. This also provides the `chart` object to allow users to do more advanced functionality and makes the parameter an object so that we can easily extend it with other properties in the future