### PR TITLE
Shave off some bytes

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -323,10 +323,7 @@ class Chart {
 		me.scales = scales;
 
 		each(scales, (scale) => {
-			// Set LayoutItem parameters for backwards compatibility
-			scale.fullSize = scale.options.fullSize;
-			scale.position = scale.options.position;
-			scale.weight = scale.options.weight;
+			layouts.configure(me, scale, scale.options);
 			layouts.addBox(me, scale);
 		});
 	}

--- a/src/core/core.layouts.js
+++ b/src/core/core.layouts.js
@@ -284,17 +284,9 @@ export default {
 	 * @param {object} options - the new item options.
 	 */
 	configure(chart, item, options) {
-		const props = ['fullSize', 'position', 'weight'];
-		const ilen = props.length;
-		let i = 0;
-		let prop;
-
-		for (; i < ilen; ++i) {
-			prop = props[i];
-			if (Object.prototype.hasOwnProperty.call(options, prop)) {
-				item[prop] = options[prop];
-			}
-		}
+		item.fullSize = options.fullSize;
+		item.position = options.position;
+		item.weight = options.weight;
 	},
 
 	/**


### PR DESCRIPTION
Remove some duplicate and unnecessary code.

`layouts.addBox` adds some defaults, so no harm done setting to undefined.
```js
		// initialize item with default values
		item.fullSize = item.fullSize || false;
		item.position = item.position || 'top';
		item.weight = item.weight || 0;
```