### PR TITLE
Use full height for fullWidth box when left/right

### DIFF
--- a/src/core/core.layouts.js
+++ b/src/core/core.layouts.js
@@ -47,14 +47,14 @@ function setLayoutDims(layouts, params) {
 	let i, ilen, layout;
 	for (i = 0, ilen = layouts.length; i < ilen; ++i) {
 		layout = layouts[i];
-		// store width used instead of chartArea.w in fitBoxes
-		layout.width = layout.horizontal
-			? layout.box.fullWidth && params.availableWidth
-			: params.vBoxMaxWidth;
-		// store height used instead of chartArea.h in fitBoxes
-		layout.height = layout.horizontal
-			? params.hBoxMaxHeight
-			: layout.box.fullWidth && params.availableHeight;
+		// store dimensions used instead of available chartArea in fitBoxes
+		if (layout.horizontal) {
+			layout.width = layout.box.fullWidth && params.availableWidth;
+			layout.height = params.hBoxMaxHeight;
+		} else {
+			layout.width = params.vBoxMaxWidth;
+			layout.height = layout.box.fullWidth && params.availableHeight;
+		}
 	}
 }
 

--- a/src/core/core.layouts.js
+++ b/src/core/core.layouts.js
@@ -52,7 +52,9 @@ function setLayoutDims(layouts, params) {
 			? layout.box.fullWidth && params.availableWidth
 			: params.vBoxMaxWidth;
 		// store height used instead of chartArea.h in fitBoxes
-		layout.height = layout.horizontal && params.hBoxMaxHeight;
+		layout.height = layout.horizontal
+			? params.hBoxMaxHeight
+			: layout.box.fullWidth && params.availableHeight;
 	}
 }
 
@@ -187,8 +189,8 @@ function placeBoxes(boxes, chartArea, params) {
 		} else {
 			box.left = x;
 			box.right = x + box.width;
-			box.top = chartArea.top;
-			box.bottom = chartArea.top + chartArea.h;
+			box.top = box.fullWidth ? userPadding.top : chartArea.top;
+			box.bottom = box.fullWidth ? params.outerHeight - userPadding.right : chartArea.top + chartArea.h;
 			box.height = box.bottom - box.top;
 			x = box.right;
 		}
@@ -344,6 +346,7 @@ export default {
 			outerHeight: height,
 			padding,
 			availableWidth,
+			availableHeight,
 			vBoxMaxWidth: availableWidth / 2 / verticalBoxes.length,
 			hBoxMaxHeight: availableHeight / 2
 		});


### PR DESCRIPTION
Noticed when looked into https://github.com/chartjs/Chart.js/issues/7321#issuecomment-702569702

The box marked as `fullWidth` (legend/title), when placed left or right, received only chartArea.height as the maxHeight parameter to `update`.

The `fullWidth` property name is no longer optimal, but I'm not sure if its a good idea to change it.