### PR TITLE
Split geometric types to their own definition file

### DIFF
--- a/types/geometric.d.ts
+++ b/types/geometric.d.ts
@@ -1,0 +1,11 @@
+export interface ChartArea {
+  top: number;
+  left: number;
+  right: number;
+  bottom: number;
+}
+
+export interface Point {
+  x: number;
+  y: number;
+}

--- a/types/helpers/helpers.canvas.d.ts
+++ b/types/helpers/helpers.canvas.d.ts
@@ -1,4 +1,5 @@
-import { ChartArea, PointStyle } from '../index.esm';
+import { PointStyle } from '../index.esm';
+import { ChartArea } from '../geometric';
 
 /**
  * Clears the entire canvas associated to the given `chart`.

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -12,6 +12,9 @@
  * }
  */
 
+import { ChartArea, Point } from './geometric';
+// export { ChartArea, Point } from './geometric';
+
 export interface ParsingOptions {
   /**
    * How to parse the dataset. The parsing can be disabled by specifying parsing: false at chart options or dataset. If parsing is disabled, data must be sorted and in the formats the associated chart type and scales use internally.
@@ -1452,12 +1455,6 @@ export interface ChartEvent {
   x: number | null;
   y: number | null;
 }
-
-export interface Point {
-  x: number;
-  y: number;
-}
-
 export interface ChartComponent {
   id: string;
   defaults?: any;
@@ -1470,13 +1467,6 @@ export interface ChartComponent {
 }
 
 export type TimeUnit = 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year';
-
-export interface ChartArea {
-  top: number;
-  left: number;
-  right: number;
-  bottom: number;
-}
 
 export interface ScriptableContext {
   chart: Chart;

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -13,7 +13,7 @@
  */
 
 import { ChartArea, Point } from './geometric';
-// export { ChartArea, Point } from './geometric';
+export { ChartArea, Point } from './geometric';
 
 export interface ParsingOptions {
   /**


### PR DESCRIPTION
First PR to start re-splitting the TS definitions into modules. This moves `ChartArea` and `Point` to a new `geometric.d.ts` file.
