### PR TITLE
[beta.6][types] fix inconsistency in types for LABEL

### DIFF
--- a/types/core/index.d.ts
+++ b/types/core/index.d.ts
@@ -172,7 +172,7 @@ export interface ActiveElement extends ActiveDataPoint {
 export declare class Chart<
 	TYPE extends ChartType = ChartType,
 	DATA extends unknown[] = DefaultDataPoint<TYPE>,
-	LABEL = string
+	LABEL = unknown
 	> {
 	readonly platform: BasePlatform;
 	readonly id: string;

--- a/types/interfaces.d.ts
+++ b/types/interfaces.d.ts
@@ -175,7 +175,7 @@ export interface ChartData<
 export interface ChartConfiguration<
   TYPE extends ChartType = ChartType,
   DATA extends unknown[] = DefaultDataPoint<TYPE>,
-  LABEL = string
+  LABEL = unknown
 > {
   type: TYPE;
   data: ChartData<TYPE, DATA, LABEL>;


### PR DESCRIPTION
This is my mistake. When I fixed LABEL type for ChartData, I did not notice that this type is inherited through the Chart and ChartConfiguration. Made a small and short fix.

If anyone needs a workaround before a fix is released, just specify the explicit types. Or by default:
```ts
Chart<ChartType, DefaultDataPoint<ChartType>, unknown>
```