### PR TITLE
[v3-beta][types] Rename Chart instance interface to ChartInstance

### DIFF
--- a/types/controllers/index.d.ts
+++ b/types/controllers/index.d.ts
@@ -1,4 +1,4 @@
-import { Chart, DatasetController } from '../core';
+import { ChartInstance, DatasetController } from '../core';
 import { IChartArea, IChartComponent, ScriptableAndArrayOptions, ScriptableOptions } from '../core/interfaces';
 import {
   IArcHoverOptions,
@@ -89,7 +89,7 @@ export interface IBarControllerChartOptions {
 export interface BarController extends DatasetController {}
 export const BarController: IChartComponent & {
   prototype: BarController;
-  new (chart: Chart, datasetIndex: number): BarController;
+  new (chart: ChartInstance, datasetIndex: number): BarController;
 };
 
 export interface IBubbleControllerDatasetOptions
@@ -117,7 +117,7 @@ export interface IBubbleDataPoint {
 export interface BubbleController extends DatasetController {}
 export const BubbleController: IChartComponent & {
   prototype: BubbleController;
-  new (chart: Chart, datasetIndex: number): BubbleController;
+  new (chart: ChartInstance, datasetIndex: number): BubbleController;
 };
 
 export interface ILineControllerDatasetOptions
@@ -159,7 +159,7 @@ export interface ILineControllerChartOptions {
 export interface LineController extends DatasetController {}
 export const LineController: IChartComponent & {
   prototype: LineController;
-  new (chart: Chart, datasetIndex: number): LineController;
+  new (chart: ChartInstance, datasetIndex: number): LineController;
 };
 
 export type IScatterControllerDatasetOptions = ILineControllerDatasetOptions;
@@ -179,7 +179,7 @@ export interface IScatterControllerChartOptions extends ILineControllerChartOpti
 export interface ScatterController extends LineController {}
 export const ScatterController: IChartComponent & {
   prototype: ScatterController;
-  new (chart: Chart, datasetIndex: number): ScatterController;
+  new (chart: ChartInstance, datasetIndex: number): ScatterController;
 };
 
 export interface IDoughnutControllerDatasetOptions
@@ -244,7 +244,7 @@ export interface DoughnutController extends DatasetController {
 
 export const DoughnutController: IChartComponent & {
   prototype: DoughnutController;
-  new (chart: Chart, datasetIndex: number): DoughnutController;
+  new (chart: ChartInstance, datasetIndex: number): DoughnutController;
 };
 
 export type IPieControllerDatasetOptions = IDoughnutControllerDatasetOptions;
@@ -256,7 +256,7 @@ export type IPieDataPoint = IDoughnutDataPoint;
 export interface PieController extends DoughnutController {}
 export const PieController: IChartComponent & {
   prototype: PieController;
-  new (chart: Chart, datasetIndex: number): PieController;
+  new (chart: ChartInstance, datasetIndex: number): PieController;
 };
 
 export interface IPolarAreaControllerDatasetOptions extends IDoughnutControllerDatasetOptions {
@@ -288,7 +288,7 @@ export interface PolarAreaController extends DoughnutController {
 }
 export const PolarAreaController: IChartComponent & {
   prototype: PolarAreaController;
-  new (chart: Chart, datasetIndex: number): PolarAreaController;
+  new (chart: ChartInstance, datasetIndex: number): PolarAreaController;
 };
 
 export interface IRadarControllerDatasetOptions
@@ -322,5 +322,5 @@ export type IRadarControllerChartOptions = ILineControllerChartOptions;
 export interface RadarController extends DatasetController {}
 export const RadarController: IChartComponent & {
   prototype: RadarController;
-  new (chart: Chart, datasetIndex: number): RadarController;
+  new (chart: ChartInstance, datasetIndex: number): RadarController;
 };

--- a/types/core/index.d.ts
+++ b/types/core/index.d.ts
@@ -89,23 +89,23 @@ export class Animation {
 }
 
 export interface IAnimationEvent {
-  chart: Chart;
+  chart: ChartInstance;
   numSteps: number;
   currentState: number;
 }
 
 export class Animator {
-  listen(chart: Chart, event: 'complete' | 'progress', cb: (event: IAnimationEvent) => void): void;
-  add(chart: Chart, items: readonly Animation[]): void;
-  has(chart: Chart): boolean;
-  start(chart: Chart): void;
-  running(chart: Chart): boolean;
-  stop(chart: Chart): void;
-  remove(chart: Chart): boolean;
+  listen(chart: ChartInstance, event: 'complete' | 'progress', cb: (event: IAnimationEvent) => void): void;
+  add(chart: ChartInstance, items: readonly Animation[]): void;
+  has(chart: ChartInstance): boolean;
+  start(chart: ChartInstance): void;
+  running(chart: ChartInstance): boolean;
+  stop(chart: ChartInstance): void;
+  remove(chart: ChartInstance): boolean;
 }
 
 export class Animations {
-  constructor(chart: Chart, animations: {});
+  constructor(chart: ChartInstance, animations: {});
   configure(animations: {}): void;
   update(target: any, values: any): undefined | boolean;
 }
@@ -169,11 +169,11 @@ export type IAnimationOptions = IAnimationSpecContainer & {
   /**
    * Callback called on each step of an animation.
    */
-  onProgress: (this: Chart, event: IAnimationEvent) => void;
+  onProgress: (this: ChartInstance, event: IAnimationEvent) => void;
   /**
    *Callback called when all animations are completed.
    */
-  onComplete: (this: Chart, event: IAnimationEvent) => void;
+  onComplete: (this: ChartInstance, event: IAnimationEvent) => void;
 
   active: IAnimationSpecContainer;
   hide: IAnimationSpecContainer;
@@ -232,7 +232,7 @@ export interface IParsingOptions {
     | false;
 }
 
-export interface Chart<
+export interface ChartInstance<
   T = unknown,
   L = string,
   C extends IChartConfiguration<IChartType, T, L> = IChartConfiguration<IChartType, T, L>
@@ -300,14 +300,14 @@ export declare type ChartItem =
   | ArrayLike<CanvasRenderingContext2D | HTMLCanvasElement | OffscreenCanvas>;
 
 export const Chart: {
-  prototype: Chart;
+  prototype: ChartInstance;
   new <T = unknown, L = string, C extends IChartConfiguration<IChartType, T, L> = IChartConfiguration<IChartType, T, L>>(
     item: ChartItem,
     config: C
-  ): Chart<T, L, C>;
+  ): ChartInstance<T, L, C>;
 
   readonly version: string;
-  readonly instances: { [key: string]: Chart };
+  readonly instances: { [key: string]: ChartInstance };
   readonly registry: Registry;
   register(...items: IChartComponentLike[]): void;
   unregister(...items: IChartComponentLike[]): void;
@@ -326,9 +326,9 @@ export enum UpdateModeEnum {
 export type UpdateMode = keyof typeof UpdateModeEnum;
 
 export class DatasetController<E extends Element = Element, DSE extends Element = Element> {
-  constructor(chart: Chart, datasetIndex: number);
+  constructor(chart: ChartInstance, datasetIndex: number);
 
-  readonly chart: Chart;
+  readonly chart: ChartInstance;
   readonly index: number;
   readonly _cachedMeta: IChartMeta<E, DSE>;
   enableOptionSharing: boolean;
@@ -486,7 +486,7 @@ export interface InteractionItem {
 }
 
 export type InteractionModeFunction = (
-  chart: Chart,
+  chart: ChartInstance,
   e: IEvent,
   options: IInteractionOptions,
   useFinalPosition?: boolean
@@ -595,26 +595,26 @@ export const layouts: {
   /**
    * Register a box to a chart.
    * A box is simply a reference to an object that requires layout. eg. Scales, Legend, Title.
-   * @param {Chart} chart - the chart to use
+   * @param {ChartInstance} chart - the chart to use
    * @param {ILayoutItem} item - the item to add to be laid out
    */
-  addBox(chart: Chart, item: ILayoutItem): void;
+  addBox(chart: ChartInstance, item: ILayoutItem): void;
 
   /**
    * Remove a layoutItem from a chart
-   * @param {Chart} chart - the chart to remove the box from
+   * @param {ChartInstance} chart - the chart to remove the box from
    * @param {ILayoutItem} layoutItem - the item to remove from the layout
    */
-  removeBox(chart: Chart, layoutItem: ILayoutItem): void;
+  removeBox(chart: ChartInstance, layoutItem: ILayoutItem): void;
 
   /**
    * Sets (or updates) options on the given `item`.
-   * @param {Chart} chart - the chart in which the item lives (or will be added to)
+   * @param {ChartInstance} chart - the chart in which the item lives (or will be added to)
    * @param {ILayoutItem} item - the item to configure with the given options
    * @param options - the new item options.
    */
   configure(
-    chart: Chart,
+    chart: ChartInstance,
     item: ILayoutItem,
     options: { fullWidth?: number; position?: LayoutPosition; weight?: number }
   ): void;
@@ -622,11 +622,11 @@ export const layouts: {
   /**
    * Fits boxes of the given chart into the given size by having each box measure itself
    * then running a fitting algorithm
-   * @param {Chart} chart - the chart
+   * @param {ChartInstance} chart - the chart
    * @param {number} width - the width to fit into
    * @param {number} height - the height to fit into
    */
-  update(chart: Chart, width: number, height: number): void;
+  update(chart: ChartInstance, width: number, height: number): void;
 };
 
 export interface PluginService {
@@ -634,12 +634,12 @@ export interface PluginService {
    * Calls enabled plugins for `chart` on the specified hook and with the given args.
    * This method immediately returns as soon as a plugin explicitly returns false. The
    * returned value can be used, for instance, to interrupt the current action.
-   * @param {Chart} chart - The chart instance for which plugins should be called.
+   * @param {ChartInstance} chart - The chart instance for which plugins should be called.
    * @param {string} hook - The name of the plugin method to call (e.g. 'beforeUpdate').
    * @param {Array} [args] - Extra arguments to apply to the hook call.
    * @returns {boolean} false if any of the plugins return false, else returns true.
    */
-  notify(chart: Chart, hook: string, args: any[]): boolean;
+  notify(chart: ChartInstance, hook: string, args: any[]): boolean;
   invalidate(): void;
 }
 
@@ -648,190 +648,190 @@ export interface IPlugin<O = {}> {
 
   /**
    * @desc Called before initializing `chart`.
-   * @param {Chart} chart - The chart instance.
+   * @param {ChartInstance} chart - The chart instance.
    * @param {object} options - The plugin options.
    */
-  beforeInit?(chart: Chart, options: O): void;
+  beforeInit?(chart: ChartInstance, options: O): void;
   /**
    * @desc Called after `chart` has been initialized and before the first update.
-   * @param {Chart} chart - The chart instance.
+   * @param {ChartInstance} chart - The chart instance.
    * @param {object} options - The plugin options.
    */
-  afterInit?(chart: Chart, options: O): void;
+  afterInit?(chart: ChartInstance, options: O): void;
   /**
    * @desc Called before updating `chart`. If any plugin returns `false`, the update
    * is cancelled (and thus subsequent render(s)) until another `update` is triggered.
-   * @param {Chart} chart - The chart instance.
+   * @param {ChartInstance} chart - The chart instance.
    * @param {object} options - The plugin options.
    * @returns {boolean} `false` to cancel the chart update.
    */
-  beforeUpdate?(chart: Chart, options: O): boolean | void;
+  beforeUpdate?(chart: ChartInstance, options: O): boolean | void;
   /**
    * @desc Called after `chart` has been updated and before rendering. Note that this
    * hook will not be called if the chart update has been previously cancelled.
-   * @param {Chart} chart - The chart instance.
+   * @param {ChartInstance} chart - The chart instance.
    * @param {object} options - The plugin options.
    */
-  afterUpdate?(chart: Chart, options: O): void;
+  afterUpdate?(chart: ChartInstance, options: O): void;
   /**
    * @desc Called during chart reset
-   * @param {Chart} chart - The chart instance.
+   * @param {ChartInstance} chart - The chart instance.
    * @param {object} options - The plugin options.
    * @since version 3.0.0
    */
-  reset?(chart: Chart, options: O): void;
+  reset?(chart: ChartInstance, options: O): void;
   /**
    * @desc Called before updating the `chart` datasets. If any plugin returns `false`,
    * the datasets update is cancelled until another `update` is triggered.
-   * @param {Chart} chart - The chart instance.
+   * @param {ChartInstance} chart - The chart instance.
    * @param {object} options - The plugin options.
    * @returns {boolean} false to cancel the datasets update.
    * @since version 2.1.5
    */
-  beforeDatasetsUpdate?(chart: Chart, options: O): boolean | void;
+  beforeDatasetsUpdate?(chart: ChartInstance, options: O): boolean | void;
   /**
    * @desc Called after the `chart` datasets have been updated. Note that this hook
    * will not be called if the datasets update has been previously cancelled.
-   * @param {Chart} chart - The chart instance.
+   * @param {ChartInstance} chart - The chart instance.
    * @param {object} options - The plugin options.
    * @since version 2.1.5
    */
-  afterDatasetsUpdate?(chart: Chart, options: O): void;
+  afterDatasetsUpdate?(chart: ChartInstance, options: O): void;
   /**
    * @desc Called before updating the `chart` dataset at the given `args.index`. If any plugin
    * returns `false`, the datasets update is cancelled until another `update` is triggered.
-   * @param {Chart} chart - The chart instance.
+   * @param {ChartInstance} chart - The chart instance.
    * @param {object} args - The call arguments.
    * @param {number} args.index - The dataset index.
    * @param {object} args.meta - The dataset metadata.
    * @param {object} options - The plugin options.
    * @returns {boolean} `false` to cancel the chart datasets drawing.
    */
-  beforeDatasetUpdate?(chart: Chart, args: { index: number; meta: IChartMeta }, options: O): boolean | void;
+  beforeDatasetUpdate?(chart: ChartInstance, args: { index: number; meta: IChartMeta }, options: O): boolean | void;
   /**
    * @desc Called after the `chart` datasets at the given `args.index` has been updated. Note
    * that this hook will not be called if the datasets update has been previously cancelled.
-   * @param {Chart} chart - The chart instance.
+   * @param {ChartInstance} chart - The chart instance.
    * @param {object} args - The call arguments.
    * @param {number} args.index - The dataset index.
    * @param {object} args.meta - The dataset metadata.
    * @param {object} options - The plugin options.
    */
-  afterDatasetUpdate?(chart: Chart, args: { index: number; meta: IChartMeta }, options: O): void;
+  afterDatasetUpdate?(chart: ChartInstance, args: { index: number; meta: IChartMeta }, options: O): void;
   /**
    * @desc Called before laying out `chart`. If any plugin returns `false`,
    * the layout update is cancelled until another `update` is triggered.
-   * @param {Chart} chart - The chart instance.
+   * @param {ChartInstance} chart - The chart instance.
    * @param {object} options - The plugin options.
    * @returns {boolean} `false` to cancel the chart layout.
    */
-  beforeLayout?(chart: Chart, options: O): boolean | void;
+  beforeLayout?(chart: ChartInstance, options: O): boolean | void;
   /**
    * @desc Called after the `chart` has been laid out. Note that this hook will not
    * be called if the layout update has been previously cancelled.
-   * @param {Chart} chart - The chart instance.
+   * @param {ChartInstance} chart - The chart instance.
    * @param {object} options - The plugin options.
    */
-  afterLayout?(chart: Chart, options: O): void;
+  afterLayout?(chart: ChartInstance, options: O): void;
   /**
    * @desc Called before rendering `chart`. If any plugin returns `false`,
    * the rendering is cancelled until another `render` is triggered.
-   * @param {Chart} chart - The chart instance.
+   * @param {ChartInstance} chart - The chart instance.
    * @param {object} options - The plugin options.
    * @returns {boolean} `false` to cancel the chart rendering.
    */
-  beforeRender?(chart: Chart, options: O): boolean | void;
+  beforeRender?(chart: ChartInstance, options: O): boolean | void;
   /**
    * @desc Called after the `chart` has been fully rendered (and animation completed). Note
    * that this hook will not be called if the rendering has been previously cancelled.
-   * @param {Chart} chart - The chart instance.
+   * @param {ChartInstance} chart - The chart instance.
    * @param {object} options - The plugin options.
    */
-  afterRender?(chart: Chart, options: O): void;
+  afterRender?(chart: ChartInstance, options: O): void;
   /**
    * @desc Called before drawing `chart` at every animation frame. If any plugin returns `false`,
    * the frame drawing is cancelled untilanother `render` is triggered.
-   * @param {Chart} chart - The chart instance.
+   * @param {ChartInstance} chart - The chart instance.
    * @param {object} options - The plugin options.
    * @returns {boolean} `false` to cancel the chart drawing.
    */
-  beforeDraw?(chart: Chart, options: O): boolean | void;
+  beforeDraw?(chart: ChartInstance, options: O): boolean | void;
   /**
    * @desc Called after the `chart` has been drawn. Note that this hook will not be called
    * if the drawing has been previously cancelled.
-   * @param {Chart} chart - The chart instance.
+   * @param {ChartInstance} chart - The chart instance.
    * @param {object} options - The plugin options.
    */
-  afterDraw?(chart: Chart, options: O): void;
+  afterDraw?(chart: ChartInstance, options: O): void;
   /**
    * @desc Called before drawing the `chart` datasets. If any plugin returns `false`,
    * the datasets drawing is cancelled until another `render` is triggered.
-   * @param {Chart} chart - The chart instance.
+   * @param {ChartInstance} chart - The chart instance.
    * @param {object} options - The plugin options.
    * @returns {boolean} `false` to cancel the chart datasets drawing.
    */
-  beforeDatasetsDraw?(chart: Chart, options: O): boolean | void;
+  beforeDatasetsDraw?(chart: ChartInstance, options: O): boolean | void;
   /**
    * @desc Called after the `chart` datasets have been drawn. Note that this hook
    * will not be called if the datasets drawing has been previously cancelled.
-   * @param {Chart} chart - The chart instance.
+   * @param {ChartInstance} chart - The chart instance.
    * @param {object} options - The plugin options.
    */
-  afterDatasetsDraw?(chart: Chart, options: O): void;
+  afterDatasetsDraw?(chart: ChartInstance, options: O): void;
   /**
    * @desc Called before drawing the `chart` dataset at the given `args.index` (datasets
    * are drawn in the reverse order). If any plugin returns `false`, the datasets drawing
    * is cancelled until another `render` is triggered.
-   * @param {Chart} chart - The chart instance.
+   * @param {ChartInstance} chart - The chart instance.
    * @param {object} args - The call arguments.
    * @param {number} args.index - The dataset index.
    * @param {object} args.meta - The dataset metadata.
    * @param {object} options - The plugin options.
    * @returns {boolean} `false` to cancel the chart datasets drawing.
    */
-  beforeDatasetDraw?(chart: Chart, args: { index: number; meta: IChartMeta }, options: O): boolean | void;
+  beforeDatasetDraw?(chart: ChartInstance, args: { index: number; meta: IChartMeta }, options: O): boolean | void;
   /**
    * @desc Called after the `chart` datasets at the given `args.index` have been drawn
    * (datasets are drawn in the reverse order). Note that this hook will not be called
    * if the datasets drawing has been previously cancelled.
-   * @param {Chart} chart - The chart instance.
+   * @param {ChartInstance} chart - The chart instance.
    * @param {object} args - The call arguments.
    * @param {number} args.index - The dataset index.
    * @param {object} args.meta - The dataset metadata.
    * @param {object} options - The plugin options.
    */
-  afterDatasetDraw?(chart: Chart, args: { index: number; meta: IChartMeta }, options: O): void;
+  afterDatasetDraw?(chart: ChartInstance, args: { index: number; meta: IChartMeta }, options: O): void;
   /**
    * @desc Called before processing the specified `event`. If any plugin returns `false`,
    * the event will be discarded.
-   * @param {Chart} chart - The chart instance.
+   * @param {ChartInstance} chart - The chart instance.
    * @param {IEvent} event - The event object.
    * @param {object} options - The plugin options.
-   * @param {boolean} replay - True if this event is replayed from `Chart.update`
+   * @param {boolean} replay - True if this event is replayed from `ChartInstance.update`
    */
-  beforeEvent?(chart: Chart, event: IEvent, options: O, replay: boolean): void;
+  beforeEvent?(chart: ChartInstance, event: IEvent, options: O, replay: boolean): void;
   /**
    * @desc Called after the `event` has been consumed. Note that this hook
    * will not be called if the `event` has been previously discarded.
-   * @param {Chart} chart - The chart instance.
+   * @param {ChartInstance} chart - The chart instance.
    * @param {IEvent} event - The event object.
    * @param {object} options - The plugin options.
-   * @param {boolean} replay - True if this event is replayed from `Chart.update`
+   * @param {boolean} replay - True if this event is replayed from `ChartInstance.update`
    */
-  afterEvent?(chart: Chart, event: IEvent, options: O, replay: boolean): void;
+  afterEvent?(chart: ChartInstance, event: IEvent, options: O, replay: boolean): void;
   /**
    * @desc Called after the chart as been resized.
-   * @param {Chart} chart - The chart instance.
+   * @param {ChartInstance} chart - The chart instance.
    * @param {number} size - The new canvas display size (eq. canvas.style width & height).
    * @param {object} options - The plugin options.
    */
-  resize?(chart: Chart, size: number, options: O): void;
+  resize?(chart: ChartInstance, size: number, options: O): void;
   /**
    * Called after the chart as been destroyed.
-   * @param {Chart} chart - The chart instance.
+   * @param {ChartInstance} chart - The chart instance.
    * @param {object} options - The plugin options.
    */
-  destroy?(chart: Chart, options: O): void;
+  destroy?(chart: ChartInstance, options: O): void;
 }
 
 export declare type IChartComponentLike = IChartComponent | IChartComponent[] | { [key: string]: IChartComponent };
@@ -946,7 +946,7 @@ export interface Scale<O extends IScaleOptions = IScaleOptions> extends Element<
   readonly id: string;
   readonly type: string;
   readonly ctx: CanvasRenderingContext2D;
-  readonly chart: Chart;
+  readonly chart: ChartInstance;
 
   width: number;
   height: number;
@@ -1061,7 +1061,7 @@ export const Scale: {
 };
 
 export interface IScriptAbleScaleContext {
-  chart: Chart;
+  chart: ChartInstance;
   scale: Scale;
   index: number;
   tick: ITick;

--- a/types/core/interfaces.d.ts
+++ b/types/core/interfaces.d.ts
@@ -1,4 +1,4 @@
-import { Chart, Element, InteractionMode } from '.';
+import { ChartInstance, Element, InteractionMode } from '.';
 import { IChartDataset } from '../interfaces';
 
 export type Color = string | CanvasGradient | CanvasPattern;
@@ -55,7 +55,7 @@ export interface IPadding {
 }
 
 export interface IScriptableContext {
-  chart: Chart;
+  chart: ChartInstance;
   dataPoint: any;
   dataIndex: number;
   dataset: IChartDataset;
@@ -121,7 +121,7 @@ export interface ICoreChartOptions {
   /**
    * Called when a resize occurs. Gets passed two arguments: the chart instance and the new size.
    */
-  onResize(chart: Chart, size: { width: number; height: number }): void;
+  onResize(chart: ChartInstance, size: { width: number; height: number }): void;
 
   /**
    * Override the window's default devicePixelRatio.

--- a/types/helpers/helpers.canvas.d.ts
+++ b/types/helpers/helpers.canvas.d.ts
@@ -3,7 +3,7 @@ import { IChartArea } from '../core/interfaces';
 
 /**
  * Clears the entire canvas associated to the given `chart`.
- * @param {Chart} chart - The chart for which to clear the canvas.
+ * @param {ChartInstance} chart - The chart for which to clear the canvas.
  */
 export function clear(chart: { ctx: CanvasRenderingContext2D }): void;
 

--- a/types/platform/index.d.ts
+++ b/types/platform/index.d.ts
@@ -1,4 +1,4 @@
-import { Chart } from '../core';
+import { ChartInstance } from '../core';
 import { IEvent } from '../core/interfaces';
 
 export class BasePlatform {
@@ -21,19 +21,19 @@ export class BasePlatform {
   releaseContext(context: CanvasRenderingContext2D): boolean;
   /**
    * Registers the specified listener on the given chart.
-   * @param {Chart} chart - Chart from which to listen for event
+   * @param {ChartInstance} chart - Chart from which to listen for event
    * @param {string} type - The ({@link IEvent}) type to listen for
    * @param listener - Receives a notification (an object that implements
    * the {@link IEvent} interface) when an event of the specified type occurs.
    */
-  addEventListener(chart: Chart, type: string, listener: (e: IEvent) => void): void;
+  addEventListener(chart: ChartInstance, type: string, listener: (e: IEvent) => void): void;
   /**
    * Removes the specified listener previously registered with addEventListener.
-   * @param {Chart} chart - Chart from which to remove the listener
+   * @param {ChartInstance} chart - Chart from which to remove the listener
    * @param {string} type - The ({@link IEvent}) type to remove
    * @param listener - The listener function to remove from the event target.
    */
-  removeEventListener(chart: Chart, type: string, listener: (e: IEvent) => void): void;
+  removeEventListener(chart: ChartInstance, type: string, listener: (e: IEvent) => void): void;
   /**
    * @returns {number} the current devicePixelRatio of the device this platform is connected to.
    */

--- a/types/plugins/index.d.ts
+++ b/types/plugins/index.d.ts
@@ -1,4 +1,4 @@
-import { Chart, Element, IAnimationSpecContainer, InteractionMode, LayoutPosition, IPlugin } from '../core';
+import { ChartInstance, Element, IAnimationSpecContainer, InteractionMode, LayoutPosition, IPlugin } from '../core';
 import { Color, IChartArea, IFontSpec, Scriptable, TextAlign, IEvent, IHoverInteractionOptions } from '../core/interfaces';
 import { PointStyle } from '../elements';
 import { IChartData, IChartDataset } from '../interfaces';
@@ -158,7 +158,7 @@ export interface ILegendOptions {
     /**
      * Generates legend items for each thing in the legend. Default implementation returns the text + styling for the color box. See Legend Item for details.
      */
-    generateLabels(chart: Chart): ILegendItem[];
+    generateLabels(chart: ChartInstance): ILegendItem[];
 
     /**
      * Filters legend items out of the legend. Receives 2 parameters, a Legend Item and the chart data
@@ -307,22 +307,22 @@ export interface ITooltipPlugin<O = {}> {
   /**
    * @desc Called before drawing the `tooltip`. If any plugin returns `false`,
    * the tooltip drawing is cancelled until another `render` is triggered.
-   * @param {Chart} chart - The chart instance.
+   * @param {ChartInstance} chart - The chart instance.
    * @param {object} args - The call arguments.
    * @param {Tooltip} args.tooltip - The tooltip.
    * @param {object} options - The plugin options.
    * @returns {boolean} `false` to cancel the chart tooltip drawing.
    */
-  beforeTooltipDraw?(chart: Chart, args: { tooltip: TooltipModel }, options: O): boolean | void;
+  beforeTooltipDraw?(chart: ChartInstance, args: { tooltip: TooltipModel }, options: O): boolean | void;
   /**
    * @desc Called after drawing the `tooltip`. Note that this hook will not
    * be called if the tooltip drawing has been previously cancelled.
-   * @param {Chart} chart - The chart instance.
+   * @param {ChartInstance} chart - The chart instance.
    * @param {object} args - The call arguments.
    * @param {Tooltip} args.tooltip - The tooltip.
    * @param {object} options - The plugin options.
    */
-  afterTooltipDraw?(chart: Chart, args: { tooltip: TooltipModel }, options: O): void;
+  afterTooltipDraw?(chart: ChartInstance, args: { tooltip: TooltipModel }, options: O): void;
 }
 
 export interface ITooltipOptions extends IHoverInteractionOptions {
@@ -334,7 +334,7 @@ export interface ITooltipOptions extends IHoverInteractionOptions {
   /**
    * 	See custom tooltip section.
    */
-  custom(this: TooltipModel, args: { chart: Chart; tooltip: TooltipModel }): void;
+  custom(this: TooltipModel, args: { chart: ChartInstance; tooltip: TooltipModel }): void;
   /**
    * The mode for positioning the tooltip
    */
@@ -486,7 +486,7 @@ export interface ITooltipItem {
   /**
    * The chart the tooltip is being shown on
    */
-  chart: Chart;
+  chart: ChartInstance;
 
   /**
    * Label for the tooltip


### PR DESCRIPTION
Another thing about types that poses some problems for developer experience. Not a bug, but the IDE code analyzers get confused, this PR should fix it.
We have double "Chart" type. One for chart factory and second for chart instance. As result, IDE get confused (honestly, me too) and autocomplete doesn't work very well:
![Screen Shot 2020-09-09 at 6 36 03 PM](https://user-images.githubusercontent.com/8962340/92622797-266bb880-f2ce-11ea-86dd-6336532be301.png)
![Screen Shot 2020-09-09 at 6 36 32 PM](https://user-images.githubusercontent.com/8962340/92622805-2966a900-f2ce-11ea-95e9-09987de5e984.png)

So the idea of this PR is to rename the type for instance to `ChartInstance`. After this PR the issue is resolved:
![Screen Shot 2020-09-09 at 6 49 28 PM](https://user-images.githubusercontent.com/8962340/92623015-63d04600-f2ce-11ea-835f-6e2a4c2724c3.png)
![Screen Shot 2020-09-09 at 6 49 39 PM](https://user-images.githubusercontent.com/8962340/92623024-659a0980-f2ce-11ea-9900-e5163efbdf12.png)

I hope you will find this useful.