### PR TITLE
Fix disabling hover

### DIFF
--- a/src/core/core.config.js
+++ b/src/core/core.config.js
@@ -40,7 +40,6 @@ export function determineAxis(id, scaleOptions) {
 }
 
 function mergeScaleConfig(config, options) {
-	options = options || {};
 	const chartDefaults = defaults.controllers[config.type] || {scales: {}};
 	const configScales = options.scales || {};
 	const chartIndexAxis = getIndexAxis(config.type, options);
@@ -101,13 +100,17 @@ function mergeConfig(...args/* config objects ... */) {
 }
 
 function includeDefaults(config, options) {
+	options = options || {};
+
 	const scaleConfig = mergeScaleConfig(config, options);
+	const hoverEanbled = options.interaction !== false && options.hover !== false;
+
 	options = mergeConfig(
 		defaults,
 		defaults.controllers[config.type],
-		options || {});
+		options);
 
-	options.hover = merge(Object.create(null), [
+	options.hover = hoverEanbled && merge(Object.create(null), [
 		defaults.interaction,
 		defaults.hover,
 		options.interaction,

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -217,6 +217,82 @@ describe('Chart', function() {
 			}
 			expect(createChart).toThrow(new Error('"area" is not a registered controller.'));
 		});
+
+		describe('should disable hover', function() {
+			it('when options.hover=false', function() {
+				var chart = acquireChart({
+					type: 'line',
+					options: {
+						hover: false
+					}
+				});
+				expect(chart.options.hover).toBeFalse();
+			});
+
+			it('when options.interation=false and options.hover is not defined', function() {
+				var chart = acquireChart({
+					type: 'line',
+					options: {
+						interaction: false
+					}
+				});
+				expect(chart.options.hover).toBeFalse();
+			});
+
+			it('when options.interation=false and options.hover is defined', function() {
+				var chart = acquireChart({
+					type: 'line',
+					options: {
+						interaction: false,
+						hover: {mode: 'nearest'}
+					}
+				});
+				expect(chart.options.hover).toBeFalse();
+			});
+		});
+
+		it('should activate element on hover', function(done) {
+			var chart = acquireChart({
+				type: 'line',
+				data: {
+					labels: ['A', 'B', 'C', 'D'],
+					datasets: [{
+						data: [10, 20, 30, 100]
+					}]
+				}
+			});
+
+			var point = chart.getDatasetMeta(0).data[1];
+
+			afterEvent(chart, 'mousemove', function() {
+				expect(chart.getActiveElements()).toEqual([{datasetIndex: 0, index: 1, element: point}]);
+				done();
+			});
+			jasmine.triggerMouseEvent(chart, 'mousemove', point);
+		});
+
+		it('should not activate elements when hover is disabled', function(done) {
+			var chart = acquireChart({
+				type: 'line',
+				data: {
+					labels: ['A', 'B', 'C', 'D'],
+					datasets: [{
+						data: [10, 20, 30, 100]
+					}]
+				},
+				options: {
+					hover: false
+				}
+			});
+
+			var point = chart.getDatasetMeta(0).data[1];
+
+			afterEvent(chart, 'mousemove', function() {
+				expect(chart.getActiveElements()).toEqual([]);
+				done();
+			});
+			jasmine.triggerMouseEvent(chart, 'mousemove', point);
+		});
 	});
 
 	describe('when merging scale options', function() {


### PR DESCRIPTION
Currently `hover: false` does not disable hover anymore.
This fixes that and in addition `interaction: false` disables it too (as one would expect).

https://codepen.io/kurkle/pen/MWeNQrm

I did not make changes to tooltips, because we should first move the options.

