### PR TITLE
Use one location for dataset type options/defaults

### DIFF
--- a/docs/docs/configuration/animations.mdx
+++ b/docs/docs/configuration/animations.mdx
@@ -125,7 +125,6 @@ These keys can be configured in following paths:
 
 * `` - chart options
 * `controllers[type]` - controller type options
-* `controllers[type].datasets` - dataset type options
 * `datasets[type]` - dataset type options
 
 These paths are valid under `defaults` for global confuguration and `options` for instance configuration.

--- a/docs/docs/general/options.md
+++ b/docs/docs/general/options.md
@@ -10,6 +10,7 @@ Options are resolved from top to bottom, using a context dependent route.
 
 * options
 * defaults.controllers[`config.type`]
+* defaults.datasets[`config.type`]
 * defaults
 
 ### Dataset level options

--- a/docs/docs/general/options.md
+++ b/docs/docs/general/options.md
@@ -18,18 +18,16 @@ Options are resolved from top to bottom, using a context dependent route.
 
 * dataset
 * options.datasets[`dataset.type`]
-* options.controllers[`dataset.type`].datasets
 * options
 * defaults.datasets[`dataset.type`]
-* defaults.controllers[`dataset.type`].datasets
 * defaults
 
 ### Dataset animation options
 
 * dataset.animation
-* options.controllers[`dataset.type`].datasets.animation
+* options.datasets[`dataset.type`].animation
 * options.animation
-* defaults.controllers[`dataset.type`].datasets.animation
+* defaults.datasets[`dataset.type`].animation
 * defaults.animation
 
 ### Dataset element level options
@@ -38,12 +36,10 @@ Each scope is looked up with `elementType` prefix in the option name first, then
 
 * dataset
 * options.datasets[`dataset.type`]
-* options.controllers[`dataset.type`].datasets
 * options.controllers[`dataset.type`].elements[`elementType`]
 * options.elements[`elementType`]
 * options
 * defaults.datasets[`dataset.type`]
-* defaults.controllers[`dataset.type`].datasets
 * defaults.controllers[`dataset.type`].elements[`elementType`]
 * defaults.elements[`elementType`]
 * defaults

--- a/src/core/core.config.js
+++ b/src/core/core.config.js
@@ -176,7 +176,7 @@ export default class Config {
       () => [
         `datasets.${datasetType}`,
         `controllers.${datasetType}`,
-        `controllers.${datasetType}.datasets`,
+        `datasets.${datasetType}`,
         ''
       ]);
   }
@@ -193,11 +193,9 @@ export default class Config {
       () => [
         `datasets.${datasetType}.transitions.${transition}`,
         `controllers.${datasetType}.transitions.${transition}`,
-        `controllers.${datasetType}.datasets.transitions.${transition}`,
         `transitions.${transition}`,
         `datasets.${datasetType}`,
         `controllers.${datasetType}`,
-        `controllers.${datasetType}.datasets`,
         ''
       ]);
   }
