### PR TITLE
Fix typo in test options

### DIFF
--- a/test/specs/controller.bar.tests.js
+++ b/test/specs/controller.bar.tests.js
@@ -1219,7 +1219,7 @@ describe('Chart.controllers.bar', function() {
 			},
 			options: {
 				elements: {
-					bars: {
+					bar: {
 						backgroundColor: 'rgb(255, 0, 0)',
 						borderColor: 'rgb(0, 0, 255)',
 						borderWidth: 2,


### PR DESCRIPTION
Does not actually affect the test, because the options are changed before compared to anything.
