### PR TITLE
Update anchorlinks and offscreen canvas compatibility

### DIFF
--- a/docs/docs/axes/_common.md
+++ b/docs/docs/axes/_common.md
@@ -1,4 +1,4 @@
-### Common to all axes
+### Common options to all axes
 
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------

--- a/docs/docs/axes/_common_ticks.md
+++ b/docs/docs/axes/_common_ticks.md
@@ -1,4 +1,4 @@
-### Common to all axes
+### Common tick options to all axes
 
 | Name | Type | Scriptable | Default | Description
 | ---- | ---- | :-------------------------------: | ------- | -----------

--- a/docs/docs/axes/cartesian/_common_ticks.md
+++ b/docs/docs/axes/cartesian/_common_ticks.md
@@ -1,4 +1,4 @@
-### Common options to all cartesian axes
+### Common tick options to all cartesian axes
 
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------

--- a/docs/docs/general/performance.md
+++ b/docs/docs/general/performance.md
@@ -74,15 +74,15 @@ new Chart(ctx, {
 });
 ```
 
-## Parallel rendering with web workers (Chrome only)
+## Parallel rendering with web workers (Chromium only)
 
-Chrome (in version 69) added the ability to [transfer rendering control of a canvas](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/transferControlToOffscreen) to a web worker. Web workers can use the [OffscreenCanvas API](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas) to render from a web worker onto canvases in the DOM. Chart.js is a canvas-based library and supports rendering in a web worker - just pass an OffscreenCanvas into the Chart constructor instead of a Canvas element. Note that as of today, this API is only supported in Chrome.
+Chromium (Chrome: version 69, Edge: 79, Opera: 56) added the ability to [transfer rendering control of a canvas](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/transferControlToOffscreen) to a web worker. Web workers can use the [OffscreenCanvas API](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas) to render from a web worker onto canvases in the DOM. Chart.js is a canvas-based library and supports rendering in a web worker - just pass an OffscreenCanvas into the Chart constructor instead of a Canvas element. Note that as of today, this API is only supported in Chromium based browsers.
 
 By moving all Chart.js calculations onto a separate thread, the main thread can be freed up for other uses. Some tips and tricks when using Chart.js in a web worker:
 * Transferring data between threads can be expensive, so ensure that your config and data objects are as small as possible. Try generating them on the worker side if you can (workers can make HTTP requests!) or passing them to your worker as ArrayBuffers, which can be transferred quickly from one thread to another.
 * You can't transfer functions between threads, so if your config object includes functions you'll have to strip them out before transferring and then add them back later.
 * You can't access the DOM from worker threads, so Chart.js plugins that use the DOM (including any mouse interactions) will likely not work.
-* Ensure that you have a fallback if you support browsers other than the most modern Chrome browser.
+* Ensure that you have a fallback if you support browsers other than the most modern Chromium browsers.
 * Resizing the chart must be done manually. See an example in the worker code below.
 
 Example main thread code:


### PR DESCRIPTION
Whenn trying to get an anchor link to Common options to all cartesian axes underneath: https://www.chartjs.org/docs/master/axes/cartesian/index#tick-configuration. It would link to the top so added what it was about in the anchor tag so it shouldnt happen anymore.

After looking at availebility for offscreencanvas I saw that all the chromium browsers support it now so adjusted that. (https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas)