### PR TITLE
fix color type & add background and border color

### DIFF
--- a/types/core/interfaces.d.ts
+++ b/types/core/interfaces.d.ts
@@ -99,7 +99,17 @@ export interface CoreChartOptions extends ParsingOptions {
    * base color
    * @see Defaults.color
    */
-  color: string;
+  color: Color;
+    /**
+   * base background color
+   * @see Defaults.backgroundColor
+   */
+  backgroundColor: Color;
+    /**
+   * base border color
+   * @see Defaults.borderColor
+   */
+  borderColor: Color;
   /**
    * base font
    * @see Defaults.font


### PR DESCRIPTION
As discussed here #8088 , the chart default color type needs to be updated. `backgroundColor` and `borderColor` also added with respective _typedoc_ comments.