### PR TITLE
Rename helpers.clear to helpers.clearCanvas

### DIFF
--- a/docs/docs/getting-started/v3-migration.md
+++ b/docs/docs/getting-started/v3-migration.md
@@ -488,6 +488,7 @@ All helpers are now exposed in a flat hierarchy, e.g., `Chart.helpers.canvas.cli
 * The second parameter to `drawPoint` is now the full options object, so `style`, `rotation`, and `radius` are no longer passed explicitly
 * `helpers.getMaximumHeight` was replaced by `helpers.dom.getMaximumSize`
 * `helpers.getMaximumWidth` was replaced by `helpers.dom.getMaximumSize`
+* `helpers.clear` was renamed to `helpers.clearCanvas` and now takes `canvas` and optionally `ctx` as parameter(s).
 
 #### Platform
 

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -8,7 +8,7 @@ import registry from './core.registry';
 import Config, {determineAxis, getIndexAxis} from './core.config';
 import {retinaScale} from '../helpers/helpers.dom';
 import {each, callback as callCallback, uid, valueOrDefault, _elementsEqual} from '../helpers/helpers.core';
-import {clear as canvasClear, clipArea, unclipArea, _isPointInArea} from '../helpers/helpers.canvas';
+import {clearCanvas, clipArea, unclipArea, _isPointInArea} from '../helpers/helpers.canvas';
 // @ts-ignore
 import {version} from '../../package.json';
 
@@ -180,7 +180,7 @@ class Chart {
 	}
 
 	clear() {
-		canvasClear(this);
+		clearCanvas(this.canvas, this.ctx);
 		return this;
 	}
 
@@ -824,7 +824,7 @@ class Chart {
 
 	destroy() {
 		const me = this;
-		const canvas = me.canvas;
+		const {canvas, ctx} = me;
 		let i, ilen;
 
 		me.stop();
@@ -837,8 +837,8 @@ class Chart {
 
 		if (canvas) {
 			me.unbindEvents();
-			canvasClear(me);
-			me.platform.releaseContext(me.ctx);
+			clearCanvas(canvas, ctx);
+			me.platform.releaseContext(ctx);
 			me.canvas = null;
 			me.ctx = null;
 		}

--- a/src/helpers/helpers.canvas.js
+++ b/src/helpers/helpers.canvas.js
@@ -107,11 +107,13 @@ export function _alignPixel(chart, pixel, width) {
 }
 
 /**
- * Clears the entire canvas associated to the given `chart`.
- * @param {Chart} chart - The chart for which to clear the canvas.
+ * Clears the entire canvas.
+ * @param {HTMLCanvasElement} canvas
+ * @param {CanvasRenderingContext2D} [ctx]
  */
-export function clear(chart) {
-	chart.ctx.clearRect(0, 0, chart.width, chart.height);
+export function clearCanvas(canvas, ctx) {
+	ctx = ctx || canvas.getContext('2d');
+	ctx.clearRect(0, 0, canvas.width, canvas.height);
 }
 
 export function drawPoint(ctx, options, x, y) {

--- a/test/specs/helpers.canvas.tests.js
+++ b/test/specs/helpers.canvas.tests.js
@@ -5,7 +5,7 @@ describe('Chart.helpers.canvas', function() {
 
 	var helpers = Chart.helpers;
 
-	describe('clear', function() {
+	describe('clearCanvas', function() {
 		it('should clear the chart canvas', function() {
 			var chart = acquireChart({}, {
 				canvas: {
@@ -15,7 +15,7 @@ describe('Chart.helpers.canvas', function() {
 
 			spyOn(chart.ctx, 'clearRect');
 
-			helpers.clear(chart.canvas, chart.ctx);
+			helpers.clearCanvas(chart.canvas, chart.ctx);
 
 			expect(chart.ctx.clearRect.calls.count()).toBe(1);
 			expect(chart.ctx.clearRect.calls.first().object).toBe(chart.ctx);

--- a/test/specs/helpers.canvas.tests.js
+++ b/test/specs/helpers.canvas.tests.js
@@ -15,7 +15,7 @@ describe('Chart.helpers.canvas', function() {
 
 			spyOn(chart.ctx, 'clearRect');
 
-			helpers.clear(chart);
+			helpers.clear(chart.canvas, chart.ctx);
 
 			expect(chart.ctx.clearRect.calls.count()).toBe(1);
 			expect(chart.ctx.clearRect.calls.first().object).toBe(chart.ctx);

--- a/types/helpers/helpers.canvas.d.ts
+++ b/types/helpers/helpers.canvas.d.ts
@@ -3,11 +3,7 @@ import { Color } from '../color';
 import { ChartArea } from '../geometric';
 import { CanvasFontSpec } from './helpers.options';
 
-/**
- * Clears the entire canvas associated to the given `chart`.
- * @param {Chart} chart - The chart for which to clear the canvas.
- */
-export function clear(chart: { ctx: CanvasRenderingContext2D }): void;
+export function clearCanvas(canvas: HTMLCanvasElement, ctx?: CanvasRenderingContext2D): void;
 
 export function clipArea(ctx: CanvasRenderingContext2D, area: ChartArea): void;
 


### PR DESCRIPTION
- Change the parameters to `canvas` and optional `ctx` (for performance). 

This is needed if we start drawing to multiple canvases.