### PR TITLE
Remove distribution option from fixtures

### DIFF
--- a/test/fixtures/scale.time/bar-large-gap-between-data.js
+++ b/test/fixtures/scale.time/bar-large-gap-between-data.js
@@ -36,7 +36,6 @@ module.exports = {
         x: {
           display: false,
           type: 'time',
-          distribution: 'linear',
           ticks: {
             source: 'auto'
           },

--- a/test/fixtures/scale.time/source-auto-linear.js
+++ b/test/fixtures/scale.time/source-auto-linear.js
@@ -16,8 +16,7 @@ module.exports = {
           },
           ticks: {
             source: 'auto'
-          },
-          distribution: 'linear'
+          }
         },
         y: {
           display: false

--- a/test/fixtures/scale.time/source-data-linear.js
+++ b/test/fixtures/scale.time/source-data-linear.js
@@ -16,8 +16,7 @@ module.exports = {
           },
           ticks: {
             source: 'data'
-          },
-          distribution: 'linear'
+          }
         },
         y: {
           display: false

--- a/test/fixtures/scale.time/source-labels-linear-offset-min-max.js
+++ b/test/fixtures/scale.time/source-labels-linear-offset-min-max.js
@@ -18,8 +18,7 @@ module.exports = {
           },
           ticks: {
             source: 'labels'
-          },
-          distribution: 'linear'
+          }
         },
         y: {
           display: false

--- a/test/fixtures/scale.time/source-labels-linear.js
+++ b/test/fixtures/scale.time/source-labels-linear.js
@@ -16,8 +16,7 @@ module.exports = {
           },
           ticks: {
             source: 'labels'
-          },
-          distribution: 'linear'
+          }
         },
         y: {
           display: false

--- a/test/fixtures/scale.time/ticks-reverse-linear-min-max.js
+++ b/test/fixtures/scale.time/ticks-reverse-linear-min-max.js
@@ -15,7 +15,6 @@ module.exports = {
           time: {
             parser: 'YYYY'
           },
-          distribution: 'linear',
           reverse: true,
           ticks: {
             source: 'labels'

--- a/test/fixtures/scale.time/ticks-reverse-linear.js
+++ b/test/fixtures/scale.time/ticks-reverse-linear.js
@@ -13,7 +13,6 @@ module.exports = {
           time: {
             parser: 'YYYY'
           },
-          distribution: 'linear',
           reverse: true,
           ticks: {
             source: 'labels'

--- a/test/fixtures/scale.timeseries/normalize.js
+++ b/test/fixtures/scale.timeseries/normalize.js
@@ -22,7 +22,6 @@ module.exports = {
           time: {
             parser: 'YYYY'
           },
-          distribution: 'linear',
           ticks: {
             source: 'data'
           }


### PR DESCRIPTION
The distribution option was removed in favor of `timeseries` scale. It was still present in some fixtures.