### PR TITLE
Add clarification where the default intersect comes from in tooltip

### DIFF
--- a/docs/docs/configuration/tooltip.md
+++ b/docs/docs/configuration/tooltip.md
@@ -11,7 +11,7 @@ Namespace: `options.plugins.tooltip`, the global options for the chart tooltips 
 | `enabled` | `boolean` | `true` | Are on-canvas tooltips enabled?
 | `external` | `function` | `null` | See [external tooltip](#external-custom-tooltips) section.
 | `mode` | `string` | | Sets which elements appear in the tooltip. [more...](interactions/modes.md#interaction-modes).
-| `intersect` | `boolean` | | If true, the tooltip mode applies only when the mouse position intersects with an element. If false, the mode will be applied at all times.
+| `intersect` | `boolean` | `interaction.mode` | If true, the tooltip mode applies only when the mouse position intersects with an element. If false, the mode will be applied at all times.
 | `position` | `string` | `'average'` | The mode for positioning the tooltip. [more...](#position-modes)
 | `callbacks` | `object` | | See the [callbacks section](#tooltip-callbacks).
 | `itemSort` | `function` | | Sort tooltip items. [more...](#sort-callback)


### PR DESCRIPTION
Specify that the default intersect mode comes options.interaction so it doesnt give confusing behaviour if people dont know why it's true or false if they start working on someone elses code and they setted it in the interactions.mode