### PR TITLE
JS test files should have tabs to correctly lint

### DIFF
--- a/test/fixtures/controller.doughnut/doughnut-circumference-per-dataset.js
+++ b/test/fixtures/controller.doughnut/doughnut-circumference-per-dataset.js
@@ -1,33 +1,33 @@
 module.exports = {
-    config: {
-        type: 'doughnut',
-        data: {
-            labels: ['A', 'B', 'C', 'D', 'E'],
-            datasets: [{
-                data: [1, 5, 10, 50, 100],
-                backgroundColor: [
-                    'rgba(255, 99, 132, 0.8)',
-                    'rgba(54, 162, 235, 0.8)',
-                    'rgba(255, 206, 86, 0.8)',
-                    'rgba(75, 192, 192, 0.8)',
-                    'rgba(153, 102, 255, 0.8)'
-                ],
-                borderWidth: 1,
-                borderColor: [
-                    'rgb(255, 99, 132)',
-                    'rgb(54, 162, 235)',
-                    'rgb(255, 206, 86)',
-                    'rgb(75, 192, 192)',
-                    'rgb(153, 102, 255)'
-                ],
-                circumference: 180
-            }]
-        },
-        options: {
-            circumference: 57.32,
-            responsive: false,
-            legend: false,
-            title: false
-        }
-    }
-}
+	config: {
+		type: 'doughnut',
+		data: {
+			labels: ['A', 'B', 'C', 'D', 'E'],
+			datasets: [{
+				data: [1, 5, 10, 50, 100],
+				backgroundColor: [
+					'rgba(255, 99, 132, 0.8)',
+					'rgba(54, 162, 235, 0.8)',
+					'rgba(255, 206, 86, 0.8)',
+					'rgba(75, 192, 192, 0.8)',
+					'rgba(153, 102, 255, 0.8)'
+				],
+				borderWidth: 1,
+				borderColor: [
+					'rgb(255, 99, 132)',
+					'rgb(54, 162, 235)',
+					'rgb(255, 206, 86)',
+					'rgb(75, 192, 192)',
+					'rgb(153, 102, 255)'
+				],
+				circumference: 180
+			}]
+		},
+		options: {
+			circumference: 57.32,
+			responsive: false,
+			legend: false,
+			title: false
+		}
+	}
+};

--- a/test/fixtures/controller.doughnut/doughnut-rotation-per-dataset.js
+++ b/test/fixtures/controller.doughnut/doughnut-rotation-per-dataset.js
@@ -1,51 +1,51 @@
 module.exports = {
-    config: {
-        type: 'doughnut',
-        data: {
-            labels: ['A', 'B', 'C', 'D', 'E'],
-            datasets: [{
-                data: [1, 5, 10, 50, 100],
-                backgroundColor: [
-                    'rgba(255, 99, 132, 0.8)',
-                    'rgba(54, 162, 235, 0.8)',
-                    'rgba(255, 206, 86, 0.8)',
-                    'rgba(75, 192, 192, 0.8)',
-                    'rgba(153, 102, 255, 0.8)'
-                ],
-                borderWidth: 1,
-                borderColor: [
-                    'rgb(255, 99, 132)',
-                    'rgb(54, 162, 235)',
-                    'rgb(255, 206, 86)',
-                    'rgb(75, 192, 192)',
-                    'rgb(153, 102, 255)'
-                ],
-                rotation: -90
-            }, {
-                data: [1, 5, 10, 50, 100],
-                backgroundColor: [
-                    'rgba(255, 99, 132, 0.8)',
-                    'rgba(54, 162, 235, 0.8)',
-                    'rgba(255, 206, 86, 0.8)',
-                    'rgba(75, 192, 192, 0.8)',
-                    'rgba(153, 102, 255, 0.8)'
-                ],
-                borderWidth: 1,
-                borderColor: [
-                    'rgb(255, 99, 132)',
-                    'rgb(54, 162, 235)',
-                    'rgb(255, 206, 86)',
-                    'rgb(75, 192, 192)',
-                    'rgb(153, 102, 255)'
-                ],
-                rotation: 0
-            }]
-        },
-        options: {
-            circumference: 180,
-            responsive: false,
-            legend: false,
-            title: false
-        }
-    }
-}
+	config: {
+		type: 'doughnut',
+		data: {
+			labels: ['A', 'B', 'C', 'D', 'E'],
+			datasets: [{
+				data: [1, 5, 10, 50, 100],
+				backgroundColor: [
+					'rgba(255, 99, 132, 0.8)',
+					'rgba(54, 162, 235, 0.8)',
+					'rgba(255, 206, 86, 0.8)',
+					'rgba(75, 192, 192, 0.8)',
+					'rgba(153, 102, 255, 0.8)'
+				],
+				borderWidth: 1,
+				borderColor: [
+					'rgb(255, 99, 132)',
+					'rgb(54, 162, 235)',
+					'rgb(255, 206, 86)',
+					'rgb(75, 192, 192)',
+					'rgb(153, 102, 255)'
+				],
+				rotation: -90
+			}, {
+				data: [1, 5, 10, 50, 100],
+				backgroundColor: [
+					'rgba(255, 99, 132, 0.8)',
+					'rgba(54, 162, 235, 0.8)',
+					'rgba(255, 206, 86, 0.8)',
+					'rgba(75, 192, 192, 0.8)',
+					'rgba(153, 102, 255, 0.8)'
+				],
+				borderWidth: 1,
+				borderColor: [
+					'rgb(255, 99, 132)',
+					'rgb(54, 162, 235)',
+					'rgb(255, 206, 86)',
+					'rgb(75, 192, 192)',
+					'rgb(153, 102, 255)'
+				],
+				rotation: 0
+			}]
+		},
+		options: {
+			circumference: 180,
+			responsive: false,
+			legend: false,
+			title: false
+		}
+	}
+};


### PR DESCRIPTION
I noticed this when looking at #7827. Only the Windows CI fails the lint step though all should have been failing.