### PR TITLE
Bubble: Use point.size() in getMaxOverflow

### DIFF
--- a/src/controllers/controller.bubble.js
+++ b/src/controllers/controller.bubble.js
@@ -34,10 +34,10 @@ export default class BubbleController extends DatasetController {
 	getMaxOverflow() {
 		const me = this;
 		const meta = me._cachedMeta;
-		let i = (meta.data || []).length - 1;
+		const data = meta.data;
 		let max = 0;
-		for (; i >= 0; --i) {
-			max = Math.max(max, me.getStyle(i, true).radius);
+		for (let i = data.length - 1; i >= 0; --i) {
+			max = Math.max(max, data[i].size());
 		}
 		return max > 0 && max;
 	}


### PR DESCRIPTION
The new max (default) overflow is the diameter of the largest point, accounting for `borderWidth` and `hoverRadius`. 
