### PR TITLE
add `borderRadiusPercentage` for bar

### DIFF
--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -516,6 +516,7 @@ BarController.defaults = {
 		'borderSkipped',
 		'borderWidth',
 		'borderRadius',
+		'borderRadiusPercentage',
 		'barPercentage',
 		'barThickness',
 		'base',

--- a/src/elements/element.bar.js
+++ b/src/elements/element.bar.js
@@ -1,5 +1,5 @@
 import Element from '../core/core.element';
-import {toTRBL, toTRBLCorners} from '../helpers/helpers.options';
+import {percentageToPx, toTRBL, toTRBLCorners} from '../helpers/helpers.options';
 import {PI, HALF_PI} from '../helpers/helpers.math';
 
 /**
@@ -84,8 +84,15 @@ function parseBorderWidth(bar, maxW, maxH) {
 
 function parseBorderRadius(bar, maxW, maxH) {
 	const value = bar.options.borderRadius;
-	const o = toTRBLCorners(value);
-	const maxR = Math.min(maxW, maxH);
+	const percentage = bar.options.borderRadiusPercentage;
+  const maxR = Math.min(maxW, maxH);
+  let o;
+  // if set the `borderRadiusPercentage`, ignore borderRadius
+  if(percentage){
+    o = percentageToPx(percentage, maxR)
+  }else{
+    o = toTRBLCorners(value);
+  }
 	const skip = parseBorderSkipped(bar);
 
 	return {
@@ -256,7 +263,8 @@ BarElement.id = 'bar';
 BarElement.defaults = {
 	borderSkipped: 'start',
 	borderWidth: 0,
-	borderRadius: 0
+	borderRadius: 0,
+  borderRadiusPercentage: 0,
 };
 
 /**

--- a/src/helpers/helpers.options.js
+++ b/src/helpers/helpers.options.js
@@ -93,6 +93,26 @@ export function toTRBLCorners(value) {
 	};
 }
 
+export function percentageToPx(value, basePx){
+  let tl, tr, bl, br;
+
+	if (isObject(value)) {
+		tl = basePx * value.topLeft;
+		tr = basePx * value.topRight;
+		bl = basePx * value.bottomLeft;
+		br = basePx * value.bottomRight;
+	} else {
+		tl = tr = bl = br = basePx * value;
+	}
+
+	return {
+		topLeft: tl,
+		topRight: tr,
+		bottomLeft: bl,
+		bottomRight: br
+	};
+}
+
 /**
  * Converts the given value into a padding object with pre-computed width/height.
  * @param {number|object} value - If a number, set the value to all TRBL component,

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -1807,10 +1807,16 @@ export interface BarOptions extends CommonOptions {
 	borderSkipped: 'start' | 'end' | 'left' | 'right' | 'bottom' | 'top';
 
 	/**
-	 * Border radius
+	 * Border radius. May be affected by `borderRadiusPercentage`
 	 * @default 0
 	 */
 	borderRadius: number | BorderRadius;
+
+	/**
+	 * Border radius percentage. if Not equal to the default value, More important than `borderRadius`
+	 * @default 0
+	 */
+	borderRadiusPercentage: number | BorderRadius;
 }
 
 export interface BorderRadius {


### PR DESCRIPTION
I want to set `borderRadius` use percentage in `bar` chart like `css`:
```css
border-radius: 50%;
```
The maximum is half of the smallest edge, So I set `borderRadiusPercentage` `0~1` for `css` `0%~50%`.
I think `borderRadiusPercentage` is of great use when I resize chart.
I just set `borderRadiusPercentage: 1` to keep a clircle border radius when I resize chart.
`borderRadius` is not affected by `borderRadiusPercentage` when not set.
> I really hope you will adopt my commit! Thanks!
>You can inform me to correct if there is a mistake.