### PR TITLE
Prevent 2nd parse call with zero count

### DIFF
--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -975,7 +975,10 @@ export default class DatasetController {
 			me._removeElements(numData, numMeta - numData);
 		}
 		// Re-parse the old elements (new elements are parsed in _insertElements)
-		me.parse(0, Math.min(numData, numMeta));
+		const count = Math.min(numData, numMeta);
+		if (count) {
+			me.parse(0, count);
+		}
 	}
 
 	/**


### PR DESCRIPTION
This caused `chartjs-chart-sankey` to fail, because it did not check the start/count parameters properly.

