### PR TITLE
Tooltip: Render when animations are disabled

### DIFF
--- a/docs/docs/getting-started/v3-migration.md
+++ b/docs/docs/getting-started/v3-migration.md
@@ -504,3 +504,4 @@ All helpers are now exposed in a flat hierarchy, e.g., `Chart.helpers.canvas.cli
 * `afterEvent` and `beforeEvent` now receive a wrapped `event` as the `event` property of the second argument. The native event is available via `args.event.native`.
 * Initial `resize` is no longer silent. Meaning that `resize` event can fire between `beforeInit` and `afterInit`
 * New hooks: `install`, `start`, `stop`, and `uninstall`
+* `afterEvent` should notify about changes that need a render by setting `args.changed` to true. Because the `args` are shared with all plugins, it should only be set to true and not false.

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -1031,7 +1031,7 @@ class Chart {
 		args.cancellable = false;
 		me.notifyPlugins('afterEvent', args);
 
-		if (changed) {
+		if (changed || args.changed) {
 			me.render();
 		}
 

--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -1089,7 +1089,10 @@ export default {
 		if (chart.tooltip) {
 			// If the event is replayed from `update`, we should evaluate with the final positions.
 			const useFinalPosition = args.replay;
-			chart.tooltip.handleEvent(args.event, useFinalPosition);
+			if (chart.tooltip.handleEvent(args.event, useFinalPosition)) {
+				// notify chart about the change, so it will render
+				args.changed = true;
+			}
 		}
 	},
 

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -975,10 +975,11 @@ export interface Plugin<O = {}> extends ExtendedPlugin {
 	 * @param {Chart} chart - The chart instance.
 	 * @param {object} args - The call arguments.
 	 * @param {ChartEvent} args.event - The event object.
-	 * @param {boolean} replay - True if this event is replayed from `Chart.update`
+	 * @param {boolean} args.replay - True if this event is replayed from `Chart.update`
+	 * @param {boolean} [args.changed] - Set to true if the plugin needs a render. Should only be changed to true, because this args object is passed through all plugins.
 	 * @param {object} options - The plugin options.
 	 */
-	afterEvent?(chart: Chart, args: { event: ChartEvent, replay: boolean }, options: O): void;
+	afterEvent?(chart: Chart, args: { event: ChartEvent, replay: boolean, changed?: boolean }, options: O): void;
 	/**
 	 * @desc Called after the chart as been resized.
 	 * @param {Chart} chart - The chart instance.


### PR DESCRIPTION
See the following pen. It has different modes for hover and tooltip. Tooltip only appears if it is changed in sync with hover.

[Pen](https://codepen.io/kurkle/pen/dypdomQ)

![image](https://user-images.githubusercontent.com/27971921/103336428-d2553180-4a80-11eb-900a-8a47d67761a4.png)

no tooltip, even though mouse is over the point:
![image](https://user-images.githubusercontent.com/27971921/103336455-e731c500-4a80-11eb-80bb-badaebc984ed.png)
