### PR TITLE
Doughnut controller overrides `getLabelAndValue`

### DIFF
--- a/src/controllers/controller.doughnut.js
+++ b/src/controllers/controller.doughnut.js
@@ -185,6 +185,18 @@ export default class DoughnutController extends DatasetController {
 		return 0;
 	}
 
+	getLabelAndValue(index) {
+		const me = this;
+		const meta = me._cachedMeta;
+		const chart = me.chart;
+		const labels = chart.data.labels || [];
+
+		return {
+			label: labels[index] || '',
+			value: meta._parsed[index],
+		};
+	}
+
 	getMaxBorderWidth(arcs) {
 		const me = this;
 		let max = 0;
@@ -334,8 +346,8 @@ DoughnutController.defaults = {
 				return '';
 			},
 			label(tooltipItem) {
-				let dataLabel = tooltipItem.chart.data.labels[tooltipItem.dataIndex];
-				const value = ': ' + tooltipItem.dataset.data[tooltipItem.dataIndex];
+				let dataLabel = tooltipItem.label;
+				const value = ': ' + tooltipItem.formattedValue;
 
 				if (isArray(dataLabel)) {
 					// show value on first line of multiline label


### PR DESCRIPTION
Allows the use of `tooltipItem.label` and `tooltipItem.formattedValue` in doughnut/pie charts

Resolves #7699 