### PR TITLE
Remove +-10px limit from bar controller

### DIFF
--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -1,7 +1,7 @@
 import DatasetController from '../core/core.datasetController';
 import {
 	clipArea, unclipArea, _arrayUnique, isArray, isNullOrUndef,
-	valueOrDefault, resolveObjectKey, _limitValue, sign
+	valueOrDefault, resolveObjectKey, sign
 } from '../helpers';
 
 function getAllScaleValues(scale) {

--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -428,14 +428,8 @@ export default class BarController extends DatasetController {
 			start += value;
 		}
 
-		// Limit the bar to only extend up to 10 pixels past scale bounds (chartArea)
-		// So we don't try to draw so huge rectangles.
-		// https://github.com/chartjs/Chart.js/issues/5247
-		// TODO: use borderWidth instead (need to move the parsing from rectangle)
 		const startValue = !isNullOrUndef(baseValue) && !floating ? baseValue : start;
-		let base = _limitValue(vScale.getPixelForValue(startValue),
-			vScale._startPixel - 10,
-			vScale._endPixel + 10);
+		let base = vScale.getPixelForValue(startValue);
 
 		if (this.chart.getDataVisibility(index)) {
 			head = vScale.getPixelForValue(start + length);

--- a/test/specs/controller.bar.tests.js
+++ b/test/specs/controller.bar.tests.js
@@ -630,7 +630,7 @@ describe('Chart.controllers.bar', function() {
 		].forEach(function(expected, i) {
 			expect(meta.data[i].x).toBeCloseToPixel(expected.x);
 			expect(meta.data[i].y).toBeCloseToPixel(expected.y);
-			expect(meta.data[i].base).toBeCloseToPixel(522);
+			expect(meta.data[i].base).toBeCloseToPixel(1024);
 			expect(meta.data[i].width).toBeCloseToPixel(46);
 			expect(meta.data[i].options).toEqual(jasmine.objectContaining({
 				backgroundColor: 'red',
@@ -828,10 +828,10 @@ describe('Chart.controllers.bar', function() {
 		var meta0 = chart.getDatasetMeta(0);
 
 		[
-			{b: 522, w: 92 / 2, x: 38, y: 512},
-			{b: 522, w: 92 / 2, x: 166, y: 819},
-			{b: 522, w: 92 / 2, x: 294, y: 922},
-			{b: 522, w: 92 / 2, x: 422.5, y: 0}
+			{b: 1024, w: 92 / 2, x: 38, y: 512},
+			{b: 1024, w: 92 / 2, x: 166, y: 819},
+			{b: 1024, w: 92 / 2, x: 294, y: 922},
+			{b: 1024, w: 92 / 2, x: 422.5, y: 0}
 		].forEach(function(values, i) {
 			expect(meta0.data[i].base).toBeCloseToPixel(values.b);
 			expect(meta0.data[i].width).toBeCloseToPixel(values.w);
@@ -843,8 +843,8 @@ describe('Chart.controllers.bar', function() {
 
 		[
 			{b: 512, w: 92 / 2, x: 89, y: 0},
-			{b: 522, w: 92 / 2, x: 217, y: 0},
-			{b: 522, w: 92 / 2, x: 345, y: 0},
+			{b: 819.2, w: 92 / 2, x: 217, y: 0},
+			{b: 921.6, w: 92 / 2, x: 345, y: 0},
 			{b: 0, w: 92 / 2, x: 473.5, y: 0}
 		].forEach(function(values, i) {
 			expect(meta1.data[i].base).toBeCloseToPixel(values.b);


### PR DESCRIPTION
#5247 is still resolved: https://codepen.io/kurkle/pen/zYBJrgz

This is because we already limit the `getPixelForValue` to sane values.

https://github.com/chartjs/chartjs-plugin-datalabels/pull/181#issuecomment-723018306
https://github.com/chartjs/chartjs-plugin-datalabels/pull/181