### PR TITLE
Use provided options in tooltip plugin

### DIFF
--- a/src/core/core.defaults.js
+++ b/src/core/core.defaults.js
@@ -1,4 +1,4 @@
-import {merge, valueOrDefault} from '../helpers/helpers.core';
+import {isObject, merge, valueOrDefault} from '../helpers/helpers.core';
 
 /**
  * @param {object} node
@@ -102,14 +102,19 @@ export class Defaults {
 		Object.defineProperties(scopeObject, {
 			// A private property is defined to hold the actual value, when this property is set in its scope (set in the setter)
 			[privateName]: {
+				value: scopeObject[name],
 				writable: true
 			},
 			// The actual property is defined as getter/setter so we can do the routing when value is not locally set.
 			[name]: {
 				enumerable: true,
 				get() {
-					// @ts-ignore
-					return valueOrDefault(this[privateName], targetScopeObject[targetName]);
+					const local = this[privateName];
+					const target = targetScopeObject[targetName];
+					if (isObject(local)) {
+						return Object.assign({}, target, local);
+					}
+					return valueOrDefault(local, target);
 				},
 				set(value) {
 					this[privateName] = value;

--- a/test/specs/plugin.tooltip.tests.js
+++ b/test/specs/plugin.tooltip.tests.js
@@ -1344,37 +1344,39 @@ describe('Plugin.Tooltip', function() {
 				yAlign: 'top',
 
 				options: {
+					enabled: true,
+
 					xPadding: 5,
 					yPadding: 5,
 
 					// Body
 					bodyFont: {
-						color: '#fff',
 						family: defaults.font.family,
 						style: defaults.font.style,
 						size: defaults.font.size,
 					},
+					bodyColor: '#fff',
 					bodyAlign: body,
 					bodySpacing: 2,
 
 					// Title
 					titleFont: {
-						color: '#fff',
 						family: defaults.font.family,
 						style: 'bold',
 						size: defaults.font.size,
 					},
+					titleColor: '#fff',
 					titleAlign: title,
 					titleSpacing: 2,
 					titleMarginBottom: 6,
 
 					// Footer
 					footerFont: {
-						color: '#fff',
 						family: defaults.font.family,
 						style: 'bold',
 						size: defaults.font.size,
 					},
+					footerColor: '#fff',
 					footerAlign: footer,
 					footerSpacing: 2,
 					footerMarginTop: 6,


### PR DESCRIPTION
While trying to stop merging all the defaults to the used provided options, these changes are needed. The goal is to consider anything provided in config.options before anything from defaults. When we merge all the things together, there is no way of knowing what the user provided options were.