### PR TITLE
Fixes wrong and missing options to bar element and dataset documentation

### DIFF
--- a/docs/docs/charts/bar.mdx
+++ b/docs/docs/charts/bar.mdx
@@ -93,7 +93,7 @@ the color of the bars is generally set this way.
 | [`indexAxis`](#general) | `string` | - | - | `'x'`
 | [`label`](#general) | `string` | - | - | `''`
 | [`order`](#general) | `number` | - | - | `0`
-| [`pointStyle`](../configuration/elements.md#point-styles) | `string`\|`Image` | Yes | False | `'circle'`
+| [`pointStyle`](../configuration/elements.md#point-styles) | `string`\|`Image` | Yes | - | `'circle'`
 | [`xAxisID`](#general) | `string` | - | - | first x axis
 | [`yAxisID`](#general) | `string` | - | - | first y axis
 
@@ -120,7 +120,7 @@ The style of each bar can be controlled with the following properties:
 | [`borderSkipped`](#borderskipped) | The edge to skip when drawing bar.
 | [`borderWidth`](#borderwidth) | The bar border width (in pixels).
 | [`borderRadius`](#borderradius) | The bar border radius (in pixels).
-| `clip` | How to clip relative to chartArea. Positive value allows overflow, negative value clips that many pixels inside chartArea. `0` = clip at chartArea. Clipping can also be configured per side: `clip: {left: 5, top: false, right: -2, bottom: 0}`
+| `pointStyle` | Style of the point for legend. [more...](../configuration/elements.md#point-styles)
 
 All these values, if `undefined`, fallback to the associated [`elements.bar.*`](../configuration/elements.md#bar-configuration) options.
 

--- a/docs/docs/configuration/elements.md
+++ b/docs/docs/configuration/elements.md
@@ -80,6 +80,8 @@ Global bar options: `Chart.defaults.elements.bar`.
 | `borderWidth` | `number` | `0` | Bar stroke width.
 | `borderColor` | [`Color`](../general/colors.md) | `Chart.defaults.borderColor` | Bar stroke color.
 | `borderSkipped` | `string` | `'start'` | Skipped (excluded) border: `'start'`, `'end'`, `'bottom'`, `'left'`, `'top'` or `'right'`.
+| `borderRadius` | `number`\|`object` | `0` | The bar border radius (in pixels).
+| [`pointStyle`](#point-styles) | `string`\|`Image` | `'circle'` | Style of the point for legend.
 
 ## Arc Configuration
 


### PR DESCRIPTION
- removes `clip` options from "Styling" section because already defined in "General" one
- adds `pointStyle` option to "Styling" section
- adds `borderRadius` and `pointStyle` options to bar element 