### PR TITLE
Fix remaining issues in samples

### DIFF
--- a/docs/docs/configuration/tooltip.md
+++ b/docs/docs/configuration/tooltip.md
@@ -199,11 +199,8 @@ The tooltip items passed to the tooltip callbacks implement the following interf
     // Index of this data item in the dataset
     dataIndex: number,
 
-    // X position of matching point
-    x: number,
-
-    // Y position of matching point
-    y: number
+    // The chart element (point, arc, bar, etc.) for this tooltip item
+    element: Element,
 }
 ```
 
@@ -277,8 +274,7 @@ var myPieChart = new Chart(ctx, {
                     tableRoot.innerHTML = innerHtml;
                 }
 
-                // `this` will be the overall tooltip
-                var position = this._chart.canvas.getBoundingClientRect();
+                var position = context.chart.canvas.getBoundingClientRect();
 
                 // Display, position, and set styles for font
                 tooltipEl.style.opacity = 1;

--- a/docs/docs/configuration/tooltip.md
+++ b/docs/docs/configuration/tooltip.md
@@ -197,7 +197,13 @@ The tooltip items passed to the tooltip callbacks implement the following interf
     datasetIndex: number,
 
     // Index of this data item in the dataset
-    dataIndex: number
+    dataIndex: number,
+
+    // X position of matching point
+    x: number,
+
+    // Y position of matching point
+    y: number
 }
 ```
 

--- a/docs/docs/getting-started/v3-migration.md
+++ b/docs/docs/getting-started/v3-migration.md
@@ -341,6 +341,7 @@ The following properties and methods were removed:
 * Legend `onClick`, `onHover`, and `onLeave` options now receive the legend as the 3rd argument in addition to implicitly via `this`
 * Legend `onClick`, `onHover`, and `onLeave` options now receive a wrapped `event` as the first parameter. The previous first parameter value is accessible via `event.native`.
 * `Title.margins` is now private
+* The tooltip item's `x` and `y` attributes were replaced by `element`. You can use `element.x` and `element.y` or `element.tooltipPosition()` instead.
 
 #### Removal of private APIs
 

--- a/docs/docs/getting-started/v3-migration.md
+++ b/docs/docs/getting-started/v3-migration.md
@@ -341,7 +341,6 @@ The following properties and methods were removed:
 * Legend `onClick`, `onHover`, and `onLeave` options now receive the legend as the 3rd argument in addition to implicitly via `this`
 * Legend `onClick`, `onHover`, and `onLeave` options now receive a wrapped `event` as the first parameter. The previous first parameter value is accessible via `event.native`.
 * `Title.margins` is now private
-* The tooltip item's `x` and `y` attributes were removed. Use `datasetIndex` and `dataIndex` to get the element and any corresponding data from it
 
 #### Removal of private APIs
 

