### PR TITLE
Option resolution with proxies

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -22,6 +22,7 @@ rules:
   max-statements: ["warn", 30]
   no-empty-function: "off"
   no-use-before-define: ["error", { "functions": false }]
+  no-labels: ["error", { "allowLoop": true }]
   # disable everything, except Rest/Spread Properties in ES2018
   es/no-async-iteration: "error"
   es/no-malformed-template-literals: "error"

--- a/src/helpers/helpers.options.js
+++ b/src/helpers/helpers.options.js
@@ -223,11 +223,17 @@ export function _resolver(scopes, prefixes = ['']) {
  */
 export function _withContext(options, context) {
 	const cache = Object.create(null);
+	const scriptables = new Set();
 	return new Proxy(cache, {
 		get(target, prop, proxy) {
 			let value = valueOrDefault(Reflect.get(target, prop), Reflect.get(options, prop));
 			if (scriptable(value)) {
+				if (scriptables.has(prop)) {
+					throw new Error('Recursion detected: ' + [...scriptables].join('->') + '->' + prop.toString());
+				}
+				scriptables.add(prop);
 				value = value(context, proxy);
+				scriptables.delete(prop);
 			}
 			if (indexable(prop, value)) {
 				value = value[context.index % value.length];

--- a/test/specs/helpers.options.tests.js
+++ b/test/specs/helpers.options.tests.js
@@ -280,5 +280,18 @@ describe('Chart.helpers.options', function() {
 			expect(opts.backgroundColor).toEqual('green');
 			expect(opts.hoverColor).toEqual(getHoverColor('blue'));
 		});
+
+		it('should thrown on recursion', function() {
+			const options = {
+				foo: (ctx, opts) => opts.bar,
+				bar: (ctx, opts) => opts.xyz,
+				xyz: (ctx, opts) => opts.foo
+			};
+			const resolver = _resolver([options]);
+			const opts = _withContext(resolver, {test: true});
+			expect(function() {
+				return opts.foo;
+			}).toThrowError('Recursion detected: foo->bar->xyz->foo');
+		});
 	});
 });

--- a/test/specs/helpers.options.tests.js
+++ b/test/specs/helpers.options.tests.js
@@ -1,4 +1,4 @@
-const {toLineHeight, toPadding, toFont, resolve, toTRBLCorners} = Chart.helpers;
+const {toLineHeight, toPadding, toFont, resolve, toTRBLCorners, getHoverColor, _resolver, _withContext} = Chart.helpers;
 
 describe('Chart.helpers.options', function() {
 	describe('toLineHeight', function() {
@@ -243,6 +243,42 @@ describe('Chart.helpers.options', function() {
 			expect(resolve([input, 'foo'], {v: 42}, 1)).toBe('foo');
 			expect(resolve([input, 'foo'], {v: 42}, 5)).toBe('bar');
 			expect(resolve([input, ['foo', 'bar']], {v: 42}, 1)).toBe('bar');
+		});
+	});
+
+	describe('_resolver', function() {
+		it('should resolve to raw values', function() {
+			const defaults = {
+				color: 'red',
+				backgroundColor: 'green',
+				hoverColor: (ctx, options) => getHoverColor(options.color)
+			};
+			const options = {
+				color: 'blue'
+			};
+			const resolver = _resolver([options, defaults]);
+			expect(resolver.color).toEqual('blue');
+			expect(resolver.backgroundColor).toEqual('green');
+			expect(resolver.hoverColor).toEqual(defaults.hoverColor);
+
+		});
+	});
+
+	describe('_withContext', function() {
+		it('should resolve to final values', function() {
+			const defaults = {
+				color: 'red',
+				backgroundColor: 'green',
+				hoverColor: (ctx, options) => getHoverColor(options.color)
+			};
+			const options = {
+				color: ['white', 'blue']
+			};
+			const resolver = _resolver([options, defaults]);
+			const opts = _withContext(resolver, {index: 1});
+			expect(opts.color).toEqual('blue');
+			expect(opts.backgroundColor).toEqual('green');
+			expect(opts.hoverColor).toEqual(getHoverColor('blue'));
 		});
 	});
 });

--- a/test/specs/helpers.options.tests.js
+++ b/test/specs/helpers.options.tests.js
@@ -1,6 +1,6 @@
-const {toLineHeight, toPadding, toFont, resolve, toTRBLCorners, getHoverColor, _resolver, _withContext} = Chart.helpers;
-
 describe('Chart.helpers.options', function() {
+	const {toLineHeight, toPadding, toFont, resolve, toTRBLCorners, getHoverColor, _resolver, _withContext} = Chart.helpers;
+
 	describe('toLineHeight', function() {
 		it ('should support keyword values', function() {
 			expect(toLineHeight('normal', 16)).toBe(16 * 1.2);


### PR DESCRIPTION
As #8008 gets overly complicated, I thought of an (yet another) alternative way for resolving the options.

Using proxies, and split in 2 parts.

`_resolver` resolves the raw values on property access (and caches that).
`_withContext` applies an context on top of that. 

One really nice advantage of this method is, that we can pass the `_withContext` object to the scriptable function, so all other values at that context are available. See the tests for example.

Hoping for comments on this :)