### PR TITLE
Stop defaulting to `r` axis for Scale with id `r`

### DIFF
--- a/src/core/core.config.js
+++ b/src/core/core.config.js
@@ -34,7 +34,7 @@ function axisFromPosition(position) {
 }
 
 export function determineAxis(id, scaleOptions) {
-  if (id === 'x' || id === 'y' || id === 'r') {
+  if (id === 'x' || id === 'y') {
     return id;
   }
   return scaleOptions.axis || axisFromPosition(scaleOptions.position) || id.charAt(0).toLowerCase();


### PR DESCRIPTION
```js
scales: {
  r: {
    axis: 'y'
  }
}
```
ended up with `position: 'chartArea'`, which is not expected

https://jsfiddle.net/e7qf51cv/ (the labels for r-scale are at upper left corner)