### PR TITLE
Rename lineTension back to tension

### DIFF
--- a/docs/docs/charts/line.mdx
+++ b/docs/docs/charts/line.mdx
@@ -25,7 +25,7 @@ export const ExampleChart = () => {
           data: [65, 59, 80, 81, 56, 55, 40],
           fill: false,
           borderColor: 'rgb(75, 192, 192)',
-          lineTension: 0.1
+          tension: 0.1
         }]
       },
       options: {
@@ -72,7 +72,7 @@ The line chart allows a number of properties to be specified for each dataset. T
 | [`hoverBorderJoinStyle`](#line-styling) | `string` | Yes | - | `undefined`
 | [`hoverBorderWidth`](#line-styling) | `number` | Yes | - | `undefined`
 | [`label`](#general) | `string` | - | - | `''`
-| [`lineTension`](#line-styling) | `number` | - | - | `0`
+| [`tension`](#line-styling) | `number` | - | - | `0`
 | [`order`](#general) | `number` | - | - | `0`
 | [`pointBackgroundColor`](#point-styling) | `Color` | Yes | Yes | `'rgba(0, 0, 0, 0.1)'`
 | [`pointBorderColor`](#point-styling) | `Color` | Yes | Yes | `'rgba(0, 0, 0, 0.1)'`
@@ -131,7 +131,7 @@ The style of the line can be controlled with the following properties:
 | `borderJoinStyle` | Line joint style. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineJoin).
 | `borderWidth` | The line width (in pixels).
 | `fill` | How to fill the area under the line. See [area charts](area.md).
-| `lineTension` | Bezier curve tension of the line. Set to 0 to draw straightlines. This option is ignored if monotone cubic interpolation is used.
+| `tension` | Bezier curve tension of the line. Set to 0 to draw straightlines. This option is ignored if monotone cubic interpolation is used.
 | `showLine` | If false, the line is not drawn for this dataset.
 | `spanGaps` | If true, lines will be drawn between points with no or null data. If false, points with `NaN` data will create a break in the line. Can also be a number specifying the maximum gap length to span. The unit of the value depends on the scale used.
 
@@ -171,7 +171,7 @@ The following values are supported for `stepped`.
 * `'after'`: Step-after Interpolation
 * `'middle'`: Step-middle Interpolation
 
-If the `stepped` value is set to anything other than false, `lineTension` will be ignored.
+If the `stepped` value is set to anything other than false, `tension` will be ignored.
 
 ## Configuration Options
 

--- a/docs/docs/charts/radar.mdx
+++ b/docs/docs/charts/radar.mdx
@@ -96,7 +96,7 @@ The radar chart allows a number of properties to be specified for each dataset. 
 | [`fill`](#line-styling) | <code>boolean&#124;string</code> | Yes | - | `true`
 | [`label`](#general) | `string` | - | - | `''`
 | [`order`](#general) | `number` | - | - | `0`
-| [`lineTension`](#line-styling) | `number` | - | - | `0`
+| [`tension`](#line-styling) | `number` | - | - | `0`
 | [`pointBackgroundColor`](#point-styling) | `Color` | Yes | Yes | `'rgba(0, 0, 0, 0.1)'`
 | [`pointBorderColor`](#point-styling) | `Color` | Yes | Yes | `'rgba(0, 0, 0, 0.1)'`
 | [`pointBorderWidth`](#point-styling) | `number` | Yes | Yes | `1`
@@ -148,7 +148,7 @@ The style of the line can be controlled with the following properties:
 | `borderJoinStyle` | Line joint style. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineJoin).
 | `borderWidth` | The line width (in pixels).
 | `fill` | How to fill the area under the line. See [area charts](area.md).
-| `lineTension` | Bezier curve tension of the line. Set to 0 to draw straight lines.
+| `tension` | Bezier curve tension of the line. Set to 0 to draw straight lines.
 | `spanGaps` | If true, lines will be drawn between points with no or null data. If false, points with `NaN` data will create a break in the line.
 
 If the value is `undefined`, `spanGaps` fallback to the associated [chart configuration options](#configuration-options). The rest of the values fallback to the associated [`elements.line.*`](../configuration/elements.md#line-configuration) options.

--- a/docs/docs/getting-started/v3-migration.md
+++ b/docs/docs/getting-started/v3-migration.md
@@ -90,7 +90,6 @@ A number of changes were made to the configuration options passed to the `Chart`
 * `scales.[x/y]Axes.time.min` was renamed to `scales[id].min`
 * `scales.[x/y]Axes.zeroLine*` options of axes were removed. Use scriptable scale options instead.
 * The dataset option `steppedLine` was removed. Use `stepped`
-* The dataset option `tension` was removed. Use `lineTension`
 * The chart option `showLines` was renamed to `showLine` to match the dataset option.
 * Dataset options are now configured as `options[type].datasets` rather than `options.datasets[type]`
 * To override the platform class used in a chart instance, pass `platform: PlatformClass` in the config object. Note that the class should be passed, not an instance of the class.

--- a/samples/charts/line/interpolation-modes.html
+++ b/samples/charts/line/interpolation-modes.html
@@ -51,7 +51,7 @@
 					borderColor: window.chartColors.green,
 					backgroundColor: 'rgba(0, 0, 0, 0)',
 					fill: false,
-					lineTension: 0
+					tension: 0
 				}]
 			},
 			options: {

--- a/samples/scales/financial.html
+++ b/samples/scales/financial.html
@@ -117,7 +117,7 @@
 					type: 'line',
 					pointRadius: 0,
 					fill: false,
-					lineTension: 0,
+					tension: 0,
 					borderWidth: 2
 				}]
 			},

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -93,7 +93,7 @@ export default class LineController extends DatasetController {
 		// to https://github.com/chartjs/Chart.js/issues/2435#issuecomment-216718158
 		// This option gives lines the ability to span gaps
 		values.spanGaps = valueOrDefault(config.spanGaps, options.spanGaps);
-		values.tension = valueOrDefault(config.lineTension, lineOptions.tension);
+		values.tension = valueOrDefault(config.tension, lineOptions.tension);
 		values.stepped = resolve([config.stepped, lineOptions.stepped]);
 
 		if (!showLine) {

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -79,7 +79,7 @@ export default class RadarController extends DatasetController {
 		const showLine = valueOrDefault(config.showLine, options.showLine);
 
 		values.spanGaps = valueOrDefault(config.spanGaps, options.spanGaps);
-		values.tension = valueOrDefault(config.lineTension, options.elements.line.tension);
+		values.tension = valueOrDefault(config.tension, options.elements.line.tension);
 
 		if (!showLine) {
 			values.borderWidth = 0;

--- a/test/fixtures/element.line/skip/all.js
+++ b/test/fixtures/element.line/skip/all.js
@@ -7,7 +7,7 @@ module.exports = {
 					data: [{x: 0, y: NaN}, {x: NaN, y: 0}, {x: NaN, y: -10}, {x: 19, y: NaN}],
 					borderColor: 'red',
 					fill: true,
-					lineTension: 0
+					tension: 0
 				}
 			]
 		},

--- a/test/fixtures/element.line/skip/first-span.js
+++ b/test/fixtures/element.line/skip/first-span.js
@@ -8,7 +8,7 @@ module.exports = {
 					borderColor: 'red',
 					fill: true,
 					spanGaps: true,
-					lineTension: 0
+					tension: 0
 				}
 			]
 		},

--- a/test/fixtures/element.line/skip/first.js
+++ b/test/fixtures/element.line/skip/first.js
@@ -7,7 +7,7 @@ module.exports = {
 					data: [{x: NaN, y: 10}, {x: 5, y: 0}, {x: 15, y: -10}, {x: 19, y: -5}],
 					borderColor: 'red',
 					fill: true,
-					lineTension: 0
+					tension: 0
 				}
 			]
 		},

--- a/test/fixtures/element.line/skip/last-span.js
+++ b/test/fixtures/element.line/skip/last-span.js
@@ -8,7 +8,7 @@ module.exports = {
 					borderColor: 'red',
 					fill: true,
 					spanGaps: true,
-					lineTension: 0
+					tension: 0
 				}
 			]
 		},

--- a/test/fixtures/element.line/skip/last.js
+++ b/test/fixtures/element.line/skip/last.js
@@ -7,7 +7,7 @@ module.exports = {
 					data: [{x: 0, y: 10}, {x: 5, y: 0}, {x: 15, y: -10}, {x: NaN, y: -5}],
 					borderColor: 'red',
 					fill: true,
-					lineTension: 0
+					tension: 0
 				}
 			]
 		},

--- a/test/fixtures/element.line/skip/middle-span.js
+++ b/test/fixtures/element.line/skip/middle-span.js
@@ -8,7 +8,7 @@ module.exports = {
 					borderColor: 'red',
 					fill: true,
 					spanGaps: true,
-					lineTension: 0
+					tension: 0
 				}
 			]
 		},

--- a/test/fixtures/element.line/skip/middle.js
+++ b/test/fixtures/element.line/skip/middle.js
@@ -7,7 +7,7 @@ module.exports = {
 					data: [{x: 0, y: 10}, {x: 5, y: 0}, {x: NaN, y: -10}, {x: 19, y: -5}],
 					borderColor: 'red',
 					fill: true,
-					lineTension: 0
+					tension: 0
 				}
 			]
 		},

--- a/test/fixtures/element.line/stepped/after.js
+++ b/test/fixtures/element.line/stepped/after.js
@@ -7,7 +7,7 @@ module.exports = {
 					data: [{x: 1, y: 10}, {x: 5, y: 0}, {x: 15, y: -10}, {x: 19, y: -5}],
 					borderColor: 'red',
 					fill: false,
-					lineTension: 0,
+					tension: 0,
 					stepped: 'after'
 				}
 			]

