### PR TITLE
Upgrade TypeDoc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -857,7 +857,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -876,7 +876,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -2393,12 +2393,6 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
-    "highlight.js": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
-      "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==",
-      "dev": true
-    },
     "hosted-git-info": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
@@ -3294,9 +3288,9 @@
       }
     },
     "marked": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.0.tgz",
-      "integrity": "sha512-tiRxakgbNPBr301ihe/785NntvYyhxlqcL3YaC8CaxJQh7kiaEtrN9B/eK2I2943Yjkh5gw25chYFDQhOMCwMA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.7.tgz",
+      "integrity": "sha512-No11hFYcXr/zkBvL6qFmAp1z6BKY3zqLMHny/JN/ey+al7qwCM2+CMBL9BOgqMxZU36fz4cCWfn2poWIf7QRXA==",
       "dev": true
     },
     "media-typer": {
@@ -3423,6 +3417,32 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "onigasm": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
+      "integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^5.1.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true
+        }
       }
     },
     "optionator": {
@@ -3925,6 +3945,37 @@
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
         "rechoir": "^0.6.2"
+      }
+    },
+    "shiki": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.2.7.tgz",
+      "integrity": "sha512-bwVc7cdtYYHEO9O+XJ8aNOskKRfaQd5Y4ovLRfbQkmiLSUaR+bdlssbZUUhbQ0JAFMYcTcJ5tjG5KtnufttDHQ==",
+      "dev": true,
+      "requires": {
+        "onigasm": "^2.2.5",
+        "shiki-languages": "^0.2.7",
+        "shiki-themes": "^0.2.7",
+        "vscode-textmate": "^5.2.0"
+      }
+    },
+    "shiki-languages": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/shiki-languages/-/shiki-languages-0.2.7.tgz",
+      "integrity": "sha512-REmakh7pn2jCn9GDMRSK36oDgqhh+rSvJPo77sdWTOmk44C5b0XlYPwJZcFOMJWUZJE0c7FCbKclw4FLwUKLRw==",
+      "dev": true,
+      "requires": {
+        "vscode-textmate": "^5.2.0"
+      }
+    },
+    "shiki-themes": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/shiki-themes/-/shiki-themes-0.2.7.tgz",
+      "integrity": "sha512-ZMmboDYw5+SEpugM8KGUq3tkZ0vXg+k60XX6NngDK7gc1Sv6YLUlanpvG3evm57uKJvfXsky/S5MzSOTtYKLjA==",
+      "dev": true,
+      "requires": {
+        "json5": "^2.1.0",
+        "vscode-textmate": "^5.2.0"
       }
     },
     "skip-regex": {
@@ -4444,22 +4495,22 @@
       }
     },
     "typedoc": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.19.2.tgz",
-      "integrity": "sha512-oDEg1BLEzi1qvgdQXc658EYgJ5qJLVSeZ0hQ57Eq4JXy6Vj2VX4RVo18qYxRWz75ifAaYuYNBUCnbhjd37TfOg==",
+      "version": "0.20.9",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.9.tgz",
+      "integrity": "sha512-GCaE9Hn+VFY2i9wBxFbCv/KZCgHw4+6hiYRdJ0y2DudcWvpgLeCIBJYP1e70MtKCZzs4FT+ydLxInr/hyXrY4Q==",
       "dev": true,
       "requires": {
+        "colors": "^1.4.0",
         "fs-extra": "^9.0.1",
         "handlebars": "^4.7.6",
-        "highlight.js": "^10.2.0",
         "lodash": "^4.17.20",
         "lunr": "^2.3.9",
-        "marked": "^1.1.1",
+        "marked": "^1.2.5",
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
-        "semver": "^7.3.2",
         "shelljs": "^0.8.4",
-        "typedoc-default-themes": "^0.11.4"
+        "shiki": "^0.2.7",
+        "typedoc-default-themes": "0.12.0"
       },
       "dependencies": {
         "fs-extra": {
@@ -4475,25 +4526,27 @@
           }
         },
         "jsonfile": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
-          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6",
-            "universalify": "^1.0.0"
+            "universalify": "^2.0.0"
+          },
+          "dependencies": {
+            "universalify": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+              "dev": true
+            }
           }
         },
         "lodash": {
           "version": "4.17.20",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
           "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-          "dev": true
-        },
-        "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
         },
         "universalify": {
@@ -4505,9 +4558,9 @@
       }
     },
     "typedoc-default-themes": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.11.4.tgz",
-      "integrity": "sha512-Y4Lf+qIb9NTydrexlazAM46SSLrmrQRqWiD52593g53SsmUFioAsMWt8m834J6qsp+7wHRjxCXSZeiiW5cMUdw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.0.tgz",
+      "integrity": "sha512-0hHBxwmfxE0rkIslOiO39fJyYwaScQEhUIxcpqx3uS1BL3zhFW5oQfUaPx2cv2XLL/GXhYFxhdFLoVmNptbxEQ==",
       "dev": true
     },
     "typescript": {
@@ -4523,9 +4576,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.11.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.2.tgz",
-      "integrity": "sha512-G440NU6fewtnQftSgqRV1r2A5ChKbU1gqFCJ7I8S7MPpY/eZZfLGefaY6gUZYiWebMaO+txgiQ1ZyLDuNWJulg==",
+      "version": "3.12.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.4.tgz",
+      "integrity": "sha512-L5i5jg/SHkEqzN18gQMTWsZk3KelRsfD1wUVNqtq0kzqWQqcJjyL8yc1o8hJgRrWqrAl2mUFbhfznEIoi7zi2A==",
       "dev": true,
       "optional": true
     },
@@ -4593,6 +4646,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
       "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "rollup-plugin-dts": "^2.0.1",
     "rollup-plugin-istanbul": "^2.0.1",
     "rollup-plugin-terser": "^7.0.2",
-    "typedoc": "^0.19.2",
+    "typedoc": "^0.20.9",
     "typescript": "^4.1.3",
     "yargs": "^16.2.0"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,13 +12,14 @@
   },
   "typedocOptions": {
     "name": "Chart.js",
+    "entryPoints": ["src/index.esm.js"],
     "excludeExternals": true,
     "excludeNotExported": true,
     "includeVersion": true,
-    "inputFiles": ["./src"],
     "out": "./dist/docs/typedoc"
   },
   "include": [
-    "./src/**/*.js"
+    "./src/**/*.js",
+    "./types"
   ]
 }


### PR DESCRIPTION
Upgrade TypeDoc to major new version

I also tried generating the docs from the type declarations instead of the code, but the result was rather overwhelming. You can test it out by changing `entryPoints` to `types/index.esm.d.ts`. The docs are better typed if we do that and it generates really good docs for `Plugin` (https://github.com/chartjs/Chart.js/issues/8229), but the list of exported types is too large to navigate or comprehend