### PR TITLE
Provide a method to quickly register all imports in ESM builds

### DIFF
--- a/docs/docs/getting-started/integration.md
+++ b/docs/docs/getting-started/integration.md
@@ -80,6 +80,13 @@ Chart.register(
 var myChart = new Chart(ctx, {...});
 ```
 
+A short registration format is also available to quickly register everything.
+
+```javascript
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+```
+
 ## Require JS
 
 **Important:** RequireJS [can **not** load CommonJS module as is](https://requirejs.org/docs/commonjs.html#intro), so be sure to require one of the UMD builds instead (i.e. `dist/chart.js`, `dist/chart.min.js`, etc.).

--- a/src/index.esm.js
+++ b/src/index.esm.js
@@ -4,3 +4,22 @@ export * from './elements';
 export * from './platform';
 export * from './plugins';
 export * from './scales';
+
+import * as controllers from './controllers';
+import * as elements from './elements';
+import * as plugins from './plugins';
+import * as scales from './scales';
+
+export {
+  controllers,
+  elements,
+  plugins,
+  scales,
+};
+
+export const registerables = [
+  controllers,
+  elements,
+  plugins,
+  scales,
+];

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -497,6 +497,8 @@ export declare class Chart<
 	static unregister(...items: ChartComponentLike[]): void;
 }
 
+export const registerables: readonly ChartComponentLike[];
+
 export declare type ChartItem =
 	| string
 	| CanvasRenderingContext2D


### PR DESCRIPTION
I tested this with https://github.com/etimberg/chartjs-tree-shaking-test and confirmed that it works.

This is an alternative to #8419