### PR TITLE
Line: Use Path2D as cache

### DIFF
--- a/src/elements/element.line.js
+++ b/src/elements/element.line.js
@@ -3,6 +3,7 @@ import {_bezierInterpolation, _pointInLine, _steppedInterpolation} from '../help
 import {_computeSegments, _boundSegments} from '../helpers/helpers.segment';
 import {_steppedLineTo, _bezierCurveTo} from '../helpers/helpers.canvas';
 import {_updateBezierControlPoints} from '../helpers/helpers.curve';
+import {_coordsAnimated} from '../helpers/helpers.extras';
 
 /**
  * @typedef { import("./element.point").default } PointElement
@@ -198,11 +199,6 @@ function _getInterpolationMethod(options) {
 	return _pointInLine;
 }
 
-function coordsAnimated(point) {
-	const anims = point.$animations;
-	return anims && ((anims.x && anims.x.active) || (anims.y && anims.y.active));
-}
-
 export default class LineElement extends Element {
 
 	constructor(cfg) {
@@ -376,7 +372,10 @@ export default class LineElement extends Element {
 
 		ctx.restore();
 
-		if (points.length && coordsAnimated(points[0])) {
+		if (_coordsAnimated(points[0]) || _coordsAnimated(points[points.length - 1])) {
+			// When point coordinates are animating, we need to recalculate the
+			// path (and control points when beziers are used). Only coordinates
+			// matter, other animations are ignored.
 			this._pointsUpdated = false;
 			this._path = undefined;
 		}

--- a/src/elements/element.line.js
+++ b/src/elements/element.line.js
@@ -50,7 +50,7 @@ function pathVars(points, segment, params) {
 /**
  * Create path from points, grouping by truncated x-coordinate
  * Points need to be in order by x-coordinate for this to work efficiently
- * @param {CanvasRenderingContext2D} ctx - Context
+ * @param {CanvasRenderingContext2D|Path2D} ctx - Context
  * @param {LineElement} line
  * @param {object} segment
  * @param {number} segment.start - start index of the segment, referring the points array
@@ -97,7 +97,7 @@ function pathSegment(ctx, line, segment, params) {
 /**
  * Create path from points, grouping by truncated x-coordinate
  * Points need to be in order by x-coordinate for this to work efficiently
- * @param {CanvasRenderingContext2D} ctx - Context
+ * @param {CanvasRenderingContext2D|Path2D} ctx - Context
  * @param {LineElement} line
  * @param {object} segment
  * @param {number} segment.start - start index of the segment, referring the points array
@@ -198,6 +198,11 @@ function _getInterpolationMethod(options) {
 	return _pointInLine;
 }
 
+function coordsAnimated(point) {
+	const anims = point.$animations;
+	return anims && ((anims.x && anims.x.active) || (anims.y && anims.y.active));
+}
+
 export default class LineElement extends Element {
 
 	constructor(cfg) {
@@ -206,6 +211,7 @@ export default class LineElement extends Element {
 		this.options = undefined;
 		this._loop = undefined;
 		this._fullLoop = undefined;
+		this._path = undefined;
 		this._points = undefined;
 		this._segments = undefined;
 		this._pointsUpdated = false;
@@ -228,6 +234,7 @@ export default class LineElement extends Element {
 	set points(points) {
 		this._points = points;
 		delete this._segments;
+		delete this._path;
 	}
 
 	get points() {
@@ -317,7 +324,7 @@ export default class LineElement extends Element {
 
 	/**
 	 * Append all segments of this line to current path.
-	 * @param {CanvasRenderingContext2D} ctx
+	 * @param {CanvasRenderingContext2D|Path2D} ctx
 	 * @param {number} [start]
 	 * @param {number} [count]
 	 * @returns {undefined|boolean} - true if line is a full loop (path should be closed)
@@ -357,16 +364,22 @@ export default class LineElement extends Element {
 
 		setStyle(ctx, options);
 
-		ctx.beginPath();
-
-		if (this.path(ctx, start, count)) {
-			ctx.closePath();
+		let path = this._path;
+		if (!path) {
+			path = this._path = new Path2D();
+			if (this.path(path, start, count)) {
+				path.closePath();
+			}
 		}
 
-		ctx.stroke();
+		ctx.stroke(path);
+
 		ctx.restore();
 
-		this._pointsUpdated = false;
+		if (points.length && coordsAnimated(points[0])) {
+			this._pointsUpdated = false;
+			this._path = undefined;
+		}
 	}
 }
 

--- a/src/helpers/helpers.extras.js
+++ b/src/helpers/helpers.extras.js
@@ -1,3 +1,4 @@
+
 export function fontString(pixelSize, fontStyle, fontFamily) {
 	return fontStyle + ' ' + pixelSize + 'px ' + fontFamily;
 }
@@ -55,3 +56,14 @@ export const _toLeftRightCenter = (align) => align === 'start' ? 'left' : align 
  * @private
  */
 export const _alignStartEnd = (align, start, end) => align === 'start' ? start : align === 'end' ? end : (start + end) / 2;
+
+/**
+ * Return true if `x` or `y` property (coordinates) of the element is currently animated.
+ * @param {object} element
+ * @returns {boolean}
+ * @private
+ */
+export function _coordsAnimated(element) {
+	const anims = element && element.$animations;
+	return anims && ((anims.x && anims.x.active) || (anims.y && anims.y.active));
+}


### PR DESCRIPTION
Targeting the interaction speed in uPlot benchmarks:

master:

![image](https://user-images.githubusercontent.com/27971921/103180148-bcd2e280-489b-11eb-911c-bbacf21127a4.png)
![image](https://user-images.githubusercontent.com/27971921/103180156-ceb48580-489b-11eb-98e5-672ec978fa68.png)

pr:

![image](https://user-images.githubusercontent.com/27971921/103180168-e0962880-489b-11eb-9c37-d1a5b300d690.png)
![image](https://user-images.githubusercontent.com/27971921/103180177-f60b5280-489b-11eb-84e1-f2e68be9824c.png)

