### PR TITLE
Check index bounds of datasets for isDatasetVisible

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -859,11 +859,16 @@ class Chart {
 	}
 
 	isDatasetVisible(datasetIndex) {
+		const dataset = this.data.datasets[datasetIndex];
+		if (!dataset) {
+			return false;
+		}
+
 		const meta = this.getDatasetMeta(datasetIndex);
 
 		// meta.hidden is a per chart dataset hidden flag override with 3 states: if true or false,
 		// the dataset.hidden value is ignored, else if null, the dataset hidden state is returned.
-		return typeof meta.hidden === 'boolean' ? !meta.hidden : !this.data.datasets[datasetIndex].hidden;
+		return typeof meta.hidden === 'boolean' ? !meta.hidden : !dataset.hidden;
 	}
 
 	setDatasetVisibility(datasetIndex, visible) {

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -1468,6 +1468,22 @@ describe('Chart', function() {
 		});
 	});
 
+	describe('isDatasetVisible', function() {
+		it('should return false if index is out of bounds', function() {
+			var chart = acquireChart({
+				type: 'line',
+				data: {
+					datasets: [{
+						data: [0, 1, 2]
+					}],
+					labels: ['a', 'b', 'c']
+				}
+			});
+
+			expect(chart.isDatasetVisible(1)).toBe(false);
+		});
+	});
+
 	describe('getChart', function() {
 		it('should get the chart from the canvas ID', function() {
 			var chart = acquireChart({


### PR DESCRIPTION
Added a check of index bounds within `isDatasetVisible` function.

Fixes https://github.com/chartjs/Chart.js/issues/7985