### PR TITLE
Update type map names

### DIFF
--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -606,9 +606,9 @@ export interface Defaults extends CoreChartOptions, ElementChartOptions, PluginC
 			>;
 	};
 
-	scale: ScaleOptions;
+	scale: ScaleOptionsByType;
 	scales: {
-		[key in ScaleType]: ScaleOptions<key>;
+		[key in ScaleType]: ScaleOptionsByType<key>;
 	};
 
 	set(values: AnyObject): AnyObject;
@@ -3123,7 +3123,7 @@ export interface ChartTypeRegistry {
 
 export type ChartType = keyof ChartTypeRegistry;
 
-export type ScaleOptions<TScale extends ScaleType = ScaleType> = DeepPartial<
+export type ScaleOptionsByType<TScale extends ScaleType = ScaleType> = DeepPartial<
 	{ [key in ScaleType]: { type: key } & ScaleTypeRegistry[key]['options'] }[TScale]
 >;
 
@@ -3135,7 +3135,7 @@ export type DatasetChartOptions<TType extends ChartType = ChartType> = {
 
 export type ScaleChartOptions<TType extends ChartType = ChartType> = {
 	scales: {
-		[key: string]: ScaleOptions<ChartTypeRegistry[TType]['scales']>;
+		[key: string]: ScaleOptionsByType<ChartTypeRegistry[TType]['scales']>;
 	};
 };
 

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -1844,7 +1844,7 @@ export interface ElementOptionsByType {
 	point: PointOptions & PointHoverOptions;
 }
 export interface ElementChartOptions {
-	elements: { [k in keyof ElementOptionsByType]: ElementOptionsByType[k]; };
+	elements: Partial<ElementOptionsByType>;
 }
 
 export class BasePlatform {
@@ -2483,7 +2483,7 @@ export interface PluginOptionsByType {
 	tooltip: TooltipOptions;
 }
 export interface PluginChartOptions {
-	plugins: { [k in keyof PluginOptionsByType]: PluginOptionsByType[k]; };
+	plugins: Partial<PluginOptionsByType>;
 }
 
 export interface GridLineOptions {

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -594,11 +594,12 @@ export interface DatasetControllerChartComponent extends ChartComponent {
 }
 
 export type AnyObject = Record<string, unknown>;
-export interface Defaults extends CoreChartOptions, ElementChartOptions {
+export interface Defaults extends CoreChartOptions, ElementChartOptions, PluginChartOptions {
 	controllers: {
 		[key in ChartType]: DeepPartial<
 			CoreChartOptions &
 			ElementChartOptions &
+			PluginChartOptions &
 			DatasetChartOptions<key>[key] &
 			ScaleChartOptions<key> &
 			ChartTypeRegistry[key]['chartOptions']
@@ -609,8 +610,6 @@ export interface Defaults extends CoreChartOptions, ElementChartOptions {
 	scales: {
 		[key in ScaleType]: ScaleOptions<key>;
 	};
-
-	plugins: PluginOptions;
 
 	set(values: AnyObject): AnyObject;
 	set(scope: string, values: AnyObject): AnyObject;
@@ -1411,8 +1410,6 @@ export interface CoreChartOptions extends ParsingOptions {
 	layout: {
 		padding: Scriptable<number | ChartArea, ScriptableContext>;
 	};
-
-	plugins: PluginOptions;
 }
 
 export type EasingFunction =
@@ -2479,12 +2476,16 @@ export interface TooltipItem {
 	element: Element;
 }
 
-export interface PluginOptions {
+export interface PluginOptionsByType {
 	filler: FillerOptions;
 	legend: LegendOptions;
 	title: TitleOptions;
 	tooltip: TooltipOptions;
 }
+export interface PluginChartOptions {
+	plugins: { [k in keyof PluginOptionsByType]: PluginOptionsByType[k]; };
+}
+
 export interface GridLineOptions {
 	/**
 	 * @default true
@@ -3141,6 +3142,7 @@ export type ScaleChartOptions<TType extends ChartType = ChartType> = {
 export type ChartOptions<TType extends ChartType = ChartType> = DeepPartial<
 	CoreChartOptions &
 	ElementChartOptions &
+	PluginChartOptions &
 	DatasetChartOptions<TType> &
 	ScaleChartOptions<TType> &
 	ChartTypeRegistry[TType]['chartOptions']

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -1840,14 +1840,14 @@ export const BarElement: ChartComponent & {
 	new (cfg: any): BarElement;
 };
 
-export interface ElementOptions {
+export interface ElementOptionsByType {
 	arc: ArcOptions & ArcHoverOptions;
 	bar: BarOptions & BarHoverOptions;
 	line: LineOptions & LineHoverOptions;
 	point: PointOptions & PointHoverOptions;
 }
 export interface ElementChartOptions {
-	elements: ElementOptions;
+	elements: { [k in keyof ElementOptionsByType]: ElementOptionsByType[k]; };
 }
 
 export class BasePlatform {

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -1339,12 +1339,12 @@ export interface CoreChartOptions extends ParsingOptions {
 	 * @see Defaults.color
 	 */
 	color: Color;
-		/**
+	/**
 	 * base background color
 	 * @see Defaults.backgroundColor
 	 */
 	backgroundColor: Color;
-		/**
+	/**
 	 * base border color
 	 * @see Defaults.borderColor
 	 */
@@ -1558,7 +1558,7 @@ export interface VisualElement {
 	getRange?(axis: 'x' | 'y'): number;
 }
 
-export interface CommonOptions {
+export interface CommonElementOptions {
 	borderWidth: number;
 	borderColor: Color;
 	backgroundColor: Color;
@@ -1586,7 +1586,7 @@ export interface ArcProps {
 	circumference: number;
 }
 
-export interface ArcOptions extends CommonOptions {
+export interface ArcOptions extends CommonElementOptions {
 	/**
 	 * Arc stroke alignment.
 	 */
@@ -1612,7 +1612,7 @@ export const ArcElement: ChartComponent & {
 
 export interface LineProps {}
 
-export interface LineOptions extends CommonOptions {
+export interface LineOptions extends CommonElementOptions {
 	/**
 	 * Line cap style. See MDN.
 	 * @default 'butt'
@@ -1699,7 +1699,7 @@ export type PointStyle =
 	| HTMLImageElement
 	| HTMLCanvasElement;
 
-export interface PointOptions extends CommonOptions {
+export interface PointOptions extends CommonElementOptions {
 	/**
 	 * Point radius
 	 * @default 3
@@ -1800,7 +1800,7 @@ export interface BarProps {
 	height: number;
 }
 
-export interface BarOptions extends CommonOptions {
+export interface BarOptions extends CommonElementOptions {
 	/**
 	 * The base value for the bar in data units along the value axis.
 	 */


### PR DESCRIPTION
Following on from the discussion in #8290. I went with a format of `PluginOptionsByType` since the size doesn't matter and it indicates clearly what the key is.

The changes I made are:
* Rename `CommonOptions` to `CommonElementOptions`
* Rename `ElementOptions` to `ElementOptionsByType`
* Rename `PluginOptions` to `PluginOptionsByType`
* Added `PluginChartOptions` definition and removed plugins from `CoreChartOptions` to match how elements are done
