### PR TITLE
Warn on console when something is throttled

### DIFF
--- a/src/helpers/helpers.extras.js
+++ b/src/helpers/helpers.extras.js
@@ -36,6 +36,8 @@ export function throttled(fn, thisArg, updateFn) {
 				ticking = false;
 				fn.apply(thisArg, args);
 			});
+		} else {
+			console.warn('throttled!');
 		}
 	};
 }


### PR DESCRIPTION
Trying to find if then timeout failures in windows ci are due to throttled event(s).
