### PR TITLE
Cache the lineheight regex

### DIFF
--- a/src/helpers/helpers.options.js
+++ b/src/helpers/helpers.options.js
@@ -2,6 +2,8 @@ import defaults from '../core/core.defaults';
 import {isArray, isObject, valueOrDefault} from './helpers.core';
 import {toFontString} from './helpers.canvas';
 
+const LINE_HEIGHT = new RegExp(/^(normal|(\d+(?:\.\d+)?)(px|em|%)?)$/);
+
 /**
  * @alias Chart.helpers.options
  * @namespace
@@ -15,7 +17,7 @@ import {toFontString} from './helpers.canvas';
  * @since 2.7.0
  */
 export function toLineHeight(value, size) {
-	const matches = ('' + value).match(/^(normal|(\d+(?:\.\d+)?)(px|em|%)?)$/);
+	const matches = ('' + value).match(LINE_HEIGHT);
 	if (!matches || matches[1] === 'normal') {
 		return size * 1.2;
 	}


### PR DESCRIPTION
I noticed this in the uplot benchmark. It's not a big win, but it is free. It drops the time to call `toFont` from ~1.5ms to ~0.5ms
