### PR TITLE
Update index.esm.d.ts

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -8,7 +8,7 @@ import Ticks from './core.ticks';
 
 /**
  * @typedef { import("./core.controller").default } Chart
- * @typedef {{value:any, label?:string, major?:boolean, $context?:any}} Tick
+ * @typedef {{value:number | string, label?:string, major?:boolean, $context?:any}} Tick
  */
 
 defaults.set('scale', {

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -2589,7 +2589,7 @@ export interface TickOptions {
 	/**
 	 * Returns the string representation of the tick value as it should be displayed on the chart. See callback.
 	 */
-	callback: (tickValue: unknown, index: number, ticks: Tick[]) => string;
+	callback: (tickValue: number | string, index: number, ticks: Tick[]) => string;
 	/**
 	 * If true, show tick labels.
 	 * @default true


### PR DESCRIPTION
tickValue is to my knowledge always a number or a string so this will make it so people wont have to parse it themselfs. Issue raised in #8470

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
