### PR TITLE
Make dataset animations obey chart level disable

### DIFF
--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -804,9 +804,9 @@ export default class DatasetController {
 
 		const info = {cacheable: true};
 		const context = me._getContext(index, active);
-		const datasetAnim = resolve([me._config.animation], context, index, info);
 		const chartAnim = resolve([chart.options.animation], context, index, info);
-		let config = mergeIf({}, [datasetAnim, chartAnim]);
+		const datasetAnim = resolve([me._config.animation], context, index, info);
+		let config = chartAnim && mergeIf({}, [datasetAnim, chartAnim]);
 
 		if (config[mode]) {
 			config = Object.assign({}, config, config[mode]);

--- a/test/specs/core.datasetController.tests.js
+++ b/test/specs/core.datasetController.tests.js
@@ -624,43 +624,82 @@ describe('Chart.DatasetController', function() {
 			// Remove test from global defaults
 			delete Chart.defaults.elements.line.globalTest;
 		});
-	});
 
-	it('should resove names in object notation', function() {
-		Chart.defaults.elements.line.global = 'global';
+		it('should resove names in object notation', function() {
+			Chart.defaults.elements.line.global = 'global';
 
-		const chart = acquireChart({
-			type: 'line',
-			data: {
-				datasets: [{
-					data: [1],
-					datasetTest: 'dataset'
-				}]
-			},
-			options: {
-				elements: {
-					line: {
-						element: 'element'
+			const chart = acquireChart({
+				type: 'line',
+				data: {
+					datasets: [{
+						data: [1],
+						datasetTest: 'dataset'
+					}]
+				},
+				options: {
+					elements: {
+						line: {
+							element: 'element'
+						}
 					}
 				}
-			}
+			});
+
+			const controller = chart.getDatasetMeta(0).controller;
+
+			expect(controller._resolveOptions(
+				{
+					dataset: 'datasetTest',
+					element: 'elementTest',
+					global: 'globalTest'},
+				{type: 'line'})
+			).toEqual({
+				dataset: 'dataset',
+				element: 'element',
+				global: 'global'
+			});
+
+			// Remove test from global defaults
+			delete Chart.defaults.elements.line.global;
+		});
+	});
+
+	describe('_resolveAnimations', function() {
+		it('should resolve to empty Animations when globally disabled', function() {
+			const chart = acquireChart({
+				type: 'line',
+				data: {
+					datasets: [{
+						data: [1],
+						animation: {
+							test: {duration: 10}
+						}
+					}]
+				},
+				options: {
+					animation: false
+				}
+			});
+
+			const controller = chart.getDatasetMeta(0).controller;
+
+			expect(controller._resolveAnimations(0)._properties.size).toEqual(0);
 		});
 
-		const controller = chart.getDatasetMeta(0).controller;
+		it('should resolve to empty Animations when disabled at dataset level', function() {
+			const chart = acquireChart({
+				type: 'line',
+				data: {
+					datasets: [{
+						data: [1],
+						animation: false
+					}]
+				}
+			});
 
-		expect(controller._resolveOptions(
-			{
-				dataset: 'datasetTest',
-				element: 'elementTest',
-				global: 'globalTest'},
-			{type: 'line'})
-		).toEqual({
-			dataset: 'dataset',
-			element: 'element',
-			global: 'global'
+			const controller = chart.getDatasetMeta(0).controller;
+
+			expect(controller._resolveAnimations(0)._properties.size).toEqual(0);
 		});
-
-		// Remove test from global defaults
-		delete Chart.defaults.elements.line.global;
 	});
 });


### PR DESCRIPTION
Noticed this when running tests on `chartjs-chart-sankey` and going from `alpha.2` to `beta`.
My tests fail because I have some dataset level default animations and the tests just (try to) disable animation at chart level.