### PR TITLE
fix default font color for legend

### DIFF
--- a/docs/docs/configuration/legend.md
+++ b/docs/docs/configuration/legend.md
@@ -125,7 +125,7 @@ var chart = new Chart(ctx, {
             legend: {
                 display: true,
                 labels: {
-                    fontColor: 'rgb(255, 99, 132)'
+                    color: 'rgb(255, 99, 132)'
                 }
             }
         }

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -311,7 +311,7 @@ export class Legend extends Element {
 		const rtlHelper = getRtlAdapter(opts.rtl, me.left, me._minSize.width);
 		const ctx = me.ctx;
 		const labelFont = toFont(labelOpts.font, me.chart.options.font);
-		const fontColor = labelOpts.color;
+		const fontColor = labelOpts.color || defaultColor;
 		const fontSize = labelFont.size;
 		let cursor;
 


### PR DESCRIPTION
Solves #8136 
Default collor did not apply anymore on legend font color
<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
