### PR TITLE
[v3-beta][types] fix a wrong Option infer

### DIFF
--- a/types/interfaces.d.ts
+++ b/types/interfaces.d.ts
@@ -153,10 +153,10 @@ export type IRadarControllerConfiguration<T = number, L = string> = IChartConfig
   IRadarControllerChartOptions
 >;
 
-export type ConfigurationOptions<O> = O extends IChartConfiguration<IChartType, unknown, unknown, infer O> ? O : never;
-export type ConfigurationData<O> = O extends IChartConfiguration<IChartType, infer T, infer L, infer DS, unknown>
+export type ConfigurationOptions<O> = O extends IChartConfiguration<IChartType, infer T, infer L, infer DS, infer O> ? O : never;
+export type ConfigurationData<O> = O extends IChartConfiguration<IChartType, infer T, infer L, infer DS, infer O>
   ? IChartData<T, L, DS>
   : never;
-export type ConfigurationDataset<O> = O extends IChartConfiguration<IChartType, unknown, unknown, infer DS, unknown>
+export type ConfigurationDataset<O> = O extends IChartConfiguration<IChartType, infer T, infer L, infer DS, infer O>
   ? DS
   : never;


### PR DESCRIPTION
The issue is that "infer O" takes type from the Dataset type instead of Options.
``` ts
export type ConfigurationOptions<O> = O extends IChartConfiguration<unknown, unknown, unknown, infer O> ? O : never;
```
It should be:
``` ts
export type ConfigurationOptions<O> = O extends IChartConfiguration<unknown, unknown, unknown, unknown, infer O> ? O : never;
```

However we cannot set the `unknown` type for the dataset because `unknown` cannot be IChartDataset. Then I thought, why do we need to use an `unknown` type for no-need types? We can use the type definition everywhere and only return the type we need. Let me know what do you think about it.
