### PR TITLE
Document the `fullSize` property of the title plugin

### DIFF
--- a/docs/docs/configuration/title.md
+++ b/docs/docs/configuration/title.md
@@ -13,6 +13,7 @@ Namespace: `options.plugins.title`, the global options for the chart title is de
 | `align` | `string` | `'center'` | Alignment of the title. [more...](#align)
 | `color` | [`Color`](../general/colors.md) | `Chart.defaults.color` | Color of text.
 | `display` | `boolean` | `false` | Is the title shown?
+| `fullSize` | `boolean` | `true` | Marks that this box should take the full width/height of the canvas. If `false`, the box is sized and placed above/beside the chart area.
 | `position` | `string` | `'top'` | Position of title. [more...](#position)
 | `font` | `Font` | `{style: 'bold'}` | See [Fonts](../general/fonts.md)
 | `padding` | `number`\|`{top: number, bottom: number}` | `10` | Adds padding above and below the title text if a single number is specified. It is also possible to change top and bottom padding separately.

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -2189,7 +2189,13 @@ export interface TitleOptions {
 	 */
 	color: Color;
 	font: FontSpec;
-	// fullSize: boolean;
+
+	/**
+	 * Marks that this box should take the full width/height of the canvas (moving other boxes). If set to `false`, places the box above/beside the
+	 * chart area
+	 * @default true
+	 */
+	fullSize: boolean;
 	/**
 	 * 	Adds padding above and below the title text if a single number is specified. It is also possible to change top and bottom padding separately.
 	 */


### PR DESCRIPTION
Noticed that this was not documented when closing out #4657 
