### PR TITLE
Improve performance of getting parsed data

### DIFF
--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -205,7 +205,7 @@ export default class BarController extends DatasetController {
 		const me = this;
 		const meta = me._cachedMeta;
 		const {iScale, vScale} = meta;
-		const parsed = me.getParsed(index);
+		const parsed = me.getParsed()[index];
 		const custom = parsed._custom;
 		const value = isFloatBar(custom)
 			? '[' + custom.start + ', ' + custom.end + ']'
@@ -263,7 +263,7 @@ export default class BarController extends DatasetController {
 
 			// all borders are drawn for floating bar
 			/* TODO: float bars border skipping magic
-			if (me.getParsed(i)._custom) {
+			if (me.getParsed()[index]._custom) {
 				model.borderSkipped = null;
 			}
 			*/
@@ -350,12 +350,13 @@ export default class BarController extends DatasetController {
 	_getRuler() {
 		const me = this;
 		const meta = me._cachedMeta;
+		const parsed = me.getParsed();
 		const iScale = meta.iScale;
 		const pixels = [];
 		let i, ilen;
 
 		for (i = 0, ilen = meta.data.length; i < ilen; ++i) {
-			pixels.push(iScale.getPixelForValue(me.getParsed(i)[iScale.axis], i));
+			pixels.push(iScale.getPixelForValue(parsed[i][iScale.axis], i));
 		}
 
 		// Note: a potential optimization would be to skip computing this
@@ -383,7 +384,7 @@ export default class BarController extends DatasetController {
 		const meta = me._cachedMeta;
 		const vScale = meta.vScale;
 		const minBarLength = options.minBarLength;
-		const parsed = me.getParsed(index);
+		const parsed = me.getParsed()[index];
 		const custom = parsed._custom;
 		let value = parsed[vScale.axis];
 		let start = 0;
@@ -459,12 +460,13 @@ export default class BarController extends DatasetController {
 		const vScale = meta.vScale;
 		const rects = meta.data;
 		const ilen = rects.length;
+		const parsed = me.getParsed();
 		let i = 0;
 
 		clipArea(chart.ctx, chart.chartArea);
 
 		for (; i < ilen; ++i) {
-			if (!isNaN(me.getParsed(i)[vScale.axis])) {
+			if (!isNaN(parsed[i][vScale.axis])) {
 				rects[i].draw(me._ctx);
 			}
 		}

--- a/src/controllers/controller.bubble.js
+++ b/src/controllers/controller.bubble.js
@@ -45,7 +45,7 @@ export default class BubbleController extends DatasetController {
 		const me = this;
 		const meta = me._cachedMeta;
 		const {xScale, yScale} = meta;
-		const parsed = me.getParsed(index);
+		const parsed = me.getParsed()[index];
 		const x = xScale.getLabelForValue(parsed.x);
 		const y = yScale.getLabelForValue(parsed.y);
 		const r = parsed._custom;
@@ -71,11 +71,12 @@ export default class BubbleController extends DatasetController {
 		const firstOpts = me.resolveDataElementOptions(start, mode);
 		const sharedOptions = me.getSharedOptions(mode, points[start], firstOpts);
 		const includeOptions = me.includeOptions(mode, sharedOptions);
+		const data = me.getParsed();
 
 		for (let i = 0; i < points.length; i++) {
 			const point = points[i];
 			const index = start + i;
-			const parsed = !reset && me.getParsed(index);
+			const parsed = !reset && data[index];
 			const x = reset ? xScale.getPixelForDecimal(0.5) : xScale.getPixelForValue(parsed.x);
 			const y = reset ? yScale.getBasePixel() : yScale.getPixelForValue(parsed.y);
 			const properties = {
@@ -107,7 +108,7 @@ export default class BubbleController extends DatasetController {
 		const me = this;
 		const chart = me.chart;
 		const dataset = me.getDataset();
-		const parsed = me.getParsed(index);
+		const parsed = me.getParsed()[index];
 		let values = super.resolveDataElementOptions(index, mode);
 
 		// Scriptable options

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -35,12 +35,13 @@ export default class LineController extends DatasetController {
 		const includeOptions = me.includeOptions(mode, sharedOptions);
 		const spanGaps = valueOrDefault(me._config.spanGaps, me.chart.options.spanGaps);
 		const maxGapLength = isNumber(spanGaps) ? spanGaps : Number.POSITIVE_INFINITY;
+		const data = me.getParsed();
 		let prevParsed;
 
 		for (let i = 0; i < points.length; ++i) {
 			const index = start + i;
 			const point = points[i];
-			const parsed = me.getParsed(index);
+			const parsed = data[index];
 			const x = xScale.getPixelForValue(parsed.x, index);
 			const y = reset ? yScale.getBasePixel() : yScale.getPixelForValue(_stacked ? me.applyStack(yScale, parsed) : parsed.y, index);
 			const properties = {

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -9,7 +9,7 @@ export default class RadarController extends DatasetController {
 	getLabelAndValue(index) {
 		const me = this;
 		const vScale = me._cachedMeta.vScale;
-		const parsed = me.getParsed(index);
+		const parsed = me.getParsed()[index];
 
 		return {
 			label: vScale.getLabels()[index],

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -483,8 +483,8 @@ export default class DatasetController {
 	/**
 	 * @protected
 	 */
-	getParsed(index) {
-		return this._cachedMeta._parsed[index];
+	getParsed() {
+		return this._cachedMeta._parsed;
 	}
 
 	/**
@@ -594,7 +594,7 @@ export default class DatasetController {
 		const meta = me._cachedMeta;
 		const iScale = meta.iScale;
 		const vScale = meta.vScale;
-		const parsed = me.getParsed(index);
+		const parsed = me.getParsed()[index];
 		return {
 			label: iScale ? '' + iScale.getLabelForValue(parsed[iScale.axis]) : '',
 			value: vScale ? '' + vScale.getLabelForValue(parsed[vScale.axis]) : ''

--- a/test/specs/core.datasetController.tests.js
+++ b/test/specs/core.datasetController.tests.js
@@ -282,43 +282,44 @@ describe('Chart.DatasetController', function() {
 
 		var meta = chart.getDatasetMeta(0);
 		var controller = meta.controller;
+		var parsed = controller.getParsed();
 		var first, last;
 
-		first = controller.getParsed(0);
-		last = controller.getParsed(5);
+		first = parsed[0];
+		last = parsed[5];
 		data.push({x: 6, y: 6}, {x: 7, y: 7}, {x: 8, y: 8});
 		data.push({x: 9, y: 9});
 		expect(meta.data.length).toBe(10);
-		expect(controller.getParsed(0)).toBe(first);
-		expect(controller.getParsed(5)).toBe(last);
+		expect(parsed[0]).toBe(first);
+		expect(parsed[5]).toBe(last);
 
-		last = controller.getParsed(9);
+		last = parsed[9];
 		data.pop();
 		expect(meta.data.length).toBe(9);
-		expect(controller.getParsed(0)).toBe(first);
-		expect(controller.getParsed(9)).toBe(undefined);
-		expect(controller.getParsed(8)).toEqual({x: 8, y: 8});
+		expect(parsed[0]).toBe(first);
+		expect(parsed[9]).toBe(undefined);
+		expect(parsed[8]).toEqual({x: 8, y: 8});
 
-		last = controller.getParsed(8);
+		last = parsed[8];
 		data.shift();
 		data.shift();
 		data.shift();
 		expect(meta.data.length).toBe(6);
-		expect(controller.getParsed(5)).toBe(last);
+		expect(parsed[5]).toBe(last);
 
-		first = controller.getParsed(0);
-		last = controller.getParsed(5);
+		first = parsed[0];
+		last = parsed[5];
 		data.splice(1, 4, {x: 10, y: 10}, {x: 11, y: 11});
 		expect(meta.data.length).toBe(4);
-		expect(controller.getParsed(0)).toBe(first);
-		expect(controller.getParsed(3)).toBe(last);
-		expect(controller.getParsed(1)).toEqual({x: 10, y: 10});
+		expect(parsed[0]).toBe(first);
+		expect(parsed[3]).toBe(last);
+		expect(parsed[1]).toEqual({x: 10, y: 10});
 
 		data.unshift({x: 12, y: 12}, {x: 13, y: 13}, {x: 14, y: 14}, {x: 15, y: 15});
 		data.unshift({x: 16, y: 16}, {x: 17, y: 17});
 		expect(meta.data.length).toBe(10);
-		expect(controller.getParsed(6)).toBe(first);
-		expect(controller.getParsed(9)).toBe(last);
+		expect(parsed[6]).toBe(first);
+		expect(parsed[9]).toBe(last);
 	});
 
 	it('should re-synchronize metadata when the data object reference changes', function() {

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -327,8 +327,8 @@ describe('Time scale tests', function() {
 
 		var xScale = chart.scales.x;
 		var controller = chart.getDatasetMeta(0).controller;
-		expect(xScale.getLabelForValue(controller.getParsed(0)[xScale.id])).toBeTruthy();
-		expect(xScale.getLabelForValue(controller.getParsed(0)[xScale.id])).toBe('Jan 1, 2015, 8:00:00 pm');
+		expect(xScale.getLabelForValue(controller.getParsed()[0][xScale.id])).toBeTruthy();
+		expect(xScale.getLabelForValue(controller.getParsed()[0][xScale.id])).toBe('Jan 1, 2015, 8:00:00 pm');
 		expect(xScale.getLabelForValue(xScale.getValueForPixel(xScale.getPixelForTick(6)))).toBe('Jan 10, 2015, 12:00:00 pm');
 	});
 
@@ -407,7 +407,7 @@ describe('Time scale tests', function() {
 
 		var xScale = chart.scales.x;
 		var controller = chart.getDatasetMeta(0).controller;
-		var value = controller.getParsed(0)[xScale.id];
+		var value = controller.getParsed()[0][xScale.id];
 		expect(xScale.getLabelForValue(value)).toBeTruthy();
 		expect(xScale.getLabelForValue(value)).toBe('Jan 1, 2015, 8:00:00 pm');
 	});
@@ -468,7 +468,7 @@ describe('Time scale tests', function() {
 
 		var xScale = chart.scales.x;
 		var controller = chart.getDatasetMeta(0).controller;
-		var label = xScale.getLabelForValue(controller.getParsed(0)[xScale.id]);
+		var label = xScale.getLabelForValue(controller.getParsed()[0][xScale.id]);
 		expect(label).toEqual('Jan 8, 2018, 5:14:23 am');
 	});
 


### PR DESCRIPTION
It's more efficient to do an array access per data point than a function call per data point

I didn't add to the migration guide since it's a protected method new in 3.0