### PR TITLE
Stop deploying docs / drafting releases from forks

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,5 +1,5 @@
 # This workflow publishes new documentation to https://chartjs.org/docs/master after every commit
-name: CI
+name: Deploy docs
 
 on:
   push:
@@ -7,9 +7,16 @@ on:
       - master
 
 jobs:
-  build:
+  correct_repository:
     runs-on: ubuntu-latest
+    steps:
+    - name: fail on fork
+      if: github.repository_owner != 'chartjs'
+      run: exit 1
 
+  build:
+    needs: correct_repository
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,7 +6,15 @@ on:
       - master
 
 jobs:
+  correct_repository:
+    runs-on: ubuntu-latest
+    steps:
+    - name: fail on fork
+      if: github.repository_owner != 'chartjs'
+      run: exit 1
+
   update_release_draft:
+    needs: correct_repository
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v5


### PR DESCRIPTION
Prevents draft releases on for repositories and saves some CPU cycles.