### PR TITLE
Fix small bugs when animations are disabled

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -1002,13 +1002,13 @@ class Chart {
 	/**
 	 * @private
 	 */
-	_updateHoverStyles(active, lastActive) {
+	_updateHoverStyles(active, lastActive, replay) {
 		const me = this;
 		const options = me.options || {};
 		const hoverOptions = options.hover;
 		const diff = (a, b) => a.filter(x => !b.some(y => x.datasetIndex === y.datasetIndex && x.index === y.index));
 		const deactivated = diff(lastActive, active);
-		const activated = diff(active, lastActive);
+		const activated = replay ? active : diff(active, lastActive);
 
 		if (deactivated.length) {
 			me.updateHoverStyle(deactivated, hoverOptions.mode, false);
@@ -1093,7 +1093,7 @@ class Chart {
 		changed = !_elementsEqual(active, lastActive);
 		if (changed || replay) {
 			me._active = active;
-			me._updateHoverStyles(active, lastActive);
+			me._updateHoverStyles(active, lastActive, replay);
 		}
 
 		return changed;

--- a/src/core/core.element.js
+++ b/src/core/core.element.js
@@ -37,7 +37,7 @@ export default class Element {
 		}
 		const ret = {};
 		props.forEach(prop => {
-			ret[prop] = anims[prop] && anims[prop].active ? anims[prop]._to : me[prop];
+			ret[prop] = anims[prop] && anims[prop].active() ? anims[prop]._to : me[prop];
 		});
 		return ret;
 	}

--- a/src/helpers/helpers.extras.js
+++ b/src/helpers/helpers.extras.js
@@ -65,5 +65,5 @@ export const _alignStartEnd = (align, start, end) => align === 'start' ? start :
  */
 export function _coordsAnimated(element) {
 	const anims = element && element.$animations;
-	return anims && ((anims.x && anims.x.active) || (anims.y && anims.y.active));
+	return anims && ((anims.x && anims.x.active()) || (anims.y && anims.y.active()));
 }

--- a/test/specs/core.element.tests.js
+++ b/test/specs/core.element.tests.js
@@ -8,7 +8,7 @@ describe('Chart.element', function() {
 			expect(elem.getProps(['x', 'y'])).toEqual(jasmine.objectContaining({x: 10, y: 1.5}));
 			expect(elem.getProps(['x', 'y'], true)).toEqual(jasmine.objectContaining({x: 10, y: 1.5}));
 
-			elem.$animations = {x: {active: true, _to: 20}};
+			elem.$animations = {x: {active: () => true, _to: 20}};
 			expect(elem.getProps(['x', 'y'])).toEqual(jasmine.objectContaining({x: 10, y: 1.5}));
 			expect(elem.getProps(['x', 'y'], true)).toEqual(jasmine.objectContaining({x: 20, y: 1.5}));
 		});


### PR DESCRIPTION
Regressions related to issue #4991

- When hovering same element after update and the event is replayed, `lastActive` and `active` have the same contents, but none of the elements have hover styles applied. => apply hover styles to all active elements in replayed event.

- `Animation.active` is a function, it was used as a property in couple of places.
