### PR TITLE
Events: Only render when needed

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -998,11 +998,13 @@ class Chart {
 			return;
 		}
 
-		me._handleEvent(e, replay);
+		const changed = me._handleEvent(e, replay);
 
 		me._plugins.notify(me, 'afterEvent', [e, replay]);
 
-		me.render();
+		if (changed) {
+			me.render();
+		}
 
 		return me;
 	}


### PR DESCRIPTION
Looks like we are currently rendering after every event. This is bad if animations are disabled, because we are actually re-drawing the whole chart after each event.
