### PR TITLE
Add "arrow" point style

### DIFF
--- a/types/elements/index.d.ts
+++ b/types/elements/index.d.ts
@@ -148,6 +148,7 @@ export type PointStyle =
   | 'rectRot'
   | 'star'
   | 'triangle'
+  | 'arrow'
   | HTMLImageElement
   | HTMLCanvasElement;
 


### PR DESCRIPTION
I think it could be useful to implement another basic point style : "arrow".
I missed it trying to plot orientation related data (like wind direction) using point rotation (at first I used the "triangle" style but its rotation symmetry makes it unusable).

Maybe the "arrow" could be implemented like this  (in </src/helpers/helpers.canvas.js> around line #148) ?:

    case 'arrow':
		ctx.moveTo(x + Math.sin(rad) * radius, y - Math.cos(rad) * radius);
		rad += TWO_THIRDS_PI;
		ctx.lineTo(x + Math.sin(rad) * radius, y - Math.cos(rad) * radius);
		ctx.lineTo(x, y);	
		rad += TWO_THIRDS_PI;
		ctx.lineTo(x + Math.sin(rad) * radius, y - Math.cos(rad) * radius);
		ctx.closePath();
		break;	

Thanks for reading (and creating such a great piece of software)!!

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
