### PR TITLE
Create standardized text render method

### DIFF
--- a/docs/docs/axes/_common_ticks.md
+++ b/docs/docs/axes/_common_ticks.md
@@ -8,6 +8,6 @@
 | `font` | `Font` | Yes | `Chart.defaults.font` | See [Fonts](../general/fonts.md)
 | `major` | `object` | | `{}` | [Major ticks configuration](./styling.mdx#major-tick-configuration).
 | `padding` | `number` | | `0` | Sets the offset of the tick labels from the axis
-| `textStrokeColor` | `string` | | `` | The color of the stroke around the text.
-| `textStrokeWidth` | `number` | | `0` | Stroke width around the text.
+| `textStrokeColor` | [`Color`](../general/colors.md) | Yes | `` | The color of the stroke around the text.
+| `textStrokeWidth` | `number` | Yes | `0` | Stroke width around the text.
 | `z` | `number` | | `0` | z-index of tick layer. Useful when ticks are drawn on chart area. Values &lt;= 0 are drawn under datasets, &gt; 0 on top.

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -1386,6 +1386,8 @@ export default class Scale extends Element {
 			lineCount = isArray(label) ? label.length : 1;
 			const halfCount = lineCount / 2;
 			const color = resolve([optionTicks.color], me.getContext(i), i);
+			const strokeColor = resolve([optionTicks.textStrokeColor], me.getContext(i), i);
+			const strokeWidth = resolve([optionTicks.textStrokeWidth], me.getContext(i), i);
 
 			if (isHorizontal) {
 				x = pixel;
@@ -1417,15 +1419,16 @@ export default class Scale extends Element {
 			}
 
 			items.push({
-				x,
-				y,
 				rotation,
 				label,
 				font,
 				color,
+				strokeColor,
+				strokeWidth,
 				textOffset,
 				textAlign,
 				textBaseline,
+				translation: [x, y]
 			});
 		}
 
@@ -1603,15 +1606,7 @@ export default class Scale extends Element {
 			const tickFont = item.font;
 			const label = item.label;
 			let y = item.textOffset;
-			renderText(ctx, label, 0, y, tickFont, {
-				color: item.color,
-				rotation: item.rotation,
-				strokeColor: optionTicks.textStrokeColor,
-				strokeWidth: optionTicks.textStrokeWidth,
-				textAlign: item.textAlign,
-				textBaseline: item.textBaseline,
-				translation: [item.x, item.y],
-			});
+			renderText(ctx, label, 0, y, tickFont, item);
 		}
 	}
 

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -1603,22 +1603,18 @@ export default class Scale extends Element {
 			const tickFont = item.font;
 			const useStroke = optionTicks.textStrokeWidth > 0 && optionTicks.textStrokeColor !== '';
 
-			// Make sure we draw text in the correct color and font
-			ctx.save();
-			ctx.translate(item.x, item.y);
-			ctx.rotate(item.rotation);
-
 			const label = item.label;
 			let y = item.textOffset;
 			renderText(ctx, label, 0, y, tickFont, {
 				color: item.color,
+				rotation: item.rotation,
 				stroke: useStroke,
 				strokeColor: optionTicks.textStrokeColor,
 				strokeWidth: optionTicks.textStrokeWidth,
 				textAlign: item.textAlign,
 				textBaseline: item.textBaseline,
+				translation: [item.x, item.y],
 			});
-			ctx.restore();
 		}
 	}
 
@@ -1684,15 +1680,13 @@ export default class Scale extends Element {
 			rotation = isLeft ? -HALF_PI : HALF_PI;
 		}
 
-		ctx.save();
-		ctx.translate(scaleLabelX, scaleLabelY);
-		ctx.rotate(rotation);
 		renderText(ctx, scaleLabel.labelString, 0, 0, scaleLabelFont, {
 			color: scaleLabel.color,
+			rotation,
 			textAlign,
 			textBaseline: 'middle',
+			translation: [scaleLabelX, scaleLabelY],
 		});
