### PR TITLE
[types][beta-5] fixed stacked scale, changed default type for data.labels

### DIFF
--- a/docs/docs/general/data-structures.md
+++ b/docs/docs/general/data-structures.md
@@ -46,7 +46,28 @@ options: {
 }
 ```
 
-### `parsing` can also be specified per dataset
+## Object
+
+```javascript
+data: {
+    January: 10,
+    February: 20
+}
+```
+
+In this mode, property name is used for `index` scale and value for `value` scale. For vertical charts, index scale is `x` and value scale is `y`.
+
+## Dataset Configuration
+
+| Name | Type | Description
+| ---- | ---- | -----------
+| `label` | `string` | The label for the dataset which appears in the legend and tooltips.
+| `clip` | <code>number&#124;object</code> | How to clip relative to chartArea. Positive value allows overflow, negative value clips that many pixels inside chartArea. 0 = clip at chartArea. Clipping can also be configured per side: clip: {left: 5, top: false, right: -2, bottom: 0}
+| `order` | `number` | The drawing order of dataset. Also affects order for stacking, tooltip and legend.
+| `stack` | `string` | The ID of the group to which this dataset belongs to (when stacked, each group will be a separate stack).
+| `parsing` | <code>boolean&#124;object</code> | How to parse the dataset. The parsing can be disabled by specifying parsing: false at chart options or dataset. If parsing is disabled, data must be sorted and in the formats the associated chart type and scales use internally.
+
+### parsing
 
 ```javascript
 const data = [{x: 'Jan', net: 100, cogs: 50, gm: 50}, {x: 'Feb', net: 120, cogs: 55, gm: 75}];
@@ -76,14 +97,3 @@ const cfg = {
     },
 };
 ```
-
-## Object
-
-```javascript
-data: {
-    January: 10,
-    February: 20
-}
-```
-
-In this mode, property name is used for `index` scale and value for `value` scale. For vertical charts, index scale is `x` and value scale is `y`.

--- a/types/controllers/index.d.ts
+++ b/types/controllers/index.d.ts
@@ -26,6 +26,11 @@ export interface IControllerDatasetOptions {
    * The drawing order of dataset. Also affects order for stacking, tooltip and legend.
    */
   order: number;
+
+  /**
+   * The ID of the group to which this dataset belongs to (when stacked, each group will be a separate stack).
+   */
+  stack: string;
 }
 
 export interface IBarControllerDatasetOptions
@@ -71,11 +76,6 @@ export interface IBarControllerDatasetOptions
    * Set this to ensure that bars have a minimum length in pixels.
    */
   minBarLength: number;
-
-  /**
-   * The ID of the group to which this dataset belongs to (when stacked, each group will be a separate stack).
-   */
-  stack: string;
 }
 
 export interface IBarControllerChartOptions {

--- a/types/interfaces.d.ts
+++ b/types/interfaces.d.ts
@@ -176,7 +176,7 @@ export type IChartDataset<
 export interface IChartData<
   TYPE extends IChartType = IChartType,
   DATA extends unknown[] = DefaultDataPoint<TYPE>,
-  LABEL = string
+  LABEL = unknown
 > {
   labels: LABEL[];
   datasets: IChartDataset<TYPE, DATA>[];

--- a/types/scales/index.d.ts
+++ b/types/scales/index.d.ts
@@ -122,6 +122,12 @@ export interface ICartesianScaleOptions extends ICoreScaleOptions {
     };
   };
 
+	/**
+	 * 	If true, data will be comprised between datasets of data
+	 * @default false
+	 */
+  stacked?: boolean;
+
   ticks: ITickOptions & {
     /**
      * The number of ticks to examine when deciding how many labels will fit. Setting a smaller value will be faster, but may be less accurate when there is large variability in label length.
@@ -193,7 +199,6 @@ export const CategoryScale: IChartComponent & {
 };
 
 export type ILinearScaleOptions = ICartesianScaleOptions & {
-  stacked?: boolean;
 
   /**
    *	if true, scale will include 0 if it is not already included.
@@ -243,7 +248,6 @@ export const LinearScale: IChartComponent & {
 };
 
 export type ILogarithmicScaleOptions = ICartesianScaleOptions & {
-  stacked?: boolean;
 
   /**
    * Adjustment used when calculating the maximum data value.


### PR DESCRIPTION
fix https://github.com/chartjs/Chart.js/issues/7821

Also changed the type for data.labels, the value can be `string`, `Date`, etc. Since not all types are known, set unknown by default.