### PR TITLE
Disable fastPathSegment when data is decimated

### DIFF
--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -12,7 +12,7 @@ export default class LineController extends DatasetController {
   update(mode) {
     const me = this;
     const meta = me._cachedMeta;
-    const {dataset: line, data: points = []} = meta;
+    const {dataset: line, data: points = [], _dataset} = meta;
     // @ts-ignore
     const animationsDisabled = me.chart._animationsDisabled;
     let {start, count} = getStartAndCountOfVisiblePoints(meta, points, animationsDisabled);
@@ -26,6 +26,7 @@ export default class LineController extends DatasetController {
     }
 
     // Update Line
+    line._decimated = !!_dataset._decimated;
     line.points = points;
 
     // In resize mode only point locations change, so no need to set the options.

--- a/src/elements/element.line.js
+++ b/src/elements/element.line.js
@@ -179,7 +179,7 @@ function fastPathSegment(ctx, line, segment, params) {
 function _getSegmentMethod(line) {
   const opts = line.options;
   const borderDash = opts.borderDash && opts.borderDash.length;
-  const useFastPath = !line._loop && !opts.tension && !opts.stepped && !borderDash;
+  const useFastPath = !line._decimated && !line._loop && !opts.tension && !opts.stepped && !borderDash;
   return useFastPath ? fastPathSegment : pathSegment;
 }
 
@@ -210,6 +210,7 @@ export default class LineElement extends Element {
     this._path = undefined;
     this._points = undefined;
     this._segments = undefined;
+    this._decimated = false;
     this._pointsUpdated = false;
 
     if (cfg) {


### PR DESCRIPTION
Decimating the data twice degrades the quality. No noticeable performance difference in uPlot bench.

![decimation](https://user-images.githubusercontent.com/27971921/108604196-0f6cde80-73b5-11eb-95bf-87cc4f40c4e4.gif)
