### PR TITLE
Give elements their own interface definition

### DIFF
--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -1834,14 +1834,16 @@ export const BarElement: ChartComponent & {
 	new (cfg: any): BarElement;
 };
 
-export interface ElementChartOptions {
-	elements: {
-		arc: ArcOptions & ArcHoverOptions;
-		bar: BarOptions & BarHoverOptions;
-		line: LineOptions & LineHoverOptions;
-		point: PointOptions & PointHoverOptions;
-	};
+export interface ElementOptions {
+	arc: ArcOptions & ArcHoverOptions;
+	bar: BarOptions & BarHoverOptions;
+	line: LineOptions & LineHoverOptions;
+	point: PointOptions & PointHoverOptions;
 }
+export interface ElementChartOptions {
+	elements: ElementOptions;
+}
+
 export class BasePlatform {
 	/**
 	 * Called at chart construction time, returns a context2d instance implementing


### PR DESCRIPTION
From what I understand, if we want to allow registering additional element options (see [here][1] for an example), then the element options need to be a top-level interface so that they can be used with TypeScript's [declaration merging][2].

[1]: https://github.com/chartjs/chartjs-plugin-annotation/pull/275#issuecomment-742754562
[2]: https://www.typescriptlang.org/docs/handbook/declaration-merging.html

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
