### PR TITLE
v2 note not nessecary in v3 docs and update example

### DIFF
--- a/docs/docs/developers/api.md
+++ b/docs/docs/developers/api.md
@@ -33,7 +33,7 @@ A `mode` string can be provided to indicate what should be updated and what anim
 Example:
 
 ```javascript
-myChart.update();
+myChart.update('active');
 ```
 
 See [Updating Charts](updates.md) for more details.

--- a/docs/docs/developers/api.md
+++ b/docs/docs/developers/api.md
@@ -28,8 +28,6 @@ myLineChart.data.datasets[0].data[2] = 50; // Would update the first dataset's v
 myLineChart.update(); // Calling update now animates the position of March from 90 to 50.
 ```
 
-> **Note:** replacing the data reference (e.g. `myLineChart.data = {datasets: [...]}` only works starting **version 2.6**. Prior that, replacing the entire data object could be achieved with the following workaround: `myLineChart.config.data = {datasets: [...]}`.
-
 A `mode` string can be provided to indicate what should be updated and what animation configuration should be used. Core calls this method using any of `'active'`, `'hide'`, `'reset'`, `'resize'`, `'show'` or `undefined`. `'none'` is also a supported mode for skipping animations for single update. Please see [animations](../configuration/animations.mdx) docs for more details.
 
 Example:


### PR DESCRIPTION
Note about a feature that is only available from a specific sub version in version 2. Not necessary to put in the v3 documentation.
And updated the update example with a mode option
<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