@@ -214,7 +212,6 @@ export default class Config {
     return cachedKeys(`${datasetType}-${elementType}`,
       () => [
         `datasets.${datasetType}`,
-        `controllers.${datasetType}.datasets`,
         `controllers.${datasetType}.elements.${elementType}`,
         `elements.${elementType}`,
         ''

--- a/src/core/core.config.js
+++ b/src/core/core.config.js
@@ -176,7 +176,6 @@ export default class Config {
       () => [
         `datasets.${datasetType}`,
         `controllers.${datasetType}`,
-        `datasets.${datasetType}`,
         ''
       ]);
   }

--- a/src/core/core.config.js
+++ b/src/core/core.config.js
@@ -272,12 +272,12 @@ export default class Config {
    * @return {object[]}
    */
   chartOptionScopes() {
-    const controllerDefaults = defaults.controllers[this.type] || {};
+    const type = this.type;
     return [
       this.options,
-      controllerDefaults,
-      controllerDefaults.datasets || {},
-      {type: this.type},
+      defaults.controllers[type] || {},
+      defaults.datasets[type] || {},
+      {type},
       defaults,
       defaults.descriptors
     ];

--- a/src/core/core.defaults.js
+++ b/src/core/core.defaults.js
@@ -31,6 +31,7 @@ export class Defaults {
     this.borderColor = 'rgba(0,0,0,0.1)';
     this.color = '#666';
     this.controllers = {};
+    this.datasets = {};
     this.devicePixelRatio = (context) => context.chart.platform.getDevicePixelRatio();
     this.elements = {};
     this.events = [

--- a/src/core/core.registry.js
+++ b/src/core/core.registry.js
@@ -10,7 +10,7 @@ import {each, callback as call, _capitalize} from '../helpers/helpers.core';
  */
 export class Registry {
   constructor() {
-    this.controllers = new TypedRegistry(DatasetController, 'controllers');
+    this.controllers = new TypedRegistry(DatasetController, 'controllers', {datasets: 'datasets.{id}'});
     this.elements = new TypedRegistry(Element, 'elements');
     this.plugins = new TypedRegistry(Object, 'plugins');
     this.scales = new TypedRegistry(Scale, 'scales');

--- a/src/core/core.typedRegistry.js
+++ b/src/core/core.typedRegistry.js
@@ -76,18 +76,7 @@ export default class TypedRegistry {
 }
 
 function registerDefaults(item, scope, parentScope, relocate) {
-  let defs = item.defaults;
-  if (relocate) {
-    defs = Object.assign({}, defs);
-    const keys = Object.keys(relocate);
-    for (const key of keys) {
-      if (defs[key]) {
-        const dest = relocate[key].replace('{id}', item.id);
-        defaults.set(dest, defs[key]);
-        delete defs[key];
-      }
-    }
-  }
+  const defs = relocate ? relocateDefaults(item, relocate) : item.defaults;
 
   // Inherit the parent's defaults and keep existing defaults
   const itemDefaults = Object.assign(
@@ -106,6 +95,19 @@ function registerDefaults(item, scope, parentScope, relocate) {
   if (item.descriptors) {
     defaults.describe(scope, item.descriptors);
   }
+}
+
+function relocateDefaults(item, relocate) {
+  const defs = Object.assign({}, item.defaults);
+  const keys = Object.keys(relocate);
+  for (const key of keys) {
+    if (defs[key]) {
+      const dest = relocate[key].replace('{id}', item.id);
+      defaults.set(dest, defs[key]);
+      delete defs[key];
+    }
+  }
+  return defs;
 }
 
 function routeDefaults(scope, routes) {

--- a/test/specs/controller.bar.tests.js
+++ b/test/specs/controller.bar.tests.js
@@ -1306,7 +1306,7 @@ describe('Chart.controllers.bar', function() {
       var chart = window.acquireChart(this.config);
       var meta = chart.getDatasetMeta(0);
       var xScale = chart.scales[meta.xAxisID];
-      var options = Chart.defaults.controllers.bar.datasets;
+      var options = Chart.defaults.datasets.bar;
 
       var categoryPercentage = options.categoryPercentage;
       var barPercentage = options.barPercentage;
@@ -1482,7 +1482,7 @@ describe('Chart.controllers.bar', function() {
             expected = barThickness;
           } else {
             var scale = chart.scales.x;
-            var options = Chart.defaults.controllers.bar.datasets;
+            var options = Chart.defaults.datasets.bar;
             var categoryPercentage = options.categoryPercentage;
             var barPercentage = options.barPercentage;
             var tickInterval = scale.getPixelForTick(1) - scale.getPixelForTick(0);

--- a/test/specs/controller.line.tests.js
+++ b/test/specs/controller.line.tests.js
@@ -511,18 +511,18 @@ describe('Chart.controllers.line', function() {
 
   describe('dataset global defaults', function() {
     beforeEach(function() {
-      this._defaults = Chart.helpers.clone(Chart.defaults.controllers.line.datasets);
+      this._defaults = Chart.helpers.clone(Chart.defaults.datasets.line);
     });
 
     afterEach(function() {
-      Chart.defaults.controllers.line.datasets = this._defaults;
+      Chart.defaults.datasets.line = this._defaults;
       delete this._defaults;
     });
 
     it('should utilize the dataset global default options', function() {
-      Chart.defaults.controllers.line.datasets = Chart.defaults.controllers.line.datasets || {};
+      Chart.defaults.datasets.line = Chart.defaults.datasets.line || {};
 
-      Chart.helpers.merge(Chart.defaults.controllers.line.datasets, {
+      Chart.helpers.merge(Chart.defaults.datasets.line, {
         spanGaps: true,
         tension: 0.231,
         backgroundColor: '#add',
@@ -563,9 +563,9 @@ describe('Chart.controllers.line', function() {
     });
 
     it('should be overriden by user-supplied values', function() {
-      Chart.defaults.controllers.line.datasets = Chart.defaults.controllers.line.datasets || {};
+      Chart.defaults.datasets.line = Chart.defaults.datasets.line || {};
 
-      Chart.helpers.merge(Chart.defaults.controllers.line.datasets, {
+      Chart.helpers.merge(Chart.defaults.datasets.line, {
         spanGaps: true,
         tension: 0.231
       });

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -104,7 +104,7 @@ describe('Chart', function() {
 
       var options = chart.options;
       expect(options.font.size).toBe(defaults.font.size);
-      expect(options.showLine).toBe(defaults.controllers.line.datasets.showLine);
+      expect(options.showLine).toBe(defaults.datasets.line.showLine);
       expect(options.spanGaps).toBe(true);
       expect(options.hover.onHover).toBe(callback);
       expect(options.hover.mode).toBe('test');
@@ -128,7 +128,7 @@ describe('Chart', function() {
 
       var options = chart.options;
       expect(options.font.size).toBe(defaults.font.size);
-      expect(options.showLine).toBe(defaults.controllers.line.datasets.showLine);
+      expect(options.showLine).toBe(defaults.datasets.line.showLine);
       expect(options.spanGaps).toBe(true);
       expect(options.hover.onHover).toBe(callback);
       expect(options.hover.mode).toBe('test');

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -172,7 +172,7 @@ describe('Chart', function() {
     });
 
     it('should initialize config with default dataset options', function() {
-      var defaults = Chart.defaults.controllers.pie.datasets;
+      var defaults = Chart.defaults.datasets.pie;
 
       var chart = acquireChart({
         type: 'pie'


### PR DESCRIPTION
Combine `controllers[type].datasets` into `datasets[type]`, for simpler options lookup and consistent defaults/options.
