### PR TITLE
Fix broken links in documentation

### DIFF
--- a/docs/docs/developers/plugins.md
+++ b/docs/docs/developers/plugins.md
@@ -118,4 +118,4 @@ var chart = new Chart(ctx, {
 
 ## Plugin Core API
 
-Read more about the [existing plugin extension hooks](../jsdoc/IPlugin.html).
+Read more about the [existing plugin extension hooks](https://github.com/chartjs/Chart.js/blob/master/types/index.esm.d.ts#L733).

--- a/docs/docs/developers/updates.md
+++ b/docs/docs/developers/updates.md
@@ -97,7 +97,7 @@ function updateScale(chart) {
 }
 ```
 
-Code sample for updating options can be found in [toggle-scale-type.html](./../../../samples/latest/scales/toggle-scale-type.html).
+Code sample for updating options can be found in [toggle-scale-type.html](https://www.chartjs.org/samples/latest/scales/toggle-scale-type.html).
 
 ## Preventing Animations
 

--- a/docs/docs/getting-started/index.mdx
+++ b/docs/docs/getting-started/index.mdx
@@ -4,7 +4,7 @@ title: Getting Started
 
 Let's get started using Chart.js!
 
-First, we need to have a canvas in our page. It's recommended to give the chart its own container for [responsiveness](../general/responsive.md).
+First, we need to have a canvas in our page. It's recommended to give the chart its own container for [responsiveness](../configuration/responsive.md).
 
 ```html
 <div>


### PR DESCRIPTION
Will temporarely fix #8229 until a better solution can be used with the TypeDoc.