### PR TITLE
Enable changing the chart type

### DIFF
--- a/src/core/core.config.js
+++ b/src/core/core.config.js
@@ -51,8 +51,9 @@ function mergeScaleConfig(config, options) {
 		const scaleConf = configScales[id];
 		const axis = determineAxis(id, scaleConf);
 		const defaultId = getDefaultScaleIDFromAxis(axis, chartIndexAxis);
+		const defaultScaleOptions = chartDefaults.scales || {};
 		firstIDs[axis] = firstIDs[axis] || id;
-		scales[id] = mergeIf(Object.create(null), [{axis}, scaleConf, chartDefaults.scales[axis], chartDefaults.scales[defaultId]]);
+		scales[id] = mergeIf(Object.create(null), [{axis}, scaleConf, defaultScaleOptions[axis], defaultScaleOptions[defaultId]]);
 	});
 
 	// Backward compatibility
@@ -161,6 +162,10 @@ export default class Config {
 
 	get type() {
 		return this._config.type;
+	}
+
+	set type(type) {
+		this._config.type = type;
 	}
 
 	get data() {


### PR DESCRIPTION
Allows changing of the chart type, and fixes a crash, enabling the work around in #5647 to continue working.

There's still a problem where the old scales / legend callback are kept merged in the old options. 
![bar-to-doughnut](https://user-images.githubusercontent.com/6757853/103016141-9c0f3380-450f-11eb-9d95-53b6c2367b92.PNG)
