### PR TITLE
Better error message when importing charts incorrectly.

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -202,9 +202,22 @@ function isDomSupported() {
 function getCanvas(item) {
 	if (isDomSupported() && typeof item === 'string') {
 		item = document.getElementById(item);
-	} else if (item.length) {
+	} else if (Array.isArray(item) && item.length) {
 		// Support for array based queries (such as jQuery)
 		item = item[0];
+	} else {
+		// No dom element was found
+		throw new Error(
+			`No DOM element was found when trying to setup Chartjs canvas.
+
+Tips:
+
+- Check if the dom element requested is indeed present in the html file.
+
+- Check if the .js file where you are defining your chart is executing after the definition of the canvas in the html file.
+
+			`
+		);
 	}
 
 	if (item && item.canvas) {

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -7,7 +7,7 @@ import {BasicPlatform, DomPlatform} from '../platform';
 import PluginService from './core.plugins';
 import registry from './core.registry';
 import {getMaximumWidth, getMaximumHeight, retinaScale} from '../helpers/helpers.dom';
-import {mergeIf, merge, _merger, each, callback as callCallback, uid, valueOrDefault, _elementsEqual} from '../helpers/helpers.core';
+import {mergeIf, merge, _merger, each, callback as callCallback, uid, valueOrDefault, _elementsEqual, isArray} from '../helpers/helpers.core';
 import {clear as canvasClear, clipArea, unclipArea, _isPointInArea} from '../helpers/helpers.canvas';
 // @ts-ignore
 import {version} from '../../package.json';
@@ -202,7 +202,7 @@ function isDomSupported() {
 function getCanvas(item) {
 	if (isDomSupported() && typeof item === 'string') {
 		item = document.getElementById(item);
-	} else if (Array.isArray(item) && item.length) {
+	} else if (isArray(item) && item.length) {
 		// Support for array based queries (such as jQuery)
 		item = item[0];
 	}
@@ -291,7 +291,7 @@ class Chart {
 			// the chart initialization but after setting basic chart / controller properties that
 			// can help to figure out that the chart is not valid (e.g chart.canvas !== null);
 			// https://github.com/chartjs/Chart.js/issues/2807
-			console.error("Failed to create chart: can't acquire context from the given item \n\n Tips: \n\n-Check if the dom element requested is indeed present in the html file. \n\n-Check if the .js file where you are defining your chart is executing after the definition of the canvas in the html file.\n");
+			console.error("Failed to create chart: can't acquire context from the given item");
 			return;
 		}
 

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -7,7 +7,7 @@ import {BasicPlatform, DomPlatform} from '../platform';
 import PluginService from './core.plugins';
 import registry from './core.registry';
 import {getMaximumWidth, getMaximumHeight, retinaScale} from '../helpers/helpers.dom';
-import {mergeIf, merge, _merger, each, callback as callCallback, uid, valueOrDefault, _elementsEqual, isArray} from '../helpers/helpers.core';
+import {mergeIf, merge, _merger, each, callback as callCallback, uid, valueOrDefault, _elementsEqual} from '../helpers/helpers.core';
 import {clear as canvasClear, clipArea, unclipArea, _isPointInArea} from '../helpers/helpers.canvas';
 // @ts-ignore
 import {version} from '../../package.json';
@@ -202,7 +202,7 @@ function isDomSupported() {
 function getCanvas(item) {
 	if (isDomSupported() && typeof item === 'string') {
 		item = document.getElementById(item);
-	} else if (isArray(item) && item.length) {
+	} else if (item && item.length) {
 		// Support for array based queries (such as jQuery)
 		item = item[0];
 	}

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -205,19 +205,6 @@ function getCanvas(item) {
 	} else if (Array.isArray(item) && item.length) {
 		// Support for array based queries (such as jQuery)
 		item = item[0];
-	} else {
-		// No dom element was found
-		throw new Error(
-			`No DOM element was found when trying to setup Chartjs canvas.
-
-Tips:
-
-- Check if the dom element requested is indeed present in the html file.
-
-- Check if the .js file where you are defining your chart is executing after the definition of the canvas in the html file.
-
-			`
-		);
 	}
 
 	if (item && item.canvas) {
@@ -304,7 +291,7 @@ class Chart {
 			// the chart initialization but after setting basic chart / controller properties that
 			// can help to figure out that the chart is not valid (e.g chart.canvas !== null);
 			// https://github.com/chartjs/Chart.js/issues/2807
-			console.error("Failed to create chart: can't acquire context from the given item");
+			console.error("Failed to create chart: can't acquire context from the given item \n\n Tips: \n\n-Check if the dom element requested is indeed present in the html file. \n\n-Check if the .js file where you are defining your chart is executing after the definition of the canvas in the html file.\n");
 			return;
 		}
 


### PR DESCRIPTION
When i first tried to use chartjs, i imported the js files in the following way:

![chartjshtml](https://user-images.githubusercontent.com/34402401/93009572-4a8efa00-f559-11ea-90f2-d9651f290464.png)

chartTest.js being the file in which I define the chart called speedChart.  
This is wrong of course because i should define the chart after the canvas is rendered.  

So when i try to run the app the following error is thrown:

![previousError](https://user-images.githubusercontent.com/34402401/93009686-4ca58880-f55a-11ea-81cf-27708b857863.png)

Leaving me a bit confused on why it was happening. 🤔 

Maybe you can call me oblivious for getting right into coding without reading the docs, but i still think that a better error can save people some time when trying to setup chartjs!

The new error message is as follows: 

![newError](https://user-images.githubusercontent.com/34402401/93022048-11887100-f5bd-11ea-979f-5569d572c9a2.png)

Hopefully it can save people some time. 👍 