### PR TITLE
Use interpolation in fill: 'stack' (and fix interpolation)

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -67,7 +67,7 @@ module.exports = function(karma) {
 			{pattern: 'test/BasicChartWebWorker.js', included: false},
 			{pattern: 'src/index.js', watched: false},
 			'node_modules/chartjs-adapter-moment/dist/chartjs-adapter-moment.js',
-			{pattern: specPattern, watched: false}
+			{pattern: specPattern}
 		],
 
 		preprocessors: {

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -10,6 +10,7 @@ import * as interpolation from './helpers.interpolation';
 import * as options from './helpers.options';
 import * as math from './helpers.math';
 import * as rtl from './helpers.rtl';
+import * as segment from './helpers.segment';
 
 import {color, getHoverColor} from './helpers.color';
 import {requestAnimFrame, fontString} from './helpers.extras';
@@ -25,6 +26,7 @@ export default {
 	options,
 	math,
 	rtl,
+	segment,
 
 	requestAnimFrame,
 	// -- Canvas methods

--- a/src/plugins/plugin.filler.js
+++ b/src/plugins/plugin.filler.js
@@ -209,12 +209,14 @@ function buildStackLine(source) {
 function getLinesBelow(chart, index) {
 	const below = [];
 	const metas = chart.getSortedVisibleDatasetMetas();
+	const isLineAndNotInHideAnimation = meta => meta.type === 'line' && !meta.hidden;
+
 	for (let i = 0; i < metas.length; i++) {
 		const meta = metas[i];
 		if (meta.index === index) {
 			break;
 		}
-		if (meta.type === 'line' && !meta.hidden) {
+		if (isLineAndNotInHideAnimation(meta)) {
 			below.unshift(meta.dataset);
 		}
 	}

--- a/src/plugins/plugin.filler.js
+++ b/src/plugins/plugin.filler.js
@@ -201,6 +201,8 @@ function buildStackLine(source) {
 	return new Line({points, options: {}});
 }
 
+const isLineAndNotInHideAnimation = (meta) => meta.type === 'line' && !meta.hidden;
+
 /**
  * @param {Chart} chart
  * @param {number} index
@@ -209,7 +211,6 @@ function buildStackLine(source) {
 function getLinesBelow(chart, index) {
 	const below = [];
 	const metas = chart.getSortedVisibleDatasetMetas();
-	const isLineAndNotInHideAnimation = (meta) => meta.type === 'line' && !meta.hidden;
 
 	for (let i = 0; i < metas.length; i++) {
 		const meta = metas[i];

--- a/src/plugins/plugin.filler.js
+++ b/src/plugins/plugin.filler.js
@@ -170,11 +170,11 @@ function pointsFromSegments(boundary, line) {
 		const first = linePoints[segment.start];
 		const last = linePoints[segment.end];
 		if (y !== null) {
-			points.push({x: first.x, y, _prop: 'x', _ref: first});
-			points.push({x: last.x, y, _prop: 'x', _ref: last});
+			points.push({x: first.x, y});
+			points.push({x: last.x, y});
 		} else if (x !== null) {
-			points.push({x, y: first.y, _prop: 'y', _ref: first});
-			points.push({x, y: last.y, _prop: 'y', _ref: last});
+			points.push({x, y: first.y});
+			points.push({x, y: last.y});
 		}
 	});
 	return points;
@@ -310,7 +310,6 @@ function getTarget(source) {
 function createBoundaryLine(boundary, line) {
 	let points = [];
 	let _loop = false;
-	let _refPoints = false;
 
 	if (isArray(boundary)) {
 		_loop = true;
@@ -318,15 +317,13 @@ function createBoundaryLine(boundary, line) {
 		points = boundary;
 	} else {
 		points = pointsFromSegments(boundary, line);
-		_refPoints = true;
 	}
 
 	return points.length ? new Line({
 		points,
 		options: {tension: 0},
 		_loop,
-		_fullLoop: _loop,
-		_refPoints
+		_fullLoop: _loop
 	}) : null;
 }
 
@@ -396,17 +393,6 @@ function _segments(line, target, property) {
 	const points = line.points;
 	const tpoints = target.points;
 	const parts = [];
-
-	if (target._refPoints) {
-		// Update properties from reference points. (In case those points are animating)
-		for (let i = 0, ilen = tpoints.length; i < ilen; ++i) {
-			const point = tpoints[i];
-			const prop = point._prop;
-			if (prop) {
-				point[prop] = point._ref[prop];
-			}
-		}
-	}
 
 	for (let i = 0; i < segments.length; i++) {
 		const segment = segments[i];

--- a/src/plugins/plugin.filler.js
+++ b/src/plugins/plugin.filler.js
@@ -209,7 +209,7 @@ function buildStackLine(source) {
 function getLinesBelow(chart, index) {
 	const below = [];
 	const metas = chart.getSortedVisibleDatasetMetas();
-	const isLineAndNotInHideAnimation = meta => meta.type === 'line' && !meta.hidden;
+	const isLineAndNotInHideAnimation = (meta) => meta.type === 'line' && !meta.hidden;
 
 	for (let i = 0; i < metas.length; i++) {
 		const meta = metas[i];

--- a/test/specs/helpers.segment.tests.js
+++ b/test/specs/helpers.segment.tests.js
@@ -1,0 +1,44 @@
+const {_boundSegment} = Chart.helpers.segment;
+
+describe('helpers.segments', function() {
+	describe('_boundSegment', function() {
+		const points = [{x: 10, y: 1}, {x: 20, y: 2}, {x: 30, y: 3}];
+		const segment = {start: 0, end: 2, loop: false};
+
+		it('should not find segment from before the line', function() {
+			expect(_boundSegment(segment, points, {property: 'x', start: 5, end: 9.99999})).toEqual([]);
+		});
+
+		it('should not find segment from after the line', function() {
+			expect(_boundSegment(segment, points, {property: 'x', start: 30.00001, end: 800})).toEqual([]);
+		});
+
+		it('should find segment when starting before line', function() {
+			expect(_boundSegment(segment, points, {property: 'x', start: 5, end: 15})).toEqual([{start: 0, end: 1, loop: false}]);
+		});
+
+		it('should find segment directly on point', function() {
+			expect(_boundSegment(segment, points, {property: 'x', start: 10, end: 10})).toEqual([{start: 0, end: 0, loop: false}]);
+		});
+
+		it('should find segment from range between points', function() {
+			expect(_boundSegment(segment, points, {property: 'x', start: 11, end: 14})).toEqual([{start: 0, end: 1, loop: false}]);
+		});
+
+		it('should find segment from point between points', function() {
+			expect(_boundSegment(segment, points, {property: 'x', start: 22, end: 22})).toEqual([{start: 1, end: 2, loop: false}]);
+		});
+
+		it('should find whole segment', function() {
+			expect(_boundSegment(segment, points, {property: 'x', start: 0, end: 50})).toEqual([{start: 0, end: 2, loop: false}]);
+		});
+
+		it('should find correct segment from near points', function() {
+			expect(_boundSegment(segment, points, {property: 'x', start: 10.001, end: 29.999})).toEqual([{start: 0, end: 2, loop: false}]);
+		});
+
+		it('should find segment from after the line', function() {
+			expect(_boundSegment(segment, points, {property: 'x', start: 25, end: 35})).toEqual([{start: 1, end: 2, loop: false}]);
+		});
+	});
+});


### PR DESCRIPTION
Found some bugs in `_boundSegment` while doing this, so added a bunch of tests and fixed it.

Only thing this really changes in the filler, is if a line in the middle of stack has `spanGaps: true` with gap(s), then the fill is done properly by interpolating the point at the `NaN` value(s).
