### PR TITLE
Fix memory leak on destroy

### DIFF
--- a/src/core/core.config.js
+++ b/src/core/core.config.js
@@ -156,9 +156,13 @@ export default class Config {
 
   update(options) {
     const config = this._config;
+    this.clearCache();
+    config.options = initOptions(config, options);
+  }
+
+  clearCache() {
     this._scopeCache.clear();
     this._resolverCache.clear();
-    config.options = initOptions(config, options);
   }
 
   /**

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -831,6 +831,8 @@ class Chart {
       me._destroyDatasetMeta(i);
     }
 
+    me.config.clearCache();
+
     if (canvas) {
       me.unbindEvents();
       clearCanvas(canvas, ctx);


### PR DESCRIPTION
Dataset reference was kept in config cache after destroy.