### PR TITLE
Render points while animations are active

### DIFF
--- a/src/elements/element.point.js
+++ b/src/elements/element.point.js
@@ -1,5 +1,5 @@
 import Element from '../core/core.element';
-import {_isPointInArea, drawPoint} from '../helpers/helpers.canvas';
+import {drawPoint} from '../helpers/helpers.canvas';
 
 export default class Point extends Element {
 
@@ -46,7 +46,7 @@ export default class Point extends Element {
 		return (radius + borderWidth) * 2;
 	}
 
-	draw(ctx, chartArea) {
+	draw(ctx) {
 		const me = this;
 		const options = me.options;
 
@@ -54,13 +54,10 @@ export default class Point extends Element {
 			return;
 		}
 
-		// Clipping for Points.
-		if (chartArea === undefined || _isPointInArea(me, chartArea)) {
-			ctx.strokeStyle = options.borderColor;
-			ctx.lineWidth = options.borderWidth;
-			ctx.fillStyle = options.backgroundColor;
-			drawPoint(ctx, options, me.x, me.y);
-		}
+		ctx.strokeStyle = options.borderColor;
+		ctx.lineWidth = options.borderWidth;
+		ctx.fillStyle = options.backgroundColor;
+		drawPoint(ctx, options, me.x, me.y);
 	}
 
 	getRange() {


### PR DESCRIPTION
This PR changes the point element's behavior to be rendered while in animation event when it's out of the chart's area.
This will solve the following issue https://github.com/chartjs/Chart.js/issues/7209.