### PR TITLE
dataset tooltip now shows correctly

### DIFF
--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -1146,7 +1146,10 @@ export default {
 					const item = tooltipItems[0];
 					const labels = item.chart.data.labels;
 					const labelCount = labels ? labels.length : 0;
-					if (item.label) {
+
+					if (item?.chart?.config?.options?.tooltips?.mode === 'dataset') {
+						return item.dataset.label || '';
+					} else if (item.label) {
 						return item.label;
 					} else if (labelCount > 0 && item.dataIndex < labelCount) {
 						return labels[item.dataIndex];
@@ -1163,6 +1166,10 @@ export default {
 			// Args are: (tooltipItem, data)
 			beforeLabel: noop,
 			label(tooltipItem) {
+				if (tooltipItem?.chart?.config?.options?.tooltips?.mode === 'dataset') {
+					return tooltipItem.label + ': ' + tooltipItem.formattedValue || tooltipItem.formattedValue;
+				}
+
 				let label = tooltipItem.dataset.label || '';
 
 				if (label) {

--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -1147,7 +1147,7 @@ export default {
 					const labels = item.chart.data.labels;
 					const labelCount = labels ? labels.length : 0;
 
-					if (item?.chart?.config?.options?.tooltips?.mode === 'dataset') {
+					if (this && this.options && this.options.mode === 'dataset') {
 						return item.dataset.label || '';
 					} else if (item.label) {
 						return item.label;
@@ -1166,7 +1166,7 @@ export default {
 			// Args are: (tooltipItem, data)
 			beforeLabel: noop,
 			label(tooltipItem) {
-				if (tooltipItem?.chart?.config?.options?.tooltips?.mode === 'dataset') {
+				if (this && this.options && this.options.mode === 'dataset') {
 					return tooltipItem.label + ': ' + tooltipItem.formattedValue || tooltipItem.formattedValue;
 				}
 


### PR DESCRIPTION
Fixed #7990 
Tooltip for dataset mode now gets displayed correctly

Example of the tooltips sample page with the new code: https://codepen.io/leelenaleee/pen/KKMxbLK
