### PR TITLE
Fix controller specific animations

### DIFF
--- a/src/core/core.config.js
+++ b/src/core/core.config.js
@@ -173,7 +173,12 @@ export default class Config {
 	 */
   datasetScopeKeys(datasetType) {
     return cachedKeys(datasetType,
-      () => [`datasets.${datasetType}`, `controllers.${datasetType}.datasets`, '']);
+      () => [
+        `datasets.${datasetType}`,
+        `controllers.${datasetType}`,
+        `controllers.${datasetType}.datasets`,
+        ''
+      ]);
   }
 
   /**
@@ -186,6 +191,7 @@ export default class Config {
     return cachedKeys(`${datasetType}.animation`,
       () => [
         `datasets.${datasetType}.animation`,
+        `controllers.${datasetType}.animation`,
         `controllers.${datasetType}.datasets.animation`,
         'animation'
       ]);


### PR DESCRIPTION
Closes: #8443 

The controller animation options are not under `dataset`, so they were not read from defaults.