### PR TITLE
Prevent test timeouts due to Chrome backgrounding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
             - 'src/**'
           test:
             - 'test/**'
+            - 'karma.conf.js'
           types:
             - 'types/**'
     - name: Install

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/no-commonjs */
-
 const commonjs = require('@rollup/plugin-commonjs');
 const istanbul = require('rollup-plugin-istanbul');
 const json = require('@rollup/plugin-json');
@@ -49,7 +47,10 @@ module.exports = function(karma) {
 			chrome: {
 				base: 'Chrome',
 				flags: [
-					'--disable-accelerated-2d-canvas'
+					'--disable-accelerated-2d-canvas',
+					'--disable-background-timer-throttling',
+					'--disable-backgrounding-occluded-windows',
+					'--disable-renderer-backgrounding'
 				]
 			},
 			firefox: {


### PR DESCRIPTION
Add some flags for Chrome to avoid throttling/pausing if the browser is backgrounded. I hope the random timeouts during tests are due to this.

I've noticed same behavior locally, when in `dev` mode and the browser ends up in the background.
