### PR TITLE
Fix/scatter tooltip mode

### DIFF
--- a/docs/docs/charts/line.mdx
+++ b/docs/docs/charts/line.mdx
@@ -87,7 +87,7 @@ The line chart allows a number of properties to be specified for each dataset. T
 | [`pointRadius`](#point-styling) | `number` | Yes | Yes | `3`
 | [`pointRotation`](#point-styling) | `number` | Yes | Yes | `0`
 | [`pointStyle`](#point-styling) | `string`\|`Image` | Yes | Yes | `'circle'`
-| [`showLine`](#line-styling) | `boolean` | - | - | `undefined`
+| [`showLine`](#line-styling) | `boolean` | - | - | `true`
 | [`spanGaps`](#line-styling) | `boolean`\|`number` | - | - | `undefined`
 | [`stepped`](#stepped) | `boolean`\|`string` | - | - | `false`
 | [`xAxisID`](#general) | `string` | - | - | first x axis

--- a/docs/docs/charts/scatter.mdx
+++ b/docs/docs/charts/scatter.mdx
@@ -50,6 +50,7 @@ function example() {
 ## Dataset Properties
 
 The scatter chart supports all of the same properties as the [line chart](./charts/line.mdx#dataset-properties).
+By default, the scatter chart will override the showLine property of the line chart to `false`.
 
 ## Data Structure
 

--- a/src/controllers/controller.scatter.js
+++ b/src/controllers/controller.scatter.js
@@ -24,9 +24,12 @@ ScatterController.defaults = {
 		fill: false
 	},
 
+	interaction: {
+		mode: 'point'
+	},
+
 	plugins: {
 		tooltip: {
-			mode: 'point',
 			callbacks: {
 				title() {
 					return '';     // doesn't make sense for scatter since data are formatted as a point

--- a/src/controllers/controller.scatter.js
+++ b/src/controllers/controller.scatter.js
@@ -26,6 +26,7 @@ ScatterController.defaults = {
 
 	plugins: {
 		tooltip: {
+			mode: 'point',
 			callbacks: {
 				title() {
 					return '';     // doesn't make sense for scatter since data are formatted as a point

--- a/test/specs/controller.scatter.tests.js
+++ b/test/specs/controller.scatter.tests.js
@@ -31,4 +31,36 @@ describe('Chart.controllers.scatter', function() {
 
 		jasmine.triggerMouseEvent(chart, 'mousemove', point);
 	});
+
+	it('should only show a single point in the tooltip on multiple datasets', function(done) {
+		var chart = window.acquireChart({
+			type: 'scatter',
+			data: {
+				datasets: [{
+					data: [{
+						x: 10,
+						y: 15
+					}],
+					label: 'dataset1'
+				},
+				{
+					data: [{
+						x: 20,
+						y: 10
+					}],
+					label: 'dataset2'
+				}],
+			},
+			options: {}
+		});
+		var point = chart.getDatasetMeta(0).data[0];
+
+		afterEvent(chart, 'mousemove', function() {
+			expect(chart.tooltip.body[0].lines).toEqual(['(10, 15)']);
+
+			done();
+		});
+
+		jasmine.triggerMouseEvent(chart, 'mousemove', point);
+	});
 });

--- a/test/specs/controller.scatter.tests.js
+++ b/test/specs/controller.scatter.tests.js
@@ -40,6 +40,10 @@ describe('Chart.controllers.scatter', function() {
 					data: [{
 						x: 10,
 						y: 15
+					},
+					{
+						x: 12,
+						y: 10
 					}],
 					label: 'dataset1'
 				},
@@ -47,16 +51,20 @@ describe('Chart.controllers.scatter', function() {
 					data: [{
 						x: 20,
 						y: 10
+					},
+					{
+						x: 4,
+						y: 8
 					}],
 					label: 'dataset2'
-				}],
+				}]
 			},
 			options: {}
 		});
-		var point = chart.getDatasetMeta(0).data[0];
+		var point = chart.getDatasetMeta(0).data[1];
 
 		afterEvent(chart, 'mousemove', function() {
-			expect(chart.tooltip.body[0].lines).toEqual(['(10, 15)']);
+			expect(chart.tooltip.body.length).toEqual(1);
 
 			done();
 		});


### PR DESCRIPTION
Resolves #8350
In 2.9 it was already like this (only showing point) so no updating of the migration guide neccesarry 

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
