### PR TITLE
Revert "Update spelling of cancellable (#8236)"

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -462,7 +462,7 @@ class Chart {
 		// https://github.com/chartjs/Chart.js/issues/5111#issuecomment-355934167
 		me._plugins.invalidate();
 
-		if (me.notifyPlugins('beforeUpdate', {mode, cancellable: true}) === false) {
+		if (me.notifyPlugins('beforeUpdate', {mode, cancelable: true}) === false) {
 			return;
 		}
 
@@ -508,7 +508,7 @@ class Chart {
 	_updateLayout() {
 		const me = this;
 
-		if (me.notifyPlugins('beforeLayout', {cancellable: true}) === false) {
+		if (me.notifyPlugins('beforeLayout', {cancelable: true}) === false) {
 			return;
 		}
 
@@ -548,7 +548,7 @@ class Chart {
 		const me = this;
 		const isFunction = typeof mode === 'function';
 
-		if (me.notifyPlugins('beforeDatasetsUpdate', {mode, cancellable: true}) === false) {
+		if (me.notifyPlugins('beforeDatasetsUpdate', {mode, cancelable: true}) === false) {
 			return;
 		}
 
@@ -567,7 +567,7 @@ class Chart {
 	_updateDataset(index, mode) {
 		const me = this;
 		const meta = me.getDatasetMeta(index);
-		const args = {meta, index, mode, cancellable: true};
+		const args = {meta, index, mode, cancelable: true};
 
 		if (me.notifyPlugins('beforeDatasetUpdate', args) === false) {
 			return;
@@ -575,13 +575,13 @@ class Chart {
 
 		meta.controller._update(mode);
 
-		args.cancellable = false;
+		args.cancelable = false;
 		me.notifyPlugins('afterDatasetUpdate', args);
 	}
 
 	render() {
 		const me = this;
-		if (me.notifyPlugins('beforeRender', {cancellable: true}) === false) {
+		if (me.notifyPlugins('beforeRender', {cancelable: true}) === false) {
 			return;
 		}
 
@@ -609,7 +609,7 @@ class Chart {
 			return;
 		}
 
-		if (me.notifyPlugins('beforeDraw', {cancellable: true}) === false) {
+		if (me.notifyPlugins('beforeDraw', {cancelable: true}) === false) {
 			return;
 		}
 
@@ -666,7 +666,7 @@ class Chart {
 	_drawDatasets() {
 		const me = this;
 
-		if (me.notifyPlugins('beforeDatasetsDraw', {cancellable: true}) === false) {
+		if (me.notifyPlugins('beforeDatasetsDraw', {cancelable: true}) === false) {
 			return;
 		}
 
@@ -691,7 +691,7 @@ class Chart {
 		const args = {
 			meta,
 			index: meta.index,
-			cancellable: true
+			cancelable: true
 		};
 
 		if (me.notifyPlugins('beforeDatasetDraw', args) === false) {
@@ -709,7 +709,7 @@ class Chart {
 
 		unclipArea(ctx);
 
-		args.cancellable = false;
+		args.cancelable = false;
 		me.notifyPlugins('afterDatasetDraw', args);
 	}
 
@@ -1024,7 +1024,7 @@ class Chart {
 	 */
 	_eventHandler(e, replay) {
 		const me = this;
-		const args = {event: e, replay, cancellable: true};
+		const args = {event: e, replay, cancelable: true};
 
 		if (me.notifyPlugins('beforeEvent', args) === false) {
 			return;
@@ -1032,7 +1032,7 @@ class Chart {
 
 		const changed = me._handleEvent(e, replay);
 
-		args.cancellable = false;
+		args.cancelable = false;
 		me.notifyPlugins('afterEvent', args);
 
 		if (changed || args.changed) {

--- a/src/core/core.plugins.js
+++ b/src/core/core.plugins.js
@@ -50,7 +50,7 @@ export default class PluginService {
 			const plugin = descriptor.plugin;
 			const method = plugin[hook];
 			const params = [chart, args, descriptor.options];
-			if (callCallback(method, params, plugin) === false && args.cancellable) {
+			if (callCallback(method, params, plugin) === false && args.cancelable) {
 				return false;
 			}
 		}

--- a/test/specs/core.plugin.tests.js
+++ b/test/specs/core.plugin.tests.js
@@ -151,7 +151,7 @@ describe('Chart.plugins', function() {
 				spyOn(plugin, 'hook').and.callThrough();
 			});
 
-			var ret = chart.notifyPlugins('hook', {cancellable: true});
+			var ret = chart.notifyPlugins('hook', {cancelable: true});
 			expect(ret).toBeFalsy();
 			expect(plugins[0].hook).toHaveBeenCalled();
 			expect(plugins[1].hook).toHaveBeenCalled();


### PR DESCRIPTION
In https://github.com/chartjs/Chart.js/pull/8236 I updated the spelling to the more common spelling. However, it turns out that `Event` has a `cancelable` property and so now it's confusing the we have two different spellings of `cancelable`. I hadn't realized this at first, but after running into it I think we're better off with the slightly less common spelling in order to be consistent with the web API