### PR TITLE
Add tests and clean up resolveObjectKey helper

### DIFF
--- a/src/helpers/helpers.core.js
+++ b/src/helpers/helpers.core.js
@@ -278,13 +278,12 @@ export function resolveObjectKey(obj, key) {
 		return obj[key];
 	}
 	const keys = key.split('.');
-	for (let i = 0, n = keys.length; i < n; ++i) {
+	for (let i = 0, n = keys.length; i < n && obj; ++i) {
 		const k = keys[i];
-		if (k in obj) {
-			obj = obj[k];
-		} else {
-			return;
+		if (!k) {
+			break;
 		}
+		obj = obj[k];
 	}
 	return obj;
 }

--- a/src/helpers/helpers.core.js
+++ b/src/helpers/helpers.core.js
@@ -274,8 +274,13 @@ export function _deprecated(scope, value, previous, current) {
 }
 
 export function resolveObjectKey(obj, key) {
-	if (key.length < 3) {
-		return obj[key];
+	// Special cases for `x` and `y` keys. It's quite a lot faster to aceess this way.
+	// Those are the default keys Chart.js is resolving, so it makes sense to be fast.
+	if (key === 'x') {
+		return obj.x;
+	}
+	if (key === 'y') {
+		return obj.y;
 	}
 	const keys = key.split('.');
 	for (let i = 0, n = keys.length; i < n && obj; ++i) {


### PR DESCRIPTION
Needed to resolve empty key to the root object in #8008, so modified the helper to work in that situation.
The function did not have any unit tests, so added some to make sure it works as expected.

## Performance

Performance was measured in Brave Version 1.16.72 Chromium: 86.0.4240.183 (Official Build) (64-bit), using uPlot bench data, stacked (and thus parsing enabled) and creating the chart 20 times in a loop. (loop so randon GC impact is minimized)

### master

![image](https://user-images.githubusercontent.com/27971921/98557286-b0270a80-22ac-11eb-9b3a-0f5de9f311bf.png)

### pr

![image](https://user-images.githubusercontent.com/27971921/98557399-d187f680-22ac-11eb-9c73-4818a6f40ce0.png)