### PR TITLE
perf: resolveObjectKey

### DIFF
--- a/src/helpers/helpers.core.js
+++ b/src/helpers/helpers.core.js
@@ -283,13 +283,15 @@ export function _deprecated(scope, value, previous, current) {
   }
 }
 
+const emptyString = '';
+const dot = '.';
 function indexOfDotOrLength(key, start) {
-  const idx = key.indexOf('.', start);
+  const idx = key.indexOf(dot, start);
   return idx === -1 ? key.length : idx;
 }
 
 export function resolveObjectKey(obj, key) {
-  if (key === '') {
+  if (key === emptyString) {
     return obj;
   }
   let pos = 0;

--- a/src/helpers/helpers.core.js
+++ b/src/helpers/helpers.core.js
@@ -283,22 +283,24 @@ export function _deprecated(scope, value, previous, current) {
   }
 }
 
+function indexOfDotOrLength(key, start) {
+  const idx = key.indexOf('.', start);
+  return idx === -1 ? key.length : idx;
+}
+
 export function resolveObjectKey(obj, key) {
-  // Special cases for `x` and `y` keys. It's quite a lot faster to aceess this way.
-  // Those are the default keys Chart.js is resolving, so it makes sense to be fast.
-  if (key === 'x') {
-    return obj.x;
+  if (!key) {
+    return obj;
   }
-  if (key === 'y') {
-    return obj.y;
-  }
-  const keys = key.split('.');
-  for (let i = 0, n = keys.length; i < n && obj; ++i) {
-    const k = keys[i];
-    if (!k) {
+  let pos = 0;
+  let idx = indexOfDotOrLength(key, pos);
+  while (idx > pos) {
+    obj = obj[key.substr(pos, idx - pos)];
+    if (!obj) {
       break;
     }
-    obj = obj[k];
+    pos = idx + 1;
+    idx = indexOfDotOrLength(key, pos);
   }
   return obj;
 }

--- a/src/helpers/helpers.core.js
+++ b/src/helpers/helpers.core.js
@@ -289,7 +289,7 @@ function indexOfDotOrLength(key, start) {
 }
 
 export function resolveObjectKey(obj, key) {
-  if (!key) {
+  if (key === '') {
     return obj;
   }
   let pos = 0;


### PR DESCRIPTION
After #8374 the resolveObjectKey is used extensively.

This optimizes it as far as I could get it (a 25k point line chart with couple of per point scriptable options):

![image](https://user-images.githubusercontent.com/27971921/107989995-1faf4300-6fdc-11eb-93e9-24dc5f8bc4ac.png)

vs master:

![image](https://user-images.githubusercontent.com/27971921/107990058-3fdf0200-6fdc-11eb-8c8f-edf7c007bb7c.png)