-		ctx.restore();
 	}
 
 	draw(chartArea) {

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -1,6 +1,6 @@
 import defaults from './core.defaults';
 import Element from './core.element';
-import {_alignPixel, _measureText} from '../helpers/helpers.canvas';
+import {_alignPixel, _measureText, renderText} from '../helpers/helpers.canvas';
 import {callback as call, each, finiteOrDefault, isArray, isFinite, isNullOrUndef, isObject, valueOrDefault} from '../helpers/helpers.core';
 import {_factorize, toDegrees, toRadians, _int16Range, HALF_PI} from '../helpers/helpers.math';
 import {toFont, resolve, toPadding} from '../helpers/helpers.options';
@@ -1596,7 +1596,7 @@ export default class Scale extends Element {
 
 		const ctx = me.ctx;
 		const items = me._labelItems || (me._labelItems = me._computeLabelItems(chartArea));
-		let i, j, ilen, jlen;
+		let i, ilen;
 
 		for (i = 0, ilen = items.length; i < ilen; ++i) {
 			const item = items[i];
@@ -1619,21 +1619,9 @@ export default class Scale extends Element {
 
 			const label = item.label;
 			let y = item.textOffset;
-			if (isArray(label)) {
-				for (j = 0, jlen = label.length; j < jlen; ++j) {
-					// We just make sure the multiline element is a string here..
-					if (useStroke) {
-						ctx.strokeText('' + label[j], 0, y);
-					}
-					ctx.fillText('' + label[j], 0, y);
-					y += tickFont.lineHeight;
-				}
-			} else {
-				if (useStroke) {
-					ctx.strokeText(label, 0, y);
-				}
-				ctx.fillText(label, 0, y);
-			}
+			renderText(ctx, label, 0, y, tickFont.lineHeight, {
+				stroke: useStroke,
+			});
 			ctx.restore();
 		}
 	}
@@ -1707,7 +1695,7 @@ export default class Scale extends Element {
 		ctx.textBaseline = 'middle';
 		ctx.fillStyle = scaleLabel.color;
 		ctx.font = scaleLabelFont.string;
-		ctx.fillText(scaleLabel.labelString, 0, 0);
+		renderText(ctx, scaleLabel.labelString, 0, 0, scaleLabelFont.lineHeight);
 		ctx.restore();
 	}
 

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -1607,8 +1607,6 @@ export default class Scale extends Element {
 			ctx.save();
 			ctx.translate(item.x, item.y);
 			ctx.rotate(item.rotation);
-			ctx.textAlign = item.textAlign;
-			ctx.textBaseline = item.textBaseline;
 
 			const label = item.label;
 			let y = item.textOffset;
@@ -1617,6 +1615,8 @@ export default class Scale extends Element {
 				stroke: useStroke,
 				strokeColor: optionTicks.textStrokeColor,
 				strokeWidth: optionTicks.textStrokeWidth,
+				textAlign: item.textAlign,
+				textBaseline: item.textBaseline,
 			});
 			ctx.restore();
 		}
@@ -1687,10 +1687,10 @@ export default class Scale extends Element {
 		ctx.save();
 		ctx.translate(scaleLabelX, scaleLabelY);
 		ctx.rotate(rotation);
-		ctx.textAlign = textAlign;
-		ctx.textBaseline = 'middle';
 		renderText(ctx, scaleLabel.labelString, 0, 0, scaleLabelFont, {
 			color: scaleLabel.color,
+			textAlign,
+			textBaseline: 'middle',
 		});
 		ctx.restore();
 	}

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -1601,14 +1601,11 @@ export default class Scale extends Element {
 		for (i = 0, ilen = items.length; i < ilen; ++i) {
 			const item = items[i];
 			const tickFont = item.font;
-			const useStroke = optionTicks.textStrokeWidth > 0 && optionTicks.textStrokeColor !== '';
-
 			const label = item.label;
 			let y = item.textOffset;
 			renderText(ctx, label, 0, y, tickFont, {
 				color: item.color,
 				rotation: item.rotation,
-				stroke: useStroke,
 				strokeColor: optionTicks.textStrokeColor,
 				strokeWidth: optionTicks.textStrokeWidth,
 				textAlign: item.textAlign,

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -1607,20 +1607,16 @@ export default class Scale extends Element {
 			ctx.save();
 			ctx.translate(item.x, item.y);
 			ctx.rotate(item.rotation);
-			ctx.font = tickFont.string;
-			ctx.fillStyle = item.color;
 			ctx.textAlign = item.textAlign;
 			ctx.textBaseline = item.textBaseline;
 
-			if (useStroke) {
-				ctx.strokeStyle = optionTicks.textStrokeColor;
-				ctx.lineWidth = optionTicks.textStrokeWidth;
-			}
-
 			const label = item.label;
 			let y = item.textOffset;
-			renderText(ctx, label, 0, y, tickFont.lineHeight, {
+			renderText(ctx, label, 0, y, tickFont, {
+				color: item.color,
 				stroke: useStroke,
+				strokeColor: optionTicks.textStrokeColor,
+				strokeWidth: optionTicks.textStrokeWidth,
 			});
 			ctx.restore();
 		}
@@ -1693,9 +1689,9 @@ export default class Scale extends Element {
 		ctx.rotate(rotation);
 		ctx.textAlign = textAlign;
 		ctx.textBaseline = 'middle';
-		ctx.fillStyle = scaleLabel.color;
-		ctx.font = scaleLabelFont.string;
-		renderText(ctx, scaleLabel.labelString, 0, 0, scaleLabelFont.lineHeight);
+		renderText(ctx, scaleLabel.labelString, 0, 0, scaleLabelFont, {
+			color: scaleLabel.color,
+		});
 		ctx.restore();
 	}
 

--- a/src/helpers/helpers.canvas.js
+++ b/src/helpers/helpers.canvas.js
@@ -299,6 +299,16 @@ export function renderText(ctx, text, x, y, font, opts = {}) {
 	const lines = isArray(text) ? text : [text];
 	let i, line;
 
+	ctx.save();
+
+	if (opts.translation) {
+		ctx.translate(opts.translation[0], opts.translation[1]);
+	}
+
+	if (!isNullOrUndef(opts.rotation)) {
+		ctx.rotate(opts.rotation);
+	}
+
 	ctx.font = font.fontString;
 
 	if (opts.color) {
@@ -353,4 +363,6 @@ export function renderText(ctx, text, x, y, font, opts = {}) {
 		}
 		y += font.lineHeight;
 	}
+
+	ctx.restore();
 }

--- a/src/helpers/helpers.canvas.js
+++ b/src/helpers/helpers.canvas.js
@@ -295,14 +295,28 @@ export function _bezierCurveTo(ctx, previous, target, flip) {
 /**
  * Render text onto the canvas
  */
-export function renderText(ctx, text, x, y, lineHeight, opts = {}) {
+export function renderText(ctx, text, x, y, font, opts = {}) {
 	const lines = isArray(text) ? text : [text];
 	let i, line;
+
+	ctx.font = font.fontString;
+
+	if (opts.color) {
+		ctx.fillStyle = opts.color;
+	}
 
 	for (i = 0; i < lines.length; ++i) {
 		line = lines[i];
 
 		if (opts.stroke) {
+			if (opts.strokeColor) {
+				ctx.strokeStyle = opts.strokeColor;
+			}
+
+			if (!isNullOrUndef(opts.strokeWidth)) {
+				ctx.lineWidth = opts.strokeWidth;
+			}
+
 			ctx.strokeText(line, x, y, opts.maxWidth);
 		}
 
@@ -329,6 +343,6 @@ export function renderText(ctx, text, x, y, lineHeight, opts = {}) {
 			ctx.lineTo(right, yDecoration);
 			ctx.stroke();
 		}
-		y += lineHeight;
+		y += font.lineHeight;
 	}
 }

--- a/src/helpers/helpers.canvas.js
+++ b/src/helpers/helpers.canvas.js
@@ -291,3 +291,44 @@ export function _bezierCurveTo(ctx, previous, target, flip) {
 		target.x,
 		target.y);
 }
+
+/**
+ * Render text onto the canvas
+ */
+export function renderText(ctx, text, x, y, lineHeight, opts = {}) {
+	const lines = isArray(text) ? text : [text];
+	let i, line;
+
+	for (i = 0; i < lines.length; ++i) {
+		line = lines[i];
+
+		if (opts.stroke) {
+			ctx.strokeText(line, x, y, opts.maxWidth);
+		}
+
+		ctx.fillText(line, x, y, opts.maxWidth);
+
+		if (opts.strikethrough || opts.underline) {
+			/**
+			 * Now that IE11 support has been dropped, we can use more
+			 * of the TextMetrics object. The actual bounding boxes
+			 * are unflagged in Chrome, Firefox, Edge, and Safari so they
+			 * can be safely used.
+			 * See https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics#Browser_compatibility
+			 */
+			const metrics = ctx.measureText(line);
+			const left = x - metrics.actualBoundingBoxLeft;
+			const right = x + metrics.actualBoundingBoxRight;
+			const top = y - metrics.actualBoundingBoxAscent;
+			const bottom = y + metrics.actualBoundingBoxDescent;
+			const yDecoration = opts.strikethrough ? (top + bottom) / 2 : bottom;
+
+			ctx.beginPath();
+			ctx.lineWidth = 2;
+			ctx.moveTo(left, yDecoration);
+			ctx.lineTo(right, yDecoration);
+			ctx.stroke();
+		}
+		y += lineHeight;
+	}
+}

--- a/src/helpers/helpers.canvas.js
+++ b/src/helpers/helpers.canvas.js
@@ -297,6 +297,7 @@ export function _bezierCurveTo(ctx, previous, target, flip) {
  */
 export function renderText(ctx, text, x, y, font, opts = {}) {
 	const lines = isArray(text) ? text : [text];
+	const stroke = opts.strokeWidth > 0 && opts.strokeColor !== '';
 	let i, line;
 
 	ctx.save();
@@ -326,7 +327,7 @@ export function renderText(ctx, text, x, y, font, opts = {}) {
 	for (i = 0; i < lines.length; ++i) {
 		line = lines[i];
 
-		if (opts.stroke) {
+		if (stroke) {
 			if (opts.strokeColor) {
 				ctx.strokeStyle = opts.strokeColor;
 			}

--- a/src/helpers/helpers.canvas.js
+++ b/src/helpers/helpers.canvas.js
@@ -324,7 +324,7 @@ export function renderText(ctx, text, x, y, lineHeight, opts = {}) {
 			const yDecoration = opts.strikethrough ? (top + bottom) / 2 : bottom;
 
 			ctx.beginPath();
-			ctx.lineWidth = 2;
+			ctx.lineWidth = opts.decorationWidth || 2;
 			ctx.moveTo(left, yDecoration);
 			ctx.lineTo(right, yDecoration);
 			ctx.stroke();

--- a/src/helpers/helpers.canvas.js
+++ b/src/helpers/helpers.canvas.js
@@ -305,6 +305,14 @@ export function renderText(ctx, text, x, y, font, opts = {}) {
 		ctx.fillStyle = opts.color;
 	}
 
+	if (opts.textAlign) {
+		ctx.textAlign = opts.textAlign;
+	}
+
+	if (opts.textBaseline) {
+		ctx.textBaseline = opts.textBaseline;
+	}
+
 	for (i = 0; i < lines.length; ++i) {
 		line = lines[i];
 

--- a/src/helpers/helpers.canvas.js
+++ b/src/helpers/helpers.canvas.js
@@ -355,6 +355,7 @@ export function renderText(ctx, text, x, y, font, opts = {}) {
 			const bottom = y + metrics.actualBoundingBoxDescent;
 			const yDecoration = opts.strikethrough ? (top + bottom) / 2 : bottom;
 
+			ctx.strokeStyle = ctx.fillStyle;
 			ctx.beginPath();
 			ctx.lineWidth = opts.decorationWidth || 2;
 			ctx.moveTo(left, yDecoration);

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -1,7 +1,7 @@
 import defaults from '../core/core.defaults';
 import Element from '../core/core.element';
 import layouts from '../core/core.layouts';
-import {drawPoint} from '../helpers/helpers.canvas';
+import {drawPoint, renderText} from '../helpers/helpers.canvas';
 import {
 	callback as call, valueOrDefault, toFont, isObject,
 	toPadding, getRtlAdapter, overrideTextDirection, restoreTextDirection,
@@ -305,20 +305,10 @@ export class Legend extends Element {
 			ctx.restore();
 		};
 
-		const fillText = function(x, y, legendItem, textWidth) {
+		const fillText = function(x, y, legendItem) {
 			const halfFontSize = fontSize / 2;
 			const xLeft = rtlHelper.xPlus(x, boxWidth + halfFontSize);
-			const yMiddle = y + (itemHeight / 2);
-			ctx.fillText(legendItem.text, xLeft, yMiddle);
-
-			if (legendItem.hidden) {
-				// Strikethrough the text if hidden
-				ctx.beginPath();
-				ctx.lineWidth = 2;
-				ctx.moveTo(xLeft, yMiddle);
-				ctx.lineTo(rtlHelper.xPlus(xLeft, textWidth), yMiddle);
-				ctx.stroke();
-			}
+			renderText(ctx, legendItem.text, xLeft, y + (itemHeight / 2), labelFont.lineHeight, {strikethrough: legendItem.hidden});
 		};
 
 		// Horizontal
@@ -369,7 +359,7 @@ export class Legend extends Element {
 			legendHitBoxes[i].top = y;
 
 			// Fill the actual label
-			fillText(realX, y, legendItem, textWidth);
+			fillText(realX, y, legendItem);
 
 			if (isHorizontal) {
 				cursor.x += width + padding;
@@ -429,7 +419,7 @@ export class Legend extends Element {
 		ctx.fillStyle = titleOpts.color;
 		ctx.font = titleFont.string;
 
-		ctx.fillText(titleOpts.text, x, y);
+		renderText(ctx, titleOpts.text, x, y, titleFont.lineHeight);
 	}
 
 	/**

--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -308,7 +308,7 @@ export class Legend extends Element {
 		const fillText = function(x, y, legendItem) {
 			const halfFontSize = fontSize / 2;
 			const xLeft = rtlHelper.xPlus(x, boxWidth + halfFontSize);
-			renderText(ctx, legendItem.text, xLeft, y + (itemHeight / 2), labelFont.lineHeight, {strikethrough: legendItem.hidden});
+			renderText(ctx, legendItem.text, xLeft, y + (itemHeight / 2), labelFont, {strikethrough: legendItem.hidden});
 		};
 
 		// Horizontal
@@ -419,7 +419,7 @@ export class Legend extends Element {
 		ctx.fillStyle = titleOpts.color;
 		ctx.font = titleFont.string;
 
-		renderText(ctx, titleOpts.text, x, y, titleFont.lineHeight);
+		renderText(ctx, titleOpts.text, x, y, titleFont);
 	}
 
 	/**

--- a/src/plugins/plugin.title.js
+++ b/src/plugins/plugin.title.js
@@ -97,16 +97,12 @@ export class Title extends Element {
 		const {titleX, titleY, maxWidth, rotation} = me._drawArgs(offset);
 
 		ctx.save();
-
-		ctx.fillStyle = opts.color;
-		ctx.font = fontOpts.string;
-
 		ctx.translate(titleX, titleY);
 		ctx.rotate(rotation);
 		ctx.textAlign = _toLeftRightCenter(opts.align);
 		ctx.textBaseline = 'middle';
 
-		renderText(ctx, opts.text, 0, 0, lineHeight, {maxWidth});
+		renderText(ctx, opts.text, 0, 0, fontOpts, {color: opts.color, maxWidth});
 		ctx.restore();
 	}
 }

--- a/src/plugins/plugin.title.js
+++ b/src/plugins/plugin.title.js
@@ -96,16 +96,14 @@ export class Title extends Element {
 		const offset = lineHeight / 2 + me._padding.top;
 		const {titleX, titleY, maxWidth, rotation} = me._drawArgs(offset);
 
-		ctx.save();
-		ctx.translate(titleX, titleY);
-		ctx.rotate(rotation);
 		renderText(ctx, opts.text, 0, 0, fontOpts, {
 			color: opts.color,
 			maxWidth,
+			rotation,
 			textAlign: _toLeftRightCenter(opts.align),
 			textBaseline: 'middle',
+			translation: [titleX, titleY],
 		});
-		ctx.restore();
 	}
 }
 

--- a/src/plugins/plugin.title.js
+++ b/src/plugins/plugin.title.js
@@ -99,10 +99,12 @@ export class Title extends Element {
 		ctx.save();
 		ctx.translate(titleX, titleY);
 		ctx.rotate(rotation);
-		ctx.textAlign = _toLeftRightCenter(opts.align);
-		ctx.textBaseline = 'middle';
-
-		renderText(ctx, opts.text, 0, 0, fontOpts, {color: opts.color, maxWidth});
+		renderText(ctx, opts.text, 0, 0, fontOpts, {
+			color: opts.color,
+			maxWidth,
+			textAlign: _toLeftRightCenter(opts.align),
+			textBaseline: 'middle',
+		});
 		ctx.restore();
 	}
 }

--- a/src/plugins/plugin.title.js
+++ b/src/plugins/plugin.title.js
@@ -2,6 +2,7 @@ import Element from '../core/core.element';
 import layouts from '../core/core.layouts';
 import {PI, isArray, toPadding, toFont} from '../helpers';
 import {_toLeftRightCenter, _alignStartEnd} from '../helpers/helpers.extras';
+import {renderText} from '../helpers/helpers.canvas';
 
 export class Title extends Element {
 	/**
@@ -105,17 +106,7 @@ export class Title extends Element {
 		ctx.textAlign = _toLeftRightCenter(opts.align);
 		ctx.textBaseline = 'middle';
 
-		const text = opts.text;
-		if (isArray(text)) {
-			let y = 0;
-			for (let i = 0; i < text.length; ++i) {
-				ctx.fillText(text[i], 0, y, maxWidth);
-				y += lineHeight;
-			}
-		} else {
-			ctx.fillText(text, 0, 0, maxWidth);
-		}
-
+		renderText(ctx, opts.text, 0, 0, lineHeight, {maxWidth});
 		ctx.restore();
 	}
 }

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -1,5 +1,5 @@
 import defaults from '../core/core.defaults';
-import {_longestText} from '../helpers/helpers.canvas';
+import {_longestText, renderText} from '../helpers/helpers.canvas';
 import {HALF_PI, isNumber, TAU, toDegrees, toRadians, _normalizeAngle} from '../helpers/helpers.math';
 import LinearScaleBase from './scale.linearbase';
 import Ticks from '../core/core.ticks';
@@ -142,20 +142,6 @@ function getTextAlignForAngle(angle) {
 	return 'right';
 }
 
-function fillText(ctx, text, position, lineHeight) {
-	let y = position.y + lineHeight / 2;
-	let i, ilen;
-
-	if (isArray(text)) {
-		for (i = 0, ilen = text.length; i < ilen; ++i) {
-			ctx.fillText(text[i], position.x, y);
-			y += lineHeight;
-		}
-	} else {
-		ctx.fillText(text, position.x, y);
-	}
-}
-
 function adjustPointPositionForLabelHeight(angle, textSize, position) {
 	if (angle === 90 || angle === 270) {
 		position.y -= (textSize.h / 2);
@@ -188,7 +174,13 @@ function drawPointLabels(scale) {
 		const angle = toDegrees(scale.getIndexAngle(i));
 		ctx.textAlign = getTextAlignForAngle(angle);
 		adjustPointPositionForLabelHeight(angle, scale._pointLabelSizes[i], pointLabelPosition);
-		fillText(ctx, scale.pointLabels[i], pointLabelPosition, plFont.lineHeight);
+		renderText(
+			ctx,
+			scale.pointLabels[i],
+			pointLabelPosition.x,
+			pointLabelPosition.y + (plFont.lineHeight / 2),
+			plFont.lineHeight
+		);
 	}
 	ctx.restore();
 }
@@ -500,7 +492,7 @@ export default class RadialLinearScale extends LinearScaleBase {
 			}
 
 			ctx.fillStyle = tickOpts.color;
-			ctx.fillText(tick.label, 0, -offset);
+			renderText(ctx, tick.label, 0, -offset, tickFont.lineHeight);
 		});
 
 		ctx.restore();

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -169,7 +169,6 @@ function drawPointLabels(scale) {
 		const context = scale.getContext(i);
 		const plFont = toFont(resolve([pointLabelOpts.font], context, i), scale.chart.options.font);
 		const angle = toDegrees(scale.getIndexAngle(i));
-		ctx.textAlign = getTextAlignForAngle(angle);
 		adjustPointPositionForLabelHeight(angle, scale._pointLabelSizes[i], pointLabelPosition);
 		renderText(
 			ctx,
@@ -179,6 +178,7 @@ function drawPointLabels(scale) {
 			plFont,
 			{
 				color: resolve([pointLabelOpts.color], context, i),
+				textAlign: getTextAlignForAngle(angle),
 			}
 		);
 	}

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -168,9 +168,6 @@ function drawPointLabels(scale) {
 
 		const context = scale.getContext(i);
 		const plFont = toFont(resolve([pointLabelOpts.font], context, i), scale.chart.options.font);
-		ctx.font = plFont.string;
-		ctx.fillStyle = resolve([pointLabelOpts.color], context, i);
-
 		const angle = toDegrees(scale.getIndexAngle(i));
 		ctx.textAlign = getTextAlignForAngle(angle);
 		adjustPointPositionForLabelHeight(angle, scale._pointLabelSizes[i], pointLabelPosition);
@@ -179,7 +176,10 @@ function drawPointLabels(scale) {
 			scale.pointLabels[i],
 			pointLabelPosition.x,
 			pointLabelPosition.y + (plFont.lineHeight / 2),
-			plFont.lineHeight
+			plFont,
+			{
+				color: resolve([pointLabelOpts.color], context, i),
+			}
 		);
 	}
 	ctx.restore();
@@ -474,7 +474,6 @@ export default class RadialLinearScale extends LinearScaleBase {
 
 			const context = me.getContext(index);
 			const tickFont = me._resolveTickFontOptions(index);
-			ctx.font = tickFont.string;
 			offset = me.getDistanceFromCenterForValue(me.ticks[index].value);
 
 			const showLabelBackdrop = resolve([tickOpts.showLabelBackdrop], context, index);
@@ -491,8 +490,9 @@ export default class RadialLinearScale extends LinearScaleBase {
 				);
 			}
 
-			ctx.fillStyle = tickOpts.color;
-			renderText(ctx, tick.label, 0, -offset, tickFont.lineHeight);
+			renderText(ctx, tick.label, 0, -offset, tickFont, {
+				color: tickOpts.color,
+			});
 		});
 
 		ctx.restore();

--- a/test/context.js
+++ b/test/context.js
@@ -10,6 +10,7 @@ const Context = function() {
 	this._lineWidth = null;
 	this._strokeStyle = null;
 	this._textAlign = null;
+	this._textBaseline = null;
 
 	// Define properties here so that we can record each time they are set
 	Object.defineProperties(this, {
@@ -74,6 +75,15 @@ const Context = function() {
 			set: function(align) {
 				this._textAlign = align;
 				this.record('setTextAlign', [align]);
+			}
+		},
+		textBaseline: {
+			get: function() {
+				return this._textBaseline;
+			},
+			set: function(baseline) {
+				this._textBaseline = baseline;
+				this.record('setTextBaseline', [baseline]);
 			}
 		}
 	});

--- a/test/context.js
+++ b/test/context.js
@@ -98,7 +98,20 @@ Context.prototype._initMethods = function() {
 		lineTo: function() {},
 		measureText: function(text) {
 			// return the number of characters * fixed size
-			return text ? {width: text.length * 10} : {width: 0};
+			// Uses fake numbers for the bounding box
+			return text ? {
+				actualBoundingBoxAscent: 4,
+				actualBoundingBoxDescent: 8,
+				actualBoundingBoxLeft: 15,
+				actualBoundingBoxRight: 25,
+				width: text.length * 10
+			} : {
+				actualBoundingBoxAscent: 0,
+				actualBoundingBoxDescent: 0,
+				actualBoundingBoxLeft: 0,
+				actualBoundingBoxRight: 0,
+				width: 0
+			};
 		},
 		moveTo: function() {},
 		quadraticCurveTo: function() {},

--- a/test/specs/helpers.canvas.tests.js
+++ b/test/specs/helpers.canvas.tests.js
@@ -107,11 +107,17 @@ describe('Chart.helpers.canvas', function() {
 			helpers.renderText(context, ['foo', 'foo2'], 0, 0, font);
 
 			expect(context.getCalls()).toEqual([{
+				name: 'save',
+				args: [],
+			}, {
 				name: 'fillText',
 				args: ['foo', 0, 0, undefined],
 			}, {
 				name: 'fillText',
 				args: ['foo2', 0, 20, undefined],
+			}, {
+				name: 'restore',
+				args: [],
 			}]);
 		});
 
@@ -120,8 +126,14 @@ describe('Chart.helpers.canvas', function() {
 			var font = {fontString: '', lineHeight: 20};
 			helpers.renderText(context, 'foo', 0, 0, font, {maxWidth: 30});
 			expect(context.getCalls()).toEqual([{
+				name: 'save',
+				args: [],
+			}, {
 				name: 'fillText',
 				args: ['foo', 0, 0, 30],
+			}, {
+				name: 'restore',
+				args: [],
 			}]);
 		});
 
@@ -130,11 +142,17 @@ describe('Chart.helpers.canvas', function() {
 			var font = {fontString: '', lineHeight: 20};
 			helpers.renderText(context, 'foo', 0, 0, font, {stroke: true});
 			expect(context.getCalls()).toEqual([{
+				name: 'save',
+				args: [],
+			}, {
 				name: 'strokeText',
 				args: ['foo', 0, 0, undefined],
 			}, {
 				name: 'fillText',
 				args: ['foo', 0, 0, undefined],
+			}, {
+				name: 'restore',
+				args: [],
 			}]);
 		});
 
@@ -144,6 +162,9 @@ describe('Chart.helpers.canvas', function() {
 			helpers.renderText(context, 'foo', 0, 0, font, {decorationWidth: 3, underline: true});
 
 			expect(context.getCalls()).toEqual([{
+				name: 'save',
+				args: [],
+			}, {
 				name: 'fillText',
 				args: ['foo', 0, 0, undefined],
 			}, {
@@ -164,6 +185,9 @@ describe('Chart.helpers.canvas', function() {
 			}, {
 				name: 'stroke',
 				args: [],
+			}, {
+				name: 'restore',
+				args: [],
 			}]);
 		});
 
@@ -173,6 +197,9 @@ describe('Chart.helpers.canvas', function() {
 			helpers.renderText(context, 'foo', 0, 0, font, {strikethrough: true});
 
 			expect(context.getCalls()).toEqual([{
+				name: 'save',
+				args: [],
+			}, {
 				name: 'fillText',
 				args: ['foo', 0, 0, undefined],
 			}, {
@@ -193,6 +220,9 @@ describe('Chart.helpers.canvas', function() {
 			}, {
 				name: 'stroke',
 				args: [],
+			}, {
+				name: 'restore',
+				args: [],
 			}]);
 		});
 
@@ -202,11 +232,17 @@ describe('Chart.helpers.canvas', function() {
 			helpers.renderText(context, 'foo', 0, 0, font, {color: 'red'});
 
 			expect(context.getCalls()).toEqual([{
+				name: 'save',
+				args: [],
+			}, {
 				name: 'setFillStyle',
 				args: ['red'],
 			}, {
 				name: 'fillText',
 				args: ['foo', 0, 0, undefined],
+			}, {
+				name: 'restore',
+				args: [],
 			}]);
 		});
 
@@ -215,6 +251,9 @@ describe('Chart.helpers.canvas', function() {
 			var font = {fontString: '', lineHeight: 20};
 			helpers.renderText(context, 'foo', 0, 0, font, {stroke: true, strokeColor: 'red', strokeWidth: 2});
 			expect(context.getCalls()).toEqual([{
+				name: 'save',
+				args: [],
+			}, {
 				name: 'setStrokeStyle',
 				args: ['red'],
 			}, {
@@ -226,6 +265,9 @@ describe('Chart.helpers.canvas', function() {
 			}, {
 				name: 'fillText',
 				args: ['foo', 0, 0, undefined],
+			}, {
+				name: 'restore',
+				args: [],
 			}]);
 		});
 
@@ -235,6 +277,9 @@ describe('Chart.helpers.canvas', function() {
 			helpers.renderText(context, 'foo', 0, 0, font, {textAlign: 'left', textBaseline: 'middle'});
 
 			expect(context.getCalls()).toEqual([{
+				name: 'save',
+				args: [],
+			}, {
 				name: 'setTextAlign',
 				args: ['left'],
 			}, {
@@ -243,6 +288,32 @@ describe('Chart.helpers.canvas', function() {
 			}, {
 				name: 'fillText',
 				args: ['foo', 0, 0, undefined],
+			}, {
+				name: 'restore',
+				args: [],
+			}]);
+		});
+
+		it('should translate and rotate text', function() {
+			var context = window.createMockContext();
+			var font = {fontString: '', lineHeight: 20};
+			helpers.renderText(context, 'foo', 0, 0, font, {rotation: 90, translation: [10, 20]});
+
+			expect(context.getCalls()).toEqual([{
+				name: 'save',
+				args: [],
+			}, {
+				name: 'translate',
+				args: [10, 20],
+			}, {
+				name: 'rotate',
+				args: [90],
+			}, {
+				name: 'fillText',
+				args: ['foo', 0, 0, undefined],
+			}, {
+				name: 'restore',
+				args: [],
 			}]);
 		});
 	});

--- a/test/specs/helpers.canvas.tests.js
+++ b/test/specs/helpers.canvas.tests.js
@@ -171,6 +171,9 @@ describe('Chart.helpers.canvas', function() {
 				name: 'measureText',
 				args: ['foo'],
 			}, {
+				name: 'setStrokeStyle',
+				args: [null],
+			}, {
 				name: 'beginPath',
 				args: [],
 			}, {
@@ -205,6 +208,9 @@ describe('Chart.helpers.canvas', function() {
 			}, {
 				name: 'measureText',
 				args: ['foo'],
+			}, {
+				name: 'setStrokeStyle',
+				args: [null],
 			}, {
 				name: 'beginPath',
 				args: [],

--- a/test/specs/helpers.canvas.tests.js
+++ b/test/specs/helpers.canvas.tests.js
@@ -137,25 +137,6 @@ describe('Chart.helpers.canvas', function() {
 			}]);
 		});
 
-		it('should stroke the text', function() {
-			var context = window.createMockContext();
-			var font = {fontString: '', lineHeight: 20};
-			helpers.renderText(context, 'foo', 0, 0, font, {stroke: true});
-			expect(context.getCalls()).toEqual([{
-				name: 'save',
-				args: [],
-			}, {
-				name: 'strokeText',
-				args: ['foo', 0, 0, undefined],
-			}, {
-				name: 'fillText',
-				args: ['foo', 0, 0, undefined],
-			}, {
-				name: 'restore',
-				args: [],
-			}]);
-		});
-
 		it('should underline the text', function() {
 			var context = window.createMockContext();
 			var font = {fontString: '', lineHeight: 20};
@@ -255,7 +236,7 @@ describe('Chart.helpers.canvas', function() {
 		it('should set the stroke style if supplied', function() {
 			var context = window.createMockContext();
 			var font = {fontString: '', lineHeight: 20};
-			helpers.renderText(context, 'foo', 0, 0, font, {stroke: true, strokeColor: 'red', strokeWidth: 2});
+			helpers.renderText(context, 'foo', 0, 0, font, {strokeColor: 'red', strokeWidth: 2});
 			expect(context.getCalls()).toEqual([{
 				name: 'save',
 				args: [],

--- a/test/specs/helpers.canvas.tests.js
+++ b/test/specs/helpers.canvas.tests.js
@@ -99,4 +99,96 @@ describe('Chart.helpers.canvas', function() {
 			args: ['foobar_1']
 		}]);
 	});
+
+	describe('renderText', function() {
+		it('should render multiple lines of text', function() {
+			var context = window.createMockContext();
+			helpers.renderText(context, ['foo', 'foo2'], 0, 0, 20);
+
+			expect(context.getCalls()).toEqual([{
+				name: 'fillText',
+				args: ['foo', 0, 0, undefined],
+			}, {
+				name: 'fillText',
+				args: ['foo2', 0, 20, undefined],
+			}]);
+		});
+
+		it('should accept the text maxWidth', function() {
+			var context = window.createMockContext();
+			helpers.renderText(context, 'foo', 0, 0, 20, {maxWidth: 30});
+			expect(context.getCalls()).toEqual([{
+				name: 'fillText',
+				args: ['foo', 0, 0, 30],
+			}]);
+		});
+
+		it('should stroke the text', function() {
+			var context = window.createMockContext();
+			helpers.renderText(context, 'foo', 0, 0, 20, {stroke: true});
+			expect(context.getCalls()).toEqual([{
+				name: 'strokeText',
+				args: ['foo', 0, 0, undefined],
+			}, {
+				name: 'fillText',
+				args: ['foo', 0, 0, undefined],
+			}]);
+		});
+
+		it('should underline the text', function() {
+			var context = window.createMockContext();
+			helpers.renderText(context, 'foo', 0, 0, 20, {decorationWidth: 3, underline: true});
+
+			expect(context.getCalls()).toEqual([{
+				name: 'fillText',
+				args: ['foo', 0, 0, undefined],
+			}, {
+				name: 'measureText',
+				args: ['foo'],
+			}, {
+				name: 'beginPath',
+				args: [],
+			}, {
+				name: 'setLineWidth',
+				args: [3],
+			}, {
+				name: 'moveTo',
+				args: [-15, 8],
+			}, {
+				name: 'lineTo',
+				args: [25, 8],
+			}, {
+				name: 'stroke',
+				args: [],
+			}]);
+		});
+
+		it('should strikethrough the text', function() {
+			var context = window.createMockContext();
+			helpers.renderText(context, 'foo', 0, 0, 20, {strikethrough: true});
+
+			expect(context.getCalls()).toEqual([{
+				name: 'fillText',
+				args: ['foo', 0, 0, undefined],
+			}, {
+				name: 'measureText',
+				args: ['foo'],
+			}, {
+				name: 'beginPath',
+				args: [],
+			}, {
+				name: 'setLineWidth',
+				args: [2],
+			}, {
+				name: 'moveTo',
+				args: [-15, 2],
+			}, {
+				name: 'lineTo',
+				args: [25, 2],
+			}, {
+				name: 'stroke',
+				args: [],
+			}]);
+		});
+	});
 });

--- a/test/specs/helpers.canvas.tests.js
+++ b/test/specs/helpers.canvas.tests.js
@@ -103,7 +103,8 @@ describe('Chart.helpers.canvas', function() {
 	describe('renderText', function() {
 		it('should render multiple lines of text', function() {
 			var context = window.createMockContext();
-			helpers.renderText(context, ['foo', 'foo2'], 0, 0, 20);
+			var font = {fontString: '', lineHeight: 20};
+			helpers.renderText(context, ['foo', 'foo2'], 0, 0, font);
 
 			expect(context.getCalls()).toEqual([{
 				name: 'fillText',
@@ -116,7 +117,8 @@ describe('Chart.helpers.canvas', function() {
 
 		it('should accept the text maxWidth', function() {
 			var context = window.createMockContext();
-			helpers.renderText(context, 'foo', 0, 0, 20, {maxWidth: 30});
+			var font = {fontString: '', lineHeight: 20};
+			helpers.renderText(context, 'foo', 0, 0, font, {maxWidth: 30});
 			expect(context.getCalls()).toEqual([{
 				name: 'fillText',
 				args: ['foo', 0, 0, 30],
@@ -125,7 +127,8 @@ describe('Chart.helpers.canvas', function() {
 
 		it('should stroke the text', function() {
 			var context = window.createMockContext();
-			helpers.renderText(context, 'foo', 0, 0, 20, {stroke: true});
+			var font = {fontString: '', lineHeight: 20};
+			helpers.renderText(context, 'foo', 0, 0, font, {stroke: true});
 			expect(context.getCalls()).toEqual([{
 				name: 'strokeText',
 				args: ['foo', 0, 0, undefined],
@@ -137,7 +140,8 @@ describe('Chart.helpers.canvas', function() {
 
 		it('should underline the text', function() {
 			var context = window.createMockContext();
-			helpers.renderText(context, 'foo', 0, 0, 20, {decorationWidth: 3, underline: true});
+			var font = {fontString: '', lineHeight: 20};
+			helpers.renderText(context, 'foo', 0, 0, font, {decorationWidth: 3, underline: true});
 
 			expect(context.getCalls()).toEqual([{
 				name: 'fillText',
@@ -165,7 +169,8 @@ describe('Chart.helpers.canvas', function() {
 
 		it('should strikethrough the text', function() {
 			var context = window.createMockContext();
-			helpers.renderText(context, 'foo', 0, 0, 20, {strikethrough: true});
+			var font = {fontString: '', lineHeight: 20};
+			helpers.renderText(context, 'foo', 0, 0, font, {strikethrough: true});
 
 			expect(context.getCalls()).toEqual([{
 				name: 'fillText',
@@ -188,6 +193,39 @@ describe('Chart.helpers.canvas', function() {
 			}, {
 				name: 'stroke',
 				args: [],
+			}]);
+		});
+
+		it('should set the fill style if supplied', function() {
+			var context = window.createMockContext();
+			var font = {fontString: '', lineHeight: 20};
+			helpers.renderText(context, 'foo', 0, 0, font, {color: 'red'});
+
+			expect(context.getCalls()).toEqual([{
+				name: 'setFillStyle',
+				args: ['red'],
+			}, {
+				name: 'fillText',
+				args: ['foo', 0, 0, undefined],
+			}]);
+		});
+
+		it('should set the stroke style if supplied', function() {
+			var context = window.createMockContext();
+			var font = {fontString: '', lineHeight: 20};
+			helpers.renderText(context, 'foo', 0, 0, font, {stroke: true, strokeColor: 'red', strokeWidth: 2});
+			expect(context.getCalls()).toEqual([{
+				name: 'setStrokeStyle',
+				args: ['red'],
+			}, {
+				name: 'setLineWidth',
+				args: [2],
+			}, {
+				name: 'strokeText',
+				args: ['foo', 0, 0, undefined],
+			}, {
+				name: 'fillText',
+				args: ['foo', 0, 0, undefined],
 			}]);
 		});
 	});

--- a/test/specs/helpers.canvas.tests.js
+++ b/test/specs/helpers.canvas.tests.js
@@ -228,5 +228,22 @@ describe('Chart.helpers.canvas', function() {
 				args: ['foo', 0, 0, undefined],
 			}]);
 		});
+
+		it('should set the text alignment', function() {
+			var context = window.createMockContext();
+			var font = {fontString: '', lineHeight: 20};
+			helpers.renderText(context, 'foo', 0, 0, font, {textAlign: 'left', textBaseline: 'middle'});
+
+			expect(context.getCalls()).toEqual([{
+				name: 'setTextAlign',
+				args: ['left'],
+			}, {
+				name: 'setTextBaseline',
+				args: ['middle'],
+			}, {
+				name: 'fillText',
+				args: ['foo', 0, 0, undefined],
+			}]);
+		});
 	});
 });

--- a/test/specs/plugin.title.tests.js
+++ b/test/specs/plugin.title.tests.js
@@ -130,9 +130,6 @@ describe('Title block tests', function() {
 			name: 'save',
 			args: []
 		}, {
-			name: 'setFillStyle',
-			args: ['#666']
-		}, {
 			name: 'translate',
 			args: [300, 67.2]
 		}, {
@@ -141,6 +138,9 @@ describe('Title block tests', function() {
 		}, {
 			name: 'setTextAlign',
 			args: ['center'],
+		}, {
+			name: 'setFillStyle',
+			args: ['#666']
 		}, {
 			name: 'fillText',
 			args: ['My title', 0, 0, 400]
@@ -185,9 +185,6 @@ describe('Title block tests', function() {
 			name: 'save',
 			args: []
 		}, {
-			name: 'setFillStyle',
-			args: ['#666']
-		}, {
 			name: 'translate',
 			args: [117.2, 250]
 		}, {
@@ -196,6 +193,9 @@ describe('Title block tests', function() {
 		}, {
 			name: 'setTextAlign',
 			args: ['center'],
+		}, {
+			name: 'setFillStyle',
+			args: ['#666']
 		}, {
 			name: 'fillText',
 			args: ['My title', 0, 0, 400]
@@ -221,9 +221,6 @@ describe('Title block tests', function() {
 			name: 'save',
 			args: []
 		}, {
-			name: 'setFillStyle',
-			args: ['#666']
-		}, {
 			name: 'translate',
 			args: [117.2, 250]
 		}, {
@@ -232,6 +229,9 @@ describe('Title block tests', function() {
 		}, {
 			name: 'setTextAlign',
 			args: ['center'],
+		}, {
+			name: 'setFillStyle',
+			args: ['#666']
 		}, {
 			name: 'fillText',
 			args: ['My title', 0, 0, 400]

--- a/test/specs/plugin.title.tests.js
+++ b/test/specs/plugin.title.tests.js
@@ -136,11 +136,14 @@ describe('Title block tests', function() {
 			name: 'rotate',
 			args: [0]
 		}, {
+			name: 'setFillStyle',
+			args: ['#666']
+		}, {
 			name: 'setTextAlign',
 			args: ['center'],
 		}, {
-			name: 'setFillStyle',
-			args: ['#666']
+			name: 'setTextBaseline',
+			args: ['middle'],
 		}, {
 			name: 'fillText',
 			args: ['My title', 0, 0, 400]
@@ -191,11 +194,14 @@ describe('Title block tests', function() {
 			name: 'rotate',
 			args: [-0.5 * Math.PI]
 		}, {
+			name: 'setFillStyle',
+			args: ['#666']
+		}, {
 			name: 'setTextAlign',
 			args: ['center'],
 		}, {
-			name: 'setFillStyle',
-			args: ['#666']
+			name: 'setTextBaseline',
+			args: ['middle'],
 		}, {
 			name: 'fillText',
 			args: ['My title', 0, 0, 400]
@@ -227,11 +233,14 @@ describe('Title block tests', function() {
 			name: 'rotate',
 			args: [0.5 * Math.PI]
 		}, {
+			name: 'setFillStyle',
+			args: ['#666']
+		}, {
 			name: 'setTextAlign',
 			args: ['center'],
 		}, {
-			name: 'setFillStyle',
-			args: ['#666']
+			name: 'setTextBaseline',
+			args: ['middle'],
 		}, {
 			name: 'fillText',
 			args: ['My title', 0, 0, 400]

--- a/test/specs/plugin.tooltip.tests.js
+++ b/test/specs/plugin.tooltip.tests.js
@@ -1455,13 +1455,16 @@ describe('Plugin.Tooltip', function() {
 
 			expect(mockContext.getCalls()).toEqual(Array.prototype.concat(drawBody, [
 				{name: 'setTextAlign', args: ['left']},
+				{name: 'setTextBaseline', args: ['middle']},
 				{name: 'setFillStyle', args: ['#fff']},
 				{name: 'fillText', args: ['title', 105, 111]},
 				{name: 'setTextAlign', args: ['left']},
+				{name: 'setTextBaseline', args: ['middle']},
 				{name: 'setFillStyle', args: ['#fff']},
 				{name: 'setFillStyle', args: ['#fff']},
 				{name: 'fillText', args: ['label', 105, 129]},
 				{name: 'setTextAlign', args: ['left']},
+				{name: 'setTextBaseline', args: ['middle']},
 				{name: 'setFillStyle', args: ['#fff']},
 				{name: 'fillText', args: ['footer', 105, 147]},
 				{name: 'restore', args: []}
@@ -1475,13 +1478,16 @@ describe('Plugin.Tooltip', function() {
 
 			expect(mockContext.getCalls()).toEqual(Array.prototype.concat(drawBody, [
 				{name: 'setTextAlign', args: ['right']},
+				{name: 'setTextBaseline', args: ['middle']},
 				{name: 'setFillStyle', args: ['#fff']},
 				{name: 'fillText', args: ['title', 195, 111]},
 				{name: 'setTextAlign', args: ['right']},
+				{name: 'setTextBaseline', args: ['middle']},
 				{name: 'setFillStyle', args: ['#fff']},
 				{name: 'setFillStyle', args: ['#fff']},
 				{name: 'fillText', args: ['label', 195, 129]},
 				{name: 'setTextAlign', args: ['right']},
+				{name: 'setTextBaseline', args: ['middle']},
 				{name: 'setFillStyle', args: ['#fff']},
 				{name: 'fillText', args: ['footer', 195, 147]},
 				{name: 'restore', args: []}
@@ -1495,13 +1501,16 @@ describe('Plugin.Tooltip', function() {
 
 			expect(mockContext.getCalls()).toEqual(Array.prototype.concat(drawBody, [
 				{name: 'setTextAlign', args: ['center']},
+				{name: 'setTextBaseline', args: ['middle']},
 				{name: 'setFillStyle', args: ['#fff']},
 				{name: 'fillText', args: ['title', 150, 111]},
 				{name: 'setTextAlign', args: ['center']},
+				{name: 'setTextBaseline', args: ['middle']},
 				{name: 'setFillStyle', args: ['#fff']},
 				{name: 'setFillStyle', args: ['#fff']},
 				{name: 'fillText', args: ['label', 150, 129]},
 				{name: 'setTextAlign', args: ['center']},
+				{name: 'setTextBaseline', args: ['middle']},
 				{name: 'setFillStyle', args: ['#fff']},
 				{name: 'fillText', args: ['footer', 150, 147]},
 				{name: 'restore', args: []}
@@ -1515,13 +1524,16 @@ describe('Plugin.Tooltip', function() {
 
 			expect(mockContext.getCalls()).toEqual(Array.prototype.concat(drawBody, [
 				{name: 'setTextAlign', args: ['right']},
+				{name: 'setTextBaseline', args: ['middle']},
 				{name: 'setFillStyle', args: ['#fff']},
 				{name: 'fillText', args: ['title', 195, 111]},
 				{name: 'setTextAlign', args: ['center']},
+				{name: 'setTextBaseline', args: ['middle']},
 				{name: 'setFillStyle', args: ['#fff']},
 				{name: 'setFillStyle', args: ['#fff']},
 				{name: 'fillText', args: ['label', 150, 129]},
 				{name: 'setTextAlign', args: ['left']},
+				{name: 'setTextBaseline', args: ['middle']},
 				{name: 'setFillStyle', args: ['#fff']},
 				{name: 'fillText', args: ['footer', 105, 147]},
 				{name: 'restore', args: []}

--- a/types/color.d.ts
+++ b/types/color.d.ts
@@ -1,0 +1,1 @@
+export type Color = string | CanvasGradient | CanvasPattern;

--- a/types/helpers/helpers.canvas.d.ts
+++ b/types/helpers/helpers.canvas.d.ts
@@ -26,3 +26,19 @@ export function drawPoint(ctx: CanvasRenderingContext2D, options: DrawPointOptio
  * @return The CSS font string. See https://developer.mozilla.org/en-US/docs/Web/CSS/font
  */
 export function toFontString(font: { size: number; family: string; style?: string; weight?: string }): string | null;
+
+export interface RenderTextOpts {
+  maxWidth?: number;
+  strikethrough?: boolean;
+  stroke?: boolean;
+  underline?: boolean;
+}
+
+export function renderText(
+  ctx: CanvasRenderingContext2D,
+  text: string | string[],
+  x: number,
+  y: number,
+  lineHeight: number,
+  opts?: RenderTextOpts
+): void;

--- a/types/helpers/helpers.canvas.d.ts
+++ b/types/helpers/helpers.canvas.d.ts
@@ -28,9 +28,30 @@ export function drawPoint(ctx: CanvasRenderingContext2D, options: DrawPointOptio
 export function toFontString(font: { size: number; family: string; style?: string; weight?: string }): string | null;
 
 export interface RenderTextOpts {
+  /**
+   * The width of the strikethrough / underline
+   * @default 2
+   */
+  decorationWidth?: number;
+
+  /**
+   * The max width of the text in pixels
+   */
   maxWidth?: number;
+
+  /**
+   * Apply a strikethrough effect to the text
+   */
   strikethrough?: boolean;
+
+  /**
+   * Should the text be stroked as well as filled
+   */
   stroke?: boolean;
+
+  /**
+   * Underline the text
+   */
   underline?: boolean;
 }
 

--- a/types/helpers/helpers.canvas.d.ts
+++ b/types/helpers/helpers.canvas.d.ts
@@ -48,6 +48,12 @@ export interface RenderTextOpts {
   maxWidth?: number;
 
   /**
+   * A rotation to be applied to the canvas
+   * This is applied after the translation is applied
+   */
+  rotation?: number;
+
+  /**
    * Apply a strikethrough effect to the text
    */
   strikethrough?: boolean;
@@ -80,6 +86,11 @@ export interface RenderTextOpts {
    * textBaseline property of the context is unchanged
    */
   textBaseline: CanvasTextBaseline;
+
+  /**
+   * If specified, a translation to apply to the context
+   */
+  translation?: [number, number];
 
   /**
    * Underline the text

--- a/types/helpers/helpers.canvas.d.ts
+++ b/types/helpers/helpers.canvas.d.ts
@@ -1,5 +1,7 @@
 import { PointStyle } from '../index.esm';
+import { Color } from '../color';
 import { ChartArea } from '../geometric';
+import { CanvasFontSpec } from './helpers.options';
 
 /**
  * Clears the entire canvas associated to the given `chart`.
@@ -29,6 +31,12 @@ export function toFontString(font: { size: number; family: string; style?: strin
 
 export interface RenderTextOpts {
   /**
+   * The fill color of the text. If unset, the existing
+   * fillStyle property of the canvas is unchanged.
+   */
+  color?: Color;
+
+  /**
    * The width of the strikethrough / underline
    * @default 2
    */
@@ -50,6 +58,18 @@ export interface RenderTextOpts {
   stroke?: boolean;
 
   /**
+   * The color of the text stroke. If unset, the existing
+   * strokeStyle property of the context is unchanged
+   */
+  strokeColor?: Color;
+
+  /**
+   * The text stroke width. If unset, the existing
+   * lineWidth property of the context is unchanged
+   */
+  strokeWidth?: number;
+
+  /**
    * Underline the text
    */
   underline?: boolean;
@@ -60,6 +80,6 @@ export function renderText(
   text: string | string[],
   x: number,
   y: number,
-  lineHeight: number,
+  font: CanvasFontSpec,
   opts?: RenderTextOpts
 ): void;

--- a/types/helpers/helpers.canvas.d.ts
+++ b/types/helpers/helpers.canvas.d.ts
@@ -70,6 +70,18 @@ export interface RenderTextOpts {
   strokeWidth?: number;
 
   /**
+   * The text alignment to use. If unset, the existing
+   * textAlign property of the context is unchanged
+   */
+  textAlign: CanvasTextAlign;
+
+  /**
+   * The text baseline to use. If unset, the existing
+   * textBaseline property of the context is unchanged
+   */
+  textBaseline: CanvasTextBaseline;
+
+  /**
    * Underline the text
    */
   underline?: boolean;

--- a/types/helpers/helpers.canvas.d.ts
+++ b/types/helpers/helpers.canvas.d.ts
@@ -59,11 +59,6 @@ export interface RenderTextOpts {
   strikethrough?: boolean;
 
   /**
-   * Should the text be stroked as well as filled
-   */
-  stroke?: boolean;
-
-  /**
    * The color of the text stroke. If unset, the existing
    * strokeStyle property of the context is unchanged
    */

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -14,6 +14,7 @@
 
 import { TimeUnit } from "./adapters";
 import { AnimationEvent } from './animation';
+import { Color } from './color';
 import { Element }from './element';
 import { ChartArea, Point } from './geometric';
 import {
@@ -24,6 +25,7 @@ import {
 
 export { DateAdapterBase, DateAdapter, TimeUnit, _adapters } from './adapters';
 export { Animation, Animations, Animator, AnimationEvent } from './animation';
+export { Color } from './color';
 export { Element } from './element';
 export { ChartArea, Point } from './geometric';
 export {
@@ -1331,8 +1333,6 @@ export interface TypedRegistry<T> {
 	get(id: string): T | undefined;
 	unregister(item: ChartComponent): void;
 }
-
-export type Color = string | CanvasGradient | CanvasPattern;
 
 export interface ChartEvent {
   type:

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -2637,12 +2637,12 @@ export interface TickOptions {
    * The color of the stroke around the text.
    * @default undefined
    */
-  textStrokeColor: Color;
+  textStrokeColor: Scriptable<Color, ScriptableScaleContext>;
   /**
    * Stroke width around the text.
    * @default 0
    */
-  textStrokeWidth: number;
+  textStrokeWidth: Scriptable<number, ScriptableScaleContext>;
   /**
    * z-index of tick layer. Useful when ticks are drawn on chart area. Values <= 0 are drawn under datasets, > 0 on top.
    * @default 0


### PR DESCRIPTION
Creates a new helper, `renderText` which should take care of drawing (including stroke), strikethrough, and underlines.

If we like where this is going, I'll add some tests.