### PR TITLE
Fix custom pie chart HTML tooltip sample not showing

### DIFF
--- a/samples/tooltips/custom-pie.html
+++ b/samples/tooltips/custom-pie.html
@@ -139,7 +139,9 @@
 				responsive: true,
 				plugins: {
 					legend: false,
-					tooltip: false
+					tooltip: {
+						enabled: false
+					}
 				}
 			}
 		};


### PR DESCRIPTION
Custom pie chart tooltip was not showing
<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
