### PR TITLE
Fix import statement in docs

### DIFF
--- a/docs/docs/getting-started/integration.md
+++ b/docs/docs/getting-started/integration.md
@@ -25,7 +25,7 @@ var myChart = new Chart(ctx, {...});
 Chart.js 3 is tree-shakeable, so it is necessary to import and register the controllers, elements, scales and plugins you are going to use.
 
 ```javascript
-import Chart, LineController, Line, Point, LinearScale, CategoryScale, Title, Tooltip, Filler, Legend from 'chart.js';
+import { Chart, LineController, Line, Point, LinearScale, CategoryScale, Title, Tooltip, Filler, Legend } from 'chart.js';
 
 Chart.register(LineController, Line, Point, LinearScale, CategoryScale, Title, Tooltip, Filler, Legend);
 

--- a/docs/docs/getting-started/v3-migration.md
+++ b/docs/docs/getting-started/v3-migration.md
@@ -24,7 +24,7 @@ Chart.js 3.0 introduces a number of breaking changes. Chart.js 2.0 was released 
 * Chart.js 3 is tree-shakeable. So if you are using it as an `npm` module in a project, you need to import and register the controllers, elements, scales and plugins you want to use. You will not have to call `register` if importing Chart.js via a `script` tag, but will not get the tree shaking benefits in this case. Here is an example of registering components:
 
 ```javascript
-import Chart, LineController, Line, Point, LinearScale, Title from `chart.js`
+import { Chart, LineController, Line, Point, LinearScale, Title } from `chart.js`
 
 Chart.register(LineController, Line, Point, LinearScale, Title);
 


### PR DESCRIPTION
I got an error in Webpack when using `import` statement as it was written in the docs

>ERROR in ./javascripts/Chart.js
>Module build failed (from node_modules/babel-loader/lib/index.js):
>SyntaxError: app/assets/javascripts/Chart.js: Unexpected token, expected "{" (2:14)
>
>  1 | import React from 'react';
>> 2 | import Chart, LineController, Line, Point, LinearScale, Title, Tooltip, Legend from 'chart.js';
