### PR TITLE
Revert "Preserve object prototypes when cloning (#7381)"

### DIFF
--- a/src/helpers/helpers.core.js
+++ b/src/helpers/helpers.core.js
@@ -157,7 +157,7 @@ export function clone(source) {
 	}
 
 	if (isObject(source)) {
-		const target = Object.create(source);
+		const target = {};
 		const keys = Object.keys(source);
 		const klen = keys.length;
 		let k = 0;

--- a/test/specs/helpers.core.tests.js
+++ b/test/specs/helpers.core.tests.js
@@ -316,27 +316,6 @@ describe('Chart.helpers.core', function() {
 			expect(output.o).not.toBe(o0);
 			expect(output.o.a).not.toBe(a1);
 		});
-		it('should preserve prototype of objects', function() {
-			// https://github.com/chartjs/Chart.js/issues/7340
-			class MyConfigObject {
-				constructor(s) {
-					this._s = s;
-				}
-				func() {
-					return 10;
-				}
-			}
-			var original = new MyConfigObject('something');
-			var output = helpers.merge({}, {
-				plugins: [{
-					test: original
-				}]
-			});
-			var clone = output.plugins[0].test;
-			expect(clone).toBeInstanceOf(MyConfigObject);
-			expect(clone).toEqual(original);
-			expect(clone === original).toBeFalse();
-		});
 	});
 
 	describe('mergeIf', function() {


### PR DESCRIPTION
This reverts commit 51be3447170fc648c3b5bc3002c963be62bccdf9.

closes #7724
closes: #7725 

re-opens: #7340