### PR TITLE
Unify cartesian scale tick order

### DIFF
--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -123,23 +123,21 @@ export default class LogarithmicScale extends Scale {
 			max: me._userMax
 		};
 		const ticks = generateTicks(generationOptions, me);
-		let reverse = !me.isHorizontal();
 
 		// At this point, we need to update our max and min given the tick values since we have expanded the
 		// range of the scale
 		_setMinAndMaxByKey(ticks, me, 'value');
 
 		if (opts.reverse) {
-			reverse = !reverse;
+			ticks.reverse();
+
 			me.start = me.max;
 			me.end = me.min;
 		} else {
 			me.start = me.min;
 			me.end = me.max;
 		}
-		if (reverse) {
-			ticks.reverse();
-		}
+
 		return ticks;
 	}
 

--- a/test/specs/core.ticks.tests.js
+++ b/test/specs/core.ticks.tests.js
@@ -94,6 +94,6 @@ describe('Test tick generators', function() {
 		var yLabels = getLabels(chart.scales.y);
 
 		expect(xLabels).toEqual(['0.1', '0.2', '0.3', '0.4', '0.5', '0.6', '0.7', '0.8', '0.9', '1']);
-		expect(yLabels).toEqual(['1', '0.9', '0.8', '0.7', '0.6', '0.5', '0.4', '0.3', '0.2', '0.1']);
+		expect(yLabels).toEqual(['0.1', '0.2', '0.3', '0.4', '0.5', '0.6', '0.7', '0.8', '0.9', '1']);
 	});
 });

--- a/test/specs/scale.logarithmic.tests.js
+++ b/test/specs/scale.logarithmic.tests.js
@@ -448,8 +448,8 @@ describe('Logarithmic Scale tests', function() {
 		var tickCount = yScale.ticks.length;
 		expect(yScale.min).toBe(10);
 		expect(yScale.max).toBe(1010);
-		expect(yScale.ticks[0].value).toBe(1010);
-		expect(yScale.ticks[tickCount - 1].value).toBe(10);
+		expect(yScale.ticks[0].value).toBe(10);
+		expect(yScale.ticks[tickCount - 1].value).toBe(1010);
 	});
 
 	it('should ignore negative min and max options', function() {
@@ -535,9 +535,8 @@ describe('Logarithmic Scale tests', function() {
 			}
 		});
 
-		// Counts down because the lines are drawn top to bottom
 		var scale = chart.scales.y;
-		expect(getLabels(scale)).toEqual([80, 70, 60, 50, 40, 30, 20, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+		expect(getLabels(scale)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 30, 40, 50, 60, 70, 80]);
 		expect(scale.start).toEqual(1);
 		expect(scale.end).toEqual(80);
 	});
@@ -567,7 +566,7 @@ describe('Logarithmic Scale tests', function() {
 
 		var scale = chart.scales.y;
 		// Counts down because the lines are drawn top to bottom
-		expect(getLabels(scale)).toEqual([30, 20, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1]);
+		expect(getLabels(scale)).toEqual([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 30]);
 		expect(scale.start).toEqual(0.1);
 		expect(scale.end).toEqual(30);
 	});
@@ -598,7 +597,7 @@ describe('Logarithmic Scale tests', function() {
 		});
 
 		var scale = chart.scales.y;
-		expect(getLabels(scale)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 30, 40, 50, 60, 70, 80]);
+		expect(getLabels(scale)).toEqual([80, 70, 60, 50, 40, 30, 20, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
 		expect(scale.start).toEqual(80);
 		expect(scale.end).toEqual(1);
 	});
@@ -628,7 +627,7 @@ describe('Logarithmic Scale tests', function() {
 		});
 
 		var scale = chart.scales.y;
-		expect(getLabels(scale)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 30]);
+		expect(getLabels(scale)).toEqual([30, 20, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
 		expect(scale.start).toEqual(30);
 		expect(scale.end).toEqual(1);
 	});
@@ -651,7 +650,7 @@ describe('Logarithmic Scale tests', function() {
 			}
 		});
 
-		expect(getLabels(chart.scales.y)).toEqual(['', '', '', '50', '', '', '20', '10', '', '', '', '', '5', '', '', '2', '1']);
+		expect(getLabels(chart.scales.y)).toEqual(['1', '2', '', '', '5', '', '', '', '', '10', '20', '', '', '50', '', '', '']);
 	});
 
 	it('should build labels using the user supplied callback', function() {


### PR DESCRIPTION
Logarithmic scale ticks for vertical orientation are generated in reverse order compared to other scales. 
This PR removes the inconsistency.