### PR TITLE
Skip reset when animations are disabled

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -476,9 +476,10 @@ class Chart {
 
 		me._updateLayout();
 
-		// Only reset the conrtollers if we have animations
+		// Only reset the controllers if we have animations
 		if (!animsDisabled) {
 			// Can only reset the new controllers after the scales have been updated
+			// Reset is done to get the starting point for the initial animation
 			each(newControllers, (controller) => {
 				controller.reset();
 			});

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -453,7 +453,7 @@ class Chart {
 
 		me.config.update(me.options);
 		me.options = me.config.options;
-		me._animationsDisabled = !me.options.animation;
+		const animsDisabled = me._animationsDisabled = !me.options.animation;
 
 		me.ensureScalesHaveIDs();
 		me.buildOrUpdateScales();
@@ -476,10 +476,13 @@ class Chart {
 
 		me._updateLayout();
 
-		// Can only reset the new controllers after the scales have been updated
-		each(newControllers, (controller) => {
-			controller.reset();
-		});
+		// Only reset the conrtollers if we have animations
+		if (!animsDisabled) {
+			// Can only reset the new controllers after the scales have been updated
+			each(newControllers, (controller) => {
+				controller.reset();
+			});
+		}
 
 		me._updateDatasets(mode);
 

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -901,7 +901,7 @@ export default class DatasetController {
 	 * @protected
 	 */
 	includeOptions(mode, sharedOptions) {
-		return !sharedOptions || isDirectUpdateMode(mode);
+		return !sharedOptions || isDirectUpdateMode(mode) || this.chart._animationsDisabled;
 	}
 
 	/**


### PR DESCRIPTION
We don't need to reset the elements, when we don't animate them. This only affects the first draw.

master:
> 100 runs done in 10494ms. Average: 104ms, min: 77ms, max: 239ms, variation: 162ms.

pr: 
> 100 runs done in 5767ms. Average: 57ms, min: 33ms, max: 165ms, variation: 132ms.

note that these are not comparable to previous measures that I've posted, because I have removed the min/max options from scales here.
