### PR TITLE
Fix the parameter order of before/afterEvent

### DIFF
--- a/src/core/core.plugins.js
+++ b/src/core/core.plugins.js
@@ -289,8 +289,8 @@ function createDescriptors(plugins, options) {
  * the event will be discarded.
  * @param {Chart} chart - The chart instance.
  * @param {IEvent} event - The event object.
- * @param {object} options - The plugin options.
  * @param {boolean} replay - True if this event is replayed from `Chart.update`
+ * @param {object} options - The plugin options.
  */
 /**
  * @method IPlugin#afterEvent
@@ -298,8 +298,8 @@ function createDescriptors(plugins, options) {
  * will not be called if the `event` has been previously discarded.
  * @param {Chart} chart - The chart instance.
  * @param {IEvent} event - The event object.
- * @param {object} options - The plugin options.
  * @param {boolean} replay - True if this event is replayed from `Chart.update`
+ * @param {object} options - The plugin options.
  */
 /**
  * @method IPlugin#resize


### PR DESCRIPTION
`options` are always last in these hooks
