### PR TITLE
Refactor/cleanup range option handling

### DIFF
--- a/src/helpers/helpers.core.js
+++ b/src/helpers/helpers.core.js
@@ -66,6 +66,16 @@ export {
 };
 
 /**
+ * Returns `value` if finite, else returns `defaultValue`.
+ * @param {*} value - The value to return if defined.
+ * @param {*} defaultValue - The value to return if `value` is not finite.
+ * @returns {*}
+ */
+export function finiteOrDefault(value, defaultValue) {
+	return isNumberFinite(value) ? value : defaultValue;
+}
+
+/**
  * Returns `value` if defined, else returns `defaultValue`.
  * @param {*} value - The value to return if defined.
  * @param {*} defaultValue - The value to return if `value` is undefined.

--- a/src/scales/scale.linear.js
+++ b/src/scales/scale.linear.js
@@ -1,4 +1,4 @@
-import {isFinite, valueOrDefault} from '../helpers/helpers.core';
+import {isFinite} from '../helpers/helpers.core';
 import LinearScaleBase from './scale.linearbase';
 import Ticks from '../core/core.ticks';
 
@@ -6,16 +6,10 @@ export default class LinearScale extends LinearScaleBase {
 
 	determineDataLimits() {
 		const me = this;
-		const options = me.options;
 		const {min, max} = me.getMinMax(true);
 
-		me.min = isFinite(min) ? min : valueOrDefault(options.suggestedMin, 0);
-		me.max = isFinite(max) ? max : valueOrDefault(options.suggestedMax, 1);
-
-		// Backward compatible inconsistent min for stacked
-		if (options.stacked && min > 0) {
-			me.min = 0;
-		}
+		me.min = isFinite(min) ? min : 0;
+		me.max = isFinite(max) ? max : 1;
 
 		// Common base implementation to handle min, max, beginAtZero
 		me.handleTickRangeOptions();
@@ -37,8 +31,7 @@ export default class LinearScale extends LinearScaleBase {
 
 	// Utils
 	getPixelForValue(value) {
-		const me = this;
-		return me.getPixelForDecimal((value - me._startValue) / me._valueRange);
+		return this.getPixelForDecimal((value - this._startValue) / this._valueRange);
 	}
 
 	getValueForPixel(pixel) {

--- a/src/scales/scale.linearbase.js
+++ b/src/scales/scale.linearbase.js
@@ -125,68 +125,33 @@ export default class LinearScaleBase extends Scale {
 
 	handleTickRangeOptions() {
 		const me = this;
-		const opts = me.options;
+		const {beginAtZero, stacked} = me.options;
+		const {minDefined, maxDefined} = me.getUserBounds();
+		let {min, max} = me;
 
-		// If we are forcing it to begin at 0, but 0 will already be rendered on the chart,
-		// do nothing since that would make the chart weird. If the user really wants a weird chart
-		// axis, they can manually override it
-		if (opts.beginAtZero) {
-			const minSign = sign(me.min);
-			const maxSign = sign(me.max);
+		const setMin = v => (min = minDefined ? min : v);
+		const setMax = v => (max = maxDefined ? max : v);
+
+		if (beginAtZero || stacked) {
+			const minSign = sign(min);
+			const maxSign = sign(max);
 
 			if (minSign < 0 && maxSign < 0) {
-				// move the top up to 0
-				me.max = 0;
+				setMax(0);
 			} else if (minSign > 0 && maxSign > 0) {
-				// move the bottom down to 0
-				me.min = 0;
+				setMin(0);
 			}
 		}
 
-		const setMin = opts.min !== undefined || opts.suggestedMin !== undefined;
-		const setMax = opts.max !== undefined || opts.suggestedMax !== undefined;
+		if (min === max) {
+			setMax(max + 1);
 
-		if (opts.min !== undefined) {
-			me.min = opts.min;
-		} else if (opts.suggestedMin !== undefined) {
-			if (me.min === null) {
-				me.min = opts.suggestedMin;
-			} else {
-				me.min = Math.min(me.min, opts.suggestedMin);
+			if (!beginAtZero) {
+				setMin(min - 1);
 			}
 		}
-
-		if (opts.max !== undefined) {
-			me.max = opts.max;
-		} else if (opts.suggestedMax !== undefined) {
-			if (me.max === null) {
-				me.max = opts.suggestedMax;
-			} else {
-				me.max = Math.max(me.max, opts.suggestedMax);
-			}
-		}
-
-		if (setMin !== setMax) {
-			// We set the min or the max but not both.
-			// So ensure that our range is good
-			// Inverted or 0 length range can happen when
-			// min is set, and no datasets are visible
-			if (me.min >= me.max) {
-				if (setMin) {
-					me.max = me.min + 1;
-				} else {
-					me.min = me.max - 1;
-				}
-			}
-		}
-
-		if (me.min === me.max) {
-			me.max++;
-
-			if (!opts.beginAtZero) {
-				me.min--;
-			}
-		}
+		me.min = min;
+		me.max = max;
 	}
 
 	getTickLimit() {


### PR DESCRIPTION
- Handle `suggestedMin` / `suggestedMax` in `getUserBounds`
- If only one of the user defined limits is set and there is no (visible) data, make sure the value is considered `min` and `max`
- Move `finiteOrDefault` to helpers

## Motivation

Remove duplicate logic and thus make the scale range options easier to manage in the future.