### PR TITLE
fix canvas clearRect size calculation

### DIFF
--- a/src/helpers/helpers.canvas.js
+++ b/src/helpers/helpers.canvas.js
@@ -113,7 +113,13 @@ export function _alignPixel(chart, pixel, width) {
  */
 export function clearCanvas(canvas, ctx) {
 	ctx = ctx || canvas.getContext('2d');
+
+	ctx.save();
+	// canvas.width and canvas.height do not consider the canvas transform,
+	// while clearRect does
+	ctx.resetTransform();
 	ctx.clearRect(0, 0, canvas.width, canvas.height);
+	ctx.restore();
 }
 
 export function drawPoint(ctx, options, x, y) {


### PR DESCRIPTION
When you zoom out, on any chart, so that `window.devicePixelRatio < 1` (e.g., you're on an 1x display and zoom the browser to 80%, or on a 2x display and zoom the browser to 30%), the `clearCanvas` call only clears that percentage of the canvas.

This is because `canvas.clearRect` considers the current transform. We're currently clearing `canvas.width` and `canvas.height` which *don't* consider the transform. This PR fixes that.

(This probably went unnoticed because Chart.js was clearing more than the canvas size on retina displays, which didn't make for visual problems.)