### PR TITLE
Make all options scriptable

### DIFF
--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -266,9 +266,8 @@ export default class BarController extends DatasetController {
 		me.updateSharedOptions(sharedOptions, mode, firstOpts);
 
 		for (let i = start; i < start + count; i++) {
-			const options = sharedOptions || me.resolveDataElementOptions(i, mode);
-			const vpixels = me._calculateBarValuePixels(i, options);
-			const ipixels = me._calculateBarIndexPixels(i, ruler, options);
+			const vpixels = me._calculateBarValuePixels(i);
+			const ipixels = me._calculateBarIndexPixels(i, ruler);
 
 			const properties = {
 				horizontal,
@@ -280,7 +279,7 @@ export default class BarController extends DatasetController {
 			};
 
 			if (includeOptions) {
-				properties.options = options;
+				properties.options = sharedOptions || me.resolveDataElementOptions(i, mode);
 			}
 			me.updateElement(bars[i], i, properties, mode);
 		}
@@ -400,11 +399,11 @@ export default class BarController extends DatasetController {
 	 * Note: pixel values are not clamped to the scale area.
 	 * @private
 	 */
-	_calculateBarValuePixels(index, options) {
+	_calculateBarValuePixels(index) {
 		const me = this;
 		const meta = me._cachedMeta;
 		const vScale = meta.vScale;
-		const {base: baseValue, minBarLength} = options;
+		const {base: baseValue, minBarLength} = me.options;
 		const parsed = me.getParsed(index);
 		const custom = parsed._custom;
 		const floating = isFloatBar(custom);
@@ -459,8 +458,9 @@ export default class BarController extends DatasetController {
 	/**
 	 * @private
 	 */
-	_calculateBarIndexPixels(index, ruler, options) {
+	_calculateBarIndexPixels(index, ruler) {
 		const me = this;
+		const options = me.options;
 		const stackCount = me.chart.options.skipNull ? me._getStackCount(index) : ruler.stackCount;
 		const range = options.barThickness === 'flex'
 			? computeFlexCategoryTraits(index, ruler, options, stackCount)
@@ -510,19 +510,7 @@ BarController.id = 'bar';
 BarController.defaults = {
 	datasetElementType: false,
 	dataElementType: 'bar',
-	dataElementOptions: [
-		'backgroundColor',
-		'borderColor',
-		'borderSkipped',
-		'borderWidth',
-		'borderRadius',
-		'barPercentage',
-		'barThickness',
-		'base',
-		'categoryPercentage',
-		'maxBarThickness',
-		'minBarLength',
-	],
+
 	interaction: {
 		mode: 'index'
 	},
@@ -532,6 +520,10 @@ BarController.defaults = {
 	datasets: {
 		categoryPercentage: 0.8,
 		barPercentage: 0.9,
+		barThickness: undefined,
+		base: undefined,
+		maxBarThickness: undefined,
+		minBarLength: undefined,
 		animation: {
 			numbers: {
 				type: 'number',

--- a/src/controllers/controller.doughnut.js
+++ b/src/controllers/controller.doughnut.js
@@ -80,14 +80,14 @@ export default class DoughnutController extends DatasetController {
 	 * @private
 	 */
 	_getRotation() {
-		return toRadians(valueOrDefault(this._config.rotation, this.chart.options.rotation) - 90);
+		return toRadians(this.options.rotation - 90);
 	}
 
 	/**
 	 * @private
 	 */
 	_getCircumference() {
-		return toRadians(valueOrDefault(this._config.circumference, this.chart.options.circumference));
+		return toRadians(this.options.circumference);
 	}
 
 	/**
@@ -156,7 +156,7 @@ export default class DoughnutController extends DatasetController {
 	 */
 	_circumference(i, reset) {
 		const me = this;
-		const opts = me.chart.options;
+		const opts = me.options;
 		const meta = me._cachedMeta;
 		const circumference = me._getCircumference();
 		return reset && opts.animation.animateRotate ? 0 : this.chart.getDataVisibility(i) ? me.calculateCircumference(meta._parsed[i] * circumference / TAU) : 0;

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -1,6 +1,7 @@
 import DatasetController from '../core/core.datasetController';
 import {isNumber, _limitValue} from '../helpers/helpers.math';
 import {_lookupByKey} from '../helpers/helpers.collection';
+import {_hideLine} from '../helpers/helpers.extras';
 
 export default class LineController extends DatasetController {
 
@@ -84,7 +85,7 @@ export default class LineController extends DatasetController {
 		const values = super.resolveDatasetElementOptions(mode, prefix);
 
 		if (!this.options.showLine) {
-			values.borderWidth = 0;
+			_hideLine(values);
 		}
 
 		return values;

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -1,7 +1,5 @@
 import DatasetController from '../core/core.datasetController';
-import {valueOrDefault} from '../helpers/helpers.core';
 import {isNumber, _limitValue} from '../helpers/helpers.math';
-import {resolve} from '../helpers/helpers.options';
 import {_lookupByKey} from '../helpers/helpers.collection';
 
 export default class LineController extends DatasetController {
@@ -32,7 +30,7 @@ export default class LineController extends DatasetController {
 		if (mode !== 'resize') {
 			const properties = {
 				points,
-				options: me.resolveDatasetElementOptions()
+				options: me.resolveDatasetElementOptions(mode)
 			};
 
 			me.updateElement(line, undefined, properties, mode);
@@ -49,7 +47,7 @@ export default class LineController extends DatasetController {
 		const firstOpts = me.resolveDataElementOptions(start, mode);
 		const sharedOptions = me.getSharedOptions(firstOpts);
 		const includeOptions = me.includeOptions(mode, sharedOptions);
-		const spanGaps = valueOrDefault(me._config.spanGaps, me.chart.options.spanGaps);
+		const spanGaps = me.options.spanGaps;
 		const maxGapLength = isNumber(spanGaps) ? spanGaps : Number.POSITIVE_INFINITY;
 		let prevParsed = start > 0 && me.getParsed(start - 1);
 
@@ -78,31 +76,19 @@ export default class LineController extends DatasetController {
 	}
 
 	/**
-	 * @param {boolean} [active]
+	 * @param {string} [mode]
+	 * @param {string} [prefix]
 	 * @protected
 	 */
-	resolveDatasetElementOptions(active) {
-		const me = this;
-		const config = me._config;
-		const options = me.chart.options;
-		const lineOptions = options.elements.line;
-		const values = super.resolveDatasetElementOptions(active);
-		const showLine = valueOrDefault(config.showLine, options.showLine);
+	resolveDatasetElementOptions(mode, prefix) {
+		const values = super.resolveDatasetElementOptions(mode, prefix);
 
-		// The default behavior of lines is to break at null values, according
-		// to https://github.com/chartjs/Chart.js/issues/2435#issuecomment-216718158
-		// This option gives lines the ability to span gaps
-		values.spanGaps = valueOrDefault(config.spanGaps, options.spanGaps);
-		values.tension = valueOrDefault(config.tension, lineOptions.tension);
-		values.stepped = resolve([config.stepped, lineOptions.stepped]);
-
-		if (!showLine) {
+		if (!this.options.showLine) {
 			values.borderWidth = 0;
 		}
 
 		return values;
 	}
-
 	/**
 	 * @protected
 	 */
@@ -132,37 +118,11 @@ LineController.id = 'line';
  */
 LineController.defaults = {
 	datasetElementType: 'line',
-	datasetElementOptions: [
-		'backgroundColor',
-		'borderCapStyle',
-		'borderColor',
-		'borderDash',
-		'borderDashOffset',
-		'borderJoinStyle',
-		'borderWidth',
-		'capBezierPoints',
-		'cubicInterpolationMode',
-		'fill'
-	],
-
 	dataElementType: 'point',
-	dataElementOptions: {
-		backgroundColor: 'pointBackgroundColor',
-		borderColor: 'pointBorderColor',
-		borderWidth: 'pointBorderWidth',
-		hitRadius: 'pointHitRadius',
-		hoverHitRadius: 'pointHitRadius',
-		hoverBackgroundColor: 'pointHoverBackgroundColor',
-		hoverBorderColor: 'pointHoverBorderColor',
-		hoverBorderWidth: 'pointHoverBorderWidth',
-		hoverRadius: 'pointHoverRadius',
-		pointStyle: 'pointStyle',
-		radius: 'pointRadius',
-		rotation: 'pointRotation'
-	},
 
-	showLine: true,
-	spanGaps: false,
+	datasets: {
+		showLine: true,
+	},
 
 	interaction: {
 		mode: 'index'

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -1,7 +1,6 @@
 import DatasetController from '../core/core.datasetController';
 import {isNumber, _limitValue} from '../helpers/helpers.math';
 import {_lookupByKey} from '../helpers/helpers.collection';
-import {_hideLine} from '../helpers/helpers.extras';
 
 export default class LineController extends DatasetController {
 
@@ -83,12 +82,7 @@ export default class LineController extends DatasetController {
 	 */
 	resolveDatasetElementOptions(mode, prefix) {
 		const values = super.resolveDatasetElementOptions(mode, prefix);
-
-		if (!this.options.showLine) {
-			_hideLine(values);
-		}
-
-		return values;
+		return _applyLineControllerOptions(values, this.options);
 	}
 	/**
 	 * @protected
@@ -189,4 +183,15 @@ function scaleRangesChanged(meta) {
 
 	Object.assign(_scaleRanges, newRanges);
 	return changed;
+}
+
+
+/**
+ * @private
+ */
+export function _applyLineControllerOptions(lineOptions, controllerOptions) {
+	if (!controllerOptions.showLine) {
+		lineOptions.borderWidth = 0;
+	}
+	return lineOptions;
 }

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -1,5 +1,5 @@
 import DatasetController from '../core/core.datasetController';
-import {_hideLine} from '../helpers/helpers.extras';
+import {_applyLineControllerOptions} from './controller.line';
 
 export default class RadarController extends DatasetController {
 
@@ -74,12 +74,7 @@ export default class RadarController extends DatasetController {
 	 */
 	resolveDatasetElementOptions(mode, prefix) {
 		const values = super.resolveDatasetElementOptions(mode, prefix);
-
-		if (!this.options.showLine) {
-			_hideLine(values);
-		}
-
-		return values;
+		return _applyLineControllerOptions(values, this.options);
 	}
 }
 

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -1,4 +1,5 @@
 import DatasetController from '../core/core.datasetController';
+import {_hideLine} from '../helpers/helpers.extras';
 
 export default class RadarController extends DatasetController {
 
@@ -75,7 +76,7 @@ export default class RadarController extends DatasetController {
 		const values = super.resolveDatasetElementOptions(mode, prefix);
 
 		if (!this.options.showLine) {
-			values.borderWidth = 0;
+			_hideLine(values);
 		}
 
 		return values;

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -1,5 +1,4 @@
 import DatasetController from '../core/core.datasetController';
-import {valueOrDefault} from '../helpers/helpers.core';
 
 export default class RadarController extends DatasetController {
 
@@ -31,7 +30,7 @@ export default class RadarController extends DatasetController {
 				points,
 				_loop: true,
 				_fullLoop: labels.length === points.length,
-				options: me.resolveDatasetElementOptions()
+				options: me.resolveDatasetElementOptions(mode)
 			};
 
 			me.updateElement(line, undefined, properties, mode);
@@ -68,20 +67,14 @@ export default class RadarController extends DatasetController {
 	}
 
 	/**
-	 * @param {boolean} [active]
+	 * @param {string} [mode]
+	 * @param {string} [prefix]
 	 * @protected
 	 */
-	resolveDatasetElementOptions(active) {
-		const me = this;
-		const config = me._config;
-		const options = me.chart.options;
-		const values = super.resolveDatasetElementOptions(active);
-		const showLine = valueOrDefault(config.showLine, options.showLine);
+	resolveDatasetElementOptions(mode, prefix) {
+		const values = super.resolveDatasetElementOptions(mode, prefix);
 
-		values.spanGaps = valueOrDefault(config.spanGaps, options.spanGaps);
-		values.tension = valueOrDefault(config.tension, options.elements.line.tension);
-
-		if (!showLine) {
+		if (!this.options.showLine) {
 			values.borderWidth = 0;
 		}
 
@@ -96,46 +89,23 @@ RadarController.id = 'radar';
  */
 RadarController.defaults = {
 	datasetElementType: 'line',
-	datasetElementOptions: [
-		'backgroundColor',
-		'borderColor',
-		'borderCapStyle',
-		'borderDash',
-		'borderDashOffset',
-		'borderJoinStyle',
-		'borderWidth',
-		'fill'
-	],
-
 	dataElementType: 'point',
-	dataElementOptions: {
-		backgroundColor: 'pointBackgroundColor',
-		borderColor: 'pointBorderColor',
-		borderWidth: 'pointBorderWidth',
-		hitRadius: 'pointHitRadius',
-		hoverBackgroundColor: 'pointHoverBackgroundColor',
-		hoverBorderColor: 'pointHoverBorderColor',
-		hoverBorderWidth: 'pointHoverBorderWidth',
-		hoverRadius: 'pointHoverRadius',
-		pointStyle: 'pointStyle',
-		radius: 'pointRadius',
-		rotation: 'pointRotation'
-	},
 
 	aspectRatio: 1,
-	spanGaps: false,
+	datasets: {
+		showLine: true,
+		indexAxis: 'r'
+	},
+
 	scales: {
 		r: {
 			type: 'radialLinear',
 		}
 	},
-	datasets: {
-		indexAxis: 'r'
-	},
+
 	elements: {
 		line: {
-			fill: 'start',
-			tension: 0 // no bezier in radar
+			fill: 'start'
 		}
 	}
 };

--- a/src/core/core.config.js
+++ b/src/core/core.config.js
@@ -108,10 +108,7 @@ function includeDefaults(config, options) {
 	const scaleConfig = mergeScaleConfig(config, options);
 	const elements = options.elements;
 
-	options = mergeConfig(
-		defaults,
-		defaults.controllers[config.type],
-		options);
+	options = mergeConfig(defaults, defaults.controllers[config.type], options);
 
 	options.elements = elements;
 
@@ -128,12 +125,14 @@ function includeDefaults(config, options) {
 		defaults.plugins.title,
 		options.title
 	]);
+
 	options.tooltips = (options.tooltips !== false) && merge(Object.create(null), [
 		defaults.interaction,
 		defaults.plugins.tooltip,
 		options.interaction,
 		options.tooltips
 	]);
+
 	return options;
 }
 

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -407,9 +407,7 @@ class Chart {
 				const ControllerClass = registry.getController(type);
 				Object.assign(ControllerClass.prototype, {
 					dataElementType: registry.getElement(controllerDefaults.dataElementType),
-					datasetElementType: controllerDefaults.datasetElementType && registry.getElement(controllerDefaults.datasetElementType),
-					dataElementOptions: controllerDefaults.dataElementOptions,
-					datasetElementOptions: controllerDefaults.datasetElementOptions
+					datasetElementType: controllerDefaults.datasetElementType && registry.getElement(controllerDefaults.datasetElementType)
 				});
 				meta.controller = new ControllerClass(me, i);
 				newControllers.push(meta.controller);

--- a/src/core/core.defaults.js
+++ b/src/core/core.defaults.js
@@ -1,4 +1,5 @@
 import {merge, valueOrDefault} from '../helpers/helpers.core';
+import {privatePrefixChars} from './core.options';
 
 /**
  * @param {object} node
@@ -53,7 +54,6 @@ export class Defaults {
 		this.onHover = null;
 		this.onClick = null;
 		this.responsive = true;
-		this.showLine = true;
 		this.plugins = {};
 		this.scale = undefined;
 		this.scales = {};
@@ -114,4 +114,20 @@ export class Defaults {
 }
 
 // singleton instance
-export default new Defaults();
+const defaults = new Defaults();
+export default defaults;
+
+const filteredOpts = ['datasets', 'elements', 'scales'];
+export function datasetOptionKeys(type) {
+	const typeDefaults = defaults.controllers[type] || {};
+	const datasetDefaults = typeDefaults.datasets || {};
+	const elementDefaults = defaults.elements[typeDefaults.datasetElementType] ||
+		defaults.elements[typeDefaults.dataElementType] || {};
+	return Object.keys(typeDefaults)
+		.concat(Object.keys(datasetDefaults))
+		.concat(Object.keys(elementDefaults))
+		.concat(['animation', 'parsing', 'clip'])
+		.filter((value, index, arr) => arr.indexOf(value) === index)
+		.filter(value => filteredOpts.indexOf(value) === -1)
+		.filter(value => privatePrefixChars.indexOf(value.charAt(0)) === -1);
+}

--- a/src/core/core.options.js
+++ b/src/core/core.options.js
@@ -1,0 +1,79 @@
+import {isArray, _capitalize} from '../helpers/helpers.core';
+
+const notIndexable = ['borderDash', 'fill'];
+export const privatePrefixChars = ['_', '$'];
+const isScriptable = (value) => typeof value === 'function';
+const isIndexable = (key, value) => isArray(value) && notIndexable.indexOf(key) === -1;
+const isPrivate = (key) => privatePrefixChars.indexOf(key.charAt(0)) !== -1;
+
+export const prefixFromMode = (mode) => mode === 'active' ? 'hover' : '';
+
+export default class Options {
+	constructor(scopes, keys, prefixes) {
+		const options = this._options = Object.create(null);
+		this._contextSensitive = false;
+
+		for (let i = 0; i < keys.length; i++) {
+			const key = keys[i];
+			const value = options[key] = firstDefinedValue(scopes, key, prefixes);
+			if (isScriptable(value) || isIndexable(key, value)) {
+				this._contextSensitive = true;
+			}
+		}
+		options.$shared = !this._contextSensitive;
+	}
+
+	disableSharing() {
+		this._contextSensitive = true;
+	}
+
+	isContextSensitive() {
+		return this._contextSensitive;
+	}
+
+	resolve(context, active) {
+		const options = this._options;
+		if (!this._contextSensitive && !active) {
+			// No scriptable options used, values are already final
+			return options;
+		}
+		const result = Object.create(null);
+		const keys = Object.keys(options);
+		for (let i = 0; i < keys.length; i++) {
+			const key = keys[i];
+			if (isPrivate(key)) {
+				continue;
+			}
+			const value = options[key];
+			result[key] = isScriptable(value) ? value(context) :
+				isIndexable(key, value) ? value[context.index % value.length] : value;
+		}
+		result.$shared = false;
+		return result;
+	}
+}
+
+function firstDefinedValue(scopes, name, prefixes) {
+	const hover = prefixes.indexOf('hover') !== -1;
+	for (let prefixIndex = 0; prefixIndex < prefixes.length; prefixIndex++) {
+		const prefix = prefixes[prefixIndex];
+		if (hover && prefix === '' && name.indexOf('Color') !== -1) {
+			// prevent defaulting hovedBackgroundColor to backgroundColor,
+			// to allow adding automatic hover colors
+			continue;
+		}
+		const readKey = prefix ? prefix + _capitalize(name) : name;
+		for (let scopeIndex = 0; scopeIndex < scopes.length; scopeIndex++) {
+			const scope = scopes[scopeIndex];
+			if (!scope) {
+				continue;
+			}
+
+			const value = scope[readKey];
+			if (typeof value === 'undefined') {
+				continue;
+			}
+			return value;
+		}
+	}
+}

--- a/src/core/core.options.js
+++ b/src/core/core.options.js
@@ -62,11 +62,12 @@ function resolveValue(key, value, context) {
 	return value;
 }
 
+const containsHover = (prefixes) => prefixes.indexOf('hover') !== -1;
 const getReadKey = (prefix, name) => prefix ? prefix + _capitalize(name) : name;
 const noHoverFallback = (prefix, name) => prefix === '' && name.indexOf('Color') !== -1;
 
 function firstDefinedValue(scopes, name, prefixes) {
-	const hover = prefixes.indexOf('hover') !== -1;
+	const hover = containsHover(prefixes);
 	for (let prefixIndex = 0; prefixIndex < prefixes.length; prefixIndex++) {
 		const prefix = prefixes[prefixIndex];
 		if (hover && noHoverFallback(prefix, name)) {

--- a/src/core/core.options.js
+++ b/src/core/core.options.js
@@ -65,6 +65,7 @@ function resolveValue(key, value, context) {
 const containsHover = (prefixes) => prefixes.indexOf('hover') !== -1;
 const getReadKey = (prefix, name) => prefix ? prefix + _capitalize(name) : name;
 const noHoverFallback = (prefix, name) => prefix === '' && name.indexOf('Color') !== -1;
+const isDefined = value => typeof value !== 'undefined';
 
 function firstDefinedValue(scopes, name, prefixes) {
 	const hover = containsHover(prefixes);
@@ -76,12 +77,19 @@ function firstDefinedValue(scopes, name, prefixes) {
 			continue;
 		}
 		const readKey = getReadKey(prefix, name);
-		for (let scopeIndex = 0; scopeIndex < scopes.length; scopeIndex++) {
-			const scope = scopes[scopeIndex];
-			const value = scope && scope[readKey];
-			if (typeof value !== 'undefined') {
-				return value;
-			}
+		const value = firstValueFromScopes(scopes, readKey);
+		if (isDefined(value)) {
+			return value;
+		}
+	}
+}
+
+function firstValueFromScopes(scopes, readKey) {
+	for (let scopeIndex = 0; scopeIndex < scopes.length; scopeIndex++) {
+		const scope = scopes[scopeIndex];
+		const value = scope && scope[readKey];
+		if (isDefined(value)) {
+			return value;
 		}
 	}
 }

--- a/src/elements/element.arc.js
+++ b/src/elements/element.arc.js
@@ -214,7 +214,8 @@ ArcElement.defaults = {
 	borderAlign: 'center',
 	borderColor: '#fff',
 	borderWidth: 2,
-	offset: 0
+	offset: 0,
+	angle: undefined
 };
 
 /**

--- a/src/elements/element.line.js
+++ b/src/elements/element.line.js
@@ -383,7 +383,10 @@ LineElement.defaults = {
 	borderWidth: 3,
 	capBezierPoints: true,
 	fill: true,
-	tension: 0
+	tension: 0,
+	spanGaps: false,
+	stepped: undefined,
+	cubicInterpolationMode: undefined
 };
 
 /**

--- a/src/elements/element.point.js
+++ b/src/elements/element.point.js
@@ -77,7 +77,8 @@ PointElement.defaults = {
 	hoverBorderWidth: 1,
 	hoverRadius: 4,
 	pointStyle: 'circle',
-	radius: 3
+	radius: 3,
+	rotation: undefined
 };
 
 /**

--- a/src/helpers/helpers.extras.js
+++ b/src/helpers/helpers.extras.js
@@ -38,3 +38,10 @@ export function throttled(fn, thisArg, updateFn) {
 		}
 	};
 }
+
+/**
+ * @private
+ */
+export function _hideLine(options) {
+	options.borderWidth = 0;
+}

--- a/src/helpers/helpers.extras.js
+++ b/src/helpers/helpers.extras.js
@@ -38,10 +38,3 @@ export function throttled(fn, thisArg, updateFn) {
 		}
 	};
 }
-
-/**
- * @private
- */
-export function _hideLine(options) {
-	options.borderWidth = 0;
-}

--- a/test/fixtures/controller.bubble/radius-scriptable.js
+++ b/test/fixtures/controller.bubble/radius-scriptable.js
@@ -12,7 +12,7 @@ module.exports = {
 					{x: 5, y: 0}
 				],
 				radius: function(ctx) {
-					return ctx.dataset.data[ctx.dataIndex].x * 4;
+					return ctx.dataset.data[ctx.dataIndex]?.x * 4;
 				}
 			}]
 		},

--- a/test/specs/controller.bar.tests.js
+++ b/test/specs/controller.bar.tests.js
@@ -1245,7 +1245,7 @@ describe('Chart.controllers.bar', function() {
 		expect(bar.options.backgroundColor).toBe(helpers.getHoverColor('rgb(128, 128, 128)'));
 		expect(bar.options.borderColor).toBe(helpers.getHoverColor('rgb(15, 15, 15)'));
 		expect(bar.options.borderWidth).toBe(3.14);
-		meta.controller.removeHoverStyle(bar);
+		meta.controller.removeHoverStyle(bar, 1, 0);
 		expect(bar.options.backgroundColor).toBe('rgb(128, 128, 128)');
 		expect(bar.options.borderColor).toBe('rgb(15, 15, 15)');
 		expect(bar.options.borderWidth).toBe(3.14);
@@ -1263,7 +1263,7 @@ describe('Chart.controllers.bar', function() {
 		expect(bar.options.backgroundColor).toBe(helpers.getHoverColor('rgb(255, 255, 255)'));
 		expect(bar.options.borderColor).toBe(helpers.getHoverColor('rgb(9, 9, 9)'));
 		expect(bar.options.borderWidth).toBe(2.5);
-		meta.controller.removeHoverStyle(bar);
+		meta.controller.removeHoverStyle(bar, 1, 0);
 		expect(bar.options.backgroundColor).toBe('rgb(255, 255, 255)');
 		expect(bar.options.borderColor).toBe('rgb(9, 9, 9)');
 		expect(bar.options.borderWidth).toBe(2.5);
@@ -1361,9 +1361,9 @@ describe('Chart.controllers.bar', function() {
 			var meta = chart.getDatasetMeta(0);
 			var yScale = chart.scales[meta.yAxisID];
 
-			var config = meta.controller._config;
-			var categoryPercentage = config.categoryPercentage;
-			var barPercentage = config.barPercentage;
+			var options = meta.controller.options;
+			var categoryPercentage = options.categoryPercentage;
+			var barPercentage = options.barPercentage;
 			var stacked = yScale.options.stacked;
 
 			var totalBarHeight = 0;

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -110,7 +110,7 @@ describe('Chart', function() {
 			expect(options.hover.mode).toBe('test');
 
 			defaults.hover.onHover = null;
-			defaults.controllers.line.spanGaps = false;
+			delete defaults.controllers.line.spanGaps;
 			defaults.controllers.line.interaction.mode = defaultMode;
 		});
 
@@ -134,7 +134,7 @@ describe('Chart', function() {
 			expect(options.hover.mode).toBe('test');
 
 			defaults.hover.onHover = null;
-			defaults.controllers.line.spanGaps = false;
+			delete defaults.controllers.line.spanGaps;
 			delete defaults.controllers.line.hover.mode;
 		});
 
@@ -160,14 +160,14 @@ describe('Chart', function() {
 			});
 
 			var options = chart.options;
-			expect(options.showLine).toBe(defaults.showLine);
+			expect(options.showLine).toBe(defaults.controllers.line.showLine);
 			expect(options.spanGaps).toBe(false);
 			expect(options.hover.mode).toBe('dataset');
 			expect(options.title.position).toBe('bottom');
 
 			defaults.hover.onHover = null;
 			delete defaults.controllers.line.hover.mode;
-			defaults.controllers.line.spanGaps = false;
+			delete defaults.controllers.line.spanGaps;
 		});
 
 		it('should override axis positions that are incorrect', function() {

--- a/test/specs/core.datasetController.tests.js
+++ b/test/specs/core.datasetController.tests.js
@@ -629,85 +629,6 @@ describe('Chart.DatasetController', function() {
 		Chart.defaults.color = oldColor;
 	});
 
-	describe('_resolveOptions', function() {
-		it('should resove names in array notation', function() {
-			Chart.defaults.elements.line.globalTest = 'global';
-
-			const chart = acquireChart({
-				type: 'line',
-				data: {
-					datasets: [{
-						data: [1],
-						datasetTest: 'dataset'
-					}]
-				},
-				options: {
-					elements: {
-						line: {
-							elementTest: 'element'
-						}
-					}
-				}
-			});
-
-			const controller = chart.getDatasetMeta(0).controller;
-
-			expect(controller._resolveOptions(
-				[
-					'datasetTest',
-					'elementTest',
-					'globalTest'
-				],
-				{type: 'line'})
-			).toEqual({
-				datasetTest: 'dataset',
-				elementTest: 'element',
-				globalTest: 'global'
-			});
-
-			// Remove test from global defaults
-			delete Chart.defaults.elements.line.globalTest;
-		});
-
-		it('should resove names in object notation', function() {
-			Chart.defaults.elements.line.global = 'global';
-
-			const chart = acquireChart({
-				type: 'line',
-				data: {
-					datasets: [{
-						data: [1],
-						datasetTest: 'dataset'
-					}]
-				},
-				options: {
-					elements: {
-						line: {
-							element: 'element'
-						}
-					}
-				}
-			});
-
-			const controller = chart.getDatasetMeta(0).controller;
-
-			expect(controller._resolveOptions(
-				{
-					dataset: 'datasetTest',
-					element: 'elementTest',
-					global: 'globalTest'},
-				{type: 'line'})
-			).toEqual({
-				dataset: 'dataset',
-				element: 'element',
-				global: 'global'
-			});
-
-			// Remove test from global defaults
-			delete Chart.defaults.elements.line.global;
-		});
-	});
-
 	describe('resolveDataElementOptions', function() {
 		it('should cache options when possible', function() {
 			const chart = acquireChart({
@@ -728,7 +649,6 @@ describe('Chart.DatasetController', function() {
 
 			expect(opts0 === opts1).toBeTrue();
 			expect(opts0.$shared).toBeTrue();
-			expect(Object.isFrozen(opts0)).toBeTrue();
 		});
 
 		it('should not cache options when option sharing is disabled', function() {

--- a/test/specs/plugin.legend.tests.js
+++ b/test/specs/plugin.legend.tests.js
@@ -522,15 +522,15 @@ describe('Legend block tests', function() {
 				datasets: [{
 					label: 'dataset1',
 					backgroundColor: function(ctx) {
-						var value = ctx.dataset.data[ctx.dataIndex] || 0;
+						var value = ctx.dataset.data[ctx.index] || 0;
 						return helpers.color({r: value * 10, g: 0, b: 0}).rgbString();
 					},
 					borderWidth: function(ctx) {
-						var value = ctx.dataset.data[ctx.dataIndex] || 0;
+						var value = ctx.dataset.data[ctx.index] || 0;
 						return value;
 					},
 					borderColor: function(ctx) {
-						var value = ctx.dataset.data[ctx.dataIndex] || 0;
+						var value = ctx.dataset.data[ctx.index] || 0;
 						return helpers.color({r: 255 - value * 10, g: 0, b: 0}).rgbString();
 					},
 					data: [5, 10, 15, 20]
@@ -571,7 +571,7 @@ describe('Legend block tests', function() {
 					pointBackgroundColor: 'rgba(0,0,0,0.1)',
 					pointBorderWidth: 5,
 					pointBorderColor: 'green',
-					data: []
+					data: [1]
 				}, {
 					label: 'dataset2',
 					backgroundColor: '#f31',
@@ -580,9 +580,9 @@ describe('Legend block tests', function() {
 					borderColor: '#f31',
 					pointStyle: 'crossRot',
 					pointRotation: 15,
-					data: []
+					data: [1]
 				}],
-				labels: []
+				labels: ['a']
 			},
 			options: {
 				legend: {
@@ -638,7 +638,7 @@ describe('Legend block tests', function() {
 					pointBackgroundColor: 'rgba(0,0,0,0.1)',
 					pointBorderWidth: 5,
 					pointBorderColor: 'green',
-					data: []
+					data: [1]
 				}, {
 					label: 'dataset2',
 					backgroundColor: '#f31',
@@ -647,9 +647,9 @@ describe('Legend block tests', function() {
 					borderColor: '#f31',
 					pointStyle: 'crossRot',
 					pointRotation: 15,
-					data: []
+					data: [1]
 				}],
-				labels: []
+				labels: ['a']
 			},
 			options: {
 				legend: {

--- a/types/core/index.d.ts
+++ b/types/core/index.d.ts
@@ -281,9 +281,10 @@ export class DatasetController<E extends Element = Element, DSE extends Element 
 	addElements(): void;
 	buildOrUpdateElements(): void;
 
-	getStyle(index: number, active: boolean): any;
-	protected resolveDatasetElementOptions(active: boolean): any;
-	protected resolveDataElementOptions(index: number, mode: UpdateMode): any;
+	getStyle(index: number, active?: boolean, prefix?: string): any;
+	protected resolveControllerOptions(prefix?: string): any;
+	protected resolveDatasetElementOptions(mode?: UpdateMode, prefix?: string): any;
+	protected resolveDataElementOptions(index: number, mode?: UpdateMode, prefix?: string): any;
 	/**
 	 * Utility for checking if the options are shared and should be animated separately.
 	 * @protected


### PR DESCRIPTION
This one needs some refactoring/cleanup still, but I wanted to put it up here to see the size impact.

The main idea is to resolve from top to bottom, using known paths depending on the context we are resolving.
For dataset, there are 3 contexts, data element options, dataset options and controller options. 

- options are not merged with element defaults, because we need to know if user passed some element options and consider those at higher priority than defaults
- options are flattened to dataset level (merged from top to bottom to first !== undefined value)
- that flattened object is used to resolve against
- option names need to be defined in defaults to be resolvable

Closes: #7408

TODO:

- [ ] Tests
- [ ] Animation resolution
- [ ] Documentation