### PR TITLE
Fix/area fill and chart titles

### DIFF
--- a/docs/docs/developers/updates.md
+++ b/docs/docs/developers/updates.md
@@ -42,9 +42,11 @@ function updateConfigByMutating(chart) {
 function updateConfigAsNewObject(chart) {
     chart.options = {
         responsive: true,
-        title: {
-            display: true,
-            text: 'Chart.js'
+        plugins: {
+            title: {
+                display: true,
+                text: 'Chart.js'
+            }
         },
         scales: {
             x: {

--- a/docs/docs/getting-started/v3-migration.md
+++ b/docs/docs/getting-started/v3-migration.md
@@ -33,9 +33,11 @@ const chart = new Chart(ctx, {
     type: 'line',
     // data: ...
     options: {
-        title: {
-            display: true,
-            text: 'Chart Title'
+        plugins: {
+            title: {
+                display: true,
+                text: 'Chart Title'
+            }
         },
         scales: {
             x: {

--- a/samples/advanced/progress-bar.html
+++ b/samples/advanced/progress-bar.html
@@ -58,9 +58,11 @@
 				}]
 			},
 			options: {
-				title: {
-					display: true,
-					text: 'Chart.js Line Chart - Animation Progress Bar'
+				plugins: {
+					title: {
+						display: true,
+						text: 'Chart.js Line Chart - Animation Progress Bar'
+					}
 				},
 				animation: {
 					duration: 2000,

--- a/samples/charts/area/line-boundaries.html
+++ b/samples/charts/area/line-boundaries.html
@@ -86,10 +86,12 @@
 					}]
 				},
 				options: Chart.helpers.merge(options, {
-					title: {
-						text: 'fill: ' + boundary,
-						display: true
-					}
+					plugins: {
+						title: {
+							text: 'fill: ' + boundary,
+							display: true
+						}
+					},
 				})
 			});
 		});

--- a/samples/charts/area/line-stacked.html
+++ b/samples/charts/area/line-stacked.html
@@ -44,6 +44,7 @@
 						randomScalingFactor(),
 						randomScalingFactor()
 					],
+					fill: true
 				}, {
 					label: 'My Second dataset',
 					borderColor: window.chartColors.blue,
@@ -57,6 +58,7 @@
 						randomScalingFactor(),
 						randomScalingFactor()
 					],
+					fill: true
 				}, {
 					label: 'My Third dataset',
 					borderColor: window.chartColors.green,
@@ -70,6 +72,7 @@
 						randomScalingFactor(),
 						randomScalingFactor()
 					],
+					fill: true
 				}, {
 					label: 'My Fourth dataset',
 					borderColor: window.chartColors.yellow,
@@ -83,6 +86,7 @@
 						randomScalingFactor(),
 						randomScalingFactor()
 					],
+					fill: true
 				}]
 			},
 			options: {

--- a/samples/charts/bar/stacked.html
+++ b/samples/charts/bar/stacked.html
@@ -67,7 +67,7 @@
 				type: 'bar',
 				data: barChartData,
 				options: {
-					plugin: {
+					plugins: {
 						title: {
 							display: true,
 							text: 'Chart.js Bar Chart - Stacked'

--- a/samples/charts/line/multi-axis.html
+++ b/samples/charts/line/multi-axis.html
@@ -66,9 +66,11 @@
 						mode: 'index'
 					},
 					stacked: false,
-					title: {
-						display: true,
-						text: 'Chart.js Line Chart - Multi Axis'
+					plugins: {
+						title: {
+							display: true,
+							text: 'Chart.js Line Chart - Multi Axis'
+						}
 					},
 					scales: {
 						y: {

--- a/samples/charts/line/stepped.html
+++ b/samples/charts/line/stepped.html
@@ -45,9 +45,11 @@
 				},
 				options: {
 					responsive: true,
-					title: {
-						display: true,
-						text: details.label,
+					plugins: {
+						title: {
+							display: true,
+							text: details.label,
+						}
 					}
 				}
 			};

--- a/samples/charts/multi-series-pie.html
+++ b/samples/charts/multi-series-pie.html
@@ -48,7 +48,7 @@
 						labels: {
 							generateLabels: function(chart) {
 								// Get the default label list
-								var original = Chart.defaults.controllers.pie.legend.labels.generateLabels;
+								var original = Chart.defaults.controllers.pie.plugins.legend.labels.generateLabels;
 								var labels = original.call(this, chart);
 
 								// Build an array of colors used in the datasets of the chart

--- a/samples/charts/radar-skip-points.html
+++ b/samples/charts/radar-skip-points.html
@@ -74,9 +74,11 @@
 				}]
 			},
 			options: {
-				title: {
-					display: true,
-					text: 'Chart.js Radar Chart - Skip Points'
+				plugins: {
+					title: {
+						display: true,
+						text: 'Chart.js Radar Chart - Skip Points'
+					}
 				},
 				elements: {
 					line: {

--- a/samples/charts/scatter/basic.html
+++ b/samples/charts/scatter/basic.html
@@ -52,10 +52,12 @@
 				type: 'scatter',
 				data: scatterChartData,
 				options: {
-					title: {
-						display: true,
-						text: 'Chart.js Scatter Chart'
-					},
+					plugins: {
+						title: {
+							display: true,
+							text: 'Chart.js Scatter Chart'
+						}
+					}
 				}
 			});
 		};

--- a/samples/charts/scatter/multi-axis.html
+++ b/samples/charts/scatter/multi-axis.html
@@ -92,9 +92,11 @@
 					intersect: true,
 					mode: 'nearest'
 				},
-				title: {
-					display: true,
-					text: 'Chart.js Scatter Chart - Multi Axis'
+				plugins: {
+					title: {
+						display: true,
+						text: 'Chart.js Scatter Chart - Multi Axis'
+					}
 				},
 				scales: {
 					x: {

--- a/samples/index.html
+++ b/samples/index.html
@@ -7,6 +7,7 @@
 	<link rel="stylesheet" type="text/css" href="style.css">
 	<link rel="icon" href="favicon.ico">
 	<script src="samples.js"></script>
+	<script src="../dist/chart.min.js"></script>
 	<script src="utils.js"></script>
 	<title>Chart.js samples</title>
 </head>

--- a/samples/samples.js
+++ b/samples/samples.js
@@ -92,6 +92,9 @@
 			title: 'Radar',
 			path: 'charts/radar.html'
 		}, {
+			title: 'Radar skip points',
+			path: 'charts/radar-skip-points.html'
+		}, {
 			title: 'Combo bar/line',
 			path: 'charts/combo-bar-line.html'
 		}]

--- a/samples/scales/axis-center-position.html
+++ b/samples/scales/axis-center-position.html
@@ -61,10 +61,13 @@
 				data: scatterChartData,
 				options: {
 					responsive: true,
-					title: {
-						display: true,
-						text: title
+					plugins: {
+						title: {
+							display: true,
+							text: title
+						}
 					},
+
 					scales: {
 						x: {
 							position: xPosition,

--- a/samples/scales/filtering-labels.html
+++ b/samples/scales/filtering-labels.html
@@ -59,9 +59,11 @@
 			},
 			options: {
 				responsive: true,
-				title: {
-					display: true,
-					text: 'Chart.js Line Chart - X-Axis Filter'
+				plugins: {
+					title: {
+						display: true,
+						text: 'Chart.js Line Chart - X-Axis Filter'
+					}
 				},
 				scales: {
 					x: {

--- a/samples/scales/gridlines-display.html
+++ b/samples/scales/gridlines-display.html
@@ -50,9 +50,11 @@
 				},
 				options: {
 					responsive: true,
-					title: {
-						display: true,
-						text: title
+					plugins: {
+						title: {
+							display: true,
+							text: title
+						}
 					},
 					scales: {
 						x: {

--- a/samples/scales/gridlines-scriptable.html
+++ b/samples/scales/gridlines-scriptable.html
@@ -39,9 +39,11 @@
 			},
 			options: {
 				responsive: true,
-				title: {
-					display: true,
-					text: 'Grid Line Settings'
+				plugins: {
+					title: {
+						display: true,
+						text: 'Grid Line Settings'
+					}
 				},
 				scales: {
 					y: {

--- a/samples/scales/gridlines-style.html
+++ b/samples/scales/gridlines-style.html
@@ -39,9 +39,11 @@
 			},
 			options: {
 				responsive: true,
-				title: {
-					display: true,
-					text: 'Grid Line Settings'
+				plugins: {
+					title: {
+						display: true,
+						text: 'Grid Line Settings'
+					}
 				},
 				scales: {
 					y: {

--- a/samples/scales/linear/min-max.html
+++ b/samples/scales/linear/min-max.html
@@ -39,9 +39,11 @@
 			},
 			options: {
 				responsive: true,
-				title: {
-					display: true,
-					text: 'Min and Max Settings'
+				plugins: {
+					title: {
+						display: true,
+						text: 'Min and Max Settings'
+					}
 				},
 				scales: {
 					y: {

--- a/samples/scales/logarithmic/line.html
+++ b/samples/scales/logarithmic/line.html
@@ -60,9 +60,11 @@
 		},
 		options: {
 			responsive: true,
-			title: {
-				display: true,
-				text: 'Chart.js Line Chart - Logarithmic'
+			plugins: {
+				title: {
+					display: true,
+					text: 'Chart.js Line Chart - Logarithmic'
+				}
 			},
 			scales: {
 				x: {

--- a/samples/scales/logarithmic/scatter.html
+++ b/samples/scales/logarithmic/scatter.html
@@ -128,9 +128,11 @@
 			type: 'scatter',
 			data: scatterChartData,
 			options: {
-				title: {
-					display: true,
-					text: 'Chart.js Scatter Chart - Logarithmic X-Axis'
+				plugins: {
+					title: {
+						display: true,
+						text: 'Chart.js Scatter Chart - Logarithmic X-Axis'
+					}
 				},
 				scales: {
 					x: {

--- a/samples/scales/multiline-labels.html
+++ b/samples/scales/multiline-labels.html
@@ -69,10 +69,12 @@
 			},
 			options: {
 				responsive: true,
-				title: {
-					display: true,
-					text: 'Chart with Multiline Labels'
-				},
+				plugins: {
+					title: {
+						display: true,
+						text: 'Chart with Multiline Labels'
+					}
+				}
 			}
 		};
 

--- a/samples/scales/non-numeric-y.html
+++ b/samples/scales/non-numeric-y.html
@@ -34,9 +34,11 @@
 			},
 			options: {
 				responsive: true,
-				title: {
-					display: true,
-					text: 'Chart with Non Numeric Y Axis'
+				plugins: {
+					title: {
+						display: true,
+						text: 'Chart with Non Numeric Y Axis'
+					}
 				},
 				scales: {
 					x: {

--- a/samples/scales/time/combo.html
+++ b/samples/scales/time/combo.html
@@ -72,8 +72,11 @@
 				}]
 			},
 			options: {
-				title: {
-					text: 'Chart.js Combo Time Scale'
+				plugins: {
+					title: {
+						text: 'Chart.js Combo Time Scale',
+						display: true
+					}
 				},
 				scales: {
 					x: {

--- a/samples/scales/time/line-max-span.html
+++ b/samples/scales/time/line-max-span.html
@@ -79,9 +79,11 @@
 			options: {
 				spanGaps: 1000 * 60 * 60 * 24 * 2, // 2 days
 				responsive: true,
-				title: {
-					display: true,
-					text: 'Chart.js Time - spanGaps: 172800000 (2 days in ms)'
+				plugins: {
+					title: {
+						display: true,
+						text: 'Chart.js Time - spanGaps: 172800000 (2 days in ms)'
+					}
 				},
 				scales: {
 					x: {

--- a/samples/scales/time/line-point-data.html
+++ b/samples/scales/time/line-point-data.html
@@ -78,9 +78,11 @@
 			},
 			options: {
 				responsive: true,
-				title: {
-					display: true,
-					text: 'Chart.js Time Point Data'
+				plugins: {
+					title: {
+						display: true,
+						text: 'Chart.js Time Point Data'
+					}
 				},
 				scales: {
 					x: {

--- a/samples/scales/time/line.html
+++ b/samples/scales/time/line.html
@@ -100,8 +100,11 @@
 				}]
 			},
 			options: {
-				title: {
-					text: 'Chart.js Time Scale'
+				plugins: {
+					title: {
+						text: 'Chart.js Time Scale',
+						display: true
+					}
 				},
 				scales: {
 					x: {

--- a/samples/scales/toggle-scale-type.html
+++ b/samples/scales/toggle-scale-type.html
@@ -62,9 +62,11 @@
 			},
 			options: {
 				responsive: true,
-				title: {
-					display: true,
-					text: 'Chart.js Line Chart - ' + type
+				plugins: {
+					title: {
+						display: true,
+						text: 'Chart.js Line Chart - ' + type
+					}
 				},
 				scales: {
 					x: {


### PR DESCRIPTION
Area fill for stacked line was broken because of #8111 
Lot of samples had the title in the wrong place so it didn't show
Added import to Chart so it is available in the utils.js
Skip points for radar chart was not in the list of available samples so didnt show up in the overview 