### PR TITLE
Fix reading wrong property from font object for font string

### DIFF
--- a/src/helpers/helpers.canvas.js
+++ b/src/helpers/helpers.canvas.js
@@ -312,7 +312,7 @@ export function renderText(ctx, text, x, y, font, opts = {}) {
 		ctx.rotate(opts.rotation);
 	}
 
-	ctx.font = font.fontString;
+	ctx.font = font.string;
 
 	if (opts.color) {
 		ctx.fillStyle = opts.color;


### PR DESCRIPTION
Fix for #8311, noticed that with the new renderText helper the fontString was trying to be read from the fontoptions as a wrong key
<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
