### PR TITLE
Optimize context object construction

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -737,14 +737,7 @@ class Chart {
   }
 
   getContext() {
-    return this.$context || (this.$context = Object.create(null, {
-      chart: {
-        value: this
-      },
-      type: {
-        value: 'chart'
-      }
-    }));
+    return this.$context || (this.$context = {chart: this, type: 'chart'});
   }
 
   getVisibleDatasetCount() {

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -149,55 +149,31 @@ function getFirstScaleId(chart, axis) {
 }
 
 function createDatasetContext(parent, index, dataset) {
-  return Object.create(parent, {
-    active: {
-      writable: true,
-      value: false
+  return Object.setPrototypeOf(
+    {
+      active: false,
+      dataset,
+      datasetIndex: index,
+      index,
+      type: 'dataset'
     },
-    dataset: {
-      value: dataset
-    },
-    datasetIndex: {
-      value: index
-    },
-    index: {
-      get() {
-        return this.datasetIndex;
-      }
-    },
-    type: {
-      value: 'dataset'
-    }
-  });
+    parent
+  );
 }
 
 function createDataContext(parent, index, point, raw, element) {
-  return Object.create(parent, {
-    active: {
-      writable: true,
-      value: false
-    },
-    dataIndex: {
-      value: index
-    },
-    parsed: {
-      value: point
-    },
-    raw: {
-      value: raw
-    },
-    element: {
-      value: element
-    },
-    index: {
-      get() {
-        return this.dataIndex;
-      }
-    },
-    type: {
-      value: 'data',
-    }
-  });
+  const context = {
+    active: false,
+    dataIndex: index,
+    parsed: point,
+    raw,
+    element,
+    index,
+    mode: 'default',
+    type: 'data'
+  };
+  Object.setPrototypeOf(context, parent);
+  return context;
 }
 
 function clearStacks(meta, items) {

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -149,20 +149,19 @@ function getFirstScaleId(chart, axis) {
 }
 
 function createDatasetContext(parent, index, dataset) {
-  return Object.setPrototypeOf(
+  return Object.assign(Object.create(parent),
     {
       active: false,
       dataset,
       datasetIndex: index,
       index,
       type: 'dataset'
-    },
-    parent
+    }
   );
 }
 
 function createDataContext(parent, index, point, raw, element) {
-  const context = {
+  return Object.assign(Object.create(parent), {
     active: false,
     dataIndex: index,
     parsed: point,
@@ -171,9 +170,7 @@ function createDataContext(parent, index, point, raw, element) {
     index,
     mode: 'default',
     type: 'data'
-  };
-  Object.setPrototypeOf(context, parent);
-  return context;
+  });
 }
 
 function clearStacks(meta, items) {

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -282,27 +282,17 @@ function skip(ticks, newTicks, spacing, majorStart, majorEnd) {
 }
 
 function createScaleContext(parent, scale) {
-  return Object.create(parent, {
-    scale: {
-      value: scale
-    },
-    type: {
-      value: 'scale'
-    }
+  return Object.assign(Object.create(parent), {
+    scale,
+    type: 'scale'
   });
 }
 
 function createTickContext(parent, index, tick) {
-  return Object.create(parent, {
-    tick: {
-      value: tick
-    },
-    index: {
-      value: index
-    },
-    type: {
-      value: 'tick'
-    }
+  return Object.assign(Object.create(parent), {
+    tick,
+    index,
+    type: 'tick'
   });
 }
 


### PR DESCRIPTION
Optimize context object construction.

In a 25k point line chart, with scriptable options:

PR:
![image](https://user-images.githubusercontent.com/27971921/107766366-06886700-6d3c-11eb-9618-e919a3698a44.png)
![image](https://user-images.githubusercontent.com/27971921/107766604-5c5d0f00-6d3c-11eb-8e4b-d3cc8a1391fe.png)


master:
![image](https://user-images.githubusercontent.com/27971921/107766419-1bfd9100-6d3c-11eb-99eb-ae1a6e03dd14.png)
![image](https://user-images.githubusercontent.com/27971921/107766623-67b03a80-6d3c-11eb-8969-44db89f53e55.png)

