### PR TITLE
fix return type for setActiveElements

### DIFF
--- a/types/core/index.d.ts
+++ b/types/core/index.d.ts
@@ -299,7 +299,7 @@ export declare class Chart<
 	show(datasetIndex: number): void;
 
 	getActiveElements(): ActiveElement[];
-	setActiveElements(active: ActiveDataPoint[]);
+	setActiveElements(active: ActiveDataPoint[]): void;
 
 	destroy(): void;
 	toBase64Image(type?: string, quality?: any): string;

--- a/types/plugins/index.d.ts
+++ b/types/plugins/index.d.ts
@@ -295,7 +295,7 @@ export const Tooltip: IPlugin & {
   };
 
   getActiveElements(): ActiveElement[];
-  setActiveElements(active: ActiveDataPoint[], eventPosition: { x: number, y: number });
+  setActiveElements(active: ActiveDataPoint[], eventPosition: { x: number, y: number }): void;
 };
 
 export interface ITooltipCallbacks {


### PR DESCRIPTION
When using the latest beta with typescript in strict mode I get the error:

> Error: node_modules/chart.js/dist/chunks/index.d.ts:572:3 - error TS7010: 'setActiveElements', which lacks return-type annotation, implicitly has an 'any' return type.

> node_modules/chart.js/dist/chunks/index.d.ts:2026:3 - error TS7010: 'setActiveElements', which lacks return-type annotation, implicitly has an 'any' return type.

This change adds the return type