--- a/samples/animations/loop.html
+++ b/samples/animations/loop.html
@@ -62,17 +62,16 @@
 				}]
 			},
 			options: {
-				animation: (context) => {
-					if (context.active) {
-						return {
-							radius: {
-								duration: 400,
-								loop: true
-							}
-						};
+				animation: (context) => Object.assign({},
+					Chart.defaults.animation,
+					{
+						radius: {
+							duration: 400,
+							easing: 'linear',
+							loop: context.active
+						}
 					}
-					return Chart.defaults.animation;
-				},
+				),
 				elements: {
 					point: {
 						hoverRadius: 6

--- a/samples/tooltips/custom-line.html
+++ b/samples/tooltips/custom-line.html
@@ -160,6 +160,7 @@
 					tooltips: {
 						enabled: false,
 						mode: 'index',
+						intersect: false,
 						position: 'nearest',
 						custom: customTooltips
 					}

--- a/samples/tooltips/custom-points.html
+++ b/samples/tooltips/custom-points.html
@@ -61,12 +61,13 @@
 				tooltip.dataPoints.forEach(function(dataPoint) {
 					var content = [dataPoint.label, dataPoint.formattedValue].join(': ');
 					var $tooltip = $('#tooltip-' + dataPoint.datasetIndex);
+					var pos = dataPoint.element.tooltipPosition();
 
 					$tooltip.html(content);
 					$tooltip.css({
 						opacity: 1,
-						top: positionY + dataPoint.y + 'px',
-						left: positionX + dataPoint.x + 'px',
+						top: positionY + pos.y + 'px',
+						left: positionX + pos.x + 'px',
 					});
 				});
 			}

--- a/samples/tooltips/custom-points.html
+++ b/samples/tooltips/custom-points.html
@@ -59,7 +59,7 @@
 
 			if (tooltip.dataPoints.length > 0) {
 				tooltip.dataPoints.forEach(function(dataPoint) {
-					var content = [dataPoint.label, dataPoint.value].join(': ');
+					var content = [dataPoint.label, dataPoint.formattedValue].join(': ');
 					var $tooltip = $('#tooltip-' + dataPoint.datasetIndex);
 
 					$tooltip.html(content);

--- a/src/core/core.animation.js
+++ b/src/core/core.animation.js
@@ -50,6 +50,7 @@ export default class Animation {
 			const remain = me._duration - elapsed;
 			me._start = date;
 			me._duration = Math.floor(Math.max(remain, cfg.duration));
+			me._loop = !!cfg.loop;
 			me._to = resolve([cfg.to, to, currentValue, cfg.from]);
 			me._from = resolve([cfg.from, currentValue, to]);
 		}

--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -112,11 +112,11 @@ function splitNewlines(str) {
 
 /**
  * Private helper to create a tooltip item model
- * @param item - the chart element (point, arc, bar) to create the tooltip item for
+ * @param item - {element, index, datasetIndex} to create the tooltip item for
  * @return new tooltip item
  */
 function createTooltipItem(chart, item) {
-	const {datasetIndex, index} = item;
+	const {element, datasetIndex, index} = item;
 	const controller = chart.getDatasetMeta(datasetIndex).controller;
 	const dataset = controller.getDataset();
 	const {label, value} = controller.getLabelAndValue(index);
@@ -128,7 +128,9 @@ function createTooltipItem(chart, item) {
 		formattedValue: value,
 		dataset,
 		dataIndex: index,
-		datasetIndex
+		datasetIndex,
+		x: element.x,
+		y: element.y
 	};
 }
 
@@ -403,7 +405,8 @@ export class Tooltip extends Element {
 		}
 
 		const chart = me._chart;
-		const opts = chart.options.animation && me.options.animation;
+		const options = me.options;
+		const opts = options.enabled && chart.options.animation && options.animation;
 		const animations = new Animations(me._chart, opts);
 		me._cachedAnimations = Object.freeze(animations);
 

--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -118,7 +118,6 @@ function splitNewlines(str) {
 function createTooltipItem(chart, item) {
 	const {element, datasetIndex, index} = item;
 	const controller = chart.getDatasetMeta(datasetIndex).controller;
-	const dataset = controller.getDataset();
 	const {label, value} = controller.getLabelAndValue(index);
 
 	return {
@@ -126,11 +125,10 @@ function createTooltipItem(chart, item) {
 		label,
 		dataPoint: controller.getParsed(index),
 		formattedValue: value,
-		dataset,
+		dataset: controller.getDataset(),
 		dataIndex: index,
 		datasetIndex,
-		x: element.x,
-		y: element.y
+		element
 	};
 }
 


### PR DESCRIPTION
Closes: #7551
Closes: #7576 
Closes: #7593

* Attach the `element` to `tooltipItem`
* disable tooltip animation when internal tooltip is disabled
* disable `intersect` from custom-line sample
* use the renamed `formattedValue` in custom-points sample
* when updating running animations, update the `loop` property too