### PR TITLE
Bump package version in preparation for alpha2 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,3 +56,4 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
+  tag: next

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chart.js",
-  "version": "3.0.0-alpha",
+  "version": "3.0.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chart.js",
   "homepage": "https://www.chartjs.org",
   "description": "Simple HTML5 charts using the canvas element.",
-  "version": "3.0.0-alpha",
+  "version": "3.0.0-alpha.2",
   "license": "MIT",
   "jsdelivr": "dist/chart.min.js",
   "unpkg": "dist/chart.min.js",


### PR DESCRIPTION
We're getting close to a v3 alpha.2 release. Bump the package.json version in preparation. 

I think as we experienced last time, I'll need to manually adjust the meta-data to mark the release as a pre-release after the CI runs

## Release To Do

- [x] v3.0.0-alpha.2 release notes
- [x] Get #7435 across the line