### PR TITLE
Determine unit automatically in test

### DIFF
--- a/test/fixtures/scale.timeseries/financial-daily.js
+++ b/test/fixtures/scale.timeseries/financial-daily.js
@@ -34,9 +34,6 @@ module.exports = {
 						maxRotation: 0,
 						sampleSize: 100
 					},
-					time: {
-						unit: 'month'
-					},
 					// manually set major ticks so that test passes in all time zones with moment adapter
 					afterBuildTicks: function(scale) {
 						const major = [0, 12, 24];


### PR DESCRIPTION
It tests more functionality to determine the unit automatically. I had set it manually just while we were debugging, but now that we figured out the time zone thing we probably don't need it to be set manually anymore