### PR TITLE
Update browser support

### DIFF
--- a/docs/docs/developers/index.md
+++ b/docs/docs/developers/index.md
@@ -24,11 +24,10 @@ Latest builds are available for testing at:
 
 Chart.js offers support for the following browsers:
 
-- Chrome 50+
-- Firefox 45+
-- Internet Explorer 11
-- Edge 14+
-- Safari 9+
+- Chrome 64+
+- Firefox 69+
+- Edge 79+
+- Safari 13.1+
 
 Browser support for the canvas element is available in all modern & major mobile browsers. [CanIUse](https://caniuse.com/#feat=canvas)
 


### PR DESCRIPTION
ChartJS 3 uses [ResizeObserver](https://caniuse.com/?search=ResizeObserver) so imho browser support should be updated to browsers that support this feature.

Maybe it should also be explained similarly as for the `canvas` element.

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
