### PR TITLE
Stop reading fixedStepSize from tick options

### DIFF
--- a/docs/docs/getting-started/v3-migration.md
+++ b/docs/docs/getting-started/v3-migration.md
@@ -225,6 +225,7 @@ Animation system was completely rewritten in Chart.js v3. Each property can now 
 #### Ticks
 
 * `options.gridLines.tickMarkLength` was renamed to `options.gridLines.tickLength`.
+* `options.ticks.fixedStepSize` is no longer used. Use `options.ticks.stepSize`.
 * `options.ticks.major` and `options.ticks.minor` were replaced with scriptable options for tick fonts.
 * `Chart.Ticks.formatters.linear` was renamed to `Chart.Ticks.formatters.numeric`.
 

--- a/src/scales/scale.linearbase.js
+++ b/src/scales/scale.linearbase.js
@@ -1,4 +1,4 @@
-import {isNullOrUndef, valueOrDefault} from '../helpers/helpers.core';
+import {isNullOrUndef} from '../helpers/helpers.core';
 import {almostEquals, almostWhole, log10, _decimalPlaces, _setMinAndMaxByKey, sign} from '../helpers/helpers.math';
 import Scale from '../core/core.scale';
 import {formatNumber} from '../core/core.intl';
@@ -200,7 +200,7 @@ export default class LinearScaleBase extends Scale {
       min: opts.min,
       max: opts.max,
       precision: tickOpts.precision,
-      stepSize: valueOrDefault(tickOpts.fixedStepSize, tickOpts.stepSize)
+      stepSize: tickOpts.stepSize
     };
     const ticks = generateTicks(numericGeneratorOptions, me);
 


### PR DESCRIPTION
As its not documented, it should not be used. It was renamed to `stepSize` somewhere along the way, so now is good time to remove the fallback.