### PR TITLE
feature: choose custom point style for bar legend display

### DIFF
--- a/docs/docs/charts/bar.mdx
+++ b/docs/docs/charts/bar.mdx
@@ -93,6 +93,7 @@ the color of the bars is generally set this way.
 | [`indexAxis`](#general) | `string` | - | - | `'x'`
 | [`label`](#general) | `string` | - | - | `''`
 | [`order`](#general) | `number` | - | - | `0`
+| [`pointStyle`](../configuration/elements.md#point-styles) | `string`\|`Image` | Yes | False | `'circle'`
 | [`xAxisID`](#general) | `string` | - | - | first x axis
 | [`yAxisID`](#general) | `string` | - | - | first y axis
 
@@ -174,7 +175,6 @@ The bar chart accepts the following configuration from the associated dataset op
 | `base` | `number` | | Base value for the bar in data units along the value axis. If not set, defaults to the value axis base value.
 | `maxBarThickness` | `number` | | Set this to ensure that bars are not sized thicker than this.
 | `minBarLength` | `number` | | Set this to ensure that bars have a minimum length in pixels.
-| [`pointStyle`](../configuration/elements.md#point-styles) | `string`\|`Image` | Yes | Yes | `'circle'`
 
 ### Example Usage
 

--- a/docs/docs/charts/bar.mdx
+++ b/docs/docs/charts/bar.mdx
@@ -174,6 +174,7 @@ The bar chart accepts the following configuration from the associated dataset op
 | `base` | `number` | | Base value for the bar in data units along the value axis. If not set, defaults to the value axis base value.
 | `maxBarThickness` | `number` | | Set this to ensure that bars are not sized thicker than this.
 | `minBarLength` | `number` | | Set this to ensure that bars have a minimum length in pixels.
+| [`pointStyle`](../configuration/elements.md#point-styles) | `string`\|`Image` | Yes | Yes | `'circle'`
 
 ### Example Usage
 

--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -522,6 +522,7 @@ BarController.defaults = {
 		'categoryPercentage',
 		'maxBarThickness',
 		'minBarLength',
+		'pointStyle'
 	],
 	interaction: {
 		mode: 'index'

--- a/test/specs/plugin.legend.tests.js
+++ b/test/specs/plugin.legend.tests.js
@@ -95,7 +95,7 @@ describe('Legend block tests', function() {
 			lineJoin: undefined,
 			lineWidth: 10,
 			strokeStyle: 'green',
-			pointStyle: undefined,
+			pointStyle: 'crossRot',
 			rotation: undefined,
 			datasetIndex: 2
 		}]);
@@ -311,7 +311,7 @@ describe('Legend block tests', function() {
 			lineJoin: undefined,
 			lineWidth: 10,
 			strokeStyle: 'green',
-			pointStyle: undefined,
+			pointStyle: 'crossRot',
 			rotation: undefined,
 			datasetIndex: 2
 		}]);
@@ -887,4 +887,3 @@ describe('Legend block tests', function() {
 		});
 	});
 });
-

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -125,6 +125,12 @@ export interface BarControllerDatasetOptions
 	 * Set this to ensure that bars have a minimum length in pixels.
 	 */
 	minBarLength: number;
+
+	/**
+	 * Point style for the legend
+	 * @default 'circle;
+	 */
+	pointStyle: PointStyle;
 }
 
 export interface BarControllerChartOptions {


### PR DESCRIPTION
It was already posible to change the icon by setting the point style in the config itself, now you can also give it to the dataset to make it somehting else thena round dot

![image](https://user-images.githubusercontent.com/39033624/105782000-e141dd80-5f73-11eb-8296-88df1f00f625.png)


<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
