### PR TITLE
Fix Maximum call stack size exception in _computeLabelSizes

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -894,6 +894,8 @@ export default class Scale extends Element {
 		const widths = [];
 		const heights = [];
 		const offsets = [];
+		let widestLabelSize = 0;
+		let highestLabelSize = 0;
 		let ticks = me.ticks;
 		if (sampleSize < ticks.length) {
 			ticks = sample(ticks, sampleSize);
@@ -926,11 +928,13 @@ export default class Scale extends Element {
 			widths.push(width);
 			heights.push(height);
 			offsets.push(lineHeight / 2);
+			widestLabelSize = Math.max(width, widestLabelSize);
+			highestLabelSize = Math.max(height, highestLabelSize);
 		}
 		garbageCollect(caches, length);
 
-		const widest = widths.indexOf(Math.max.apply(null, widths));
-		const highest = heights.indexOf(Math.max.apply(null, heights));
+		const widest = widths.indexOf(widestLabelSize);
+		const highest = heights.indexOf(highestLabelSize);
 
 		function valueAt(idx) {
 			return {


### PR DESCRIPTION
Issue #7881

This is the same fix as #7883 but in the master branch for version 3.

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
