### PR TITLE
Fix/getRelativePosition NaN value with native event

### DIFF
--- a/src/helpers/helpers.dom.js
+++ b/src/helpers/helpers.dom.js
@@ -53,7 +53,7 @@ function getPositionedStyle(styles, style, suffix) {
 const useOffsetPos = (x, y, target) => (x > 0 || y > 0) && (!target || !target.shadowRoot);
 
 function getCanvasPosition(evt, canvas) {
-  const e = evt.originalEvent || evt;
+  const e = evt.native || evt;
   const touches = e.touches;
   const source = touches && touches.length ? touches[0] : e;
   const {offsetX, offsetY} = source;

--- a/test/specs/helpers.dom.tests.js
+++ b/test/specs/helpers.dom.tests.js
@@ -399,5 +399,39 @@ describe('DOM helpers tests', function() {
       expect(Math.abs(pos3.x - Math.round((event.clientX - rect3.x - 10) / 360 * 400))).toBeLessThanOrEqual(1);
       expect(Math.abs(pos3.y - Math.round((event.clientY - rect3.y - 10) / 360 * 400))).toBeLessThanOrEqual(1);
     });
+
+    it('Should not return NaN with a custom event', function(done) {
+      let dataX = null;
+      let dataY = null;
+      const chart = window.acquireChart(
+        {
+          type: 'bar',
+          data: {
+            datasets: [{
+              data: [{x: 'first', y: 10}, {x: 'second', y: 5}, {x: 'third', y: 15}]
+            }]
+          },
+          options: {
+            onHover: (e) => {
+              const canvasPosition = Chart.helpers.getRelativePosition(e, chart);
+
+              // Substitute the appropriate scale IDs
+              dataX = canvasPosition.x;
+              dataY = canvasPosition.y;
+            }
+          }
+        });
+
+      const point = chart.getDatasetMeta(0).data[1];
+
+      afterEvent(chart, 'mousemove', function() {
+        expect(dataX).not.toEqual(NaN);
+        expect(dataY).not.toEqual(NaN);
+
+        done();
+      });
+
+      jasmine.triggerMouseEvent(chart, 'mousemove', point);
+    });
   });
 });

--- a/test/specs/helpers.dom.tests.js
+++ b/test/specs/helpers.dom.tests.js
@@ -400,7 +400,7 @@ describe('DOM helpers tests', function() {
       expect(Math.abs(pos3.y - Math.round((event.clientY - rect3.y - 10) / 360 * 400))).toBeLessThanOrEqual(1);
     });
 
-    it('Should not return NaN with a custom event', function(done) {
+    it('Should not return NaN with a custom event', async function() {
       let dataX = null;
       let dataY = null;
       const chart = window.acquireChart(
@@ -415,7 +415,6 @@ describe('DOM helpers tests', function() {
             onHover: (e) => {
               const canvasPosition = Chart.helpers.getRelativePosition(e, chart);
 
-              // Substitute the appropriate scale IDs
               dataX = canvasPosition.x;
               dataY = canvasPosition.y;
             }
@@ -423,15 +422,10 @@ describe('DOM helpers tests', function() {
         });
 
       const point = chart.getDatasetMeta(0).data[1];
+      await jasmine.triggerMouseEvent(chart, 'mousemove', point);
 
-      afterEvent(chart, 'mousemove', function() {
-        expect(dataX).not.toEqual(NaN);
-        expect(dataY).not.toEqual(NaN);
-
-        done();
-      });
-
-      jasmine.triggerMouseEvent(chart, 'mousemove', point);
+      expect(dataX).not.toEqual(NaN);
+      expect(dataY).not.toEqual(NaN);
     });
   });
 });


### PR DESCRIPTION
Noticed that with the example for a custom onClick from the docs (https://www.chartjs.org/docs/master/general/interactions/events#converting-events-to-data-values) it wasnt working. This was because it tried to get the native event in the wrong way. 
<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