--- a/test/fixtures/element.line/stepped/before.js
+++ b/test/fixtures/element.line/stepped/before.js
@@ -7,7 +7,7 @@ module.exports = {
 					data: [{x: 1, y: 10}, {x: 5, y: 0}, {x: 15, y: -10}, {x: 19, y: -5}],
 					borderColor: 'red',
 					fill: false,
-					lineTension: 0,
+					tension: 0,
 					stepped: 'before'
 				}
 			]

--- a/test/fixtures/element.line/stepped/default.js
+++ b/test/fixtures/element.line/stepped/default.js
@@ -7,7 +7,7 @@ module.exports = {
 					data: [{x: 1, y: 10}, {x: 5, y: 0}, {x: 15, y: -10}, {x: 19, y: -5}],
 					borderColor: 'red',
 					fill: false,
-					lineTension: 0,
+					tension: 0,
 					stepped: true
 				}
 			]

--- a/test/fixtures/element.line/stepped/middle.js
+++ b/test/fixtures/element.line/stepped/middle.js
@@ -7,7 +7,7 @@ module.exports = {
 					data: [{x: 1, y: 10}, {x: 5, y: 0}, {x: 15, y: -10}, {x: 19, y: -5}],
 					borderColor: 'red',
 					fill: false,
-					lineTension: 0,
+					tension: 0,
 					stepped: 'middle'
 				}
 			]

