### PR TITLE
Enable data decimation plugins by separating parsed data into two arrays

### DIFF
--- a/src/controllers/controller.doughnut.js
+++ b/src/controllers/controller.doughnut.js
@@ -60,7 +60,7 @@ export default class DoughnutController extends DatasetController {
 		const meta = this._cachedMeta;
 		let i, ilen;
 		for (i = start, ilen = start + count; i < ilen; ++i) {
-			meta._parsed[i] = +data[i];
+			meta._parsedRaw[i] = meta._parsed[i] = +data[i];
 		}
 	}
 

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -471,10 +471,20 @@ class Chart {
 
 		// Make sure all dataset controllers have correct meta data counts
 		for (i = 0, ilen = me.data.datasets.length; i < ilen; i++) {
-			me.getDatasetMeta(i).controller.buildOrUpdateElements();
+			const {controller} = me.getDatasetMeta(i);
+			controller.parse(0, me.data.datasets[i].data.length);
 		}
 
 		me._updateLayout();
+
+		for (i = 0, ilen = me.data.datasets.length; i < ilen; i++) {
+			// After parse notification takes place after the layout pass
+			// to ensure that decimation plugins can take advantage of the
+			// scale dimensions
+			const controller = me.getDatasetMeta(i).controller;
+			controller._notifyAfterParse();
+			controller.buildOrUpdateElements();
+		}
 
 		// Only reset the controllers if we have animations
 		if (!animsDisabled) {
@@ -741,6 +751,7 @@ class Chart {
 				index: datasetIndex,
 				_dataset: dataset,
 				_parsed: [],
+				_parsedRaw: [],
 				_sorted: false
 			};
 		}


### PR DESCRIPTION
Enables plugins via a new hook `afterDataParse`. 

## To Do

- [ ] Ensure existing unit tests pass
- [ ] Add test coverage
- [ ] Documentation
- [ ] Typescript definitions

## Testing

I tested this on the uPlot benchmark over 100 runs. It performs noticeably better than the mainline code

### master

> 100 runs done in 5717ms. Average: 57ms, min: 41ms, max: 175ms, variation: 134ms.

### PR + decimation plugin

> 100 runs done in 3027ms. Average: 30ms, min: 22ms, max: 177ms, variation: 155ms.

The plugin i used is below.
```javascript
{
	id: 'decimate-data',
	afterDataParse: (chart, args) => {
		const { indexScale, parsed } = args;
		let decimated = [];
		let i, point, x, y, prevX, minIndex, maxIndex, minY, maxY;

		for (i = 0; i < parsed.length; ++i) {
			point = parsed[i];
			x = indexScale.getPixelForValue(point[indexScale.axis]);
			y = point[indexScale.axis === 'x' ? 'y' : 'x'];
			const truncX = x | 0;

			if (truncX === prevX) {
				// Determine `minY` / `maxY` and `avgX` while we stay within same x-position
				if (y < minY) {
					minY = y;
					minIndex = i;
				} else if (y > maxY) {
					maxY = y;
					maxIndex = i;
				}
			} else {
				// Push up to 4 points, 3 for the last interval and the first point for this interval
				if (minIndex && maxIndex) {
					decimated.push(parsed[minIndex], parsed[maxIndex]);
				}
				if (i > 0) {
					// Last point in the previous interval
					decimated.push(parsed[i - 1]);
				}
				decimated.push(point);
				prevX = truncX;
				minY = maxY = y;
				minIndex = maxIndex = i;
			}
		}

		args.data = decimated;
	}
};
```


