### PR TITLE
Prevent double plugin registers from losing the list of plugins

### DIFF
--- a/src/core/core.plugins.js
+++ b/src/core/core.plugins.js
@@ -1,5 +1,6 @@
 import defaults from './core.defaults';
 import registry from './core.registry';
+import {isNullOrUndef} from '../helpers';
 import {callback as callCallback, mergeIf, valueOrDefault} from '../helpers/helpers.core';
 
 /**
@@ -58,8 +59,15 @@ export default class PluginService {
 	}
 
 	invalidate() {
-		this._oldCache = this._cache;
-		this._cache = undefined;
+		// When plugins are registered, there is the possibility of a double
+		// invalidate situation. In this case, we only want to invalidate once.
+		// If we invalidate multiple times, the `_oldCache` is lost and all of the
+		// plugins are restarted without being correctly stopped.
+		// See https://github.com/chartjs/Chart.js/issues/8147
+		if (!isNullOrUndef(this._cache)) {
+			this._oldCache = this._cache;
+			this._cache = undefined;
+		}
 	}
 
 	/**

--- a/test/specs/core.plugin.tests.js
+++ b/test/specs/core.plugin.tests.js
@@ -342,5 +342,24 @@ describe('Chart.plugins', function() {
 
 			expect(plugin.hook).not.toHaveBeenCalled();
 		});
+
+		it('should not restart plugins when a double register occurs', function() {
+			var results = [];
+			var chart = window.acquireChart({
+				plugins: [{
+					start: function() {
+						results.push(1);
+					}
+				}]
+			});
+
+			Chart.register({id: 'abc', hook: function() {}});
+			Chart.register({id: 'def', hook: function() {}});
+
+			chart.update();
+
+			// The plugin on the chart should only be started once
+			expect(results).toEqual([1]);
+		});
 	});
 });


### PR DESCRIPTION
When `Chart.register()` was called twice in a row, the list of
plugin descriptors on the chart instance would be cleared. The
next chart update would then restart all of the plugins, not
knowing that they were already started. In the case of the Legend
and Title, this causes two boxes to appear in the layout system
thus drawing twice.

Resolves #8147 