--- a/test/fixtures/element.line/tension/one.js
+++ b/test/fixtures/element.line/tension/one.js
@@ -7,7 +7,7 @@ module.exports = {
 					data: [{x: 1, y: 10}, {x: 5, y: 0}, {x: 15, y: -10}, {x: 19, y: -5}],
 					borderColor: 'red',
 					fill: false,
-					lineTension: 1
+					tension: 1
 				}
 			]
 		},

--- a/test/fixtures/element.line/tension/zero.js
+++ b/test/fixtures/element.line/tension/zero.js
@@ -7,7 +7,7 @@ module.exports = {
 					data: [{x: 1, y: 10}, {x: 5, y: 0}, {x: 15, y: -10}, {x: 19, y: -5}],
 					borderColor: 'red',
 					fill: false,
-					lineTension: 0
+					tension: 0
 				}
 			]
 		},

--- a/test/fixtures/plugin.filler/fill-line-dataset-interpolated.js
+++ b/test/fixtures/plugin.filler/fill-line-dataset-interpolated.js
@@ -43,7 +43,7 @@ module.exports = {
 			title: false,
 			line: {
 				datasets: {
-					lineTension: 0.4,
+					tension: 0.4,
 					borderWidth: 1,
 					pointRadius: 1.5,
 				}

--- a/test/fixtures/scale.timeseries/financial-daily.js
+++ b/test/fixtures/scale.timeseries/financial-daily.js
@@ -9,7 +9,7 @@ module.exports = {
 				type: 'line',
 				pointRadius: 0,
 				fill: false,
-				lineTension: 0,
+				tension: 0,
 				borderWidth: 2
 			}]
 		},

