### PR TITLE
Fix couple of animation bugs

### DIFF
--- a/src/core/core.animations.js
+++ b/src/core/core.animations.js
@@ -5,7 +5,7 @@ import {isObject} from '../helpers/helpers.core';
 
 const numbers = ['x', 'y', 'borderWidth', 'radius', 'tension'];
 const colors = ['borderColor', 'backgroundColor'];
-const animationOptions = ['duration', 'easing', 'from', 'to', 'type', 'easing', 'loop', 'fn'];
+const animationOptions = ['delay', 'duration', 'easing', 'fn', 'from', 'loop', 'to', 'type'];
 
 defaults.set('animation', {
   // Plain properties can be overridden in each object

--- a/src/core/core.config.js
+++ b/src/core/core.config.js
@@ -1,5 +1,5 @@
 import defaults from './core.defaults';
-import {mergeIf, resolveObjectKey, isArray, isFunction, valueOrDefault} from '../helpers/helpers.core';
+import {mergeIf, resolveObjectKey, isArray, isFunction, valueOrDefault, isObject} from '../helpers/helpers.core';
 import {_attachContext, _createResolver, _descriptors} from '../helpers/helpers.config';
 
 export function getIndexAxis(type, options) {
@@ -301,13 +301,14 @@ export default class Config {
 
   /**
 	 * @param {object[]} scopes
-	 * @param {function|object} context
+	 * @param {object} [context]
+   * @param {string[]} [prefixes]
 	 */
   createResolver(scopes, context, prefixes = ['']) {
-    const cached = getResolver(this._resolverCache, scopes, prefixes);
-    return context && cached.needContext
-      ? _attachContext(cached.resolver, isFunction(context) ? context() : context)
-      : cached.resolver;
+    const {resolver} = getResolver(this._resolverCache, scopes, prefixes);
+    return isObject(context)
+      ? _attachContext(resolver, isFunction(context) ? context() : context)
+      : resolver;
   }
 }
 
@@ -323,8 +324,7 @@ function getResolver(resolverCache, scopes, prefixes) {
     const resolver = _createResolver(scopes, prefixes);
     cached = {
       resolver,
-      subPrefixes: prefixes.filter(p => !p.toLowerCase().includes('hover')),
-      needContext: needContext(resolver, Object.getOwnPropertyNames(resolver))
+      subPrefixes: prefixes.filter(p => !p.toLowerCase().includes('hover'))
     };
     cache.set(cacheKey, cached);
   }

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -777,8 +777,7 @@ export default class DatasetController {
       const config = me.chart.config;
       const scopeKeys = config.datasetAnimationScopeKeys(me._type);
       const scopes = config.getOptionScopes(me.getDataset().animation, scopeKeys);
-      const context = () => me.getContext(index, active, mode);
-      options = config.createResolver(scopes, context);
+      options = config.createResolver(scopes, me.getContext(index, active, mode));
     }
     const animations = new Animations(chart, options && options[mode] || options);
     if (options && options._cacheable) {


### PR DESCRIPTION
Noticed these while working with #8332 and figured they'd be good to get out of the way.

- `'delay'` was missing from `animationOptions`. And `'easing'` was there twice
- config.createResolver always attaches the context now. It did not find scriptable/indexable options from sub-objects when checking if the context is needed.