### PR TITLE
Add _allKeys descriptor for Object.keys behavior

### DIFF
--- a/src/core/core.config.js
+++ b/src/core/core.config.js
@@ -316,7 +316,7 @@ export default class Config {
    * @param {object[]} scopes
    * @param {object} [context]
    * @param {string[]} [prefixes]
-   * @param {{scriptable: boolean, indexable: boolean}} [descriptorDefaults]
+   * @param {{scriptable: boolean, indexable: boolean, allKeys?: boolean}} [descriptorDefaults]
    */
   createResolver(scopes, context, prefixes = [''], descriptorDefaults) {
     const {resolver} = getResolver(this._resolverCache, scopes, prefixes);

--- a/src/core/core.plugins.js
+++ b/src/core/core.plugins.js
@@ -166,5 +166,5 @@ function createDescriptors(chart, plugins, options, all) {
 function pluginOpts(config, plugin, opts, context) {
   const keys = config.pluginScopeKeys(plugin);
   const scopes = config.getOptionScopes(opts, keys);
-  return config.createResolver(scopes, context, [''], {scriptable: false, indexable: false});
+  return config.createResolver(scopes, context, [''], {scriptable: false, indexable: false, allKeys: true});
 }

--- a/src/helpers/helpers.config.js
+++ b/src/helpers/helpers.config.js
@@ -86,7 +86,7 @@ export function _createResolver(scopes, prefixes = [''], rootScopes = scopes, fa
  * @param {object} proxy - The Proxy returned by `_createResolver`
  * @param {object} context - Context object for scriptable/indexable options
  * @param {object} [subProxy] - The proxy provided for scriptable options
- * @param {{scriptable: boolean, indexable: boolean}} [descriptorDefaults] - Defaults for descriptors
+ * @param {{scriptable: boolean, indexable: boolean, allKeys?: boolean}} [descriptorDefaults] - Defaults for descriptors
  * @private
  */
 export function _attachContext(proxy, context, subProxy, descriptorDefaults) {
@@ -123,7 +123,9 @@ export function _attachContext(proxy, context, subProxy, descriptorDefaults) {
      * Also used by Object.hasOwnProperty.
      */
     getOwnPropertyDescriptor(target, prop) {
-      return Reflect.getOwnPropertyDescriptor(proxy, prop);
+      return target._descriptors.allKeys
+        ? Reflect.has(proxy, prop) ? {enumerable: true, configurable: true} : undefined
+        : Reflect.getOwnPropertyDescriptor(proxy, prop);
     },
 
     /**
@@ -162,8 +164,9 @@ export function _attachContext(proxy, context, subProxy, descriptorDefaults) {
  * @private
  */
 export function _descriptors(proxy, defaults = {scriptable: true, indexable: true}) {
-  const {_scriptable = defaults.scriptable, _indexable = defaults.indexable} = proxy;
+  const {_scriptable = defaults.scriptable, _indexable = defaults.indexable, _allKeys = defaults.allKeys} = proxy;
   return {
+    allKeys: _allKeys,
     scriptable: _scriptable,
     indexable: _indexable,
     isScriptable: isFunction(_scriptable) ? _scriptable : () => _scriptable,

--- a/test/specs/core.plugin.tests.js
+++ b/test/specs/core.plugin.tests.js
@@ -274,7 +274,8 @@ describe('Chart.plugins', function() {
       chart.notifyPlugins('hook');
 
       expect(plugin.hook).toHaveBeenCalled();
-      expect(plugin.hook.calls.first().args[2]).toEqualOptions({a: 42});
+      expect(Object.keys(plugin.hook.calls.first().args[2])).toEqual(['a']);
+      expect(plugin.hook.calls.first().args[2]).toEqual(jasmine.objectContaining({a: 42}));
 
       Chart.unregister(plugin);
     });


### PR DESCRIPTION
By default, provide plugins with options that respond with all possible keys to `Object.keys` to mimic the behavior v2 had with merged options.
