### PR TITLE
Remove unreachable code paths from plugins

### DIFF
--- a/src/plugins/plugin.filler.js
+++ b/src/plugins/plugin.filler.js
@@ -114,24 +114,18 @@ class simpleArc {
   pathSegment(ctx, bounds, opts) {
     const {x, y, radius} = this;
     bounds = bounds || {start: 0, end: TAU};
-    if (opts.reverse) {
-      ctx.arc(x, y, radius, bounds.end, bounds.start, true);
-    } else {
-      ctx.arc(x, y, radius, bounds.start, bounds.end);
-    }
+    ctx.arc(x, y, radius, bounds.end, bounds.start, true);
     return !opts.bounds;
   }
 
-  interpolate(point, property) {
+  interpolate(point) {
     const {x, y, radius} = this;
     const angle = point.angle;
-    if (property === 'angle') {
-      return {
-        x: x + Math.cos(angle) * radius,
-        y: y + Math.sin(angle) * radius,
-        angle
-      };
-    }
+    return {
+      x: x + Math.cos(angle) * radius,
+      y: y + Math.sin(angle) * radius,
+      angle
+    };
   }
 }
 

--- a/src/plugins/plugin.title.js
+++ b/src/plugins/plugin.title.js
@@ -119,24 +119,6 @@ function createTitle(chart, titleOpts) {
   chart.titleBlock = title;
 }
 
-function removeTitle(chart) {
-  const title = chart.titleBlock;
-  if (title) {
-    layouts.removeBox(chart, title);
-    delete chart.titleBlock;
-  }
-}
-
-function createOrUpdateTitle(chart, options) {
-  const title = chart.titleBlock;
-  if (title) {
-    layouts.configure(chart, title, options);
-    title.options = options;
-  } else {
-    createTitle(chart, options);
-  }
-}
-
 export default {
   id: 'title',
 
@@ -157,11 +139,9 @@ export default {
   },
 
   beforeUpdate(chart, _args, options) {
-    if (options === false) {
-      removeTitle(chart);
-    } else {
-      createOrUpdateTitle(chart, options);
-    }
+    const title = chart.titleBlock;
+    layouts.configure(chart, title, options);
+    title.options = options;
   },
 
   defaults: {


### PR DESCRIPTION
* Filler: Simple arc is always called with `reverse=true` and interpolate is always done for `angle`
* Title: `start` and `stop` hooks removed the need for create/remove in `beforeUpdate`