### PR TITLE
Remove I prefix from TS types

### DIFF
--- a/docs/docs/developers/charts.md
+++ b/docs/docs/developers/charts.md
@@ -155,16 +155,16 @@ new Chart(ctx, {
 
 If you want your new chart type to be statically typed, you must provide a `.d.ts` TypeScript declaration file. Chart.js provides a way to augment built-in types with user-defined ones, by using the concept of "declaration merging".
 
-When adding a new chart type, `IChartTypeRegistry` must contains the declarations for the new type, either by extending an existing entry in `IChartTypeRegistry` or by creating a new one.
+When adding a new chart type, `ChartTypeRegistry` must contains the declarations for the new type, either by extending an existing entry in `ChartTypeRegistry` or by creating a new one.
 
 For example, to provide typings for a new chart type that extends from a bubble chart, you would add a `.d.ts` containing:
 
 ```ts
-import { IChartTypeRegistry } from 'chart.js'
+import { ChartTypeRegistry } from 'chart.js'
 
 declare module 'chart.js' {
-    interface IChartTypeRegistry {
-        derivedBubble: IChartTypeRegistry['bubble']
+    interface ChartTypeRegistry {
+        derivedBubble: ChartTypeRegistry['bubble']
     }
 }
 ```

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -14,7 +14,7 @@ import {clear as canvasClear, clipArea, unclipArea, _isPointInArea} from '../hel
 import {version} from '../../package.json';
 
 /**
- * @typedef { import("../platform/platform.base").IEvent } IEvent
+ * @typedef { import("../platform/platform.base").Event } Event
  */
 
 const KNOWN_POSITIONS = ['top', 'bottom', 'left', 'right', 'chartArea'];
@@ -1006,7 +1006,7 @@ class Chart {
 
 	/**
 	 * Handle an event
-	 * @param {IEvent} e the event to handle
+	 * @param {Event} e the event to handle
 	 * @param {boolean} [replay] - true if the event was replayed by `update`
 	 * @return {boolean} true if the chart needs to re-render
 	 * @private

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -14,7 +14,7 @@ import {clear as canvasClear, clipArea, unclipArea, _isPointInArea} from '../hel
 import {version} from '../../package.json';
 
 /**
- * @typedef { import("../platform/platform.base").Event } Event
+ * @typedef { import("../platform/platform.base").ChartEvent } ChartEvent
  */
 
 const KNOWN_POSITIONS = ['top', 'bottom', 'left', 'right', 'chartArea'];
@@ -1006,7 +1006,7 @@ class Chart {
 
 	/**
 	 * Handle an event
-	 * @param {Event} e the event to handle
+	 * @param {ChartEvent} e the event to handle
 	 * @param {boolean} [replay] - true if the event was replayed by `update`
 	 * @return {boolean} true if the chart needs to re-render
 	 * @private

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -319,7 +319,7 @@ class Chart {
 		me.scales = scales;
 
 		each(scales, (scale) => {
-			// Set ILayoutItem parameters for backwards compatibility
+			// Set LayoutItem parameters for backwards compatibility
 			scale.fullWidth = scale.options.fullWidth;
 			scale.position = scale.options.position;
 			scale.weight = scale.options.weight;

--- a/src/core/core.interaction.js
+++ b/src/core/core.interaction.js
@@ -4,14 +4,14 @@ import {getRelativePosition as helpersGetRelativePosition} from '../helpers/help
 
 /**
  * @typedef { import("./core.controller").default } Chart
- * @typedef { import("../platform/platform.base").IEvent } IEvent
+ * @typedef { import("../platform/platform.base").Event } Event
  * @typedef {{axis?: string, intersect?: boolean}} InteractionOptions
  * @typedef {{datasetIndex: number, index: number, element: import("./core.element").default}} InteractionItem
  */
 
 /**
  * Helper function to get relative position for an event
- * @param {Event|IEvent} e - The event to get the position for
+ * @param {Event|Event} e - The event to get the position for
  * @param {Chart} chart - The chart
  * @returns {object} the event position
  */

--- a/src/core/core.interaction.js
+++ b/src/core/core.interaction.js
@@ -4,14 +4,14 @@ import {getRelativePosition as helpersGetRelativePosition} from '../helpers/help
 
 /**
  * @typedef { import("./core.controller").default } Chart
- * @typedef { import("../platform/platform.base").Event } Event
+ * @typedef { import("../platform/platform.base").ChartEvent } ChartEvent
  * @typedef {{axis?: string, intersect?: boolean}} InteractionOptions
  * @typedef {{datasetIndex: number, index: number, element: import("./core.element").default}} InteractionItem
  */
 
 /**
  * Helper function to get relative position for an event
- * @param {Event|Event} e - The event to get the position for
+ * @param {Event|ChartEvent} e - The event to get the position for
  * @param {Chart} chart - The chart
  * @returns {object} the event position
  */

--- a/src/core/core.layouts.js
+++ b/src/core/core.layouts.js
@@ -215,7 +215,7 @@ defaults.set('layout', {
 
 /**
  * @interface LayoutItem
- * @typedef {object} ILayoutItem
+ * @typedef {object} LayoutItem
  * @prop {string} position - The position of the item in the chart layout. Possible values are
  * 'left', 'top', 'right', 'bottom', and 'chartArea'
  * @prop {number} weight - The weight used to sort the item. Higher weights are further away from the chart area
@@ -241,7 +241,7 @@ export default {
 	 * Register a box to a chart.
 	 * A box is simply a reference to an object that requires layout. eg. Scales, Legend, Title.
 	 * @param {Chart} chart - the chart to use
-	 * @param {ILayoutItem} item - the item to add to be laid out
+	 * @param {LayoutItem} item - the item to add to be laid out
 	 */
 	addBox(chart, item) {
 		if (!chart.boxes) {
@@ -268,7 +268,7 @@ export default {
 	/**
 	 * Remove a layoutItem from a chart
 	 * @param {Chart} chart - the chart to remove the box from
-	 * @param {ILayoutItem} layoutItem - the item to remove from the layout
+	 * @param {LayoutItem} layoutItem - the item to remove from the layout
 	 */
 	removeBox(chart, layoutItem) {
 		const index = chart.boxes ? chart.boxes.indexOf(layoutItem) : -1;
@@ -280,7 +280,7 @@ export default {
 	/**
 	 * Sets (or updates) options on the given `item`.
 	 * @param {Chart} chart - the chart in which the item lives (or will be added to)
-	 * @param {ILayoutItem} item - the item to configure with the given options
+	 * @param {LayoutItem} item - the item to configure with the given options
 	 * @param {object} options - the new item options.
 	 */
 	configure(chart, item, options) {

--- a/src/core/core.layouts.js
+++ b/src/core/core.layouts.js
@@ -214,7 +214,7 @@ defaults.set('layout', {
 });
 
 /**
- * @interface ILayoutItem
+ * @interface LayoutItem
  * @typedef {object} ILayoutItem
  * @prop {string} position - The position of the item in the chart layout. Possible values are
  * 'left', 'top', 'right', 'bottom', and 'chartArea'

--- a/src/core/core.plugins.js
+++ b/src/core/core.plugins.js
@@ -4,7 +4,7 @@ import {mergeIf} from '../helpers/helpers.core';
 
 /**
  * @typedef { import("./core.controller").default } Chart
- * @typedef { import("../platform/platform.base").Event } Event
+ * @typedef { import("../platform/platform.base").ChartEvent } ChartEvent
  * @typedef { import("../plugins/plugin.tooltip").default } Tooltip
  */
 
@@ -301,7 +301,7 @@ function createDescriptors(plugins, options) {
  * @desc Called before processing the specified `event`. If any plugin returns `false`,
  * the event will be discarded.
  * @param {Chart} chart - The chart instance.
- * @param {Event} event - The event object.
+ * @param {ChartEvent} event - The event object.
  * @param {boolean} replay - True if this event is replayed from `Chart.update`
  * @param {object} options - The plugin options.
  */
@@ -310,7 +310,7 @@ function createDescriptors(plugins, options) {
  * @desc Called after the `event` has been consumed. Note that this hook
  * will not be called if the `event` has been previously discarded.
  * @param {Chart} chart - The chart instance.
- * @param {Event} event - The event object.
+ * @param {ChartEvent} event - The event object.
  * @param {boolean} replay - True if this event is replayed from `Chart.update`
  * @param {object} options - The plugin options.
  */

--- a/src/core/core.plugins.js
+++ b/src/core/core.plugins.js
@@ -4,7 +4,7 @@ import {mergeIf} from '../helpers/helpers.core';
 
 /**
  * @typedef { import("./core.controller").default } Chart
- * @typedef { import("../platform/platform.base").IEvent } IEvent
+ * @typedef { import("../platform/platform.base").Event } Event
  * @typedef { import("../plugins/plugin.tooltip").default } Tooltip
  */
 
@@ -108,7 +108,7 @@ function createDescriptors(plugins, options) {
 
 /**
  * Plugin extension hooks.
- * @interface IPlugin
+ * @interface Plugin
  * @typedef {object} IPlugin
  * @since 2.1.0
  */
@@ -301,7 +301,7 @@ function createDescriptors(plugins, options) {
  * @desc Called before processing the specified `event`. If any plugin returns `false`,
  * the event will be discarded.
  * @param {Chart} chart - The chart instance.
- * @param {IEvent} event - The event object.
+ * @param {Event} event - The event object.
  * @param {boolean} replay - True if this event is replayed from `Chart.update`
  * @param {object} options - The plugin options.
  */
@@ -310,7 +310,7 @@ function createDescriptors(plugins, options) {
  * @desc Called after the `event` has been consumed. Note that this hook
  * will not be called if the `event` has been previously discarded.
  * @param {Chart} chart - The chart instance.
- * @param {IEvent} event - The event object.
+ * @param {Event} event - The event object.
  * @param {boolean} replay - True if this event is replayed from `Chart.update`
  * @param {object} options - The plugin options.
  */

--- a/src/platform/platform.base.js
+++ b/src/platform/platform.base.js
@@ -28,16 +28,16 @@ export default class BasePlatform {
 	/**
 	 * Registers the specified listener on the given chart.
 	 * @param {Chart} chart - Chart from which to listen for event
-	 * @param {string} type - The ({@link IEvent}) type to listen for
+	 * @param {string} type - The ({@link Event}) type to listen for
 	 * @param {function} listener - Receives a notification (an object that implements
-	 * the {@link IEvent} interface) when an event of the specified type occurs.
+	 * the {@link Event} interface) when an event of the specified type occurs.
 	 */
 	addEventListener(chart, type, listener) {} // eslint-disable-line no-unused-vars
 
 	/**
 	 * Removes the specified listener previously registered with addEventListener.
 	 * @param {Chart} chart - Chart from which to remove the listener
-	 * @param {string} type - The ({@link IEvent}) type to remove
+	 * @param {string} type - The ({@link Event}) type to remove
 	 * @param {function} listener - The listener function to remove from the event target.
 	 */
 	removeEventListener(chart, type, listener) {} // eslint-disable-line no-unused-vars
@@ -75,8 +75,8 @@ export default class BasePlatform {
 }
 
 /**
- * @interface IEvent
- * @typedef {object} IEvent
+ * @interface Event
+ * @typedef {object} Event
  * @prop {string} type - The event type name, possible values are:
  * 'contextmenu', 'mouseenter', 'mousedown', 'mousemove', 'mouseup', 'mouseout',
  * 'click', 'dblclick', 'keydown', 'keypress', 'keyup' and 'resize'

--- a/src/platform/platform.base.js
+++ b/src/platform/platform.base.js
@@ -28,16 +28,16 @@ export default class BasePlatform {
 	/**
 	 * Registers the specified listener on the given chart.
 	 * @param {Chart} chart - Chart from which to listen for event
-	 * @param {string} type - The ({@link Event}) type to listen for
+	 * @param {string} type - The ({@link ChartEvent}) type to listen for
 	 * @param {function} listener - Receives a notification (an object that implements
-	 * the {@link Event} interface) when an event of the specified type occurs.
+	 * the {@link ChartEvent} interface) when an event of the specified type occurs.
 	 */
 	addEventListener(chart, type, listener) {} // eslint-disable-line no-unused-vars
 
 	/**
 	 * Removes the specified listener previously registered with addEventListener.
 	 * @param {Chart} chart - Chart from which to remove the listener
-	 * @param {string} type - The ({@link Event}) type to remove
+	 * @param {string} type - The ({@link ChartEvent}) type to remove
 	 * @param {function} listener - The listener function to remove from the event target.
 	 */
 	removeEventListener(chart, type, listener) {} // eslint-disable-line no-unused-vars
@@ -75,8 +75,8 @@ export default class BasePlatform {
 }
 
 /**
- * @interface Event
- * @typedef {object} Event
+ * @interface ChartEvent
+ * @typedef {object} ChartEvent
  * @prop {string} type - The event type name, possible values are:
  * 'contextmenu', 'mouseenter', 'mousedown', 'mousemove', 'mouseup', 'mouseout',
  * 'click', 'dblclick', 'keydown', 'keypress', 'keyup' and 'resize'

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -9,7 +9,7 @@ import {
 } from '../helpers/index';
 
 /**
- * @typedef { import("../platform/platform.base").Event } Event
+ * @typedef { import("../platform/platform.base").ChartEvent } ChartEvent
  */
 
 /**
@@ -587,7 +587,7 @@ export class Legend extends Element {
 
 	/**
 	 * Handle an event
-	 * @param {Event} e - The event to handle
+	 * @param {ChartEvent} e - The event to handle
 	 */
 	handleEvent(e) {
 		const me = this;

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -9,7 +9,7 @@ import {
 } from '../helpers/index';
 
 /**
- * @typedef { import("../platform/platform.base").IEvent } IEvent
+ * @typedef { import("../platform/platform.base").Event } Event
  */
 
 /**
@@ -587,7 +587,7 @@ export class Legend extends Element {
 
 	/**
 	 * Handle an event
-	 * @param {IEvent} e - The event to handle
+	 * @param {Event} e - The event to handle
 	 */
 	handleEvent(e) {
 		const me = this;

--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -8,7 +8,7 @@ import {toFont} from '../helpers/helpers.options';
 import {drawPoint} from '../helpers';
 
 /**
- * @typedef { import("../platform/platform.base").IEvent } IEvent
+ * @typedef { import("../platform/platform.base").Event } Event
  */
 
 const positioners = {
@@ -979,7 +979,7 @@ export class Tooltip extends Element {
 
 	/**
 	 * Handle an event
-	 * @param {IEvent} e - The event to handle
+	 * @param {Event} e - The event to handle
 	 * @param {boolean} [replay] - This is a replayed event (from update)
 	 * @returns {boolean} true if the tooltip changed
 	 */
@@ -1027,7 +1027,7 @@ export class Tooltip extends Element {
 	 * Determine if the active elements + event combination changes the
 	 * tooltip position
 	 * @param {array} active - Active elements
-	 * @param {IEvent} e - Event that triggered the position change
+	 * @param {Event} e - Event that triggered the position change
 	 * @returns {boolean} True if the position has changed
 	 */
 	_positionChanged(active, e) {

--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -8,7 +8,7 @@ import {toFont} from '../helpers/helpers.options';
 import {drawPoint} from '../helpers';
 
 /**
- * @typedef { import("../platform/platform.base").Event } Event
+ * @typedef { import("../platform/platform.base").ChartEvent } ChartEvent
  */
 
 const positioners = {
@@ -979,7 +979,7 @@ export class Tooltip extends Element {
 
 	/**
 	 * Handle an event
-	 * @param {Event} e - The event to handle
+	 * @param {ChartEvent} e - The event to handle
 	 * @param {boolean} [replay] - This is a replayed event (from update)
 	 * @returns {boolean} true if the tooltip changed
 	 */
@@ -1027,7 +1027,7 @@ export class Tooltip extends Element {
 	 * Determine if the active elements + event combination changes the
 	 * tooltip position
 	 * @param {array} active - Active elements
-	 * @param {Event} e - Event that triggered the position change
+	 * @param {ChartEvent} e - Event that triggered the position change
 	 * @returns {boolean} True if the position has changed
 	 */
 	_positionChanged(active, e) {

--- a/types/controllers/index.d.ts
+++ b/types/controllers/index.d.ts
@@ -1,23 +1,23 @@
 import { Chart, DatasetController } from '../core';
-import { IChartArea, IChartComponent, ScriptableAndArrayOptions, ScriptableOptions } from '../core/interfaces';
+import { ChartArea, ChartComponent, ScriptableAndArrayOptions, ScriptableOptions } from '../core/interfaces';
 import {
-  IArcHoverOptions,
-  IArcOptions,
-  ICommonHoverOptions,
-  IPointHoverOptions,
-  ILineHoverOptions,
-  ILineOptions,
-  IPointOptions,
-  IPointPrefixedHoverOptions,
-  IPointPrefixedOptions,
-  IBarOptions,
+  ArcHoverOptions,
+  ArcOptions,
+  CommonHoverOptions,
+  PointHoverOptions,
+  LineHoverOptions,
+  LineOptions,
+  PointOptions,
+  PointPrefixedHoverOptions,
+  PointPrefixedOptions,
+  BarOptions,
 } from '../elements';
 
-export interface IControllerDatasetOptions {
+export interface ControllerDatasetOptions {
   /**
    * 	How to clip relative to chartArea. Positive value allows overflow, negative value clips that many pixels inside chartArea. 0 = clip at chartArea. Clipping can also be configured per side: clip: {left: 5, top: false, right: -2, bottom: 0}
    */
-  clip: number | IChartArea;
+  clip: number | ChartArea;
   /**
    * The label for the dataset which appears in the legend and tooltips.
    */
@@ -33,10 +33,10 @@ export interface IControllerDatasetOptions {
   stack: string;
 }
 
-export interface IBarControllerDatasetOptions
-  extends IControllerDatasetOptions,
-    ScriptableAndArrayOptions<IBarOptions>,
-    ScriptableAndArrayOptions<ICommonHoverOptions> {
+export interface BarControllerDatasetOptions
+  extends ControllerDatasetOptions,
+    ScriptableAndArrayOptions<BarOptions>,
+    ScriptableAndArrayOptions<CommonHoverOptions> {
   /**
    * The base axis of the dataset. 'x' for vertical bars and 'y' for horizontal bars.
    * @default 'x'
@@ -78,7 +78,7 @@ export interface IBarControllerDatasetOptions
   minBarLength: number;
 }
 
-export interface IBarControllerChartOptions {
+export interface BarControllerChartOptions {
   /**
    * Should null or undefined values be omitted from drawing
    */
@@ -86,17 +86,17 @@ export interface IBarControllerChartOptions {
 }
 
 export interface BarController extends DatasetController {}
-export const BarController: IChartComponent & {
+export const BarController: ChartComponent & {
   prototype: BarController;
   new (chart: Chart, datasetIndex: number): BarController;
 };
 
-export interface IBubbleControllerDatasetOptions
-  extends IControllerDatasetOptions,
-    ScriptableAndArrayOptions<IPointOptions>,
-    ScriptableAndArrayOptions<IPointHoverOptions> {}
+export interface BubbleControllerDatasetOptions
+  extends ControllerDatasetOptions,
+    ScriptableAndArrayOptions<PointOptions>,
+    ScriptableAndArrayOptions<PointHoverOptions> {}
 
-export interface IBubbleDataPoint {
+export interface BubbleDataPoint {
   /**
    * X Value
    */
@@ -114,17 +114,17 @@ export interface IBubbleDataPoint {
 }
 
 export interface BubbleController extends DatasetController {}
-export const BubbleController: IChartComponent & {
+export const BubbleController: ChartComponent & {
   prototype: BubbleController;
   new (chart: Chart, datasetIndex: number): BubbleController;
 };
 
-export interface ILineControllerDatasetOptions
-  extends IControllerDatasetOptions,
-    ScriptableAndArrayOptions<IPointPrefixedOptions>,
-    ScriptableAndArrayOptions<IPointPrefixedHoverOptions>,
-    ScriptableOptions<ILineOptions>,
-    ScriptableOptions<ILineHoverOptions> {
+export interface LineControllerDatasetOptions
+  extends ControllerDatasetOptions,
+    ScriptableAndArrayOptions<PointPrefixedOptions>,
+    ScriptableAndArrayOptions<PointPrefixedHoverOptions>,
+    ScriptableOptions<LineOptions>,
+    ScriptableOptions<LineHoverOptions> {
   /**
    * The ID of the x axis to plot this dataset on.
    */
@@ -143,7 +143,7 @@ export interface ILineControllerDatasetOptions
   showLine: boolean;
 }
 
-export interface ILineControllerChartOptions {
+export interface LineControllerChartOptions {
   /**
    * If true, lines will be drawn between points with no or null data. If false, points with NaN data will create a break in the line. Can also be a number specifying the maximum gap length to span. The unit of the value depends on the scale used.
    * @default false
@@ -157,30 +157,30 @@ export interface ILineControllerChartOptions {
 }
 
 export interface LineController extends DatasetController {}
-export const LineController: IChartComponent & {
+export const LineController: ChartComponent & {
   prototype: LineController;
   new (chart: Chart, datasetIndex: number): LineController;
 };
 
-export type IScatterControllerDatasetOptions = ILineControllerDatasetOptions;
+export type ScatterControllerDatasetOptions = LineControllerDatasetOptions;
 
-export interface IScatterDataPoint {
+export interface ScatterDataPoint {
   x: number;
   y: number;
 }
 
-export type IScatterControllerChartOptions = ILineControllerChartOptions;
+export type ScatterControllerChartOptions = LineControllerChartOptions;
 
 export interface ScatterController extends LineController {}
-export const ScatterController: IChartComponent & {
+export const ScatterController: ChartComponent & {
   prototype: ScatterController;
   new (chart: Chart, datasetIndex: number): ScatterController;
 };
 
-export interface IDoughnutControllerDatasetOptions
-  extends IControllerDatasetOptions,
-    ScriptableAndArrayOptions<IArcOptions>,
-    ScriptableAndArrayOptions<IArcHoverOptions> {
+export interface DoughnutControllerDatasetOptions
+  extends ControllerDatasetOptions,
+    ScriptableAndArrayOptions<ArcOptions>,
+    ScriptableAndArrayOptions<ArcHoverOptions> {
 
   /**
    * Sweep to allow arcs to cover.
@@ -201,7 +201,7 @@ export interface IDoughnutControllerDatasetOptions
   weight: number;
 }
 
-export interface IDoughnutAnimationOptions {
+export interface DoughnutAnimationOptions {
   /**
    * 	If true, the chart will animate in with a rotation animation. This property is in the options.animation object.
    * @default true
@@ -215,7 +215,7 @@ export interface IDoughnutAnimationOptions {
   animateScale: boolean;
 }
 
-export interface IDoughnutControllerChartOptions {
+export interface DoughnutControllerChartOptions {
   /**
    * The percentage of the chart that is cut out of the middle. (50 - for doughnut, 0 - for pie)
    * @default 50
@@ -234,10 +234,10 @@ export interface IDoughnutControllerChartOptions {
    */
   circumference: number;
 
-  animation: IDoughnutAnimationOptions;
+  animation: DoughnutAnimationOptions;
 }
 
-export type IDoughnutDataPoint = number;
+export type DoughnutDataPoint = number;
 
 export interface DoughnutController extends DatasetController {
   readonly innerRadius: number;
@@ -250,24 +250,24 @@ export interface DoughnutController extends DatasetController {
   calculateCircumference(value: number): number;
 }
 
-export const DoughnutController: IChartComponent & {
+export const DoughnutController: ChartComponent & {
   prototype: DoughnutController;
   new (chart: Chart, datasetIndex: number): DoughnutController;
 };
 
-export type IPieControllerDatasetOptions = IDoughnutControllerDatasetOptions;
-export type IPieControllerChartOptions = IDoughnutControllerChartOptions;
-export type IPieAnimationOptions = IDoughnutAnimationOptions;
+export type PieControllerDatasetOptions = DoughnutControllerDatasetOptions;
+export type PieControllerChartOptions = DoughnutControllerChartOptions;
+export type PieAnimationOptions = DoughnutAnimationOptions;
 
-export type IPieDataPoint = IDoughnutDataPoint;
+export type PieDataPoint = DoughnutDataPoint;
 
 export interface PieController extends DoughnutController {}
-export const PieController: IChartComponent & {
+export const PieController: ChartComponent & {
   prototype: PieController;
   new (chart: Chart, datasetIndex: number): PieController;
 };
 
-export interface IPolarAreaControllerDatasetOptions extends IDoughnutControllerDatasetOptions {
+export interface PolarAreaControllerDatasetOptions extends DoughnutControllerDatasetOptions {
   /**
    * Arc angle to cover. - for polar only
    * @default circumference / (arc count)
@@ -275,32 +275,32 @@ export interface IPolarAreaControllerDatasetOptions extends IDoughnutControllerD
   angle: number;
 }
 
-export type IPolarAreaAnimationOptions = IDoughnutAnimationOptions;
+export type PolarAreaAnimationOptions = DoughnutAnimationOptions;
 
-export interface IPolarAreaControllerChartOptions {
+export interface PolarAreaControllerChartOptions {
   /**
    * Starting angle to draw arcs for the first item in a dataset. In degrees, 0 is at top.
    * @default 0
    */
   startAngle: number;
 
-  animation: IPolarAreaAnimationOptions;
+  animation: PolarAreaAnimationOptions;
 }
 
 export interface PolarAreaController extends DoughnutController {
   countVisibleElements(): number;
 }
-export const PolarAreaController: IChartComponent & {
+export const PolarAreaController: ChartComponent & {
   prototype: PolarAreaController;
   new (chart: Chart, datasetIndex: number): PolarAreaController;
 };
 
-export interface IRadarControllerDatasetOptions
-  extends IControllerDatasetOptions,
-    ScriptableOptions<IPointPrefixedOptions>,
-    ScriptableOptions<IPointPrefixedHoverOptions>,
-    ScriptableOptions<ILineOptions>,
-    ScriptableOptions<ILineHoverOptions> {
+export interface RadarControllerDatasetOptions
+  extends ControllerDatasetOptions,
+    ScriptableOptions<PointPrefixedOptions>,
+    ScriptableOptions<PointPrefixedHoverOptions>,
+    ScriptableOptions<LineOptions>,
+    ScriptableOptions<LineHoverOptions> {
   /**
    * The ID of the x axis to plot this dataset on.
    */
@@ -321,10 +321,10 @@ export interface IRadarControllerDatasetOptions
   showLine: boolean;
 }
 
-export type IRadarControllerChartOptions = ILineControllerChartOptions;
+export type RadarControllerChartOptions = LineControllerChartOptions;
 
 export interface RadarController extends DatasetController {}
-export const RadarController: IChartComponent & {
+export const RadarController: ChartComponent & {
   prototype: RadarController;
   new (chart: Chart, datasetIndex: number): RadarController;
 };

--- a/types/core/index.d.ts
+++ b/types/core/index.d.ts
@@ -8,7 +8,7 @@ import {
 	Point,
 	Scriptable,
 	TimeUnit,
-	Event,
+	ChartEvent,
 } from './interfaces';
 import {
 	DefaultDataPoint,
@@ -503,7 +503,7 @@ export interface InteractionItem {
 
 export type InteractionModeFunction = (
 	chart: Chart,
-	e: Event,
+	e: ChartEvent,
 	options: InteractionOptions,
 	useFinalPosition?: boolean
 ) => InteractionItem[];
@@ -827,20 +827,20 @@ export interface Plugin<O = {}> {
 	 * @desc Called before processing the specified `event`. If any plugin returns `false`,
 	 * the event will be discarded.
 	 * @param {Chart} chart - The chart instance.
-	 * @param {Event} event - The event object.
+	 * @param {ChartEvent} event - The event object.
 	 * @param {object} options - The plugin options.
 	 * @param {boolean} replay - True if this event is replayed from `Chart.update`
 	 */
-	beforeEvent?(chart: Chart, event: Event, options: O, replay: boolean): void;
+	beforeEvent?(chart: Chart, event: ChartEvent, options: O, replay: boolean): void;
 	/**
 	 * @desc Called after the `event` has been consumed. Note that this hook
 	 * will not be called if the `event` has been previously discarded.
 	 * @param {Chart} chart - The chart instance.
-	 * @param {Event} event - The event object.
+	 * @param {ChartEvent} event - The event object.
 	 * @param {object} options - The plugin options.
 	 * @param {boolean} replay - True if this event is replayed from `Chart.update`
 	 */
-	afterEvent?(chart: Chart, event: Event, options: O, replay: boolean): void;
+	afterEvent?(chart: Chart, event: ChartEvent, options: O, replay: boolean): void;
 	/**
 	 * @desc Called after the chart as been resized.
 	 * @param {Chart} chart - The chart instance.

--- a/types/core/index.d.ts
+++ b/types/core/index.d.ts
@@ -2,25 +2,25 @@ import { BasePlatform } from '../platform';
 import {
 	Color,
 	EasingFunction,
-	IChartArea,
-	IChartComponent,
-	IFontSpec,
-	IPoint,
+	ChartArea,
+	ChartComponent,
+	FontSpec,
+	Point,
 	Scriptable,
 	TimeUnit,
-	IEvent,
+	Event,
 } from './interfaces';
 import {
 	DefaultDataPoint,
-	IChartConfiguration,
-	IChartData,
-	IChartDataset,
-	IChartOptions,
-	IChartType,
-	IScaleOptions
+	ChartConfiguration,
+	ChartData,
+	ChartDataset,
+	ChartOptions,
+	ChartType,
+	ScaleOptions
 } from '../interfaces';
 
-export interface IDateAdapter {
+export interface DateAdapter {
 	/**
 	 * Returns a map of time formats for the supported formatting units defined
 	 * in Unit as well as 'datetime' representing a detailed date/time string.
@@ -74,14 +74,14 @@ export interface IDateAdapter {
 	endOf(timestamp: number, unit: TimeUnit | 'isoWeek'): number;
 }
 
-export interface DateAdapter extends IDateAdapter {
+export interface DateAdapter extends DateAdapter {
 	readonly options: any;
 }
 
 export const DateAdapter: {
 	prototype: DateAdapter;
 	new(options: any): DateAdapter;
-	override(members: Partial<IDateAdapter>): void;
+	override(members: Partial<DateAdapter>): void;
 };
 
 export const _adapters: {
@@ -96,14 +96,14 @@ export class Animation {
 	tick(date: number): void;
 }
 
-export interface IAnimationEvent {
+export interface AnimationEvent {
 	chart: Chart;
 	numSteps: number;
 	currentState: number;
 }
 
 export class Animator {
-	listen(chart: Chart, event: 'complete' | 'progress', cb: (event: IAnimationEvent) => void): void;
+	listen(chart: Chart, event: 'complete' | 'progress', cb: (event: AnimationEvent) => void): void;
 	add(chart: Chart, items: readonly Animation[]): void;
 	has(chart: Chart): boolean;
 	start(chart: Chart): void;
@@ -118,7 +118,7 @@ export class Animations {
 	update(target: any, values: any): undefined | boolean;
 }
 
-export interface IAnimationCommonSpec {
+export interface AnimationCommonSpec {
 	/**
 	 * The number of milliseconds an animation takes.
 	 * @default 1000
@@ -149,7 +149,7 @@ export interface IAnimationCommonSpec {
 	loop: boolean;
 }
 
-export interface IAnimationPropertySpec extends IAnimationCommonSpec {
+export interface AnimationPropertySpec extends AnimationCommonSpec {
 	properties: string[];
 
 	/**
@@ -169,35 +169,35 @@ export interface IAnimationPropertySpec extends IAnimationCommonSpec {
 	to: Color | number | boolean;
 }
 
-export type IAnimationSpecContainer = IAnimationCommonSpec & {
-	[prop: string]: IAnimationPropertySpec;
+export type AnimationSpecContainer = AnimationCommonSpec & {
+	[prop: string]: AnimationPropertySpec;
 };
 
-export type IAnimationOptions = IAnimationSpecContainer & {
+export type AnimationOptions = AnimationSpecContainer & {
 	/**
 	 * Callback called on each step of an animation.
 	 */
-	onProgress: (this: Chart, event: IAnimationEvent) => void;
+	onProgress: (this: Chart, event: AnimationEvent) => void;
 	/**
 	 *Callback called when all animations are completed.
 	 */
-	onComplete: (this: Chart, event: IAnimationEvent) => void;
+	onComplete: (this: Chart, event: AnimationEvent) => void;
 
-	active: IAnimationSpecContainer;
-	hide: IAnimationSpecContainer;
-	reset: IAnimationSpecContainer;
-	resize: IAnimationSpecContainer;
-	show: IAnimationSpecContainer;
+	active: AnimationSpecContainer;
+	hide: AnimationSpecContainer;
+	reset: AnimationSpecContainer;
+	resize: AnimationSpecContainer;
+	show: AnimationSpecContainer;
 };
 
-export interface IChartAnimationOptions {
-	animation: Scriptable<IAnimationOptions>;
+export interface ChartAnimationOptions {
+	animation: Scriptable<AnimationOptions>;
 	datasets: {
-		animation: Scriptable<IAnimationOptions>;
+		animation: Scriptable<AnimationOptions>;
 	};
 }
 
-export interface IChartMeta<E extends Element = Element, DSE extends Element = Element> {
+export interface ChartMeta<E extends Element = Element, DSE extends Element = Element> {
 	type: string;
 	controller: DatasetController;
 	order: number;
@@ -232,7 +232,7 @@ export interface IChartMeta<E extends Element = Element, DSE extends Element = E
 	_parsed: any[];
 }
 
-export interface IParsingOptions {
+export interface ParsingOptions {
 	parsing:
 	| {
 		[key: string]: string;
@@ -250,7 +250,7 @@ export interface ActiveElement extends ActiveDataPoint {
 }
 
 export declare class Chart<
-	TYPE extends IChartType = IChartType,
+	TYPE extends ChartType = ChartType,
 	DATA extends unknown[] = DefaultDataPoint<TYPE>,
 	LABEL = string
 	> {
@@ -258,21 +258,21 @@ export declare class Chart<
 	readonly id: string;
 	readonly canvas: HTMLCanvasElement;
 	readonly ctx: CanvasRenderingContext2D;
-	readonly config: IChartConfiguration<TYPE, DATA, LABEL>
+	readonly config: ChartConfiguration<TYPE, DATA, LABEL>
 	readonly width: number;
 	readonly height: number;
 	readonly aspectRatio: number;
-	readonly boxes: ILayoutItem[];
+	readonly boxes: LayoutItem[];
 	readonly currentDevicePixelRatio: number;
-	readonly chartArea: IChartArea;
+	readonly chartArea: ChartArea;
 	readonly scales: { [key: string]: Scale };
 	readonly scale: Scale | undefined;
 	readonly attached: boolean;
 
-	data: IChartData<TYPE, DATA, LABEL>;
-	options: IChartOptions<TYPE>;
+	data: ChartData<TYPE, DATA, LABEL>;
+	options: ChartOptions<TYPE>;
 
-	constructor(item: ChartItem, config: IChartConfiguration<TYPE, DATA, LABEL>);
+	constructor(item: ChartItem, config: ChartConfiguration<TYPE, DATA, LABEL>);
 
 	clear(): this;
 	stop(): this;
@@ -286,10 +286,10 @@ export declare class Chart<
 	render(): void;
 	draw(): void;
 
-	getElementsAtEventForMode(e: Event, mode: string, options: IInteractionOptions, useFinalPosition: boolean): InteractionItem[];
+	getElementsAtEventForMode(e: Event, mode: string, options: InteractionOptions, useFinalPosition: boolean): InteractionItem[];
 
-	getSortedVisibleDatasetMetas(): IChartMeta[];
-	getDatasetMeta(datasetIndex: number): IChartMeta;
+	getSortedVisibleDatasetMetas(): ChartMeta[];
+	getDatasetMeta(datasetIndex: number): ChartMeta;
 	getVisibleDatasetCount(): number;
 	isDatasetVisible(datasetIndex: number): boolean;
 	setDatasetVisibility(datasetIndex: number, visible: boolean): void;
@@ -311,8 +311,8 @@ export declare class Chart<
 	static readonly instances: { [key: string]: Chart };
 	static readonly registry: Registry;
 	static getChart(key: string | CanvasRenderingContext2D | HTMLCanvasElement): Chart | undefined;
-	static register(...items: IChartComponentLike[]): void;
-	static unregister(...items: IChartComponentLike[]): void;
+	static register(...items: ChartComponentLike[]): void;
+	static unregister(...items: ChartComponentLike[]): void;
 }
 
 export declare type ChartItem =
@@ -341,7 +341,7 @@ export class DatasetController<E extends Element = Element, DSE extends Element 
 
 	readonly chart: Chart;
 	readonly index: number;
-	readonly _cachedMeta: IChartMeta<E, DSE>;
+	readonly _cachedMeta: ChartMeta<E, DSE>;
 	enableOptionSharing: boolean;
 
 	linkScales(): void;
@@ -353,8 +353,8 @@ export class DatasetController<E extends Element = Element, DSE extends Element 
 	protected getMaxOverflow(): boolean | number;
 	draw(): void;
 	reset(): void;
-	getDataset(): IChartDataset;
-	getMeta(): IChartMeta<E, DSE>;
+	getDataset(): ChartDataset;
+	getMeta(): ChartMeta<E, DSE>;
 	getScaleForId(scaleID: string): Scale | undefined;
 	configure(): void;
 	initialize(): void;
@@ -390,9 +390,9 @@ export class DatasetController<E extends Element = Element, DSE extends Element 
 	setHoverStyle(element: E, datasetIndex: number, index: number): void;
 
 	parse(start: number, count: number): void;
-	protected parsePrimitiveData(meta: IChartMeta<E, DSE>, data: any[], start: number, count: number): any[];
-	protected parseArrayData(meta: IChartMeta<E, DSE>, data: any[], start: number, count: number): any[];
-	protected parseObjectData(meta: IChartMeta<E, DSE>, data: any[], start: number, count: number): any[];
+	protected parsePrimitiveData(meta: ChartMeta<E, DSE>, data: any[], start: number, count: number): any[];
+	protected parseArrayData(meta: ChartMeta<E, DSE>, data: any[], start: number, count: number): any[];
+	protected parseObjectData(meta: ChartMeta<E, DSE>, data: any[], start: number, count: number): any[];
 	protected getParsed(index: number): any;
 	protected applyStack(scale: Scale, parsed: any[]): number;
 	protected updateRangeFromParsed(
@@ -404,7 +404,7 @@ export class DatasetController<E extends Element = Element, DSE extends Element 
 	protected getMinMax(scale: Scale, canStack?: boolean): { min: number; max: number };
 }
 
-export interface IDatasetControllerChartComponent extends IChartComponent {
+export interface DatasetControllerChartComponent extends ChartComponent {
 	defaults: {
 		datasetElementType?: string | null | false;
 		dataElementType?: string | null | false;
@@ -416,7 +416,7 @@ export interface IDatasetControllerChartComponent extends IChartComponent {
 export interface Defaults {
 	readonly color: string;
 	readonly events: ('mousemove' | 'mouseout' | 'click' | 'touchstart' | 'touchmove')[];
-	readonly font: IFontSpec;
+	readonly font: FontSpec;
 	readonly interaction: {
 		mode: InteractionMode | string;
 		intersect: boolean;
@@ -432,9 +432,9 @@ export interface Defaults {
 	readonly responsive: boolean;
 
 	readonly plugins: { [key: string]: any };
-	readonly scale?: IScaleOptions;
+	readonly scale?: ScaleOptions;
 	readonly doughnut: any;
-	readonly scales: { [key: string]: IScaleOptions };
+	readonly scales: { [key: string]: ScaleOptions };
 	readonly controllers: { [key: string]: any };
 
 	set(scope: string, values: any): any;
@@ -467,7 +467,7 @@ export interface Element<T = {}, O = {}> {
 	readonly active: boolean;
 	readonly options: O;
 
-	tooltipPosition(useFinalPosition?: boolean): IPoint;
+	tooltipPosition(useFinalPosition?: boolean): Point;
 	hasValue(): boolean;
 	getProps<P extends keyof T>(props: [P], final?: boolean): Pick<T, P>;
 	getProps<P extends keyof T, P2 extends keyof T>(props: [P, P2], final?: boolean): Pick<T, P | P2>;
@@ -490,7 +490,7 @@ export const Element: {
 	new <T = {}, O = {}>(): Element<T, O>;
 };
 
-export interface IInteractionOptions {
+export interface InteractionOptions {
 	axis?: string;
 	intersect?: boolean;
 }
@@ -503,12 +503,12 @@ export interface InteractionItem {
 
 export type InteractionModeFunction = (
 	chart: Chart,
-	e: IEvent,
-	options: IInteractionOptions,
+	e: Event,
+	options: InteractionOptions,
 	useFinalPosition?: boolean
 ) => InteractionItem[];
 
-export interface IInteractionMode {
+export interface InteractionModeMap {
 	/**
 	 * Returns items at the same index. If the options.intersect parameter is true, we only return items if we intersect something
 	 * If the options.intersect mode is false, we find the nearest item and return the items at the same index as that item
@@ -539,15 +539,15 @@ export interface IInteractionMode {
 	y: InteractionModeFunction;
 }
 
-export type InteractionMode = keyof IInteractionMode;
+export type InteractionMode = keyof InteractionModeMap;
 
 export const Interaction: {
-	modes: IInteractionMode;
+	modes: InteractionModeMap;
 };
 
 export type LayoutPosition = 'left' | 'top' | 'right' | 'chartArea';
 
-export interface ILayoutItem {
+export interface LayoutItem {
 	/**
 	 * The position of the item in the chart layout. Possible values are
 	 */
@@ -579,7 +579,7 @@ export interface ILayoutItem {
 	/**
 	 * Returns an object with padding on the edges
 	 */
-	getPadding?(): IChartArea;
+	getPadding?(): ChartArea;
 
 	/**
 	 *  Width of item. Must be valid after update()
@@ -612,26 +612,26 @@ export const layouts: {
 	 * Register a box to a chart.
 	 * A box is simply a reference to an object that requires layout. eg. Scales, Legend, Title.
 	 * @param {Chart} chart - the chart to use
-	 * @param {ILayoutItem} item - the item to add to be laid out
+	 * @param {LayoutItem} item - the item to add to be laid out
 	 */
-	addBox(chart: Chart, item: ILayoutItem): void;
+	addBox(chart: Chart, item: LayoutItem): void;
 
 	/**
 	 * Remove a layoutItem from a chart
 	 * @param {Chart} chart - the chart to remove the box from
-	 * @param {ILayoutItem} layoutItem - the item to remove from the layout
+	 * @param {LayoutItem} layoutItem - the item to remove from the layout
 	 */
-	removeBox(chart: Chart, layoutItem: ILayoutItem): void;
+	removeBox(chart: Chart, layoutItem: LayoutItem): void;
 
 	/**
 	 * Sets (or updates) options on the given `item`.
 	 * @param {Chart} chart - the chart in which the item lives (or will be added to)
-	 * @param {ILayoutItem} item - the item to configure with the given options
+	 * @param {LayoutItem} item - the item to configure with the given options
 	 * @param options - the new item options.
 	 */
 	configure(
 		chart: Chart,
-		item: ILayoutItem,
+		item: LayoutItem,
 		options: { fullWidth?: number; position?: LayoutPosition; weight?: number }
 	): void;
 
@@ -659,7 +659,7 @@ export interface PluginService {
 	invalidate(): void;
 }
 
-export interface IPlugin<O = {}> {
+export interface Plugin<O = {}> {
 	id: string;
 
 	/**
@@ -728,7 +728,7 @@ export interface IPlugin<O = {}> {
 	 * @param {object} options - The plugin options.
 	 * @returns {boolean} `false` to cancel the chart datasets drawing.
 	 */
-	beforeDatasetUpdate?(chart: Chart, args: { index: number; meta: IChartMeta, mode: UpdateMode }, options: O): boolean | void;
+	beforeDatasetUpdate?(chart: Chart, args: { index: number; meta: ChartMeta, mode: UpdateMode }, options: O): boolean | void;
 	/**
 	 * @desc Called after the `chart` datasets at the given `args.index` has been updated. Note
 	 * that this hook will not be called if the datasets update has been previously cancelled.
@@ -739,7 +739,7 @@ export interface IPlugin<O = {}> {
 	 * @param {UpdateMode} args.mode - The update mode.
 	 * @param {object} options - The plugin options.
 	 */
-	afterDatasetUpdate?(chart: Chart, args: { index: number; meta: IChartMeta, mode: UpdateMode }, options: O): void;
+	afterDatasetUpdate?(chart: Chart, args: { index: number; meta: ChartMeta, mode: UpdateMode }, options: O): void;
 	/**
 	 * @desc Called before laying out `chart`. If any plugin returns `false`,
 	 * the layout update is cancelled until another `update` is triggered.
@@ -811,7 +811,7 @@ export interface IPlugin<O = {}> {
 	 * @param {object} options - The plugin options.
 	 * @returns {boolean} `false` to cancel the chart datasets drawing.
 	 */
-	beforeDatasetDraw?(chart: Chart, args: { index: number; meta: IChartMeta }, options: O): boolean | void;
+	beforeDatasetDraw?(chart: Chart, args: { index: number; meta: ChartMeta }, options: O): boolean | void;
 	/**
 	 * @desc Called after the `chart` datasets at the given `args.index` have been drawn
 	 * (datasets are drawn in the reverse order). Note that this hook will not be called
@@ -822,25 +822,25 @@ export interface IPlugin<O = {}> {
 	 * @param {object} args.meta - The dataset metadata.
 	 * @param {object} options - The plugin options.
 	 */
-	afterDatasetDraw?(chart: Chart, args: { index: number; meta: IChartMeta }, options: O): void;
+	afterDatasetDraw?(chart: Chart, args: { index: number; meta: ChartMeta }, options: O): void;
 	/**
 	 * @desc Called before processing the specified `event`. If any plugin returns `false`,
 	 * the event will be discarded.
 	 * @param {Chart} chart - The chart instance.
-	 * @param {IEvent} event - The event object.
+	 * @param {Event} event - The event object.
 	 * @param {object} options - The plugin options.
 	 * @param {boolean} replay - True if this event is replayed from `Chart.update`
 	 */
-	beforeEvent?(chart: Chart, event: IEvent, options: O, replay: boolean): void;
+	beforeEvent?(chart: Chart, event: Event, options: O, replay: boolean): void;
 	/**
 	 * @desc Called after the `event` has been consumed. Note that this hook
 	 * will not be called if the `event` has been previously discarded.
 	 * @param {Chart} chart - The chart instance.
-	 * @param {IEvent} event - The event object.
+	 * @param {Event} event - The event object.
 	 * @param {object} options - The plugin options.
 	 * @param {boolean} replay - True if this event is replayed from `Chart.update`
 	 */
-	afterEvent?(chart: Chart, event: IEvent, options: O, replay: boolean): void;
+	afterEvent?(chart: Chart, event: Event, options: O, replay: boolean): void;
 	/**
 	 * @desc Called after the chart as been resized.
 	 * @param {Chart} chart - The chart instance.
@@ -856,7 +856,7 @@ export interface IPlugin<O = {}> {
 	destroy?(chart: Chart, options: O): void;
 }
 
-export declare type IChartComponentLike = IChartComponent | IChartComponent[] | { [key: string]: IChartComponent };
+export declare type ChartComponentLike = ChartComponent | ChartComponent[] | { [key: string]: ChartComponent };
 
 /**
  * Please use the module's default export which provides a singleton instance
@@ -865,32 +865,32 @@ export declare type IChartComponentLike = IChartComponent | IChartComponent[] | 
 export interface Registry {
 	readonly controllers: TypedRegistry<DatasetController>;
 	readonly elements: TypedRegistry<Element>;
-	readonly plugins: TypedRegistry<IPlugin>;
+	readonly plugins: TypedRegistry<Plugin>;
 	readonly scales: TypedRegistry<Scale>;
 
-	add(...args: IChartComponentLike[]): void;
-	remove(...args: IChartComponentLike[]): void;
+	add(...args: ChartComponentLike[]): void;
+	remove(...args: ChartComponentLike[]): void;
 
-	addControllers(...args: IChartComponentLike[]): void;
-	addElements(...args: IChartComponentLike[]): void;
-	addPlugins(...args: IChartComponentLike[]): void;
-	addScales(...args: IChartComponentLike[]): void;
+	addControllers(...args: ChartComponentLike[]): void;
+	addElements(...args: ChartComponentLike[]): void;
+	addPlugins(...args: ChartComponentLike[]): void;
+	addScales(...args: ChartComponentLike[]): void;
 
 	getController(id: string): DatasetController | undefined;
 	getElement(id: string): Element | undefined;
-	getPlugin(id: string): IPlugin | undefined;
+	getPlugin(id: string): Plugin | undefined;
 	getScale(id: string): Scale | undefined;
 }
 
 export const registry: Registry;
 
-export interface ITick {
+export interface Tick {
 	value: number;
 	label?: string;
 	major?: boolean;
 }
 
-export interface ICoreScaleOptions {
+export interface CoreScaleOptions {
 	/**
 	 * Controls the axis global visibility (visible when true, hidden when false). When display: 'auto', the axis is visible only if at least one associated dataset is visible.
 	 * @default true
@@ -964,7 +964,7 @@ export interface ICoreScaleOptions {
 	afterUpdate(axis: Scale): void;
 }
 
-export interface Scale<O extends ICoreScaleOptions = ICoreScaleOptions> extends Element<{}, O>, IChartArea {
+export interface Scale<O extends CoreScaleOptions = CoreScaleOptions> extends Element<{}, O>, ChartArea {
 	readonly id: string;
 	readonly type: string;
 	readonly ctx: CanvasRenderingContext2D;
@@ -985,13 +985,13 @@ export interface Scale<O extends ICoreScaleOptions = ICoreScaleOptions> extends 
 	labelRotation: number;
 	min: number;
 	max: number;
-	ticks: ITick[];
-	getMatchingVisibleMetas(type?: string): IChartMeta[];
+	ticks: Tick[];
+	getMatchingVisibleMetas(type?: string): ChartMeta[];
 
-	draw(chartArea: IChartArea): void;
-	drawTitle(chartArea: IChartArea): void;
-	drawLabels(chartArea: IChartArea): void;
-	drawGrid(chartArea: IChartArea): void;
+	draw(chartArea: ChartArea): void;
+	drawTitle(chartArea: ChartArea): void;
+	drawLabels(chartArea: ChartArea): void;
+	drawGrid(chartArea: ChartArea): void;
 
 	/**
 	 * @param {number} pixel
@@ -1048,8 +1048,8 @@ export interface Scale<O extends ICoreScaleOptions = ICoreScaleOptions> extends 
 	getUserBounds(): { min: number; max: number; minDefined: boolean; maxDefined: boolean };
 	getMinMax(canStack: boolean): { min: number; max: number };
 	invalidateCaches(): void;
-	getPadding(): IChartArea;
-	getTicks(): ITick[];
+	getPadding(): ChartArea;
+	getTicks(): Tick[];
 	getLabels(): string[];
 	beforeUpdate(): void;
 	update(maxWidth: number, maxHeight: number, margins: any): void;
@@ -1062,10 +1062,10 @@ export interface Scale<O extends ICoreScaleOptions = ICoreScaleOptions> extends 
 	determineDataLimits(): void;
 	afterDataLimits(): void;
 	beforeBuildTicks(): void;
-	buildTicks(): ITick[];
+	buildTicks(): Tick[];
 	afterBuildTicks(): void;
 	beforeTickToLabelConversion(): void;
-	generateTickLabels(ticks: ITick[]): void;
+	generateTickLabels(ticks: Tick[]): void;
 	afterTickToLabelConversion(): void;
 	beforeCalculateLabelRotation(): void;
 	calculateLabelRotation(): void;
@@ -1079,17 +1079,17 @@ export interface Scale<O extends ICoreScaleOptions = ICoreScaleOptions> extends 
 }
 export const Scale: {
 	prototype: Scale;
-	new <O extends ICoreScaleOptions = ICoreScaleOptions>(cfg: any): Scale<O>;
+	new <O extends CoreScaleOptions = CoreScaleOptions>(cfg: any): Scale<O>;
 };
 
-export interface IScriptAbleScaleContext {
+export interface ScriptAbleScaleContext {
 	chart: Chart;
 	scale: Scale;
 	index: number;
-	tick: ITick;
+	tick: Tick;
 }
 
-export type ScriptAbleScale<T> = T | ((ctx: IScriptAbleScaleContext) => T);
+export type ScriptAbleScale<T> = T | ((ctx: ScriptAbleScaleContext) => T);
 
 export const Ticks: {
 	formatters: {
@@ -1120,10 +1120,10 @@ export const Ticks: {
 
 export interface TypedRegistry<T> {
 	/**
-	 * @param {IChartComponent} item
+	 * @param {ChartComponent} item
 	 * @returns {string} The scope where items defaults were registered to.
 	 */
-	register(item: IChartComponent): string;
+	register(item: ChartComponent): string;
 	get(id: string): T | undefined;
-	unregister(item: IChartComponent): void;
+	unregister(item: ChartComponent): void;
 }

--- a/types/core/index.d.ts
+++ b/types/core/index.d.ts
@@ -20,7 +20,7 @@ import {
 	ScaleOptions
 } from '../interfaces';
 
-export interface DateAdapter {
+export interface DateAdapterBase {
 	/**
 	 * Returns a map of time formats for the supported formatting units defined
 	 * in Unit as well as 'datetime' representing a detailed date/time string.
@@ -74,7 +74,7 @@ export interface DateAdapter {
 	endOf(timestamp: number, unit: TimeUnit | 'isoWeek'): number;
 }
 
-export interface DateAdapter extends DateAdapter {
+export interface DateAdapter extends DateAdapterBase {
 	readonly options: any;
 }
 

--- a/types/core/interfaces.d.ts
+++ b/types/core/interfaces.d.ts
@@ -3,7 +3,7 @@ import { ChartDataset } from '../interfaces';
 
 export type Color = string | CanvasGradient | CanvasPattern;
 
-export interface Event {
+export interface ChartEvent {
   type:
     | 'contextmenu'
     | 'mouseenter'
@@ -140,11 +140,11 @@ export interface CoreChartOptions {
   /**
    * Called when any of the events fire. Passed the event, an array of active elements (bars, points, etc), and the chart.
    */
-  onHover(event: Event, elements: Element[]): void;
+  onHover(event: ChartEvent, elements: Element[]): void;
   /**
    * Called if the event is of type 'mouseup' or 'click'. Passed the event, an array of active elements, and the chart.
    */
-  onClick(event: Event, elements: Element[]): void;
+  onClick(event: ChartEvent, elements: Element[]): void;
 
   elements: { [key: string]: ElementOptions };
 

--- a/types/core/interfaces.d.ts
+++ b/types/core/interfaces.d.ts
@@ -1,9 +1,9 @@
 import { Chart, Element, InteractionMode } from '.';
-import { IChartDataset } from '../interfaces';
+import { ChartDataset } from '../interfaces';
 
 export type Color = string | CanvasGradient | CanvasPattern;
 
-export interface IEvent {
+export interface Event {
   type:
     | 'contextmenu'
     | 'mouseenter'
@@ -22,12 +22,12 @@ export interface IEvent {
   y: number | null;
 }
 
-export interface IPoint {
+export interface Point {
   x: number;
   y: number;
 }
 
-export interface IChartComponent {
+export interface ChartComponent {
   id: string;
   defaults?: any;
   defaultRoutes?: { [property: string]: string };
@@ -40,35 +40,35 @@ export interface IChartComponent {
 
 export type TimeUnit = 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year';
 
-export interface IChartArea {
+export interface ChartArea {
   top: number;
   left: number;
   right: number;
   bottom: number;
 }
 
-export interface IPadding {
+export interface Padding {
   top: number;
   left: number;
   right: number;
   bottom: number;
 }
 
-export interface IScriptableContext {
+export interface ScriptableContext {
   chart: Chart;
   dataPoint: any;
   dataIndex: number;
-  dataset: IChartDataset;
+  dataset: ChartDataset;
   datasetIndex: number;
   active: boolean;
 }
 
-export type Scriptable<T> = T | ((ctx: IScriptableContext) => T);
+export type Scriptable<T> = T | ((ctx: ScriptableContext) => T);
 export type ScriptableOptions<T> = { [P in keyof T]: Scriptable<T[P]> };
 export type ScriptableAndArray<T> = readonly T[] | Scriptable<T>;
 export type ScriptableAndArrayOptions<T> = { [P in keyof T]: ScriptableAndArray<T[P]> };
 
-export interface IHoverInteractionOptions {
+export interface HoverInteractionOptions {
   /**
    * Sets which elements appear in the tooltip. See Interaction Modes for details.
    * @default 'nearest'
@@ -86,11 +86,11 @@ export interface IHoverInteractionOptions {
   axis: 'x' | 'y' | 'xy';
 }
 
-export interface IElementOptions {
+export interface ElementOptions {
   // TODO
 }
 
-export interface ICoreChartOptions {
+export interface CoreChartOptions {
   /**
    * base color
    * @see Defaults.color
@@ -100,7 +100,7 @@ export interface ICoreChartOptions {
    * base font
    * @see Defaults.font
    */
-  font: IFontSpec;
+  font: FontSpec;
   /**
    * Resizes the chart canvas when its container does (important note...).
    * @default true
@@ -129,7 +129,7 @@ export interface ICoreChartOptions {
    */
   devicePixelRatio: number;
 
-  hover: IHoverInteractionOptions;
+  hover: HoverInteractionOptions;
 
   /**
    * The events option defines the browser events that the chart should listen to for tooltips and hovering.
@@ -140,16 +140,16 @@ export interface ICoreChartOptions {
   /**
    * Called when any of the events fire. Passed the event, an array of active elements (bars, points, etc), and the chart.
    */
-  onHover(event: IEvent, elements: Element[]): void;
+  onHover(event: Event, elements: Element[]): void;
   /**
    * Called if the event is of type 'mouseup' or 'click'. Passed the event, an array of active elements, and the chart.
    */
-  onClick(event: IEvent, elements: Element[]): void;
+  onClick(event: Event, elements: Element[]): void;
 
-  elements: { [key: string]: IElementOptions };
+  elements: { [key: string]: ElementOptions };
 
   layout: {
-    padding: Scriptable<number | IChartArea>;
+    padding: Scriptable<number | ChartArea>;
   };
 }
 
@@ -186,7 +186,7 @@ export type EasingFunction =
   | 'easeOutBounce'
   | 'easeInOutBounce';
 
-export interface IFontSpec {
+export interface FontSpec {
   /**
    * Default font color for all text.
    * @default '#666'

--- a/types/elements/index.d.ts
+++ b/types/elements/index.d.ts
@@ -1,7 +1,7 @@
 import { Element } from '../core';
-import { Color, IChartArea, IChartComponent, IPoint } from '../core/interfaces';
+import { Color, ChartArea, ChartComponent, Point } from '../core/interfaces';
 
-export interface IVisualElement {
+export interface VisualElement {
   draw(ctx: CanvasRenderingContext2D): void;
   inRange(mouseX: number, mouseY: number, useFinalPosition?: boolean): boolean;
   inXRange(mouseX: number, useFinalPosition?: boolean): boolean;
@@ -10,25 +10,25 @@ export interface IVisualElement {
   getRange?(axis: 'x' | 'y'): number;
 }
 
-export interface ICommonOptions {
+export interface CommonOptions {
   borderWidth: number;
   borderColor: Color;
   backgroundColor: Color;
 }
 
-export interface ICommonHoverOptions {
+export interface CommonHoverOptions {
   hoverBorderWidth: number;
   hoverBorderColor: Color;
   hoverBackgroundColor: Color;
 }
 
-export interface ISegment {
+export interface Segment {
   start: number;
   end: number;
   loop: boolean;
 }
 
-export interface IArcProps {
+export interface ArcProps {
   x: number;
   y: number;
   startAngle: number;
@@ -38,7 +38,7 @@ export interface IArcProps {
   circumference: number;
 }
 
-export interface IArcOptions extends ICommonOptions {
+export interface ArcOptions extends CommonOptions {
   /**
    * Arc stroke alignment.
    */
@@ -49,22 +49,22 @@ export interface IArcOptions extends ICommonOptions {
   offset: number;
 }
 
-export interface IArcHoverOptions extends ICommonHoverOptions {
+export interface ArcHoverOptions extends CommonHoverOptions {
   hoverOffset: number;
 }
 
-export interface ArcElement<T extends IArcProps = IArcProps, O extends IArcOptions = IArcOptions>
+export interface ArcElement<T extends ArcProps = ArcProps, O extends ArcOptions = ArcOptions>
   extends Element<T, O>,
-    IVisualElement {}
+    VisualElement {}
 
-export const ArcElement: IChartComponent & {
+export const ArcElement: ChartComponent & {
   prototype: ArcElement;
   new (cfg: any): ArcElement;
 };
 
-export interface ILineProps {}
+export interface LineProps {}
 
-export interface ILineOptions extends ICommonOptions {
+export interface LineOptions extends CommonOptions {
   /**
    * Line cap style. See MDN.
    * @default 'butt'
@@ -107,32 +107,32 @@ export interface ILineOptions extends ICommonOptions {
   stepped: 'before' | 'after' | 'middle' | boolean;
 }
 
-export interface ILineHoverOptions extends ICommonHoverOptions {
+export interface LineHoverOptions extends CommonHoverOptions {
   hoverBorderCapStyle: CanvasLineCap;
   hoverBorderDash: number[];
   hoverBorderDashOffset: number;
   hoverBorderJoinStyle: CanvasLineJoin;
 }
 
-export interface LineElement<T extends ILineProps = ILineProps, O extends ILineOptions = ILineOptions>
+export interface LineElement<T extends LineProps = LineProps, O extends LineOptions = LineOptions>
   extends Element<T, O>,
-    IVisualElement {
-  updateControlPoints(chartArea: IChartArea): void;
-  points: IPoint[];
-  readonly segments: ISegment[];
-  first(): IPoint | false;
-  last(): IPoint | false;
-  interpolate(point: IPoint, property: 'x' | 'y'): undefined | IPoint | IPoint[];
-  pathSegment(ctx: CanvasRenderingContext2D, segment: ISegment, params: any): undefined | boolean;
+    VisualElement {
+  updateControlPoints(chartArea: ChartArea): void;
+  points: Point[];
+  readonly segments: Segment[];
+  first(): Point | false;
+  last(): Point | false;
+  interpolate(point: Point, property: 'x' | 'y'): undefined | Point | Point[];
+  pathSegment(ctx: CanvasRenderingContext2D, segment: Segment, params: any): undefined | boolean;
   path(ctx: CanvasRenderingContext2D): boolean;
 }
 
-export const LineElement: IChartComponent & {
+export const LineElement: ChartComponent & {
   prototype: LineElement;
   new (cfg: any): LineElement;
 };
 
-export interface IPointProps {
+export interface PointProps {
   x: number;
   y: number;
 }
@@ -151,7 +151,7 @@ export type PointStyle =
   | HTMLImageElement
   | HTMLCanvasElement;
 
-export interface IPointOptions extends ICommonOptions {
+export interface PointOptions extends CommonOptions {
   /**
    * Point radius
    * @default 3
@@ -174,7 +174,7 @@ export interface IPointOptions extends ICommonOptions {
   rotation: number;
 }
 
-export interface IPointHoverOptions extends ICommonHoverOptions {
+export interface PointHoverOptions extends CommonHoverOptions {
   /**
    * Point radius when hovered.
    * @default 4
@@ -182,7 +182,7 @@ export interface IPointHoverOptions extends ICommonHoverOptions {
   hoverRadius: number;
 }
 
-export interface IPointPrefixedOptions {
+export interface PointPrefixedOptions {
   /**
    * The fill color for points.
    */
@@ -213,7 +213,7 @@ export interface IPointPrefixedOptions {
   pointStyle: PointStyle;
 }
 
-export interface IPointPrefixedHoverOptions {
+export interface PointPrefixedHoverOptions {
   /**
    * Point background color when hovered.
    */
@@ -232,18 +232,18 @@ export interface IPointPrefixedHoverOptions {
   pointHoverRadius: number;
 }
 
-export interface PointElement<T extends IPointProps = IPointProps, O extends IPointOptions = IPointOptions>
+export interface PointElement<T extends PointProps = PointProps, O extends PointOptions = PointOptions>
   extends Element<T, O>,
-    IVisualElement {
+    VisualElement {
   readonly skip: boolean;
 }
 
-export const PointElement: IChartComponent & {
+export const PointElement: ChartComponent & {
   prototype: PointElement;
   new (cfg: any): PointElement;
 };
 
-export interface IBarProps {
+export interface BarProps {
   x: number;
   y: number;
   base: number;
@@ -252,7 +252,7 @@ export interface IBarProps {
   height: number;
 }
 
-export interface IBarOptions extends ICommonOptions {
+export interface BarOptions extends CommonOptions {
   /**
    * The base value for the bar in data units along the value axis.
    */
@@ -268,35 +268,35 @@ export interface IBarOptions extends ICommonOptions {
    * Border radius
    * @default 0
    */
-  borderRadius: number | IBorderRadius;
+  borderRadius: number | BorderRadius;
 }
 
-export interface IBorderRadius {
+export interface BorderRadius {
   topLeft: number;
   topRight: number;
   bottomLeft: number;
   bottomRight: number;
 }
 
-export interface IBarHoverOptions extends ICommonHoverOptions {
-  hoverBorderRadius: number | IBorderRadius;
+export interface BarHoverOptions extends CommonHoverOptions {
+  hoverBorderRadius: number | BorderRadius;
 }
 
 export interface BarElement<
-  T extends IBarProps = IBarProps,
-  O extends IBarOptions = IBarOptions
-> extends Element<T, O>, IVisualElement {}
+  T extends BarProps = BarProps,
+  O extends BarOptions = BarOptions
+> extends Element<T, O>, VisualElement {}
 
-export const BarElement: IChartComponent & {
+export const BarElement: ChartComponent & {
   prototype: BarElement;
   new (cfg: any): BarElement;
 };
 
-export interface IElementChartOptions {
+export interface ElementChartOptions {
   elements: {
-    arc: IArcOptions & IArcHoverOptions;
-    bar: IBarOptions & IBarHoverOptions;
-    line: ILineOptions & ILineHoverOptions;
-    point: IPointOptions & IPointHoverOptions;
+    arc: ArcOptions & ArcHoverOptions;
+    bar: BarOptions & BarHoverOptions;
+    line: LineOptions & LineHoverOptions;
+    point: PointOptions & PointHoverOptions;
   };
 }

--- a/types/helpers/helpers.canvas.d.ts
+++ b/types/helpers/helpers.canvas.d.ts
@@ -1,5 +1,5 @@
 import { PointStyle } from '../elements';
-import { IChartArea } from '../core/interfaces';
+import { ChartArea } from '../core/interfaces';
 
 /**
  * Clears the entire canvas associated to the given `chart`.
@@ -7,7 +7,7 @@ import { IChartArea } from '../core/interfaces';
  */
 export function clear(chart: { ctx: CanvasRenderingContext2D }): void;
 
-export function clipArea(ctx: CanvasRenderingContext2D, area: IChartArea): void;
+export function clipArea(ctx: CanvasRenderingContext2D, area: ChartArea): void;
 
 export function unclipArea(ctx: CanvasRenderingContext2D): void;
 

--- a/types/helpers/helpers.canvas.d.ts
+++ b/types/helpers/helpers.canvas.d.ts
@@ -11,14 +11,14 @@ export function clipArea(ctx: CanvasRenderingContext2D, area: IChartArea): void;
 
 export function unclipArea(ctx: CanvasRenderingContext2D): void;
 
-export interface IDrawPointOptions {
+export interface DrawPointOptions {
   pointStyle: PointStyle;
   rotation?: number;
   radius: number;
   borderWidth: number;
 }
 
-export function drawPoint(ctx: CanvasRenderingContext2D, options: IDrawPointOptions, x: number, y: number): void;
+export function drawPoint(ctx: CanvasRenderingContext2D, options: DrawPointOptions, x: number, y: number): void;
 
 /**
  * Converts the given font object into a CSS font string.

--- a/types/helpers/helpers.collection.d.ts
+++ b/types/helpers/helpers.collection.d.ts
@@ -1,4 +1,4 @@
-export interface IArrayListener<T> {
+export interface ArrayListener<T> {
   _onDataPush?(...item: T[]): void;
   _onDataPop?(): void;
   _onDataShift?(): void;
@@ -11,10 +11,10 @@ export interface IArrayListener<T> {
  * 'unshift') and notify the listener AFTER the array has been altered. Listeners are
  * called on the '_onData*' callbacks (e.g. _onDataPush, etc.) with same arguments.
  */
-export function listenArrayEvents<T>(array: T[], listener: IArrayListener<T>): void;
+export function listenArrayEvents<T>(array: T[], listener: ArrayListener<T>): void;
 
 /**
  * Removes the given array event listener and cleanup extra attached properties (such as
  * the _chartjs stub and overridden methods) if array doesn't have any more listeners.
  */
-export function unlistenArrayEvents<T>(array: T[], listener: IArrayListener<T>): void;
+export function unlistenArrayEvents<T>(array: T[], listener: ArrayListener<T>): void;

--- a/types/helpers/helpers.core.d.ts
+++ b/types/helpers/helpers.core.d.ts
@@ -94,7 +94,7 @@ export function each<T, TA>(
  */
 export function clone<T>(source: T): T;
 
-export interface IMergeOptions {
+export interface MergeOptions {
   merger?: (key: string, target: any, source: any, options: any) => any;
 }
 /**
@@ -106,17 +106,17 @@ export interface IMergeOptions {
  * @param {function} [options.merger] - The merge method (key, target, source, options)
  * @returns {object} The `target` object.
  */
-export function merge<T>(target: T, source: [], options?: IMergeOptions): T;
-export function merge<T, S1>(target: T, source: S1, options?: IMergeOptions): T & S1;
-export function merge<T, S1>(target: T, source: [S1], options?: IMergeOptions): T & S1;
-export function merge<T, S1, S2>(target: T, source: [S1, S2], options?: IMergeOptions): T & S1 & S2;
-export function merge<T, S1, S2, S3>(target: T, source: [S1, S2, S3], options?: IMergeOptions): T & S1 & S2 & S3;
+export function merge<T>(target: T, source: [], options?: MergeOptions): T;
+export function merge<T, S1>(target: T, source: S1, options?: MergeOptions): T & S1;
+export function merge<T, S1>(target: T, source: [S1], options?: MergeOptions): T & S1;
+export function merge<T, S1, S2>(target: T, source: [S1, S2], options?: MergeOptions): T & S1 & S2;
+export function merge<T, S1, S2, S3>(target: T, source: [S1, S2, S3], options?: MergeOptions): T & S1 & S2 & S3;
 export function merge<T, S1, S2, S3, S4>(
   target: T,
   source: [S1, S2, S3, S4],
-  options?: IMergeOptions
+  options?: MergeOptions
 ): T & S1 & S2 & S3 & S4;
-export function merge<T>(target: T, source: any[], options?: IMergeOptions): any;
+export function merge<T>(target: T, source: any[], options?: MergeOptions): any;
 
 /**
  * Recursively deep copies `source` properties into `target` *only* if not defined in target.

--- a/types/helpers/helpers.curve.d.ts
+++ b/types/helpers/helpers.curve.d.ts
@@ -1,4 +1,4 @@
-export interface ISplinePoint {
+export interface SplinePoint {
   x: number;
   y: number;
 }
@@ -8,16 +8,16 @@ export interface ISplinePoint {
  * http://scaledinnovation.com/analytics/splines/aboutSplines.html
  */
 export function splineCurve(
-  firstPoint: ISplinePoint & { skip?: boolean },
-  middlePoint: ISplinePoint,
-  afterPoint: ISplinePoint,
+  firstPoint: SplinePoint & { skip?: boolean },
+  middlePoint: SplinePoint,
+  afterPoint: SplinePoint,
   t: number
 ): {
-  previous: ISplinePoint;
-  next: ISplinePoint;
+  previous: SplinePoint;
+  next: SplinePoint;
 };
 
-export interface IMonotoneSplinePoint extends ISplinePoint {
+export interface MonotoneSplinePoint extends SplinePoint {
   skip: boolean;
   controlPointPreviousX?: number;
   controlPointPreviousY?: number;
@@ -31,4 +31,4 @@ export interface IMonotoneSplinePoint extends ISplinePoint {
  * between the dataset discrete points due to the interpolation.
  * @see https://en.wikipedia.org/wiki/Monotone_cubic_interpolation
  */
-export function splineCurveMonotone(points: readonly IMonotoneSplinePoint[]): void;
+export function splineCurveMonotone(points: readonly MonotoneSplinePoint[]): void;

--- a/types/helpers/helpers.options.d.ts
+++ b/types/helpers/helpers.options.d.ts
@@ -1,6 +1,6 @@
-import { IFontSpec } from '../core/interfaces';
+import { FontSpec } from '../core/interfaces';
 
-export interface CanvasFontSpec extends IFontSpec {
+export interface CanvasFontSpec extends FontSpec {
   string: string;
 }
 /**
@@ -8,7 +8,7 @@ export interface CanvasFontSpec extends IFontSpec {
  * @param {object} options - A object that contains font options to be parsed.
  * @return {object} The font object.
  */
-export function toFont(options: Partial<IFontSpec>): CanvasFontSpec;
+export function toFont(options: Partial<FontSpec>): CanvasFontSpec;
 
 /**
  * Converts the given line height `value` in pixels for a specific font `size`.

--- a/types/helpers/helpers.options.d.ts
+++ b/types/helpers/helpers.options.d.ts
@@ -1,6 +1,6 @@
 import { IFontSpec } from '../core/interfaces';
 
-export interface ICanvasFontSpec extends IFontSpec {
+export interface CanvasFontSpec extends IFontSpec {
   string: string;
 }
 /**
@@ -8,7 +8,7 @@ export interface ICanvasFontSpec extends IFontSpec {
  * @param {object} options - A object that contains font options to be parsed.
  * @return {object} The font object.
  */
-export function toFont(options: Partial<IFontSpec>): ICanvasFontSpec;
+export function toFont(options: Partial<IFontSpec>): CanvasFontSpec;
 
 /**
  * Converts the given line height `value` in pixels for a specific font `size`.

--- a/types/helpers/helpers.rtl.d.ts
+++ b/types/helpers/helpers.rtl.d.ts
@@ -1,11 +1,11 @@
-export interface IRTLAdapter {
+export interface RTLAdapter {
   x(x: number): number;
   setWidth(w: number): void;
   textAlign(align: 'center' | 'left' | 'right'): 'center' | 'left' | 'right';
   xPlus(x: number, value: number): number;
   leftForLtr(x: number, itemWidth: number): number;
 }
-export function getRtlAdapter(rtl: boolean, rectX: number, width: number): IRTLAdapter;
+export function getRtlAdapter(rtl: boolean, rectX: number, width: number): RTLAdapter;
 
 export function overrideTextDirection(ctx: CanvasRenderingContext2D, direction: 'ltr' | 'rtl'): void;
 

--- a/types/interfaces.d.ts
+++ b/types/interfaces.d.ts
@@ -1,40 +1,40 @@
 import {
-  IBarControllerDatasetOptions,
-  ILineControllerDatasetOptions,
-  ILineControllerChartOptions,
-  IScatterDataPoint,
-  IScatterControllerDatasetOptions,
-  IScatterControllerChartOptions,
-  IBubbleControllerDatasetOptions,
-  IBubbleDataPoint,
-  IDoughnutControllerChartOptions,
-  IDoughnutControllerDatasetOptions,
-  IDoughnutDataPoint,
-  IPieControllerChartOptions,
-  IPieControllerDatasetOptions,
-  IPieDataPoint,
-  IControllerDatasetOptions,
-  IBarControllerChartOptions,
-  IPolarAreaControllerChartOptions,
-  IPolarAreaControllerDatasetOptions,
-  IRadarControllerChartOptions,
-  IRadarControllerDatasetOptions,
+  BarControllerDatasetOptions,
+  LineControllerDatasetOptions,
+  LineControllerChartOptions,
+  ScatterDataPoint,
+  ScatterControllerDatasetOptions,
+  ScatterControllerChartOptions,
+  BubbleControllerDatasetOptions,
+  BubbleDataPoint,
+  DoughnutControllerChartOptions,
+  DoughnutControllerDatasetOptions,
+  DoughnutDataPoint,
+  PieControllerChartOptions,
+  PieControllerDatasetOptions,
+  PieDataPoint,
+  ControllerDatasetOptions,
+  BarControllerChartOptions,
+  PolarAreaControllerChartOptions,
+  PolarAreaControllerDatasetOptions,
+  RadarControllerChartOptions,
+  RadarControllerDatasetOptions,
 } from './controllers';
-import { ICoreChartOptions } from './core/interfaces';
-import { IElementChartOptions } from './elements';
+import { CoreChartOptions } from './core/interfaces';
+import { ElementChartOptions } from './elements';
 import {
-  ITooltipChartOptions,
-  IFillerControllerDatasetOptions,
-  ILegendChartOptions,
-  ITitleChartOptions,
+  TooltipChartOptions,
+  FillerControllerDatasetOptions,
+  LegendChartOptions,
+  TitleChartOptions,
 } from './plugins';
-import { IChartAnimationOptions, IParsingOptions, IPlugin } from './core';
+import { ChartAnimationOptions, ParsingOptions as ParsingOptions, Plugin } from './core';
 import {
-  ILinearScaleOptions,
-  ILogarithmicScaleOptions,
-  ICategoryScaleOptions,
-  IRadialLinearScaleOptions,
-  ITimeScaleOptions,
+  LinearScaleOptions,
+  LogarithmicScaleOptions,
+  CategoryScaleOptions,
+  RadialLinearScaleOptions as RadialLinearScaleOptions,
+  TimeScaleOptions,
 } from './scales';
 
 export type DeepPartial<T> = T extends {}
@@ -45,150 +45,150 @@ export type DeepPartial<T> = T extends {}
 
 export type DistributiveArray<T> = T extends unknown ? T[] : never
 
-export interface ICartesianScaleTypeRegistry {
+export interface CartesianScaleTypeRegistry {
   linear: {
-    options: ILinearScaleOptions;
+    options: LinearScaleOptions;
   };
   logarithmic: {
-    options: ILogarithmicScaleOptions;
+    options: LogarithmicScaleOptions;
   };
   category: {
-    options: ICategoryScaleOptions;
+    options: CategoryScaleOptions;
   };
   time: {
-    options: ITimeScaleOptions;
+    options: TimeScaleOptions;
   };
   timeseries: {
-    options: ITimeScaleOptions;
+    options: TimeScaleOptions;
   };
 }
 
-export interface IRadialScaleTypeRegistry {
+export interface RadialScaleTypeRegistry {
   radialLinear: {
-    options: IRadialLinearScaleOptions;
+    options: RadialLinearScaleOptions;
   };
 }
 
-export interface IScaleTypeRegistry extends ICartesianScaleTypeRegistry, IRadialScaleTypeRegistry {
+export interface ScaleTypeRegistry extends CartesianScaleTypeRegistry, RadialScaleTypeRegistry {
 }
 
-export type IScaleType = keyof IScaleTypeRegistry;
+export type ScaleType = keyof ScaleTypeRegistry;
 
-export interface IChartTypeRegistry {
+export interface ChartTypeRegistry {
   bar: {
-    chartOptions: IBarControllerChartOptions;
-    datasetOptions: IBarControllerDatasetOptions;
+    chartOptions: BarControllerChartOptions;
+    datasetOptions: BarControllerDatasetOptions;
     defaultDataPoint: number;
-    scales: keyof ICartesianScaleTypeRegistry;
+    scales: keyof CartesianScaleTypeRegistry;
   };
   line: {
-    chartOptions: ILineControllerChartOptions;
-    datasetOptions: ILineControllerDatasetOptions & IFillerControllerDatasetOptions;
-    defaultDataPoint: IScatterDataPoint;
-    scales: keyof ICartesianScaleTypeRegistry;
+    chartOptions: LineControllerChartOptions;
+    datasetOptions: LineControllerDatasetOptions & FillerControllerDatasetOptions;
+    defaultDataPoint: ScatterDataPoint;
+    scales: keyof CartesianScaleTypeRegistry;
   };
   scatter: {
-    chartOptions: IScatterControllerChartOptions;
-    datasetOptions: IScatterControllerDatasetOptions;
-    defaultDataPoint: IScatterDataPoint;
-    scales: keyof ICartesianScaleTypeRegistry;
+    chartOptions: ScatterControllerChartOptions;
+    datasetOptions: ScatterControllerDatasetOptions;
+    defaultDataPoint: ScatterDataPoint;
+    scales: keyof CartesianScaleTypeRegistry;
   };
   bubble: {
     chartOptions: {};
-    datasetOptions: IBubbleControllerDatasetOptions;
-    defaultDataPoint: IBubbleDataPoint;
-    scales: keyof ICartesianScaleTypeRegistry;
+    datasetOptions: BubbleControllerDatasetOptions;
+    defaultDataPoint: BubbleDataPoint;
+    scales: keyof CartesianScaleTypeRegistry;
   };
   pie: {
-    chartOptions: IPieControllerChartOptions;
-    datasetOptions: IPieControllerDatasetOptions;
-    defaultDataPoint: IPieDataPoint;
-    scales: keyof ICartesianScaleTypeRegistry;
+    chartOptions: PieControllerChartOptions;
+    datasetOptions: PieControllerDatasetOptions;
+    defaultDataPoint: PieDataPoint;
+    scales: keyof CartesianScaleTypeRegistry;
   };
   doughnut: {
-    chartOptions: IDoughnutControllerChartOptions;
-    datasetOptions: IDoughnutControllerDatasetOptions;
-    defaultDataPoint: IDoughnutDataPoint;
-    scales: keyof ICartesianScaleTypeRegistry;
+    chartOptions: DoughnutControllerChartOptions;
+    datasetOptions: DoughnutControllerDatasetOptions;
+    defaultDataPoint: DoughnutDataPoint;
+    scales: keyof CartesianScaleTypeRegistry;
   };
   polarArea: {
-    chartOptions: IPolarAreaControllerChartOptions;
-    datasetOptions: IPolarAreaControllerDatasetOptions;
+    chartOptions: PolarAreaControllerChartOptions;
+    datasetOptions: PolarAreaControllerDatasetOptions;
     defaultDataPoint: number;
-    scales: keyof IRadialScaleTypeRegistry;
+    scales: keyof RadialScaleTypeRegistry;
   };
   radar: {
-    chartOptions: IRadarControllerChartOptions;
-    datasetOptions: IRadarControllerDatasetOptions;
+    chartOptions: RadarControllerChartOptions;
+    datasetOptions: RadarControllerDatasetOptions;
     defaultDataPoint: number;
-    scales: keyof IRadialScaleTypeRegistry;
+    scales: keyof RadialScaleTypeRegistry;
   };
 }
 
-export type IChartType = keyof IChartTypeRegistry;
+export type ChartType = keyof ChartTypeRegistry;
 
-export type IScaleOptions<SCALES extends IScaleType = IScaleType> = DeepPartial<
-  { [key in IScaleType]: { type: key } & IScaleTypeRegistry[key]['options'] }[SCALES]
+export type ScaleOptions<SCALES extends ScaleType = ScaleType> = DeepPartial<
+  { [key in ScaleType]: { type: key } & ScaleTypeRegistry[key]['options'] }[SCALES]
 >;
 
-export type IDatasetChartOptions<TYPE extends IChartType = IChartType> = {
+export type DatasetChartOptions<TYPE extends ChartType = ChartType> = {
   [key in TYPE]: {
-    datasets: IChartTypeRegistry[key]['datasetOptions'];
+    datasets: ChartTypeRegistry[key]['datasetOptions'];
   };
 };
 
-export type IScaleChartOptions<TYPE extends IChartType = IChartType> = {
+export type ScaleChartOptions<TYPE extends ChartType = ChartType> = {
   scales: {
-    [key: string]: IScaleOptions<IChartTypeRegistry[TYPE]['scales']>;
+    [key: string]: ScaleOptions<ChartTypeRegistry[TYPE]['scales']>;
   };
 };
 
-export type IChartOptions<TYPE extends IChartType = IChartType> = DeepPartial<
-  ICoreChartOptions &
-  IParsingOptions &
-  ITooltipChartOptions &
-  ILegendChartOptions &
-  ITitleChartOptions &
-  IChartAnimationOptions &
-  IElementChartOptions &
-  IDatasetChartOptions<TYPE> &
-  IScaleChartOptions<TYPE> &
-  IChartTypeRegistry[TYPE]['chartOptions']
+export type ChartOptions<TYPE extends ChartType = ChartType> = DeepPartial<
+  CoreChartOptions &
+  ParsingOptions &
+  TooltipChartOptions &
+  LegendChartOptions &
+  TitleChartOptions &
+  ChartAnimationOptions &
+  ElementChartOptions &
+  DatasetChartOptions<TYPE> &
+  ScaleChartOptions<TYPE> &
+  ChartTypeRegistry[TYPE]['chartOptions']
 >;
 
-export type DefaultDataPoint<TYPE extends IChartType> = IChartType extends TYPE ? unknown[] : DistributiveArray<
-  IChartTypeRegistry[TYPE]['defaultDataPoint']
+export type DefaultDataPoint<TYPE extends ChartType> = ChartType extends TYPE ? unknown[] : DistributiveArray<
+  ChartTypeRegistry[TYPE]['defaultDataPoint']
 >;
 
-export interface IChartDatasetProperties<TYPE extends IChartType, DATA extends unknown[]> {
+export interface ChartDatasetProperties<TYPE extends ChartType, DATA extends unknown[]> {
   type?: TYPE;
   data: DATA;
 }
 
-export type IChartDataset<
-  TYPE extends IChartType = IChartType,
+export type ChartDataset<
+  TYPE extends ChartType = ChartType,
   DATA extends unknown[] = DefaultDataPoint<TYPE>
 > = DeepPartial<
-  IParsingOptions &
-  { [key in IChartType]: { type: key } & IChartTypeRegistry[key]['datasetOptions'] }[TYPE]
-> & IChartDatasetProperties<TYPE, DATA>;
+  ParsingOptions &
+  { [key in ChartType]: { type: key } & ChartTypeRegistry[key]['datasetOptions'] }[TYPE]
+> & ChartDatasetProperties<TYPE, DATA>;
 
-export interface IChartData<
-  TYPE extends IChartType = IChartType,
+export interface ChartData<
+  TYPE extends ChartType = ChartType,
   DATA extends unknown[] = DefaultDataPoint<TYPE>,
   LABEL = unknown
 > {
   labels: LABEL[];
-  datasets: IChartDataset<TYPE, DATA>[];
+  datasets: ChartDataset<TYPE, DATA>[];
 }
 
-export interface IChartConfiguration<
-  TYPE extends IChartType = IChartType,
+export interface ChartConfiguration<
+  TYPE extends ChartType = ChartType,
   DATA extends unknown[] = DefaultDataPoint<TYPE>,
   LABEL = string
 > {
   type: TYPE;
-  data: IChartData<TYPE, DATA, LABEL>;
-  options?: IChartOptions<TYPE>;
-  plugins?: IPlugin[];
+  data: ChartData<TYPE, DATA, LABEL>;
+  options?: ChartOptions<TYPE>;
+  plugins?: Plugin[];
 }

--- a/types/platform/index.d.ts
+++ b/types/platform/index.d.ts
@@ -1,5 +1,5 @@
 import { Chart } from '../core';
-import { IEvent } from '../core/interfaces';
+import { Event } from '../core/interfaces';
 
 export class BasePlatform {
   /**
@@ -22,18 +22,18 @@ export class BasePlatform {
   /**
    * Registers the specified listener on the given chart.
    * @param {Chart} chart - Chart from which to listen for event
-   * @param {string} type - The ({@link IEvent}) type to listen for
+   * @param {string} type - The ({@link Event}) type to listen for
    * @param listener - Receives a notification (an object that implements
-   * the {@link IEvent} interface) when an event of the specified type occurs.
+   * the {@link Event} interface) when an event of the specified type occurs.
    */
-  addEventListener(chart: Chart, type: string, listener: (e: IEvent) => void): void;
+  addEventListener(chart: Chart, type: string, listener: (e: Event) => void): void;
   /**
    * Removes the specified listener previously registered with addEventListener.
    * @param {Chart} chart - Chart from which to remove the listener
-   * @param {string} type - The ({@link IEvent}) type to remove
+   * @param {string} type - The ({@link Event}) type to remove
    * @param listener - The listener function to remove from the event target.
    */
-  removeEventListener(chart: Chart, type: string, listener: (e: IEvent) => void): void;
+  removeEventListener(chart: Chart, type: string, listener: (e: Event) => void): void;
   /**
    * @returns {number} the current devicePixelRatio of the device this platform is connected to.
    */

--- a/types/platform/index.d.ts
+++ b/types/platform/index.d.ts
@@ -1,5 +1,5 @@
 import { Chart } from '../core';
-import { Event } from '../core/interfaces';
+import { ChartEvent } from '../core/interfaces';
 
 export class BasePlatform {
   /**
@@ -22,18 +22,18 @@ export class BasePlatform {
   /**
    * Registers the specified listener on the given chart.
    * @param {Chart} chart - Chart from which to listen for event
-   * @param {string} type - The ({@link Event}) type to listen for
+   * @param {string} type - The ({@link ChartEvent}) type to listen for
    * @param listener - Receives a notification (an object that implements
-   * the {@link Event} interface) when an event of the specified type occurs.
+   * the {@link ChartEvent} interface) when an event of the specified type occurs.
    */
-  addEventListener(chart: Chart, type: string, listener: (e: Event) => void): void;
+  addEventListener(chart: Chart, type: string, listener: (e: ChartEvent) => void): void;
   /**
    * Removes the specified listener previously registered with addEventListener.
    * @param {Chart} chart - Chart from which to remove the listener
-   * @param {string} type - The ({@link Event}) type to remove
+   * @param {string} type - The ({@link ChartEvent}) type to remove
    * @param listener - The listener function to remove from the event target.
    */
-  removeEventListener(chart: Chart, type: string, listener: (e: Event) => void): void;
+  removeEventListener(chart: Chart, type: string, listener: (e: ChartEvent) => void): void;
   /**
    * @returns {number} the current devicePixelRatio of the device this platform is connected to.
    */

--- a/types/plugins/index.d.ts
+++ b/types/plugins/index.d.ts
@@ -1,17 +1,17 @@
-import { ActiveDataPoint, ActiveElement, Chart, Element, IAnimationSpecContainer, InteractionMode, LayoutPosition, IPlugin } from '../core';
-import { Color, IChartArea, IFontSpec, Scriptable, TextAlign, IEvent, IHoverInteractionOptions } from '../core/interfaces';
+import { ActiveDataPoint, ActiveElement, Chart, Element, AnimationSpecContainer, InteractionMode, LayoutPosition, Plugin } from '../core';
+import { Color, ChartArea, FontSpec, Scriptable, TextAlign, Event, HoverInteractionOptions } from '../core/interfaces';
 import { PointStyle } from '../elements';
-import { IChartData, IChartDataset } from '../interfaces';
+import { ChartData, ChartDataset } from '../interfaces';
 
-export const Filler: IPlugin;
+export const Filler: Plugin;
 
-export interface IFillerOptions {
+export interface FillerOptions {
   propagate: boolean;
 }
 
 export type FillTarget = number | string | { value: number } | 'start' | 'end' | 'origin' | 'stack' | false;
 
-export interface IFillTarget {
+export interface FillTarget {
   /**
    * The accepted values are the same as the filling mode values, so you may use absolute and relative dataset indexes and/or boundaries.
    */
@@ -26,16 +26,16 @@ export interface IFillTarget {
   below: Color;
 }
 
-export interface IFillerControllerDatasetOptions {
+export interface FillerControllerDatasetOptions {
   /**
    * Both line and radar charts support a fill option on the dataset object which can be used to create area between two datasets or a dataset and a boundary, i.e. the scale origin, start or end
    */
-  fill: FillTarget | IFillTarget;
+  fill: FillTarget | FillTarget;
 }
 
-export const Legend: IPlugin;
+export const Legend: Plugin;
 
-export interface ILegendItem {
+export interface LegendItem {
   /**
    * Label that will be displayed
    */
@@ -98,7 +98,7 @@ export interface ILegendItem {
 
 export interface LegendElement extends Element {}
 
-export interface ILegendOptions {
+export interface LegendOptions {
   /**
    * Is the legend shown?
    * @default true
@@ -127,15 +127,15 @@ export interface ILegendOptions {
   /**
    * A callback that is called when a click event is registered on a label item.
    */
-  onClick(this: LegendElement, e: IEvent, legendItem: ILegendItem, legend: LegendElement): void;
+  onClick(this: LegendElement, e: Event, legendItem: LegendItem, legend: LegendElement): void;
   /**
    *	A callback that is called when a 'mousemove' event is registered on top of a label item
    */
-  onHover(this: LegendElement, e: IEvent, legendItem: ILegendItem, legend: LegendElement): void;
+  onHover(this: LegendElement, e: Event, legendItem: LegendItem, legend: LegendElement): void;
   /**
    *	A callback that is called when a 'mousemove' event is registered outside of a previously hovered label item.
    */
-  onLeave(this: LegendElement, e: IEvent, legendItem: ILegendItem, legend: LegendElement): void;
+  onLeave(this: LegendElement, e: Event, legendItem: LegendItem, legend: LegendElement): void;
 
   labels: {
     /**
@@ -149,7 +149,7 @@ export interface ILegendOptions {
      */
     boxHeight: number;
 
-    font: IFontSpec;
+    font: FontSpec;
     /**
      * Padding between rows of colored boxes.
      * @default 10
@@ -158,17 +158,17 @@ export interface ILegendOptions {
     /**
      * Generates legend items for each thing in the legend. Default implementation returns the text + styling for the color box. See Legend Item for details.
      */
-    generateLabels(chart: Chart): ILegendItem[];
+    generateLabels(chart: Chart): LegendItem[];
 
     /**
      * Filters legend items out of the legend. Receives 2 parameters, a Legend Item and the chart data
      */
-    filter(item: ILegendItem, data: IChartData): boolean;
+    filter(item: LegendItem, data: ChartData): boolean;
 
     /**
      * Sorts the legend items
      */
-    sort(a: ILegendItem, b: ILegendItem, data: IChartData): number;
+    sort(a: LegendItem, b: LegendItem, data: ChartData): number;
 
     /**
      * Override point style for the legend. Only applies if usePointStyle is true
@@ -191,9 +191,9 @@ export interface ILegendOptions {
     /**
      * see Fonts
      */
-    font: IFontSpec;
+    font: FontSpec;
     position: 'center' | 'start' | 'end';
-    padding?: number | IChartArea;
+    padding?: number | ChartArea;
     /**
      * The string title.
      */
@@ -201,13 +201,13 @@ export interface ILegendOptions {
   };
 }
 
-export interface ILegendChartOptions {
-  legend: ILegendOptions;
+export interface LegendChartOptions {
+  legend: LegendOptions;
 }
 
-export const Title: IPlugin;
+export const Title: Plugin;
 
-export interface ITitleOptions {
+export interface TitleOptions {
   /**
    * Alignment of the title.
    * @default 'center'
@@ -223,7 +223,7 @@ export interface ITitleOptions {
    * @default 'top'
    */
   position: 'top' | 'left' | 'bottom' | 'right';
-  font: IFontSpec;
+  font: FontSpec;
   // fullWidth: boolean;
   /**
    * 	Adds padding above and below the title text if a single number is specified. It is also possible to change top and bottom padding separately.
@@ -235,15 +235,15 @@ export interface ITitleOptions {
   text: string | string[];
 }
 
-export interface ITitleChartOptions {
-  title: ITitleOptions;
+export interface TitleChartOptions {
+  title: TitleOptions;
 }
 
 export type TooltipAlignment = 'start' | 'center' | 'end';
 
 export interface TooltipModel {
   // The items that we are rendering in the tooltip. See Tooltip Item Interface section
-  dataPoints: ITooltipItem[];
+  dataPoints: TooltipItem[];
 
   // Positioning
   xAlign: TooltipAlignment;
@@ -287,10 +287,10 @@ export interface TooltipModel {
   opacity: number;
 
   // tooltip options
-  options: ITooltipOptions;
+  options: TooltipOptions;
 }
 
-export const Tooltip: IPlugin & {
+export const Tooltip: Plugin & {
   readonly positioners: {
     [key: string]: (items: readonly Element[], eventPosition: { x: number; y: number }) => { x: number; y: number };
   };
@@ -299,28 +299,28 @@ export const Tooltip: IPlugin & {
   setActiveElements(active: ActiveDataPoint[], eventPosition: { x: number, y: number }): void;
 };
 
-export interface ITooltipCallbacks {
-  beforeTitle(this: TooltipModel, tooltipItems: ITooltipItem[]): string | string[];
-  title(this: TooltipModel, tooltipItems: ITooltipItem[]): string | string[];
-  afterTitle(this: TooltipModel, tooltipItems: ITooltipItem[]): string | string[];
+export interface TooltipCallbacks {
+  beforeTitle(this: TooltipModel, tooltipItems: TooltipItem[]): string | string[];
+  title(this: TooltipModel, tooltipItems: TooltipItem[]): string | string[];
+  afterTitle(this: TooltipModel, tooltipItems: TooltipItem[]): string | string[];
 
-  beforeBody(this: TooltipModel, tooltipItems: ITooltipItem[]): string | string[];
-  afterBody(this: TooltipModel, tooltipItems: ITooltipItem[]): string | string[];
+  beforeBody(this: TooltipModel, tooltipItems: TooltipItem[]): string | string[];
+  afterBody(this: TooltipModel, tooltipItems: TooltipItem[]): string | string[];
 
-  beforeLabel(this: TooltipModel, tooltipItem: ITooltipItem): string | string[];
-  label(this: TooltipModel, tooltipItem: ITooltipItem): string | string[];
-  afterLabel(this: TooltipModel, tooltipItem: ITooltipItem): string | string[];
+  beforeLabel(this: TooltipModel, tooltipItem: TooltipItem): string | string[];
+  label(this: TooltipModel, tooltipItem: TooltipItem): string | string[];
+  afterLabel(this: TooltipModel, tooltipItem: TooltipItem): string | string[];
 
-  labelColor(this: TooltipModel, tooltipItem: ITooltipItem): { borderColor: Color; backgroundColor: Color };
-  labelTextColor(this: TooltipModel, tooltipItem: ITooltipItem): Color;
-  labelPointStyle(this: TooltipModel, tooltipItem: ITooltipItem): { pointStyle: PointStyle; rotation: number };
+  labelColor(this: TooltipModel, tooltipItem: TooltipItem): { borderColor: Color; backgroundColor: Color };
+  labelTextColor(this: TooltipModel, tooltipItem: TooltipItem): Color;
+  labelPointStyle(this: TooltipModel, tooltipItem: TooltipItem): { pointStyle: PointStyle; rotation: number };
 
-  beforeFooter(this: TooltipModel, tooltipItems: ITooltipItem[]): string | string[];
-  footer(this: TooltipModel, tooltipItems: ITooltipItem[]): string | string[];
-  afterFooter(this: TooltipModel, tooltipItems: ITooltipItem[]): string | string[];
+  beforeFooter(this: TooltipModel, tooltipItems: TooltipItem[]): string | string[];
+  footer(this: TooltipModel, tooltipItems: TooltipItem[]): string | string[];
+  afterFooter(this: TooltipModel, tooltipItems: TooltipItem[]): string | string[];
 }
 
-export interface ITooltipPlugin<O = {}> {
+export interface TooltipPlugin<O = {}> {
   /**
    * @desc Called before drawing the `tooltip`. If any plugin returns `false`,
    * the tooltip drawing is cancelled until another `render` is triggered.
@@ -342,7 +342,7 @@ export interface ITooltipPlugin<O = {}> {
   afterTooltipDraw?(chart: Chart, args: { tooltip: TooltipModel }, options: O): void;
 }
 
-export interface ITooltipOptions extends IHoverInteractionOptions {
+export interface TooltipOptions extends HoverInteractionOptions {
   /**
    * Are on-canvas tooltips enabled?
    * @default true
@@ -366,9 +366,9 @@ export interface ITooltipOptions extends IHoverInteractionOptions {
   /**
    * Sort tooltip items.
    */
-  itemSort: (a: ITooltipItem, b: ITooltipItem) => number;
+  itemSort: (a: TooltipItem, b: TooltipItem) => number;
 
-  filter: (e: ITooltipItem) => boolean;
+  filter: (e: TooltipItem) => boolean;
 
   /**
    * Background color of the tooltip.
@@ -379,7 +379,7 @@ export interface ITooltipOptions extends IHoverInteractionOptions {
    * See Fonts
    * @default {style: 'bold', color: '#fff'}
    */
-  titleFont: IFontSpec;
+  titleFont: FontSpec;
   /**
    * Spacing to add to top and bottom of each title line.
    * @default 2
@@ -404,7 +404,7 @@ export interface ITooltipOptions extends IHoverInteractionOptions {
    * 	See Fonts.
    * @default {color: '#fff'}
    */
-  bodyFont: IFontSpec;
+  bodyFont: FontSpec;
   /**
    * Horizontal alignment of the body text lines.
    * @default 'left'
@@ -424,7 +424,7 @@ export interface ITooltipOptions extends IHoverInteractionOptions {
    * See Fonts
    * @default {style: 'bold', color: '#fff'}
    */
-  footerFont: IFontSpec;
+  footerFont: FontSpec;
   /**
    * Horizontal alignment of the footer text lines.
    * @default 'left'
@@ -501,16 +501,16 @@ export interface ITooltipOptions extends IHoverInteractionOptions {
    */
   textDirection: string;
 
-  animation: Scriptable<IAnimationSpecContainer>;
+  animation: Scriptable<AnimationSpecContainer>;
 
-  callbacks: ITooltipCallbacks;
+  callbacks: TooltipCallbacks;
 }
 
-export interface ITooltipChartOptions {
-  tooltips: ITooltipOptions;
+export interface TooltipChartOptions {
+  tooltips: TooltipOptions;
 }
 
-export interface ITooltipItem {
+export interface TooltipItem {
   /**
    * The chart the tooltip is being shown on
    */
@@ -534,7 +534,7 @@ export interface ITooltipItem {
   /**
    * The dataset the item comes from
    */
-  dataset: IChartDataset;
+  dataset: ChartDataset;
 
   /**
    * Index of the dataset the item comes from

--- a/types/plugins/index.d.ts
+++ b/types/plugins/index.d.ts
@@ -1,5 +1,5 @@
 import { ActiveDataPoint, ActiveElement, Chart, Element, AnimationSpecContainer, InteractionMode, LayoutPosition, Plugin } from '../core';
-import { Color, ChartArea, FontSpec, Scriptable, TextAlign, Event, HoverInteractionOptions } from '../core/interfaces';
+import { Color, ChartArea, FontSpec, Scriptable, TextAlign, ChartEvent, HoverInteractionOptions } from '../core/interfaces';
 import { PointStyle } from '../elements';
 import { ChartData, ChartDataset } from '../interfaces';
 
@@ -127,15 +127,15 @@ export interface LegendOptions {
   /**
    * A callback that is called when a click event is registered on a label item.
    */
-  onClick(this: LegendElement, e: Event, legendItem: LegendItem, legend: LegendElement): void;
+  onClick(this: LegendElement, e: ChartEvent, legendItem: LegendItem, legend: LegendElement): void;
   /**
    *	A callback that is called when a 'mousemove' event is registered on top of a label item
    */
-  onHover(this: LegendElement, e: Event, legendItem: LegendItem, legend: LegendElement): void;
+  onHover(this: LegendElement, e: ChartEvent, legendItem: LegendItem, legend: LegendElement): void;
   /**
    *	A callback that is called when a 'mousemove' event is registered outside of a previously hovered label item.
    */
-  onLeave(this: LegendElement, e: Event, legendItem: LegendItem, legend: LegendElement): void;
+  onLeave(this: LegendElement, e: ChartEvent, legendItem: LegendItem, legend: LegendElement): void;
 
   labels: {
     /**

--- a/types/plugins/index.d.ts
+++ b/types/plugins/index.d.ts
@@ -11,7 +11,7 @@ export interface FillerOptions {
 
 export type FillTarget = number | string | { value: number } | 'start' | 'end' | 'origin' | 'stack' | false;
 
-export interface FillTarget {
+export interface ComplexFillTarget {
   /**
    * The accepted values are the same as the filling mode values, so you may use absolute and relative dataset indexes and/or boundaries.
    */
@@ -30,7 +30,7 @@ export interface FillerControllerDatasetOptions {
   /**
    * Both line and radar charts support a fill option on the dataset object which can be used to create area between two datasets or a dataset and a boundary, i.e. the scale origin, start or end
    */
-  fill: FillTarget | FillTarget;
+  fill: FillTarget | ComplexFillTarget;
 }
 
 export const Legend: Plugin;

--- a/types/scales/index.d.ts
+++ b/types/scales/index.d.ts
@@ -1,7 +1,7 @@
-import { ScriptAbleScale, ICoreScaleOptions, ITick, Scale } from '../core';
-import { Color, IChartComponent, IFontSpec, TimeUnit } from '../core/interfaces';
+import { ScriptAbleScale, CoreScaleOptions, Tick, Scale } from '../core';
+import { Color, ChartComponent, FontSpec, TimeUnit } from '../core/interfaces';
 
-export interface IGridLineOptions {
+export interface GridLineOptions {
   /**
    * @default true
    */
@@ -51,11 +51,11 @@ export interface IGridLineOptions {
   offsetGridLines: boolean;
 }
 
-export interface ITickOptions {
+export interface TickOptions {
   /**
    * Returns the string representation of the tick value as it should be displayed on the chart. See callback.
    */
-  callback: (tickValue: any, index: number, ticks: ITick[]) => string;
+  callback: (tickValue: any, index: number, ticks: Tick[]) => string;
   /**
    * If true, show tick labels.
    * @default true
@@ -64,7 +64,7 @@ export interface ITickOptions {
   /**
    * see Fonts
    */
-  font: ScriptAbleScale<IFontSpec>;
+  font: ScriptAbleScale<FontSpec>;
   /**
    * Sets the offset of the tick labels from the axis
    */
@@ -84,7 +84,7 @@ export interface ITickOptions {
   };
 }
 
-export interface ICartesianScaleOptions extends ICoreScaleOptions {
+export interface CartesianScaleOptions extends CoreScaleOptions {
   /**
    * Position of the axis.
    */
@@ -110,12 +110,12 @@ export interface ICartesianScaleOptions extends ICoreScaleOptions {
    */
   offset: boolean;
 
-  gridLines: IGridLineOptions;
+  gridLines: GridLineOptions;
 
   scaleLabel: {
     display: boolean;
     labelString: string;
-    font: IFontSpec;
+    font: FontSpec;
     padding: {
       top: number;
       bottom: number;
@@ -128,7 +128,7 @@ export interface ICartesianScaleOptions extends ICoreScaleOptions {
 	 */
   stacked?: boolean;
 
-  ticks: ITickOptions & {
+  ticks: TickOptions & {
     /**
      * The number of ticks to examine when deciding how many labels will fit. Setting a smaller value will be faster, but may be less accurate when there is large variability in label length.
      * @default ticks.length
@@ -186,19 +186,19 @@ export interface ICartesianScaleOptions extends ICoreScaleOptions {
   };
 }
 
-export type ICategoryScaleOptions = ICartesianScaleOptions & {
+export type CategoryScaleOptions = CartesianScaleOptions & {
   min: string | number;
   max: string | number;
   labels: string[] | string[][];
 };
 
-export interface CategoryScale<O extends ICategoryScaleOptions = ICategoryScaleOptions> extends Scale<O> {}
-export const CategoryScale: IChartComponent & {
+export interface CategoryScale<O extends CategoryScaleOptions = CategoryScaleOptions> extends Scale<O> {}
+export const CategoryScale: ChartComponent & {
   prototype: CategoryScale;
-  new <O extends ICategoryScaleOptions = ICategoryScaleOptions>(cfg: any): CategoryScale<O>;
+  new <O extends CategoryScaleOptions = CategoryScaleOptions>(cfg: any): CategoryScale<O>;
 };
 
-export type ILinearScaleOptions = ICartesianScaleOptions & {
+export type LinearScaleOptions = CartesianScaleOptions & {
 
   /**
    *	if true, scale will include 0 if it is not already included.
@@ -241,13 +241,13 @@ export type ILinearScaleOptions = ICartesianScaleOptions & {
   };
 };
 
-export interface LinearScale<O extends ILinearScaleOptions = ILinearScaleOptions> extends Scale<O> {}
-export const LinearScale: IChartComponent & {
+export interface LinearScale<O extends LinearScaleOptions = LinearScaleOptions> extends Scale<O> {}
+export const LinearScale: ChartComponent & {
   prototype: LinearScale;
-  new <O extends ILinearScaleOptions = ILinearScaleOptions>(cfg: any): LinearScale<O>;
+  new <O extends LinearScaleOptions = LinearScaleOptions>(cfg: any): LinearScale<O>;
 };
 
-export type ILogarithmicScaleOptions = ICartesianScaleOptions & {
+export type LogarithmicScaleOptions = CartesianScaleOptions & {
 
   /**
    * Adjustment used when calculating the maximum data value.
@@ -268,13 +268,13 @@ export type ILogarithmicScaleOptions = ICartesianScaleOptions & {
   };
 };
 
-export interface LogarithmicScale<O extends ILogarithmicScaleOptions = ILogarithmicScaleOptions> extends Scale<O> {}
-export const LogarithmicScale: IChartComponent & {
+export interface LogarithmicScale<O extends LogarithmicScaleOptions = LogarithmicScaleOptions> extends Scale<O> {}
+export const LogarithmicScale: ChartComponent & {
   prototype: LogarithmicScale;
-  new <O extends ILogarithmicScaleOptions = ILogarithmicScaleOptions>(cfg: any): LogarithmicScale<O>;
+  new <O extends LogarithmicScaleOptions = LogarithmicScaleOptions>(cfg: any): LogarithmicScale<O>;
 };
 
-export type ITimeScaleOptions = ICartesianScaleOptions & {
+export type TimeScaleOptions = CartesianScaleOptions & {
   /**
    * Scale boundary strategy (bypassed by min/max time options)
    * - `data`: make sure data are fully visible, ticks outside are removed
@@ -352,24 +352,24 @@ export type ITimeScaleOptions = ICartesianScaleOptions & {
   };
 };
 
-export interface TimeScale<O extends ITimeScaleOptions = ITimeScaleOptions> extends Scale<O> {
+export interface TimeScale<O extends TimeScaleOptions = TimeScaleOptions> extends Scale<O> {
   getDataTimestamps(): number[];
   getLabelTimestamps(): string[];
   normalize(values: number[]): number[];
 }
 
-export const TimeScale: IChartComponent & {
+export const TimeScale: ChartComponent & {
   prototype: TimeScale;
-  new <O extends ITimeScaleOptions = ITimeScaleOptions>(cfg: any): TimeScale<O>;
+  new <O extends TimeScaleOptions = TimeScaleOptions>(cfg: any): TimeScale<O>;
 };
 
-export interface TimeSeriesScale<O extends ITimeScaleOptions = ITimeScaleOptions> extends TimeScale<O> {}
-export const TimeSeriesScale: IChartComponent & {
+export interface TimeSeriesScale<O extends TimeScaleOptions = TimeScaleOptions> extends TimeScale<O> {}
+export const TimeSeriesScale: ChartComponent & {
   prototype: TimeSeriesScale;
-  new <O extends ITimeScaleOptions = ITimeScaleOptions>(cfg: any): TimeSeriesScale<O>;
+  new <O extends TimeScaleOptions = TimeScaleOptions>(cfg: any): TimeSeriesScale<O>;
 };
 
-export type IRadialLinearScaleOptions = ICoreScaleOptions & {
+export type RadialLinearScaleOptions = CoreScaleOptions & {
   animate: boolean;
 
   angleLines: {
@@ -406,7 +406,7 @@ export type IRadialLinearScaleOptions = ICoreScaleOptions & {
    */
   beginAtZero: boolean;
 
-  gridLines: IGridLineOptions;
+  gridLines: GridLineOptions;
 
   /**
    * User defined minimum number for the scale, overrides minimum value from data.
@@ -426,7 +426,7 @@ export type IRadialLinearScaleOptions = ICoreScaleOptions & {
     /**
      * @see https://www.chartjs.org/docs/next/axes/general/fonts.md
      */
-    font: ScriptAbleScale<IFontSpec>;
+    font: ScriptAbleScale<FontSpec>;
 
     /**
      * Callback function to transform data labels to point labels. The default implementation simply returns the current string.
@@ -444,7 +444,7 @@ export type IRadialLinearScaleOptions = ICoreScaleOptions & {
    */
   suggestedMin: number;
 
-  ticks: ITickOptions & {
+  ticks: TickOptions & {
     /**
      * Color of label backdrops.
      * @default 'rgba(255, 255, 255, 0.75)'
@@ -490,7 +490,7 @@ export type IRadialLinearScaleOptions = ICoreScaleOptions & {
   };
 };
 
-export interface RadialLinearScale<O extends IRadialLinearScaleOptions = IRadialLinearScaleOptions> extends Scale<O> {
+export interface RadialLinearScale<O extends RadialLinearScaleOptions = RadialLinearScaleOptions> extends Scale<O> {
   setCenterPoint(leftMovement: number, rightMovement: number, topMovement: number, bottomMovement: number): void;
   getIndexAngle(index: number): number;
   getDistanceFromCenterForValue(value: number): number;
@@ -499,7 +499,7 @@ export interface RadialLinearScale<O extends IRadialLinearScaleOptions = IRadial
   getPointPositionForValue(index: number, value: number): { x: number; y: number; angle: number };
   getBasePosition(index: number): { x: number; y: number; angle: number };
 }
-export const RadialLinearScale: IChartComponent & {
+export const RadialLinearScale: ChartComponent & {
   prototype: RadialLinearScale;
-  new <O extends IRadialLinearScaleOptions = IRadialLinearScaleOptions>(cfg: any): RadialLinearScale<O>;
+  new <O extends RadialLinearScaleOptions = RadialLinearScaleOptions>(cfg: any): RadialLinearScale<O>;
 };


### PR DESCRIPTION
Standardizes all of the typescript types to drop the `I` prefix. For example `IEvent` is now just `Event`.

The only non-standard change is `IInteractionMode` which changed to `InteractionModeMap` because `InteractionMode` was already defined.