### PR TITLE
Include dist/chunks in the NPM package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chart.js",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "url": "https://github.com/chartjs/Chart.js/issues"
   },
   "files": [
-    "dist/*.js",
-    "dist/*.d.ts",
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
     "helpers/**/*.js",
     "helpers/**/*.d.ts"
   ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chart.js",
   "homepage": "https://www.chartjs.org",
   "description": "Simple HTML5 charts using the canvas element.",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0-beta.3",
   "license": "MIT",
   "jsdelivr": "dist/chart.min.js",
   "unpkg": "dist/chart.min.js",


### PR DESCRIPTION
Resolves #7829. Only the first level of JS & TS files were included in the NPM package. This updates that + bumps the version number so that we can fix the package quickly.

# Master

```
~/opensource/Chart.js include-chunks-build*
❯ npm pack
npm notice 
npm notice 📦  chart.js@3.0.0-beta.2
npm notice === Tarball Contents === 
npm notice 263.6kB dist/chart.esm.js       
npm notice 153.3kB dist/chart.esm.min.js   
npm notice 396.8kB dist/chart.js           
npm notice 180.0kB dist/chart.min.js       
npm notice 1.8kB   dist/helpers.esm.js     
npm notice 36B     helpers/helpers.esm.js  
npm notice 39B     helpers/helpers.js      
npm notice 183B    helpers/package.json    
npm notice 2.7kB   package.json            
npm notice 1.1kB   LICENSE.md              
npm notice 2.2kB   README.md               
npm notice 4.2kB   dist/chart.esm.d.ts     
npm notice 14.9kB  dist/helpers.esm.d.ts   
npm notice 36B     helpers/helpers.esm.d.ts
npm notice === Tarball Details === 
npm notice name:          chart.js                                
npm notice version:       3.0.0-beta.2                            
npm notice filename:      chart.js-3.0.0-beta.2.tgz               
npm notice package size:  265.6 kB                                
npm notice unpacked size: 1.0 MB                                  
npm notice shasum:        c85a945226498ee2e128296782c3ef25dc283173
npm notice integrity:     sha512-ZrkGObAM0oKeU[...]GVI+WyKwowMLA==
npm notice total files:   14                                      
npm notice 
chart.js-3.0.0-beta.2.tgz
```

# This PR

```
~/opensource/Chart.js include-chunks-build*
❯ npm pack
npm notice 
npm notice 📦  chart.js@3.0.0-beta.2
npm notice === Tarball Contents === 
npm notice 263.6kB dist/chart.esm.js         
npm notice 153.3kB dist/chart.esm.min.js     
npm notice 396.8kB dist/chart.js             
npm notice 180.0kB dist/chart.min.js         
npm notice 1.8kB   dist/helpers.esm.js       
npm notice 36B     helpers/helpers.esm.js    
npm notice 39B     helpers/helpers.js        
npm notice 53.0kB  dist/chunks/helpers.rtl.js
npm notice 183B    helpers/package.json      
npm notice 2.7kB   package.json              
npm notice 1.1kB   LICENSE.md                
npm notice 2.2kB   README.md                 
npm notice 4.2kB   dist/chart.esm.d.ts       
npm notice 14.9kB  dist/helpers.esm.d.ts     
npm notice 36B     helpers/helpers.esm.d.ts  
npm notice 94.2kB  dist/chunks/index.d.ts    
npm notice === Tarball Details === 
npm notice name:          chart.js                                
npm notice version:       3.0.0-beta.2                            
npm notice filename:      chart.js-3.0.0-beta.2.tgz               
npm notice package size:  301.5 kB                                
npm notice unpacked size: 1.2 MB                                  
npm notice shasum:        13891e0ae395033134046da46443a25380b61ffd
npm notice integrity:     sha512-2GEi23nf7j+7G[...]1s5AWWg17bs8Q==
npm notice total files:   16                                      
npm notice 
chart.js-3.0.0-beta.2.tgz
```