### PR TITLE
Fix: beginAtZero for logarighmic

### DIFF
--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -77,6 +77,10 @@ export default class LogarithmicScale extends Scale {
 		me.min = isFinite(min) ? Math.max(0, min) : null;
 		me.max = isFinite(max) ? Math.max(0, max) : null;
 
+		if (me.options.beginAtZero) {
+			me._zero = true;
+		}
+
 		me.handleTickRangeOptions();
 	}
 
@@ -159,7 +163,6 @@ export default class LogarithmicScale extends Scale {
 
 		me._startValue = log10(start);
 		me._valueRange = log10(me.max) - log10(start);
-		me._zero = me.options.beginAtZero;
 	}
 
 	getPixelForValue(value) {

--- a/test/specs/scale.logarithmic.tests.js
+++ b/test/specs/scale.logarithmic.tests.js
@@ -345,7 +345,7 @@ describe('Logarithmic Scale tests', function() {
 			}
 		});
 
-		expect(chart.scales.y.min).toBe(1);
+		expect(chart.scales.y.min).toBe(0.1);
 		expect(chart.scales.y.max).toBe(200);
 	});
 
@@ -387,7 +387,7 @@ describe('Logarithmic Scale tests', function() {
 			}
 		});
 
-		expect(chart.scales.y.min).toBe(1);
+		expect(chart.scales.y.min).toBe(0.1);
 		expect(chart.scales.y.max).toBe(200);
 	});
 
@@ -517,7 +517,7 @@ describe('Logarithmic Scale tests', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					data: [10, 5, 1, 25, 78]
+					data: [10, 5, 2, 25, 78]
 				}],
 				labels: []
 			},
@@ -659,7 +659,7 @@ describe('Logarithmic Scale tests', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					data: [10, 5, 1, 25, 78]
+					data: [10, 5, 2, 25, 78]
 				}],
 				labels: []
 			},


### PR DESCRIPTION
The `beginAtZero` was considered too late, after handling tick range options.
As it defaults to `true`, some tests had to be altered.