### PR TITLE
[2.9] Use node v12.18.2 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-  - lts/*
+# Using node 12.18.2 instead of lts
+# https://github.com/chartjs/Chart.js/issues/7863#issuecomment-705222874
+  - "12.18.2"
 
 before_install:
   - "export CHROME_BIN=/usr/bin/google-chrome"


### PR DESCRIPTION
Due to an issue with deprecated deps (`gitbook-cli`), forcing travis to an older compatible version of nodejs.

Fixes #7863
