### PR TITLE
Add new hooks for plugins

### DIFF
--- a/docs/docs/getting-started/v3-migration.md
+++ b/docs/docs/getting-started/v3-migration.md
@@ -498,4 +498,4 @@ All helpers are now exposed in a flat hierarchy, e.g., `Chart.helpers.canvas.cli
 * `afterDatasetsUpdate`, `afterUpdate`, `beforeDatasetsUpdate`, and `beforeUpdate` now receive `args` object as second argument. `options` argument is always the last and thus was moved from 2nd to 3rd place.
 * `afterEvent` and `beforeEvent` now receive a wrapped `event` as the `event` property of the second argument. The native event is available via `args.event.native`.
 * Initial `resize` is no longer silent. Meaning that `resize` event can fire between `beforeInit` and `afterInit`
-* New hooks: `init`, `unInit`, `enabled` and `disabled`
+* New hooks: `install`, `uninstall`, `enable` and `disable`

--- a/docs/docs/getting-started/v3-migration.md
+++ b/docs/docs/getting-started/v3-migration.md
@@ -498,4 +498,4 @@ All helpers are now exposed in a flat hierarchy, e.g., `Chart.helpers.canvas.cli
 * `afterDatasetsUpdate`, `afterUpdate`, `beforeDatasetsUpdate`, and `beforeUpdate` now receive `args` object as second argument. `options` argument is always the last and thus was moved from 2nd to 3rd place.
 * `afterEvent` and `beforeEvent` now receive a wrapped `event` as the `event` property of the second argument. The native event is available via `args.event.native`.
 * Initial `resize` is no longer silent. Meaning that `resize` event can fire between `beforeInit` and `afterInit`
-* New hooks: `install`, `uninstall`, `enable` and `disable`
+* New hooks: `install`, `start`, `stop`, and `uninstall`

--- a/docs/docs/getting-started/v3-migration.md
+++ b/docs/docs/getting-started/v3-migration.md
@@ -498,3 +498,4 @@ All helpers are now exposed in a flat hierarchy, e.g., `Chart.helpers.canvas.cli
 * `afterDatasetsUpdate`, `afterUpdate`, `beforeDatasetsUpdate`, and `beforeUpdate` now receive `args` object as second argument. `options` argument is always the last and thus was moved from 2nd to 3rd place.
 * `afterEvent` and `beforeEvent` now receive a wrapped `event` as the `event` property of the second argument. The native event is available via `args.event.native`.
 * Initial `resize` is no longer silent. Meaning that `resize` event can fire between `beforeInit` and `afterInit`
+* `beforeUpdate` hook is now also called when a plugin is disabled by the update. `options` argument will be false in that case.

--- a/docs/docs/getting-started/v3-migration.md
+++ b/docs/docs/getting-started/v3-migration.md
@@ -498,4 +498,4 @@ All helpers are now exposed in a flat hierarchy, e.g., `Chart.helpers.canvas.cli
 * `afterDatasetsUpdate`, `afterUpdate`, `beforeDatasetsUpdate`, and `beforeUpdate` now receive `args` object as second argument. `options` argument is always the last and thus was moved from 2nd to 3rd place.
 * `afterEvent` and `beforeEvent` now receive a wrapped `event` as the `event` property of the second argument. The native event is available via `args.event.native`.
 * Initial `resize` is no longer silent. Meaning that `resize` event can fire between `beforeInit` and `afterInit`
-* `beforeUpdate` hook is now also called when a plugin is disabled by the update. `options` argument will be false in that case.
+* New hooks: `init`, `unInit`, `enabled` and `disabled`

