### PR TITLE
clarification that strikethrough uses same color as the label color

### DIFF
--- a/docs/docs/configuration/legend.md
+++ b/docs/docs/configuration/legend.md
@@ -52,7 +52,7 @@ The legend label configuration is nested below the legend configuration using th
 | ---- | ---- | ------- | -----------
 | `boxWidth` | `number` | `40` | Width of coloured box.
 | `boxHeight` | `number` | `font.size` | Height of the coloured box.
-| `color` | [`Color`](../general/colors.md) | `Chart.defaults.color` | Color of label.
+| `color` | [`Color`](../general/colors.md) | `Chart.defaults.color` | Color of label and the strikethrough.
 | `font` | `Font` | `Chart.defaults.font` | See [Fonts](../general/fonts.md)
 | `padding` | `number` | `10` | Padding between rows of colored boxes.
 | `generateLabels` | `function` | | Generates legend items for each thing in the legend. Default implementation returns the text + styling for the color box. See [Legend Item](#legend-item-interface) for details.


### PR DESCRIPTION
Clarification to fix #8284 I dont know if we want the strikethrough color to be customizable also as a main feature for the lib, if so I can add it to this PR.
<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