--- a/test/specs/controller.line.tests.js
+++ b/test/specs/controller.line.tests.js
@@ -512,7 +512,7 @@ describe('Chart.controllers.line', function() {
 
 			Chart.helpers.merge(Chart.defaults.line.datasets, {
 				spanGaps: true,
-				lineTension: 0.231,
+				tension: 0.231,
 				backgroundColor: '#add',
 				borderWidth: '#daa',
 				borderColor: '#dad',
@@ -555,7 +555,7 @@ describe('Chart.controllers.line', function() {
 
 			Chart.helpers.merge(Chart.defaults.line.datasets, {
 				spanGaps: true,
-				lineTension: 0.231
+				tension: 0.231
 			});
 
 			var chart = window.acquireChart({
@@ -572,7 +572,7 @@ describe('Chart.controllers.line', function() {
 				options: {
 					line: {
 						datasets: {
-							lineTension: 0.345,
+							tension: 0.345,
 							backgroundColor: '#add'
 						}
 					}
@@ -604,7 +604,7 @@ describe('Chart.controllers.line', function() {
 				line: {
 					datasets: {
 						spanGaps: true,
-						lineTension: 0.231,
+						tension: 0.231,
 						backgroundColor: '#add',
 						borderWidth: '#daa',
 						borderColor: '#dad',
@@ -642,7 +642,7 @@ describe('Chart.controllers.line', function() {
 					data: [0, 0],
 					label: 'dataset1',
 					spanGaps: true,
-					lineTension: 0.231,
+					tension: 0.231,
 					backgroundColor: '#add',
 					borderWidth: '#daa',
 					borderColor: '#dad',

--- a/test/specs/controller.radar.tests.js
+++ b/test/specs/controller.radar.tests.js
@@ -174,7 +174,7 @@ describe('Chart.controllers.radar', function() {
 		});
 
 		// Use dataset level styles for lines & points
-		chart.data.datasets[0].lineTension = 0;
+		chart.data.datasets[0].tension = 0;
 		chart.data.datasets[0].backgroundColor = 'rgb(98, 98, 98)';
 		chart.data.datasets[0].borderColor = 'rgb(8, 8, 8)';
 		chart.data.datasets[0].borderWidth = 0.55;


### PR DESCRIPTION
Revert the rename to `lineTension`. 

Motivation: try to align the options to generic scheme.

The generic scheme being for example:
`borderColor` => applies to all elements
`pointBorderColor` => applies to point elements (and legend if `usePointStyle` is set)
`barBorderColor` => applies to bar elements

and so on.

So with a generic fallback logic, we would not be looking at `lineLineTension`.