### PR TITLE
Update TypeScript ESLint configuration

### DIFF
--- a/types/.eslintrc.yml
+++ b/types/.eslintrc.yml
@@ -7,11 +7,16 @@ extends:
   - chartjs
   - plugin:@typescript-eslint/recommended
 
-# These rules were set to warning to make the linting pass initially,
-# without making any major changes to types.
 rules:
-  no-use-before-define: "warn"
-  no-shadow: "warn"
+  # Replace stock eslint rules with typescript-eslint equivalents for proper
+  # TypeScript support.
+  no-use-before-define: "off"
+  '@typescript-eslint/no-use-before-define': "error"
+  no-shadow: "off"
+  '@typescript-eslint/no-shadow': "error"
+
+  # These rules were set to warning to make the linting pass initially,
+  # without making any major changes to types.
   object-curly-spacing: ["warn", "always"]
   '@typescript-eslint/no-empty-interface': "warn"
   '@typescript-eslint/ban-types': "warn"

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -965,7 +965,7 @@ export interface Plugin<O = {}> extends ExtendedPlugin {
 	 * @param {Chart} chart - The chart instance.
 	 * @param {object} args - The call arguments.
 	 * @param {ChartEvent} args.event - The event object.
-	 * @param {boolean} replay - True if this event is replayed from `Chart.update`
+	 * @param {boolean} args.replay - True if this event is replayed from `Chart.update`
 	 * @param {object} options - The plugin options.
 	 */
 	beforeEvent?(chart: Chart, args: { event: ChartEvent, replay: boolean }, options: O): boolean | void;


### PR DESCRIPTION
Using TypeScript-specific ESLint rules fixes some spurious ESLint warnings, such as "was used before it was defined" (which isn't a problem for TS types) or bogus "was already declared in the upper scope" warnings for TypeScript enums.

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
