### PR TITLE
Removes the line hegiht property from title documentation

### DIFF
--- a/docs/docs/configuration/title.md
+++ b/docs/docs/configuration/title.md
@@ -15,7 +15,6 @@ The title configuration is passed into the `options.title` namespace. The global
 | `position` | `string` | `'top'` | Position of title. [more...](#position)
 | `font` | `Font` | `defaults.font` | See [Fonts](../general/fonts.md)
 | `padding` | <code>number&#124;{top: number, bottom: number}</code> | `10` | Adds padding above and below the title text if a single number is specified. It is also possible to change top and bottom padding separately.
-| `lineHeight` | <code>number&#124;string</code> | `1.2` | Height of an individual line of text. See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height).
 | `text` | <code>string&#124;string[]</code> | `''` | Title text to display. If specified as an array, text is rendered on multiple lines.
 
 ### Position


### PR DESCRIPTION
Fix #7630
