### PR TITLE
[2.9] Use default color value for generateLegend when backgroundColor is undefined

### DIFF
--- a/src/controllers/controller.doughnut.js
+++ b/src/controllers/controller.doughnut.js
@@ -25,6 +25,7 @@ defaults._set('doughnut', {
 		var list = document.createElement('ul');
 		var data = chart.data;
 		var datasets = data.datasets;
+		var globalDefaults = defaults.global;
 		var labels = data.labels;
 		var i, ilen, listItem, listItemSpan;
 
@@ -33,7 +34,7 @@ defaults._set('doughnut', {
 			for (i = 0, ilen = datasets[0].data.length; i < ilen; ++i) {
 				listItem = list.appendChild(document.createElement('li'));
 				listItemSpan = listItem.appendChild(document.createElement('span'));
-				listItemSpan.style.backgroundColor = datasets[0].backgroundColor[i];
+				listItemSpan.style.backgroundColor = valueOrDefault(datasets[0].backgroundColor[i], globalDefaults.defaultColor);
 				if (labels[i]) {
 					listItem.appendChild(document.createTextNode(labels[i]));
 				}

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -6,6 +6,7 @@ var elements = require('../elements/index');
 var helpers = require('../helpers/index');
 
 var resolve = helpers.options.resolve;
+var valueOrDefault = helpers.valueOrDefault;
 
 defaults._set('polarArea', {
 	scale: {
@@ -35,6 +36,7 @@ defaults._set('polarArea', {
 		var list = document.createElement('ul');
 		var data = chart.data;
 		var datasets = data.datasets;
+		var globalDefaults = defaults.global;
 		var labels = data.labels;
 		var i, ilen, listItem, listItemSpan;
 
@@ -43,7 +45,7 @@ defaults._set('polarArea', {
 			for (i = 0, ilen = datasets[0].data.length; i < ilen; ++i) {
 				listItem = list.appendChild(document.createElement('li'));
 				listItemSpan = listItem.appendChild(document.createElement('span'));
-				listItemSpan.style.backgroundColor = datasets[0].backgroundColor[i];
+				listItemSpan.style.backgroundColor = valueOrDefault(datasets[0].backgroundColor[i], globalDefaults.defaultColor);
 				if (labels[i]) {
 					listItem.appendChild(document.createTextNode(labels[i]));
 				}

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -80,6 +80,7 @@ defaults._set('global', {
 	legendCallback: function(chart) {
 		var list = document.createElement('ul');
 		var datasets = chart.data.datasets;
+		var globalDefaults = defaults.global;
 		var i, ilen, listItem, listItemSpan;
 
 		list.setAttribute('class', chart.id + '-legend');
@@ -87,7 +88,7 @@ defaults._set('global', {
 		for (i = 0, ilen = datasets.length; i < ilen; i++) {
 			listItem = list.appendChild(document.createElement('li'));
 			listItemSpan = listItem.appendChild(document.createElement('span'));
-			listItemSpan.style.backgroundColor = datasets[i].backgroundColor;
+			listItemSpan.style.backgroundColor = valueOrDefault(datasets[i].backgroundColor, globalDefaults.defaultColor);
 			if (datasets[i].label) {
 				listItem.appendChild(document.createTextNode(datasets[i].label));
 			}


### PR DESCRIPTION
Use `valueOrDefault` and fallback to default color when backgroundColor is undefined when calling `generateLegend`.
I believe this is an issue concerning version 2, so I made this PR basing 2.9 branch. Am I doing this correctly?

ref: https://github.com/chartjs/Chart.js/issues/7946
