### PR TITLE
[v3] Add locale to ChartOptions type

### DIFF
--- a/docs/docs/general/locale.md
+++ b/docs/docs/general/locale.md
@@ -1,0 +1,25 @@
+---
+title: Locale
+---
+
+For applications where the numbers of ticks on scales must be formatted accordingly with a language sensitive number formatting, you can enable this kind of formatting by setting the `locale` option.
+
+The locale is a string that is a [Unicode BCP 47 locale identifier](https://www.unicode.org/reports/tr35/tr35.html#BCP_47_Conformance).
+
+A Unicode BCP 47 locale identifier consists of
+
+  1. a language code,
+  2. (optionally) a script code,
+  3. (optionally) a region (or country) code,
+  4. (optionally) one or more variant codes, and
+  5. (optionally) one or more extension sequences,
+
+with all present components separated by hyphens. 
+
+By default the chart is using the default locale of the platform which is running on.
+
+## Configuration Options
+
+| Name | Type | Default | Description
+| ---- | ---- | ------- | -----------
+| `locale` | `string` | `undefined` | a string with a BCP 47 language tag, leveraging on [INTL NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat).

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -16,6 +16,7 @@ module.exports = {
 			'general/accessibility',
 			'general/responsive',
 			'general/device-pixel-ratio',
+			'general/locale',
 			{Interactions: ['general/interactions/index', 'general/interactions/events', 'general/interactions/modes']},
 			'general/options',
 			'general/colors',

--- a/types/core/interfaces.d.ts
+++ b/types/core/interfaces.d.ts
@@ -131,6 +131,12 @@ export interface CoreChartOptions extends ParsingOptions {
    * @default 2
    */
   aspectRatio: number;
+	
+  /**
+   * Locale used for number formatting (using `Intl.NumberFormat`).
+   * @default user's browser setting
+   */
+  locale: string;
 
   /**
    * Called when a resize occurs. Gets passed two arguments: the chart instance and the new size.


### PR DESCRIPTION
Noticed this property was still missing from the types! My first contribution to the project, hope this is enough ;)

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
