### PR TITLE
perf: resolver caching

### DIFF
--- a/src/core/core.config.js
+++ b/src/core/core.config.js
@@ -260,19 +260,14 @@ export default class Config {
 	 * Returns the option scopes for resolving chart options
 	 * @return {object[]}
 	 */
-  chartOptionsScopes() {
-    const me = this;
-    let scopes = me._scopeCache.get(0);
-    if (!scopes) {
-      scopes = [
-        me.options,
-        defaults.controllers[me.type] || {},
-        {type: me.type},
-        defaults,
-        defaults.descriptors];
-      me._scopeCache.set(0, scopes);
-    }
-    return scopes;
+  chartOptionScopes() {
+    return [
+      this.options,
+      defaults.controllers[this.type] || {},
+      {type: this.type},
+      defaults,
+      defaults.descriptors
+    ];
   }
 
   /**

--- a/src/core/core.config.js
+++ b/src/core/core.config.js
@@ -137,10 +137,8 @@ export default class Config {
 
   update(options) {
     const config = this._config;
-    if (config.options !== options) {
-      this._scopeCache.clear();
-      this._resolverCache.clear();
-    }
+    this._scopeCache.clear();
+    this._resolverCache.clear();
     config.options = initOptions(config, options);
   }
 
@@ -224,10 +222,11 @@ export default class Config {
 	 * Resolves the objects from options and defaults for option value resolution.
 	 * @param {object} mainScope - The main scope object for options
 	 * @param {string[]} scopeKeys - The keys in resolution order
+   * @param {boolean} [resetCache] - reset the cache for this mainScope
 	 */
-  getOptionScopes(mainScope, scopeKeys) {
+  getOptionScopes(mainScope, scopeKeys, resetCache) {
     let cache = this._scopeCache.get(mainScope);
-    if (!cache) {
+    if (!cache || resetCache) {
       cache = new Map();
       this._scopeCache.set(mainScope, cache);
     }

--- a/src/core/core.config.js
+++ b/src/core/core.config.js
@@ -116,6 +116,13 @@ function cachedKeys(cacheKey, generate) {
   return keys;
 }
 
+const addIfFound = (set, obj, key) => {
+  const opts = resolveObjectKey(obj, key);
+  if (opts !== undefined) {
+    set.add(opts);
+  }
+};
+
 export default class Config {
   constructor(config) {
     this._config = initConfig(config);
@@ -234,20 +241,13 @@ export default class Config {
 
     const scopes = new Set();
 
-    const addIfFound = (obj, key) => {
-      const opts = resolveObjectKey(obj, key);
-      if (opts !== undefined) {
-        scopes.add(opts);
-      }
-    };
-
     if (mainScope) {
       scopes.add(mainScope);
-      scopeKeys.forEach(key => addIfFound(mainScope, key));
+      scopeKeys.forEach(key => addIfFound(scopes, mainScope, key));
     }
-    scopeKeys.forEach(key => addIfFound(this.options, key));
-    scopeKeys.forEach(key => addIfFound(defaults, key));
-    scopeKeys.forEach(key => addIfFound(defaults.descriptors, key));
+    scopeKeys.forEach(key => addIfFound(scopes, this.options, key));
+    scopeKeys.forEach(key => addIfFound(scopes, defaults, key));
+    scopeKeys.forEach(key => addIfFound(scopes, defaults.descriptors, key));
 
     const array = [...scopes];
     if (keysCached.has(scopeKeys)) {

--- a/src/core/core.config.js
+++ b/src/core/core.config.js
@@ -206,14 +206,14 @@ export default class Config {
    */
   pluginScopeKeys(plugin) {
     const id = plugin.id;
-    const cacheKey = `plugin-${id}`;
+    const type = this.type;
+    const cacheKey = `${type}-plugin-${id}`;
     let keys = keyCache.get(cacheKey);
     if (!keys) {
       keys = [
-        `controllers.${this.type}.plugins.${id}`,
+        `controllers.${type}.plugins.${id}`,
         `plugins.${id}`,
         ...plugin.additionalOptionScopes || [],
-        ''
       ];
       keyCache.set(cacheKey, keys);
     }

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -88,7 +88,7 @@ class Chart {
       );
     }
 
-    const options = config.createResolver(config.chartOptionsScopes(), me.getContext());
+    const options = config.createResolver(config.chartOptionScopes(), me.getContext());
 
     this.platform = me._initializePlatform(initialCanvas, config);
 
@@ -445,7 +445,7 @@ class Chart {
     const config = me.config;
 
     config.update(config.options);
-    me._options = config.createResolver(config.chartOptionsScopes(), me.getContext());
+    me._options = config.createResolver(config.chartOptionScopes(), me.getContext());
 
     each(me.scales, (scale) => {
       layouts.removeBox(me, scale);

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -362,7 +362,7 @@ export default class DatasetController {
     const me = this;
     const config = me.chart.config;
     const scopeKeys = config.datasetScopeKeys(me._type);
-    const scopes = config.getOptionScopes(me.getDataset(), scopeKeys);
+    const scopes = config.getOptionScopes(me.getDataset(), scopeKeys, true);
     me.options = config.createResolver(scopes, me.getContext());
     me._parsing = me.options.parsing;
   }

--- a/src/core/core.plugins.js
+++ b/src/core/core.plugins.js
@@ -164,12 +164,7 @@ function createDescriptors(chart, plugins, options, all) {
  * @param {*} context
  */
 function pluginOpts(config, plugin, opts, context) {
-  const id = plugin.id;
-  const keys = [
-    `controllers.${config.type}.plugins.${id}`,
-    `plugins.${id}`,
-    ...plugin.additionalOptionScopes || []
-  ];
-  const scopes = config.getOptionScopes(opts || {}, keys);
+  const keys = config.pluginScopeKeys(plugin);
+  const scopes = config.getOptionScopes(opts, keys);
   return config.createResolver(scopes, context);
 }


### PR DESCRIPTION
This improves the performance of scriptable caching with big datasets. Brings the total time of my 25k point scriptable line bench to ~370ms. Master is ~1100ms.

- scope keys are cached (globally, those strings don't change between charts)
- scopes are cached (per chart), by the cached key
- plugin keys are created and cached by Config
- resolver instances are cached

TODO:
- [x] remove some duplication
- [x] don't cache with non-cached keys (user provided)
- [x] fix tests