### PR TITLE
Tooltip: clear cached animations on initialize

### DIFF
--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -393,6 +393,7 @@ export class Tooltip extends Element {
 		const me = this;
 		const chartOpts = me._chart.options;
 		me.options = resolveOptions(chartOpts.tooltips, chartOpts.font);
+		me._cachedAnimations = undefined;
 	}
 
 	/**


### PR DESCRIPTION
Tooltip was not refreshing its animation properties after initial resolve.