### PR TITLE
Fix shared option handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6965,6 +6965,12 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise-polyfill": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
+      "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==",
+      "dev": true
+    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "karma-safari-private-launcher": "^1.0.0",
     "moment": "^2.27.0",
     "pixelmatch": "^5.2.1",
+    "promise-polyfill": "^8.1.3",
     "resize-observer-polyfill": "^1.5.1",
     "rollup": "^2.25.0",
     "rollup-plugin-babel": "^4.4.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -40,7 +40,8 @@ module.exports = [
 		input,
 		plugins: [
 			inject({
-				ResizeObserver: 'resize-observer-polyfill'
+				ResizeObserver: 'resize-observer-polyfill',
+				Promise: 'promise-polyfill'
 			}),
 			json(),
 			resolve(),
@@ -61,7 +62,8 @@ module.exports = [
 		input,
 		plugins: [
 			inject({
-				ResizeObserver: 'resize-observer-polyfill'
+				ResizeObserver: 'resize-observer-polyfill',
+				Promise: 'promise-polyfill'
 			}),
 			json(),
 			resolve(),

--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -219,6 +219,7 @@ export default class BarController extends DatasetController {
 
 	initialize() {
 		const me = this;
+		me.enableOptionSharing = true;
 
 		super.initialize();
 
@@ -241,14 +242,14 @@ export default class BarController extends DatasetController {
 		const horizontal = vscale.isHorizontal();
 		const ruler = me._getRuler();
 		const firstOpts = me.resolveDataElementOptions(start, mode);
-		const sharedOptions = me.getSharedOptions(mode, rectangles[start], firstOpts);
+		const sharedOptions = me.getSharedOptions(firstOpts);
 		const includeOptions = me.includeOptions(mode, sharedOptions);
 
-		let i;
+		me.updateSharedOptions(sharedOptions, mode, firstOpts);
 
-		for (i = 0; i < rectangles.length; i++) {
+		for (let i = 0; i < rectangles.length; i++) {
 			const index = start + i;
-			const options = me.resolveDataElementOptions(index, mode);
+			const options = sharedOptions || me.resolveDataElementOptions(index, mode);
 			const vpixels = me._calculateBarValuePixels(index, options);
 			const ipixels = me._calculateBarIndexPixels(index, ruler, options);
 
@@ -261,19 +262,11 @@ export default class BarController extends DatasetController {
 				width: horizontal ? undefined : ipixels.size
 			};
 
-			// all borders are drawn for floating bar
-			/* TODO: float bars border skipping magic
-			if (me.getParsed(i)._custom) {
-				model.borderSkipped = null;
-			}
-			*/
 			if (includeOptions) {
 				properties.options = options;
 			}
 			me.updateElement(rectangles[i], index, properties, mode);
 		}
-
-		me.updateSharedOptions(sharedOptions, mode);
 	}
 
 	/**

--- a/src/controllers/controller.bubble.js
+++ b/src/controllers/controller.bubble.js
@@ -3,6 +3,10 @@ import {resolve} from '../helpers/helpers.options';
 import {resolveObjectKey} from '../helpers/helpers.core';
 
 export default class BubbleController extends DatasetController {
+	initialize() {
+		this.enableOptionSharing = true;
+		super.initialize();
+	}
 
 	/**
 	 * Parse array of objects
@@ -69,7 +73,7 @@ export default class BubbleController extends DatasetController {
 		const reset = mode === 'reset';
 		const {xScale, yScale} = me._cachedMeta;
 		const firstOpts = me.resolveDataElementOptions(start, mode);
-		const sharedOptions = me.getSharedOptions(mode, points[start], firstOpts);
+		const sharedOptions = me.getSharedOptions(firstOpts);
 		const includeOptions = me.includeOptions(mode, sharedOptions);
 
 		for (let i = 0; i < points.length; i++) {
@@ -95,7 +99,7 @@ export default class BubbleController extends DatasetController {
 			me.updateElement(point, index, properties, mode);
 		}
 
-		me.updateSharedOptions(sharedOptions, mode);
+		me.updateSharedOptions(sharedOptions, mode, firstOpts);
 	}
 
 	/**

--- a/src/controllers/controller.doughnut.js
+++ b/src/controllers/controller.doughnut.js
@@ -44,6 +44,7 @@ export default class DoughnutController extends DatasetController {
 	constructor(chart, datasetIndex) {
 		super(chart, datasetIndex);
 
+		this.enableOptionSharing = true;
 		this.innerRadius = undefined;
 		this.outerRadius = undefined;
 		this.offsetX = undefined;
@@ -129,7 +130,7 @@ export default class DoughnutController extends DatasetController {
 		const innerRadius = animateScale ? 0 : me.innerRadius;
 		const outerRadius = animateScale ? 0 : me.outerRadius;
 		const firstOpts = me.resolveDataElementOptions(start, mode);
-		const sharedOptions = me.getSharedOptions(mode, arcs[start], firstOpts);
+		const sharedOptions = me.getSharedOptions(firstOpts);
 		const includeOptions = me.includeOptions(mode, sharedOptions);
 		let startAngle = opts.rotation;
 		let i;
@@ -152,13 +153,13 @@ export default class DoughnutController extends DatasetController {
 				innerRadius
 			};
 			if (includeOptions) {
-				properties.options = me.resolveDataElementOptions(index, mode);
+				properties.options = sharedOptions || me.resolveDataElementOptions(index, mode);
 			}
 			startAngle += circumference;
 
 			me.updateElement(arc, index, properties, mode);
 		}
-		me.updateSharedOptions(sharedOptions, mode);
+		me.updateSharedOptions(sharedOptions, mode, firstOpts);
 	}
 
 	calculateTotal() {

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -5,6 +5,11 @@ import {resolve} from '../helpers/helpers.options';
 
 export default class LineController extends DatasetController {
 
+	initialize() {
+		this.enableOptionSharing = true;
+		super.initialize();
+	}
+
 	update(mode) {
 		const me = this;
 		const meta = me._cachedMeta;
@@ -31,7 +36,7 @@ export default class LineController extends DatasetController {
 		const reset = mode === 'reset';
 		const {xScale, yScale, _stacked} = me._cachedMeta;
 		const firstOpts = me.resolveDataElementOptions(start, mode);
-		const sharedOptions = me.getSharedOptions(mode, points[start], firstOpts);
+		const sharedOptions = me.getSharedOptions(firstOpts);
 		const includeOptions = me.includeOptions(mode, sharedOptions);
 		const spanGaps = valueOrDefault(me._config.spanGaps, me.chart.options.spanGaps);
 		const maxGapLength = isNumber(spanGaps) ? spanGaps : Number.POSITIVE_INFINITY;
@@ -51,7 +56,7 @@ export default class LineController extends DatasetController {
 			};
 
 			if (includeOptions) {
-				properties.options = me.resolveDataElementOptions(index, mode);
+				properties.options = sharedOptions || me.resolveDataElementOptions(index, mode);
 			}
 
 			me.updateElement(point, index, properties, mode);
@@ -59,7 +64,7 @@ export default class LineController extends DatasetController {
 			prevParsed = parsed;
 		}
 
-		me.updateSharedOptions(sharedOptions, mode);
+		me.updateSharedOptions(sharedOptions, mode, firstOpts);
 	}
 
 	/**

--- a/src/core/core.animation.js
+++ b/src/core/core.animation.js
@@ -63,7 +63,7 @@ export default class Animation {
 			// update current evaluated value, for smoother animations
 			me.tick(Date.now());
 			me._active = false;
-			me._reject();
+			me._notify(false);
 		}
 	}
 
@@ -81,7 +81,7 @@ export default class Animation {
 
 		if (!me._active) {
 			me._target[prop] = to;
-			me._resolve();
+			me._notify(true);
 			return;
 		}
 
@@ -104,17 +104,11 @@ export default class Animation {
 		});
 	}
 
-	_resolve() {
+	_notify(resolved) {
+		const method = resolved ? 'res' : 'rej';
 		const promises = this._promises || [];
 		for (let i = 0; i < promises.length; i++) {
-			promises[i].res();
-		}
-	}
-
-	_reject() {
-		const promises = this._promises || [];
-		for (let i = 0; i < promises.length; i++) {
-			promises[i].rej();
+			promises[i][method]();
 		}
 	}
 }

--- a/src/core/core.animation.js
+++ b/src/core/core.animation.js
@@ -36,6 +36,7 @@ export default class Animation {
 		this._prop = prop;
 		this._from = from;
 		this._to = to;
+		this._promises = undefined;
 	}
 
 	active() {
@@ -62,6 +63,7 @@ export default class Animation {
 			// update current evaluated value, for smoother animations
 			me.tick(Date.now());
 			me._active = false;
+			me._reject();
 		}
 	}
 
@@ -79,6 +81,7 @@ export default class Animation {
 
 		if (!me._active) {
 			me._target[prop] = to;
+			me._resolve();
 			return;
 		}
 
@@ -92,5 +95,26 @@ export default class Animation {
 		factor = me._easing(Math.min(1, Math.max(0, factor)));
 
 		me._target[prop] = me._fn(from, to, factor);
+	}
+
+	wait() {
+		const promises = this._promises || (this._promises = []);
+		return new Promise((res, rej) => {
+			promises.push({res, rej});
+		});
+	}
+
+	_resolve() {
+		const promises = this._promises || [];
+		for (let i = 0; i < promises.length; i++) {
+			promises[i].res();
+		}
+	}
+
+	_reject() {
+		const promises = this._promises || [];
+		for (let i = 0; i < promises.length; i++) {
+			promises[i].rej();
+		}
 	}
 }

--- a/src/core/core.animations.js
+++ b/src/core/core.animations.js
@@ -220,7 +220,7 @@ function awaitAll(animations, properties) {
 		}
 	}
 	// @ts-ignore
-	return Promise.allSettled(running);
+	return Promise.all(running);
 }
 
 function resolveTargetOptions(target, newOptions) {

--- a/src/core/core.animations.js
+++ b/src/core/core.animations.js
@@ -57,10 +57,10 @@ defaults.set('animation', {
 function copyOptions(target, values) {
 	const oldOpts = target.options;
 	const newOpts = values.options;
-	if (!oldOpts || !newOpts || newOpts.$shared) {
+	if (!oldOpts || !newOpts) {
 		return;
 	}
-	if (oldOpts.$shared) {
+	if (oldOpts.$shared && !newOpts.$shared) {
 		target.options = Object.assign({}, oldOpts, newOpts, {$shared: false});
 	} else {
 		Object.assign(oldOpts, newOpts);
@@ -117,8 +117,6 @@ export default class Animations {
 	 * Utility to handle animation of `options`.
 	 * This should not be called, when animating $shared options to $shared new options.
 	 * @private
-	 * @todo if new options are $shared, target.options should be replaced with those new shared
-	 *  options after all animations have completed
 	 */
 	_animateOptions(target, values) {
 		const newOptions = values.options;
@@ -129,12 +127,20 @@ export default class Animations {
 		}
 		let options = target.options;
 		if (options) {
-			if (options.$shared) {
-				// If the current / old options are $shared, meaning other elements are
-				// using the same options, we need to clone to become unique.
+			if (options.$shared && !newOptions.$shared) {
+				// Going from shared options to distinct one:
+				// Create new options object containing the old shared values and start updating that.
 				target.options = options = Object.assign({}, options, {$shared: false, $animations: {}});
 			}
 			animations = this._createAnimations(options, newOptions);
+			if (newOptions.$shared && !options.$shared) {
+				// Going from distinct options to shared options:
+				// After all animations are done, assing the shared options object to the element
+				// So any new updates to the shared options are observed
+				awaitAll(target.$animations, newOptions).then(() => {
+					target.options = newOptions;
+				});
+			}
 		} else {
 			target.options = newOptions;
 		}
@@ -214,3 +220,15 @@ export default class Animations {
 	}
 }
 
+function awaitAll(animations, properties) {
+	const running = [];
+	const keys = Object.keys(properties);
+	for (let i = 0; i < keys.length; i++) {
+		const anim = animations[keys[i]];
+		if (anim && anim.active()) {
+			running.push(anim.wait());
+		}
+	}
+	// @ts-ignore
+	return Promise.allSettled(running);
+}

--- a/src/core/core.animator.js
+++ b/src/core/core.animator.js
@@ -1,6 +1,7 @@
 import {requestAnimFrame} from '../helpers/helpers.extras';
 
 /**
+ * @typedef { import("./core.animation").default } Animation
  * @typedef { import("./core.controller").default } Chart
  */
 

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -608,11 +608,9 @@ class Chart {
 		me._updateLayout();
 
 		// Can only reset the new controllers after the scales have been updated
-		if (me.options.animation) {
-			each(newControllers, (controller) => {
-				controller.reset();
-			});
-		}
+		each(newControllers, (controller) => {
+			controller.reset();
+		});
 
 		me._updateDatasets(mode);
 

--- a/test/specs/core.animations.tests.js
+++ b/test/specs/core.animations.tests.js
@@ -43,4 +43,40 @@ describe('Chart.animations', function() {
 			options: undefined
 		})).toBeUndefined();
 	});
+
+	it('should assign shared options to target after animations complete', function(done) {
+		const chart = {
+			draw: function() {},
+			options: {
+				animation: {
+					debug: false
+				}
+			}
+		};
+		const anims = new Chart.Animations(chart, {value: {duration: 100}, option: {duration: 200}});
+
+		const target = {
+			value: 1,
+			options: {
+				option: 2
+			}
+		};
+		const sharedOpts = {option: 10, $shared: true};
+
+		expect(anims.update(target, {
+			options: sharedOpts
+		})).toBeTrue();
+
+		expect(target.options !== sharedOpts).toBeTrue();
+
+		Chart.animator.start(chart);
+
+		setTimeout(function() {
+			expect(Chart.animator.running(chart)).toBeFalse();
+			expect(target.options === sharedOpts).toBeTrue();
+
+			Chart.animator.remove(chart);
+			done();
+		}, 300);
+	});
 });

--- a/types/core/index.d.ts
+++ b/types/core/index.d.ts
@@ -345,7 +345,7 @@ export class DatasetController<E extends Element = Element, DSE extends Element 
    * Utility for checking if the options are shared and should be animated separately.
    * @protected
    */
-  protected getSharedOptions(mode: UpdateMode, el: E, options: any): undefined | { target: any; options: any };
+  protected getSharedOptions(options: any): undefined | { any };
   /**
    * Utility for determining if `options` should be included in the updated properties
    * @protected
@@ -362,7 +362,7 @@ export class DatasetController<E extends Element = Element, DSE extends Element 
    * @protected
    */
 
-  protected updateSharedOptions(sharedOptions: any, mode: UpdateMode): void;
+  protected updateSharedOptions(sharedOptions: any, mode: UpdateMode, newOptions: any): void;
   removeHoverStyle(element: E, datasetIndex: number, index: number): void;
   setHoverStyle(element: E, datasetIndex: number, index: number): void;
 

--- a/types/core/index.d.ts
+++ b/types/core/index.d.ts
@@ -320,6 +320,7 @@ export class DatasetController<E extends Element = Element, DSE extends Element 
   readonly chart: Chart;
   readonly index: number;
   readonly _cachedMeta: IChartMeta<E, DSE>;
+  enableOptionSharing: boolean;
 
   linkScales(): void;
   getAllParsedValues(scale: Scale): number[];


### PR DESCRIPTION
closes: #7730 
closes: #7546 

Changes:
* make option sharing an opt-in for controller
* shared options is a single object held by the controller
* controllers are always `reset` first, even when animations are disabled
* getSharedOptions takes only one parameter (resolved options)
* updateSharedOptions takes the new options as parameter
* animations update the target with reference to shared options, after all animations are done.
* 'default' used instead of falsy modes

https://codepen.io/kurkle/pen/poyeEmJ