--- a/src/core/core.plugins.js
+++ b/src/core/core.plugins.js
@@ -164,16 +164,16 @@ function createDescriptors(plugins, options, all) {
  * @since 3.0.0
  */
 /**
- * @method IPlugin#enable
- * @desc Called whenever a plugin status changes to enabled and plugin is about to be called on any other hook.
+ * @method IPlugin#start
+ * @desc Called when a plugin is starting due to chart initialization or plugin enablement.
  * @param {Chart} chart - The chart instance.
  * @param {object} args - The call arguments.
  * @param {object} options - The plugin options.
  * @since 3.0.0
  */
 /**
- * @method IPlugin#disable
- * @desc Called whenever a plugin status changes to disabled and chart is updated.
+ * @method IPlugin#stop
+ * @desc Called when a plugin stopping due being disabled.
  * @param {Chart} chart - The chart instance.
  * @param {object} args - The call arguments.
  * @param {object} options - The plugin options.

--- a/src/core/core.plugins.js
+++ b/src/core/core.plugins.js
@@ -93,8 +93,8 @@ export default class PluginService {
 		const previousDescriptors = this._oldCache || [];
 		const descriptors = this._cache;
 		const diff = (a, b) => a.filter(x => !b.some(y => x.plugin.id === y.plugin.id));
-		this._notify(diff(previousDescriptors, descriptors), chart, 'disable');
-		this._notify(diff(descriptors, previousDescriptors), chart, 'enable');
+		this._notify(diff(previousDescriptors, descriptors), chart, 'stop');
+		this._notify(diff(descriptors, previousDescriptors), chart, 'start');
 	}
 }
 
@@ -120,19 +120,25 @@ function allPlugins(config) {
 	return plugins;
 }
 
+function getOpts(options, all) {
+	if (!all && options === false) {
+		return null;
+	}
+	if (options === true) {
+		return {};
+	}
+	return options;
+}
+
 function createDescriptors(plugins, options, all) {
 	const result = [];
 
 	for (let i = 0; i < plugins.length; i++) {
 		const plugin = plugins[i];
 		const id = plugin.id;
-
-		let opts = options[id];
-		if (opts === false && !all) {
+		const opts = getOpts(options[id], all);
+		if (opts === null) {
 			continue;
-		}
-		if (opts === true) {
-			opts = {};
 		}
 		result.push({
 			plugin,

--- a/src/core/core.plugins.js
+++ b/src/core/core.plugins.js
@@ -34,6 +34,7 @@ export default class PluginService {
 		const result = me._notify(descriptors, chart, hook, args);
 
 		if (hook === 'destroy') {
+			me._notify(descriptors, chart, 'stop');
 			me._notify(me._init, chart, 'uninstall');
 		}
 		return result;
@@ -165,7 +166,7 @@ function createDescriptors(plugins, options, all) {
  */
 /**
  * @method IPlugin#start
- * @desc Called when a plugin is starting due to chart initialization or plugin enablement.
+ * @desc Called when a plugin is starting. This happens when chart is created or plugin is enabled.
  * @param {Chart} chart - The chart instance.
  * @param {object} args - The call arguments.
  * @param {object} options - The plugin options.
@@ -173,7 +174,7 @@ function createDescriptors(plugins, options, all) {
  */
 /**
  * @method IPlugin#stop
- * @desc Called when a plugin stopping due being disabled.
+ * @desc Called when a plugin stopping. This happens when chart is destroyed or plugin is disabled.
  * @param {Chart} chart - The chart instance.
  * @param {object} args - The call arguments.
  * @param {object} options - The plugin options.

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -653,12 +653,12 @@ export default {
 	 */
 	_element: Legend,
 
-	enabled(chart) {
+	enable(chart) {
 		const legendOpts = resolveOptions(chart.options.plugins.legend);
 		createNewLegendAndAttach(chart, legendOpts);
 	},
 
-	disabled(chart) {
+	disable(chart) {
 		layouts.removeBox(chart, chart.legend);
 		delete chart.legend;
 	},

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -653,12 +653,14 @@ export default {
 	 */
 	_element: Legend,
 
-	beforeInit(chart) {
+	enabled(chart) {
 		const legendOpts = resolveOptions(chart.options.plugins.legend);
+		createNewLegendAndAttach(chart, legendOpts);
+	},
 
-		if (legendOpts) {
-			createNewLegendAndAttach(chart, legendOpts);
-		}
+	disabled(chart) {
+		layouts.removeBox(chart, chart.legend);
+		delete chart.legend;
 	},
 
 	// During the beforeUpdate step, the layout configuration needs to run

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -653,12 +653,12 @@ export default {
 	 */
 	_element: Legend,
 
-	enable(chart) {
+	start(chart) {
 		const legendOpts = resolveOptions(chart.options.plugins.legend);
 		createNewLegendAndAttach(chart, legendOpts);
 	},
 
-	disable(chart) {
+	stop(chart) {
 		layouts.removeBox(chart, chart.legend);
 		delete chart.legend;
 	},

--- a/src/plugins/plugin.title.js
+++ b/src/plugins/plugin.title.js
@@ -184,11 +184,11 @@ export default {
 	 */
 	_element: Title,
 
-	enable(chart, _args, options) {
+	start(chart, _args, options) {
 		createTitle(chart, options);
 	},
 
-	disable(chart) {
+	stop(chart) {
 		const titleBlock = chart.titleBlock;
 		layouts.removeBox(chart, titleBlock);
 		delete chart.titleBlock;

--- a/src/plugins/plugin.title.js
+++ b/src/plugins/plugin.title.js
@@ -184,11 +184,11 @@ export default {
 	 */
 	_element: Title,
 
-	enabled(chart, _args, options) {
+	enable(chart, _args, options) {
 		createTitle(chart, options);
 	},
 
-	disabled(chart) {
+	disable(chart) {
 		const titleBlock = chart.titleBlock;
 		layouts.removeBox(chart, titleBlock);
 		delete chart.titleBlock;

--- a/src/plugins/plugin.title.js
+++ b/src/plugins/plugin.title.js
@@ -184,11 +184,17 @@ export default {
 	 */
 	_element: Title,
 
-	beforeInit(chart, options) {
+	enabled(chart, _args, options) {
 		createTitle(chart, options);
 	},
 
-	beforeUpdate(chart, args, options) {
+	disabled(chart) {
+		const titleBlock = chart.titleBlock;
+		layouts.removeBox(chart, titleBlock);
+		delete chart.titleBlock;
+	},
+
+	beforeUpdate(chart, _args, options) {
 		if (options === false) {
 			removeTitle(chart);
 		} else {

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -1386,13 +1386,13 @@ describe('Chart', function() {
 		var hooks = {
 			install: ['install'],
 			uninstall: ['uninstall'],
-			chartInit: [
+			init: [
 				'beforeInit',
 				'resize',
 				'afterInit'
 			],
-			enable: ['start'],
-			disable: ['stop'],
+			start: ['start'],
+			stop: ['stop'],
 			update: [
 				'beforeUpdate',
 				'beforeLayout',
@@ -1453,14 +1453,15 @@ describe('Chart', function() {
 
 				expect(sequence).toEqual([].concat(
 					hooks.install,
-					hooks.enable,
-					hooks.chartInit,
+					hooks.start,
+					hooks.init,
 					hooks.update,
 					hooks.render,
 					hooks.resize,
 					hooks.update,
 					hooks.render,
 					hooks.destroy,
+					hooks.stop,
 					hooks.uninstall
 				));
 
@@ -1501,7 +1502,7 @@ describe('Chart', function() {
 			chart.update();
 
 			expect(sequence).toEqual([].concat(
-				hooks.enable,
+				hooks.start,
 				hooks.update,
 				hooks.render
 			));
@@ -1510,7 +1511,7 @@ describe('Chart', function() {
 			chart.options.plugins.plugin = false;
 			chart.update();
 
-			expect(sequence).toEqual(hooks.disable);
+			expect(sequence).toEqual(hooks.stop);
 
 			sequence = [];
 			chart.destroy();

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -1391,8 +1391,8 @@ describe('Chart', function() {
 				'resize',
 				'afterInit'
 			],
-			enable: ['enable'],
-			disable: ['disable'],
+			enable: ['start'],
+			disable: ['stop'],
 			update: [
 				'beforeUpdate',
 				'beforeLayout',

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -1384,15 +1384,15 @@ describe('Chart', function() {
 
 	describe('plugin.extensions', function() {
 		var hooks = {
-			init: ['init'],
-			unInit: ['unInit'],
+			install: ['install'],
+			uninstall: ['uninstall'],
 			chartInit: [
 				'beforeInit',
 				'resize',
 				'afterInit'
 			],
-			enabled: ['enabled'],
-			disabled: ['disabled'],
+			enable: ['enable'],
+			disable: ['disable'],
 			update: [
 				'beforeUpdate',
 				'beforeLayout',
@@ -1452,8 +1452,8 @@ describe('Chart', function() {
 				chart.destroy();
 
 				expect(sequence).toEqual([].concat(
-					hooks.init,
-					hooks.enabled,
+					hooks.install,
+					hooks.enable,
 					hooks.chartInit,
 					hooks.update,
 					hooks.render,
@@ -1461,7 +1461,7 @@ describe('Chart', function() {
 					hooks.update,
 					hooks.render,
 					hooks.destroy,
-					hooks.unInit
+					hooks.uninstall
 				));
 
 				done();
@@ -1492,27 +1492,30 @@ describe('Chart', function() {
 				}
 			});
 
-			expect(sequence).toEqual([]);
+			expect(sequence).toEqual([].concat(
+				hooks.install
+			));
 
+			sequence = [];
 			chart.options.plugins.plugin = true;
 			chart.update();
 
 			expect(sequence).toEqual([].concat(
-				hooks.init,
-				hooks.enabled,
+				hooks.enable,
 				hooks.update,
 				hooks.render
 			));
 
 			sequence = [];
-
 			chart.options.plugins.plugin = false;
 			chart.update();
-			expect(sequence).toEqual(hooks.disabled);
+
+			expect(sequence).toEqual(hooks.disable);
 
 			sequence = [];
 			chart.destroy();
-			expect(sequence).toEqual(hooks.unInit);
+
+			expect(sequence).toEqual(hooks.uninstall);
 		});
 
 		it('should not notify before/afterDatasetDraw if dataset is hidden', function() {

--- a/test/specs/plugin.legend.tests.js
+++ b/test/specs/plugin.legend.tests.js
@@ -760,7 +760,7 @@ describe('Legend block tests', function() {
 			expect(chart.legend.weight).toBe(42);
 		});
 
-		xit ('should remove the legend if the new options are false', function() {
+		it ('should remove the legend if the new options are false', function() {
 			var chart = acquireChart({
 				type: 'line',
 				data: {

--- a/test/specs/plugin.title.tests.js
+++ b/test/specs/plugin.title.tests.js
@@ -295,7 +295,7 @@ describe('Title block tests', function() {
 			expect(chart.titleBlock.weight).toBe(42);
 		});
 
-		xit ('should remove the title if the new options are false', function() {
+		it ('should remove the title if the new options are false', function() {
 			var chart = acquireChart({
 				type: 'line',
 				data: {

--- a/types/core/index.d.ts
+++ b/types/core/index.d.ts
@@ -568,6 +568,30 @@ export interface Plugin<O = {}> {
 	id: string;
 
 	/**
+	 * @desc Called when initializing the plugin for the chart instance.
+	 * @param {Chart} chart - The chart instance.
+	 * @param {object} args - The call arguments.
+	 * @param {object} options - The plugin options.
+	 * @since 3.0.0
+	 */
+	init?(chart: Chart, args: {}, options: O): void;
+	/**
+	 * @desc Called when plugin is enabled
+	 * @param {Chart} chart - The chart instance.
+	 * @param {object} args - The call arguments.
+	 * @param {object} options - The plugin options.
+	 * @since 3.0.0
+	 */
+	enabled?(chart: Chart, args: {}, options: O): void;
+	/**
+	 * @desc Called plugin is disabled
+	 * @param {Chart} chart - The chart instance.
+	 * @param {object} args - The call arguments.
+	 * @param {object} options - The plugin options.
+	 * @since 3.0.0
+	 */
+	disabled?(chart: Chart, args: {}, options: O): void;
+	/**
 	 * @desc Called before initializing `chart`.
 	 * @param {Chart} chart - The chart instance.
 	 * @param {object} args - The call arguments.
@@ -772,11 +796,20 @@ export interface Plugin<O = {}> {
 	 */
 	resize?(chart: Chart, args: { size: { width: number, height: number } }, options: O): boolean | void;
 	/**
-	 * Called after the chart as been destroyed.
+	 * Called after the chart has been destroyed.
 	 * @param {Chart} chart - The chart instance.
+	 * @param {object} args - The call arguments.
 	 * @param {object} options - The plugin options.
 	 */
-	destroy?(chart: Chart, options: O): boolean | void;
+	destroy?(chart: Chart, args: {}, options: O): boolean | void;
+	/**
+	 * Called after chart is destroyed on all plugins that were initialized for that chart. This is the only hook that is called on a disabled plugin.
+	 * @param {Chart} chart - The chart instance.
+	 * @param {object} args - The call arguments.
+	 * @param {object} options - The plugin options.
+	 * @since 3.0.0
+	 */
+	unInit?(chart: Chart, args: {}, options: O): void;
 }
 
 export declare type ChartComponentLike = ChartComponent | ChartComponent[] | { [key: string]: ChartComponent };

--- a/types/core/index.d.ts
+++ b/types/core/index.d.ts
@@ -576,7 +576,7 @@ export interface Plugin<O = {}> {
 	 */
 	install?(chart: Chart, args: {}, options: O): void;
 	/**
-	 * @desc Called when a plugin is starting due to chart initialization or plugin enablement.
+	 * @desc Called when a plugin is starting. This happens when chart is created or plugin is enabled.
 	 * @param {Chart} chart - The chart instance.
 	 * @param {object} args - The call arguments.
 	 * @param {object} options - The plugin options.
@@ -584,7 +584,7 @@ export interface Plugin<O = {}> {
 	 */
 	start?(chart: Chart, args: {}, options: O): void;
 	/**
-	 * @desc Called when a plugin stopping due being disabled.
+	 * @desc Called when a plugin stopping. This happens when chart is destroyed or plugin is disabled.
 	 * @param {Chart} chart - The chart instance.
 	 * @param {object} args - The call arguments.
 	 * @param {object} options - The plugin options.

--- a/types/core/index.d.ts
+++ b/types/core/index.d.ts
@@ -576,21 +576,21 @@ export interface Plugin<O = {}> {
 	 */
 	install?(chart: Chart, args: {}, options: O): void;
 	/**
-	 * @desc Called when plugin is enabled
+	 * @desc Called when a plugin is starting due to chart initialization or plugin enablement.
 	 * @param {Chart} chart - The chart instance.
 	 * @param {object} args - The call arguments.
 	 * @param {object} options - The plugin options.
 	 * @since 3.0.0
 	 */
-	enable?(chart: Chart, args: {}, options: O): void;
+	start?(chart: Chart, args: {}, options: O): void;
 	/**
-	 * @desc Called plugin is disabled
+	 * @desc Called when a plugin stopping due being disabled.
 	 * @param {Chart} chart - The chart instance.
 	 * @param {object} args - The call arguments.
 	 * @param {object} options - The plugin options.
 	 * @since 3.0.0
 	 */
-	disable?(chart: Chart, args: {}, options: O): void;
+	stop?(chart: Chart, args: {}, options: O): void;
 	/**
 	 * @desc Called before initializing `chart`.
 	 * @param {Chart} chart - The chart instance.

--- a/types/core/index.d.ts
+++ b/types/core/index.d.ts
@@ -568,13 +568,13 @@ export interface Plugin<O = {}> {
 	id: string;
 
 	/**
-	 * @desc Called when initializing the plugin for the chart instance.
+	 * @desc Called when plugin is installed for this chart instance. This hook is also invoked for disabled plugins (options === false).
 	 * @param {Chart} chart - The chart instance.
 	 * @param {object} args - The call arguments.
 	 * @param {object} options - The plugin options.
 	 * @since 3.0.0
 	 */
-	init?(chart: Chart, args: {}, options: O): void;
+	install?(chart: Chart, args: {}, options: O): void;
 	/**
 	 * @desc Called when plugin is enabled
 	 * @param {Chart} chart - The chart instance.
@@ -582,7 +582,7 @@ export interface Plugin<O = {}> {
 	 * @param {object} options - The plugin options.
 	 * @since 3.0.0
 	 */
-	enabled?(chart: Chart, args: {}, options: O): void;
+	enable?(chart: Chart, args: {}, options: O): void;
 	/**
 	 * @desc Called plugin is disabled
 	 * @param {Chart} chart - The chart instance.
@@ -590,7 +590,7 @@ export interface Plugin<O = {}> {
 	 * @param {object} options - The plugin options.
 	 * @since 3.0.0
 	 */
-	disabled?(chart: Chart, args: {}, options: O): void;
+	disable?(chart: Chart, args: {}, options: O): void;
 	/**
 	 * @desc Called before initializing `chart`.
 	 * @param {Chart} chart - The chart instance.
@@ -803,13 +803,13 @@ export interface Plugin<O = {}> {
 	 */
 	destroy?(chart: Chart, args: {}, options: O): boolean | void;
 	/**
-	 * Called after chart is destroyed on all plugins that were initialized for that chart. This is the only hook that is called on a disabled plugin.
+	 * Called after chart is destroyed on all plugins that were installed for that chart. This hook is also invoked for disabled plugins (options === false).
 	 * @param {Chart} chart - The chart instance.
 	 * @param {object} args - The call arguments.
 	 * @param {object} options - The plugin options.
 	 * @since 3.0.0
 	 */
-	unInit?(chart: Chart, args: {}, options: O): void;
+	uninstall?(chart: Chart, args: {}, options: O): void;
 }
 
 export declare type ChartComponentLike = ChartComponent | ChartComponent[] | { [key: string]: ChartComponent };


### PR DESCRIPTION
Our internal plugins need to know when they are disabled. 
This adds a `install`, `uninstall`,  `start` and `stop` hooks.

`install` and `uninstall` are called on all plugins (disabled ones too)