### PR TITLE
Restore `datasets` namespace (revert 6955)

### DIFF
--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -39,7 +39,7 @@ var chartDifferentHoverMode = new Chart(ctx, {
 Options may be configured directly on the dataset. The dataset options can be changed at 3 different levels and are evaluated with the following priority:
 
 - per dataset: dataset.*
-- per chart: options[type].datasets.*
+- per chart: options.datasets[type].*
 - or globally: Chart.defaults.controllers[type].datasets.*
 
 where type corresponds to the dataset type.

--- a/docs/docs/getting-started/v3-migration.md
+++ b/docs/docs/getting-started/v3-migration.md
@@ -91,7 +91,6 @@ A number of changes were made to the configuration options passed to the `Chart`
 * `scales.[x/y]Axes.zeroLine*` options of axes were removed. Use scriptable scale options instead.
 * The dataset option `steppedLine` was removed. Use `stepped`
 * The chart option `showLines` was renamed to `showLine` to match the dataset option.
-* Dataset options are now configured as `options[type].datasets` rather than `options.datasets[type]`
 * To override the platform class used in a chart instance, pass `platform: PlatformClass` in the config object. Note that the class should be passed, not an instance of the class.
 * `aspectRatio` defaults to 1 for doughnut, pie, polarArea, and radar charts
 * `TimeScale` does not read `t` from object data by default anymore. The default property is `x` or `y`, depending on the orientation. See [data structures](../general/data-structures.md) for details on how to change the default.

--- a/src/core/core.config.js
+++ b/src/core/core.config.js
@@ -4,9 +4,9 @@ import {mergeIf, merge, _merger} from '../helpers/helpers.core';
 export function getIndexAxis(type, options) {
 	const typeDefaults = defaults.controllers[type] || {};
 	const datasetDefaults = typeDefaults.datasets || {};
-	const typeOptions = options[type] || {};
-	const datasetOptions = typeOptions.datasets || {};
-	return datasetOptions.indexAxis || options.indexAxis || datasetDefaults.indexAxis || 'x';
+	const datasetOptions = options.datasets || {};
+	const typeOptions = datasetOptions[type] || {};
+	return typeOptions.indexAxis || options.indexAxis || datasetDefaults.indexAxis || 'x';
 }
 
 function getAxisFromDefaultScaleID(id, indexAxis) {

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -396,7 +396,7 @@ export default class DatasetController {
 		const me = this;
 		me._config = merge(Object.create(null), [
 			defaults.controllers[me._type].datasets,
-			(me.chart.options[me._type] || {}).datasets,
+			(me.chart.options.datasets || {})[me._type],
 			me.getDataset(),
 		], {
 			merger(key, target, source) {

--- a/test/fixtures/controller.bar/bar-thickness-multiple.json
+++ b/test/fixtures/controller.bar/bar-thickness-multiple.json
@@ -16,8 +16,8 @@
         },
         "options": {
             "responsive": false,
-            "bar": {
-                "datasets": {
+            "datasets": {
+              "bar": {
                     "barPercentage": 1,
                     "categoryPercentage": 1
                 }

--- a/test/fixtures/controller.bar/bar-thickness-no-overlap.json
+++ b/test/fixtures/controller.bar/bar-thickness-no-overlap.json
@@ -16,8 +16,8 @@
         },
         "options": {
             "responsive": false,
-            "bar": {
-                "datasets": {
+            "datasets": {
+              "bar": {
                     "barPercentage": 1,
                     "categoryPercentage": 1
                 }

--- a/test/fixtures/controller.bar/bar-thickness-offset.json
+++ b/test/fixtures/controller.bar/bar-thickness-offset.json
@@ -16,8 +16,8 @@
         },
         "options": {
             "responsive": false,
-            "bar": {
-                "datasets": {
+            "datasets": {
+              "bar": {
                     "barPercentage": 1,
                     "categoryPercentage": 1
                 }

--- a/test/fixtures/controller.bar/bar-thickness-reverse.json
+++ b/test/fixtures/controller.bar/bar-thickness-reverse.json
@@ -16,8 +16,8 @@
         },
         "options": {
             "responsive": false,
-            "bar": {
-                "datasets": {
+            "datasets": {
+              "bar": {
                     "barPercentage": 1,
                     "categoryPercentage": 1
                 }

--- a/test/fixtures/controller.bar/bar-thickness-stacked.json
+++ b/test/fixtures/controller.bar/bar-thickness-stacked.json
@@ -16,8 +16,8 @@
         },
         "options": {
             "responsive": false,
-            "bar": {
-                "datasets": {
+            "datasets": {
+              "bar": {
                     "barPercentage": 1,
                     "categoryPercentage": 1
                 }

--- a/test/fixtures/controller.bar/stacking/logarithmic-strings.js
+++ b/test/fixtures/controller.bar/stacking/logarithmic-strings.js
@@ -12,8 +12,8 @@ module.exports = {
 			labels: ['label1', 'label2', 'label3', 'label4']
 		},
 		options: {
-			bar: {
-				datasets: {
+			datasets: {
+				bar: {
 					barPercentage: 1,
 				}
 			},

--- a/test/fixtures/controller.bar/stacking/logarithmic.js
+++ b/test/fixtures/controller.bar/stacking/logarithmic.js
@@ -12,8 +12,8 @@ module.exports = {
 			labels: ['label1', 'label2', 'label3', 'label4']
 		},
 		options: {
-			bar: {
-				datasets: {
+			datasets: {
+				bar: {
 					barPercentage: 1,
 				}
 			},

--- a/test/fixtures/plugin.filler/fill-line-dataset-interpolated.js
+++ b/test/fixtures/plugin.filler/fill-line-dataset-interpolated.js
@@ -39,8 +39,8 @@ module.exports = {
 		options: {
 			animation: false,
 			responsive: false,
-			line: {
-				datasets: {
+			datasets: {
+				line: {
 					tension: 0.4,
 					borderWidth: 1,
 					pointRadius: 1.5,

--- a/test/specs/controller.bar.tests.js
+++ b/test/specs/controller.bar.tests.js
@@ -1436,8 +1436,8 @@ describe('Chart.controllers.bar', function() {
 						options: {
 							legend: false,
 							title: false,
-							bar: {
-								datasets: {
+							datasets: {
+								bar: {
 									barThickness: barThickness
 								}
 							},

--- a/test/specs/controller.line.tests.js
+++ b/test/specs/controller.line.tests.js
@@ -570,8 +570,8 @@ describe('Chart.controllers.line', function() {
 					labels: ['label1', 'label2']
 				},
 				options: {
-					line: {
-						datasets: {
+					datasets: {
+						line: {
 							tension: 0.345,
 							backgroundColor: '#add'
 						}
@@ -601,8 +601,8 @@ describe('Chart.controllers.line', function() {
 				labels: ['label1', 'label2']
 			},
 			options: {
-				line: {
-					datasets: {
+				datasets: {
+					line: {
 						spanGaps: true,
 						tension: 0.231,
 						backgroundColor: '#add',


### PR DESCRIPTION
Closes #8073 

Datasets options are now created from (bar for example):

- `defaults.controllers.bar.datasets`,
- `options.datasets.bar`,
- `data.datasets`

The `defaults.controllers.bar.datasets` seems suspect. Its there because a controller needs to be able to provide chart level defaults and dataset level defaults. To align things , we could move the per controller dataset defaults to `defaults.datasets[type]` and keep `defaults.controllers[type]` as chart level controller defaults.

Thoughts?