### PR TITLE
Add default export to esm build to make date adapters work

### DIFF
--- a/src/index.esm.js
+++ b/src/index.esm.js
@@ -1,6 +1,10 @@
+import Chart from './core/core.controller';
+
 export * from './controllers';
 export * from './core';
 export * from './elements';
 export * from './platform';
 export * from './plugins';
 export * from './scales';
+
+export default Chart;


### PR DESCRIPTION
I'm currently getting:

>WARNING in node_modules/chartjs-adapter-luxon/dist/chartjs-adapter-luxon.esm.js 23:0-5
>"export 'default' (imported as 'Chart') was not found in 'chart.js'

The two choices here would be to add the default export here or to publish beta versions of the date adapters that use the named export