### PR TITLE
Resolve to false only when _fallback is used

### DIFF
--- a/src/helpers/helpers.config.js
+++ b/src/helpers/helpers.config.js
@@ -258,9 +258,9 @@ function addScopes(set, parentScopes, key, parentFallback) {
         // The fallback will resume to that new scope.
         return fallback;
       }
-    } else if (scope === false && key !== 'fill') {
-      // Fallback to `false` results to `false`, expect for `fill`.
-      // The special case (fill) should be handled through descriptors.
+    } else if (scope === false && defined(parentFallback) && key !== parentFallback) {
+      // Fallback to `false` results to `false`, when falling back to different key.
+      // For example `interaction` from `hover` or `plugins.tooltip` and `animation` from `animations`
       return null;
     }
   }
@@ -272,23 +272,25 @@ function createSubResolver(parentScopes, resolver, prop, value) {
   const fallback = resolveFallback(resolver._fallback, prop, value);
   const allScopes = [...parentScopes, ...rootScopes];
   const set = new Set([value]);
-  let key = prop;
-  while (key !== false) {
-    key = addScopes(set, allScopes, key, fallback);
-    if (key === null) {
-      return false;
-    }
+  let key = addScopesFromKey(set, allScopes, prop, fallback || prop);
+  if (key === null) {
+    return false;
   }
   if (defined(fallback) && fallback !== prop) {
-    const fallbackScopes = allScopes;
-    key = fallback;
-    while (key !== false) {
-      key = addScopes(set, fallbackScopes, key, fallback);
+    key = addScopesFromKey(set, allScopes, fallback, key);
+    if (key === null) {
+      return false;
     }
   }
   return _createResolver([...set], [''], rootScopes, fallback);
 }
 
+function addScopesFromKey(set, allScopes, key, fallback) {
+  while (key) {
+    key = addScopes(set, allScopes, key, fallback);
+  }
+  return key;
+}
 
 function _resolveWithPrefixes(prop, prefixes, scopes, proxy) {
   let value;

--- a/src/helpers/helpers.config.js
+++ b/src/helpers/helpers.config.js
@@ -172,7 +172,7 @@ export function _descriptors(proxy, defaults = {scriptable: true, indexable: tru
 }
 
 const readKey = (prefix, name) => prefix ? prefix + _capitalize(name) : name;
-const needsSubResolver = (prop, value) => isObject(value);
+const needsSubResolver = (prop, value) => isObject(value) && prop !== 'adapters';
 
 function _cached(target, prop, resolve) {
   let value = target[prop]; // cached value

--- a/test/specs/core.datasetController.tests.js
+++ b/test/specs/core.datasetController.tests.js
@@ -674,6 +674,31 @@ describe('Chart.DatasetController', function() {
     Chart.defaults.borderColor = oldColor;
   });
 
+  it('should read parsing from options when defaul is false', function() {
+    const originalDefault = Chart.defaults.parsing;
+    Chart.defaults.parsing = false;
+
+    var chart = acquireChart({
+      type: 'line',
+      data: {
+        datasets: [{
+          data: [{t: 1, y: 0}]
+        }]
+      },
+      options: {
+        parsing: {
+          xAxisKey: 't'
+        }
+      }
+    });
+
+    var meta = chart.getDatasetMeta(0);
+    expect(meta.data[0].x).not.toBeNaN();
+
+    // Reset old shared state
+    Chart.defaults.parsing = originalDefault;
+  });
+
   describe('resolveDataElementOptions', function() {
     it('should cache options when possible', function() {
       const chart = acquireChart({

--- a/test/specs/core.datasetController.tests.js
+++ b/test/specs/core.datasetController.tests.js
@@ -674,7 +674,7 @@ describe('Chart.DatasetController', function() {
     Chart.defaults.borderColor = oldColor;
   });
 
-  it('should read parsing from options when defaul is false', function() {
+  it('should read parsing from options when default is false', function() {
     const originalDefault = Chart.defaults.parsing;
     Chart.defaults.parsing = false;
 

--- a/test/specs/helpers.config.tests.js
+++ b/test/specs/helpers.config.tests.js
@@ -656,6 +656,28 @@ describe('Chart.helpers.config', function() {
       expect('test' in opts).toBeFalse();
     });
 
+    it('should not create proxy for adapters', function() {
+      const defaults = {
+        scales: {
+          time: {
+            adapters: {
+              date: {
+                locale: {
+                  method: (arg) => arg === undefined ? 'ok' : 'fail'
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const resolver = _createResolver([{}, defaults]);
+      const opts = _attachContext(resolver, {index: 1});
+      const fn = opts.scales.time.adapters.date.locale.method;
+      expect(typeof fn).toBe('function');
+      expect(fn()).toEqual('ok');
+    });
+
     describe('_indexable and _scriptable', function() {
       it('should default to true', function() {
         const options = {


### PR DESCRIPTION
Fixes #8541

The `false` from parent was too generic, this limits it to when falling back to different scope.

* `options.parsing` is no longer overwritten with `defaults.parsing: false`. But `options.interaction: false` still overrides `options.hover`.
* Any objects under `adapters` are considered plain objects (no fallback, scriptability etc).