### PR TITLE
Fix/type dateadapter override

### DIFF
--- a/types/adapters.d.ts
+++ b/types/adapters.d.ts
@@ -58,11 +58,6 @@ export interface DateAdapter {
 	endOf(timestamp: number, unit: TimeUnit | 'isoWeek'): number;
 }
 
-declare const DateAdapter: {
-	prototype: DateAdapter;
-	new(options: any): DateAdapter;
-};
-
 export const _adapters: {
 	_date: DateAdapter;
 };

--- a/types/adapters.d.ts
+++ b/types/adapters.d.ts
@@ -1,6 +1,10 @@
 export type TimeUnit = 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year';
 
-export interface DateAdapterBase {
+export interface DateAdapter {
+	// Override one or multiple of the methods to adjust to the logic of the current date library.
+	override(members: Partial<DateAdapter>): void;
+	readonly options: any;
+
 	/**
 	 * Returns a map of time formats for the supported formatting units defined
 	 * in Unit as well as 'datetime' representing a detailed date/time string.
@@ -53,16 +57,6 @@ export interface DateAdapterBase {
 	 */
 	endOf(timestamp: number, unit: TimeUnit | 'isoWeek'): number;
 }
-
-export interface DateAdapter extends DateAdapterBase {
-	readonly options: any;
-	override(members: Partial<DateAdapter>): void;
-}
-
-export const DateAdapter: {
-	prototype: DateAdapter;
-	new(options: any): DateAdapter;
-};
 
 export const _adapters: {
 	_date: DateAdapter;

--- a/types/adapters.d.ts
+++ b/types/adapters.d.ts
@@ -58,6 +58,11 @@ export interface DateAdapter {
 	endOf(timestamp: number, unit: TimeUnit | 'isoWeek'): number;
 }
 
+declare const DateAdapter: {
+	prototype: DateAdapter;
+	new(options: any): DateAdapter;
+};
+
 export const _adapters: {
 	_date: DateAdapter;
 };

--- a/types/adapters.d.ts
+++ b/types/adapters.d.ts
@@ -56,12 +56,12 @@ export interface DateAdapterBase {
 
 export interface DateAdapter extends DateAdapterBase {
 	readonly options: any;
+	override(members: Partial<DateAdapter>): void;
 }
 
 export const DateAdapter: {
 	prototype: DateAdapter;
 	new(options: any): DateAdapter;
-	override(members: Partial<DateAdapter>): void;
 };
 
 export const _adapters: {

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -24,7 +24,7 @@ import {
 	ScriptableAndArrayOptions
 } from './scriptable';
 
-export { DateAdapterBase, DateAdapter, TimeUnit, _adapters } from './adapters';
+export { DateAdapter, TimeUnit, _adapters } from './adapters';
 export { Animation, Animations, Animator, AnimationEvent } from './animation';
 export { Color } from './color';
 export { Element } from './element';


### PR DESCRIPTION
Not totally sure this is right , but since in core.adapters.js override is part of the dateadapter it seems logical it should be there.