### PR TITLE
Rename scaleLabel to title in scale options

### DIFF
--- a/docs/docs/axes/cartesian/_common.md
+++ b/docs/docs/axes/cartesian/_common.md
@@ -8,4 +8,4 @@ Namespace: `options.scales[scaleId]`
 | `position` | `string` | | Position of the axis. [more...](./index.mdx#axis-position)
 | `axis` | `string` | | Which type of axis this is. Possible values are: `'x'`, `'y'`. If not set, this is inferred from the first character of the ID which should be `'x'` or `'y'`.
 | `offset` | `boolean` | `false` | If true, extra space is added to the both edges and the axis is scaled to fit into the chart area. This is set to `true` for a bar chart by default.
-| `scaleLabel` | `object` | | Scale title configuration. [more...](../labelling.md#scale-title-configuration)
+| `title` | `object` | | Scale title configuration. [more...](../labelling.md#scale-title-configuration)

--- a/docs/docs/axes/labelling.md
+++ b/docs/docs/axes/labelling.md
@@ -6,13 +6,13 @@ When creating a chart, you want to tell the viewer what data they are viewing. T
 
 ## Scale Title Configuration
 
-Namespace: `options.scales[scaleId].scaleLabel`, it defines options for the scale title. Note that this only applies to cartesian axes.
+Namespace: `options.scales[scaleId].title`, it defines options for the scale title. Note that this only applies to cartesian axes.
 
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
 | `display` | `boolean` | `false` | If true, display the axis title.
 | `align` | `string` | `'center'` | Alignment of the axis title. Possible options are `'start'`, `'center'` and `'end'`
-| `labelString` | `string` | `''` | The text for the title. (i.e. "# of People" or "Response Choices").
+| `text` | `string` | `''` | The text for the title. (i.e. "# of People" or "Response Choices").
 | `color` | [`Color`](../general/colors.md) | `Chart.defaults.color` | Color of label.
 | `font` | `Font` | `Chart.defaults.font` | See [Fonts](../general/fonts.md)
 | `padding` | `number`\|`object` | `4` | Padding to apply around scale labels. Only `top` and `bottom` are implemented.

--- a/docs/docs/getting-started/v3-migration.md
+++ b/docs/docs/getting-started/v3-migration.md
@@ -85,6 +85,8 @@ A number of changes were made to the configuration options passed to the `Chart`
 * `scales.[x/y]Axes.categoryPercentage` was moved to dataset option `categoryPercentage`
 * `scales.[x/y]Axes.maxBarThickness` was moved to dataset option `maxBarThickness`
 * `scales.[x/y]Axes.minBarLength` was moved to dataset option `minBarLength`
+* `scales.[x/y]Axes.scaleLabel` was renamed to `scales[id].title`
+* `scales.[x/y]Axes.scaleLabel.labelString` was renamed to `scales[id].title.text`
 * `scales.[x/y]Axes.ticks.beginAtZero` was renamed to `scales[id].beginAtZero`
 * `scales.[x/y]Axes.ticks.max` was renamed to `scales[id].max`
 * `scales.[x/y]Axes.ticks.min` was renamed to `scales[id].min`
@@ -134,9 +136,9 @@ options: {
       id: 'x',
       type: 'time',
       display: true,
-      scaleLabel: {
+      title: {
         display: true,
-        labelString: 'Date'
+        text: 'Date'
       },
       ticks: {
         major: {
@@ -155,9 +157,9 @@ options: {
     yAxes: [{
       id: 'y',
       display: true,
-      scaleLabel: {
+      title: {
         display: true,
-        labelString: 'value'
+        text: 'value'
       }
     }]
   }
@@ -172,9 +174,9 @@ options: {
     x: {
       type: 'time',
       display: true,
-      scaleLabel: {
+      title: {
         display: true,
-        labelString: 'Date'
+        text: 'Date'
       },
       ticks: {
         major: {
@@ -192,9 +194,9 @@ options: {
     },
     y: {
       display: true,
-      scaleLabel: {
+      title: {
         display: true,
-        labelString: 'value'
+        text: 'value'
       }
     }
   }

--- a/samples/advanced/line-gradient.html
+++ b/samples/advanced/line-gradient.html
@@ -86,16 +86,16 @@
 				scales: {
 					x: {
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Month'
+							text: 'Month'
 						}
 					},
 					y: {
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Value'
+							text: 'Value'
 						}
 					}
 				}

--- a/samples/animations/drop.html
+++ b/samples/animations/drop.html
@@ -100,16 +100,16 @@
 				scales: {
 					x: {
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Month'
+							text: 'Month'
 						}
 					},
 					y: {
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Value'
+							text: 'Value'
 						}
 					}
 				}

--- a/samples/animations/loop.html
+++ b/samples/animations/loop.html
@@ -89,16 +89,16 @@
 				scales: {
 					x: {
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Month'
+							text: 'Month'
 						}
 					},
 					y: {
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Value'
+							text: 'Value'
 						}
 					}
 				}

--- a/samples/charts/area/line-stacked.html
+++ b/samples/charts/area/line-stacked.html
@@ -105,16 +105,16 @@
 				},
 				scales: {
 					x: {
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Month'
+							text: 'Month'
 						}
 					},
 					y: {
 						stacked: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Value'
+							text: 'Value'
 						}
 					}
 				}

--- a/samples/charts/line/basic.html
+++ b/samples/charts/line/basic.html
@@ -80,16 +80,16 @@
 				scales: {
 					x: {
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Month'
+							text: 'Month'
 						}
 					},
 					y: {
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Value'
+							text: 'Value'
 						}
 					}
 				}

--- a/samples/charts/line/interpolation-modes.html
+++ b/samples/charts/line/interpolation-modes.html
@@ -69,15 +69,15 @@
 				scales: {
 					x: {
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true
 						}
 					},
 					y: {
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Value'
+							text: 'Value'
 						},
 						suggestedMin: -10,
 						suggestedMax: 200

--- a/samples/charts/line/line-styles.html
+++ b/samples/charts/line/line-styles.html
@@ -87,16 +87,16 @@
 				scales: {
 					x: {
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Month'
+							text: 'Month'
 						}
 					},
 					y: {
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Value'
+							text: 'Value'
 						}
 					}
 				}

--- a/samples/charts/line/point-sizes.html
+++ b/samples/charts/line/point-sizes.html
@@ -105,16 +105,16 @@
 				scales: {
 					x: {
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Month'
+							text: 'Month'
 						}
 					},
 					y: {
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Value'
+							text: 'Value'
 						}
 					}
 				}

--- a/samples/charts/line/skip-points.html
+++ b/samples/charts/line/skip-points.html
@@ -71,16 +71,16 @@
 				scales: {
 					x: {
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Month'
+							text: 'Month'
 						}
 					},
 					y: {
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Value'
+							text: 'Value'
 						},
 					}
 				}

--- a/samples/legend/callbacks.html
+++ b/samples/legend/callbacks.html
@@ -103,16 +103,16 @@
 				scales: {
 					x: {
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Month'
+							text: 'Month'
 						}
 					},
 					y: {
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Value'
+							text: 'Value'
 						}
 					}
 				}

--- a/samples/legend/point-style.html
+++ b/samples/legend/point-style.html
@@ -76,16 +76,16 @@
 					scales: {
 						x: {
 							display: true,
-							scaleLabel: {
+							title: {
 								display: true,
-								labelString: 'Month'
+								text: 'Month'
 							}
 						},
 						y: {
 							display: true,
-							scaleLabel: {
+							title: {
 								display: true,
-								labelString: 'Value'
+								text: 'Value'
 							}
 						}
 					}

--- a/samples/legend/positioning.html
+++ b/samples/legend/positioning.html
@@ -77,16 +77,16 @@
 					scales: {
 						x: {
 							display: true,
-							scaleLabel: {
+							title: {
 								display: true,
-								labelString: 'Month'
+								text: 'Month'
 							}
 						},
 						y: {
 							display: true,
-							scaleLabel: {
+							title: {
 								display: true,
-								labelString: 'Value'
+								text: 'Value'
 							}
 						}
 					}

--- a/samples/legend/title.html
+++ b/samples/legend/title.html
@@ -89,16 +89,16 @@
 					scales: {
 						x: {
 							display: true,
-							scaleLabel: {
+							title: {
 								display: true,
-								labelString: 'Month'
+								text: 'Month'
 							}
 						},
 						y: {
 							display: true,
-							scaleLabel: {
+							title: {
 								display: true,
-								labelString: 'Value'
+								text: 'Value'
 							}
 						}
 					}

--- a/samples/scales/axes-labels.html
+++ b/samples/scales/axes-labels.html
@@ -80,9 +80,9 @@
 				scales: {
 					x: {
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Month',
+							text: 'Month',
 							font: {
 								color: '#911',
 								family: 'Comic Sans MS',
@@ -95,9 +95,9 @@
 					},
 					y: {
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Value',
+							text: 'Value',
 							font: {
 								color: '#191',
 								family: 'Times',

--- a/samples/scales/financial.html
+++ b/samples/scales/financial.html
@@ -176,9 +176,9 @@
 						gridLines: {
 							drawBorder: false
 						},
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Closing price ($)'
+							text: 'Closing price ($)'
 						}
 					}
 				},

--- a/samples/scales/linear/step-size.html
+++ b/samples/scales/linear/step-size.html
@@ -85,16 +85,16 @@
 				scales: {
 					x: {
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Month'
+							text: 'Month'
 						}
 					},
 					y: {
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Value'
+							text: 'Value'
 						},
 						min: 0,
 						max: 100,

--- a/samples/scales/logarithmic/scatter.html
+++ b/samples/scales/logarithmic/scatter.html
@@ -147,8 +147,8 @@
 								return '';
 							},
 						},
-						scaleLabel: {
-							labelString: 'Frequency',
+						title: {
+							text: 'Frequency',
 							display: true,
 						}
 					},
@@ -159,8 +159,8 @@
 								return tick.toString() + 'dB';
 							}
 						},
-						scaleLabel: {
-							labelString: 'Voltage',
+						title: {
+							text: 'Voltage',
 							display: true
 						}
 					}

--- a/samples/scales/non-numeric-y.html
+++ b/samples/scales/non-numeric-y.html
@@ -43,18 +43,18 @@
 				scales: {
 					x: {
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Month'
+							text: 'Month'
 						}
 					},
 					y: {
 						type: 'category',
 						position: 'left',
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Request State'
+							text: 'Request State'
 						},
 						reverse: true
 					}

--- a/samples/scales/time/line-max-span.html
+++ b/samples/scales/time/line-max-span.html
@@ -89,9 +89,9 @@
 					x: {
 						type: 'time',
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Date'
+							text: 'Date'
 						},
 						ticks: {
 							autoSkip: false,
@@ -111,9 +111,9 @@
 					},
 					y: {
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'value'
+							text: 'value'
 						}
 					}
 				}

--- a/samples/scales/time/line-point-data.html
+++ b/samples/scales/time/line-point-data.html
@@ -88,9 +88,9 @@
 					x: {
 						type: 'time',
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Date'
+							text: 'Date'
 						},
 						ticks: {
 							major: {
@@ -109,9 +109,9 @@
 					},
 					y: {
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'value'
+							text: 'value'
 						}
 					}
 				}

--- a/samples/scales/time/line.html
+++ b/samples/scales/time/line.html
@@ -114,15 +114,15 @@
 							// round: 'day'
 							tooltipFormat: 'll HH:mm'
 						},
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Date'
+							text: 'Date'
 						}
 					},
 					y: {
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'value'
+							text: 'value'
 						}
 					}
 				},

--- a/samples/title/alignment.html
+++ b/samples/title/alignment.html
@@ -107,16 +107,16 @@
 					scales: {
 						x: {
 							display: true,
-							scaleLabel: {
+							title: {
 								display: true,
-								labelString: 'Month'
+								text: 'Month'
 							}
 						},
 						y: {
 							display: true,
-							scaleLabel: {
+							title: {
 								display: true,
-								labelString: 'Value'
+								text: 'Value'
 							}
 						}
 					}

--- a/samples/tooltips/callbacks.html
+++ b/samples/tooltips/callbacks.html
@@ -83,16 +83,16 @@
 				scales: {
 					x: {
 						display: true,
-						scaleLabel: {
+						title: {
 							show: true,
-							labelString: 'Month'
+							text: 'Month'
 						}
 					},
 					y: {
 						display: true,
-						scaleLabel: {
+						title: {
 							show: true,
-							labelString: 'Value'
+							text: 'Value'
 						}
 					}
 				}

--- a/samples/tooltips/point-style.html
+++ b/samples/tooltips/point-style.html
@@ -106,16 +106,16 @@
 				scales: {
 					x: {
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Month'
+							text: 'Month'
 						}
 					},
 					y: {
 						display: true,
-						scaleLabel: {
+						title: {
 							display: true,
-							labelString: 'Value'
+							text: 'Value'
 						}
 					}
 				}

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -43,13 +43,13 @@ defaults.set('scale', {
     borderWidth: (_ctx, options) => options.lineWidth
   },
 
-  // scale label
-  scaleLabel: {
+  // scale title
+  title: {
     // display property
     display: false,
 
     // actual label
-    labelString: '',
+    text: '',
 
     // top/bottom padding
     padding: {
@@ -81,7 +81,7 @@ defaults.set('scale', {
 
 defaults.route('scale.ticks', 'color', '', 'color');
 defaults.route('scale.gridLines', 'color', '', 'borderColor');
-defaults.route('scale.scaleLabel', 'color', '', 'color');
+defaults.route('scale.title', 'color', '', 'color');
 
 defaults.describe('scale', {
   _fallback: false,
@@ -170,7 +170,7 @@ function getTickMarkLength(options) {
 /**
  * @param {object} options
  */
-function getScaleLabelHeight(options, fallback) {
+function getTitleHeight(options, fallback) {
   if (!options.display) {
     return 0;
   }
@@ -741,7 +741,7 @@ export default class Scale extends Element {
     if (maxLabelWidth + 6 > tickWidth) {
       tickWidth = maxWidth / (numTicks - (options.offset ? 0.5 : 1));
       maxHeight = me.maxHeight - getTickMarkLength(options.gridLines)
-				- tickOpts.padding - getScaleLabelHeight(options.scaleLabel, me.chart.options.font);
+				- tickOpts.padding - getTitleHeight(options.title, me.chart.options.font);
       maxLabelDiagonal = Math.sqrt(maxLabelWidth * maxLabelWidth + maxLabelHeight * maxLabelHeight);
       labelRotation = toDegrees(Math.min(
         Math.asin(Math.min((labelSizes.highest.height + 6) / tickWidth, 1)),
@@ -772,25 +772,25 @@ export default class Scale extends Element {
     const chart = me.chart;
     const opts = me.options;
     const tickOpts = opts.ticks;
-    const scaleLabelOpts = opts.scaleLabel;
+    const titleOpts = opts.title;
     const gridLineOpts = opts.gridLines;
     const display = me._isVisible();
     const labelsBelowTicks = opts.position !== 'top' && me.axis === 'x';
     const isHorizontal = me.isHorizontal();
-    const scaleLabelHeight = display && getScaleLabelHeight(scaleLabelOpts, chart.options.font);
+    const titleHeight = display && getTitleHeight(titleOpts, chart.options.font);
 
     // Width
     if (isHorizontal) {
       minSize.width = me.maxWidth;
     } else if (display) {
-      minSize.width = getTickMarkLength(gridLineOpts) + scaleLabelHeight;
+      minSize.width = getTickMarkLength(gridLineOpts) + titleHeight;
     }
 
     // height
     if (!isHorizontal) {
       minSize.height = me.maxHeight; // fill all the height
     } else if (display) {
-      minSize.height = getTickMarkLength(gridLineOpts) + scaleLabelHeight;
+      minSize.height = getTickMarkLength(gridLineOpts) + titleHeight;
     }
 
     // Don't bother fitting the ticks if we are not showing the labels
@@ -1658,67 +1658,67 @@ export default class Scale extends Element {
     const me = this;
     const ctx = me.ctx;
     const options = me.options;
-    const scaleLabel = options.scaleLabel;
+    const title = options.title;
 
-    if (!scaleLabel.display) {
+    if (!title.display) {
       return;
     }
 
-    const scaleLabelFont = toFont(scaleLabel.font);
-    const scaleLabelPadding = toPadding(scaleLabel.padding);
-    const halfLineHeight = scaleLabelFont.lineHeight / 2;
-    const scaleLabelAlign = scaleLabel.align;
+    const titleFont = toFont(title.font);
+    const titlePadding = toPadding(title.padding);
+    const halfLineHeight = titleFont.lineHeight / 2;
+    const titleAlign = title.align;
     const position = options.position;
     const isReverse = me.options.reverse;
     let rotation = 0;
     /** @type CanvasTextAlign */
     let textAlign;
-    let scaleLabelX, scaleLabelY;
+    let titleX, titleY;
 
     if (me.isHorizontal()) {
-      switch (scaleLabelAlign) {
+      switch (titleAlign) {
       case 'start':
-        scaleLabelX = me.left + (isReverse ? me.width : 0);
+        titleX = me.left + (isReverse ? me.width : 0);
         textAlign = isReverse ? 'right' : 'left';
         break;
       case 'end':
-        scaleLabelX = me.left + (isReverse ? 0 : me.width);
+        titleX = me.left + (isReverse ? 0 : me.width);
         textAlign = isReverse ? 'left' : 'right';
         break;
       default:
-        scaleLabelX = me.left + me.width / 2;
+        titleX = me.left + me.width / 2;
         textAlign = 'center';
       }
-      scaleLabelY = position === 'top'
-        ? me.top + halfLineHeight + scaleLabelPadding.top
-        : me.bottom - halfLineHeight - scaleLabelPadding.bottom;
+      titleY = position === 'top'
+        ? me.top + halfLineHeight + titlePadding.top
+        : me.bottom - halfLineHeight - titlePadding.bottom;
     } else {
       const isLeft = position === 'left';
-      scaleLabelX = isLeft
-        ? me.left + halfLineHeight + scaleLabelPadding.top
-        : me.right - halfLineHeight - scaleLabelPadding.top;
-      switch (scaleLabelAlign) {
+      titleX = isLeft
+        ? me.left + halfLineHeight + titlePadding.top
+        : me.right - halfLineHeight - titlePadding.top;
+      switch (titleAlign) {
       case 'start':
-        scaleLabelY = me.top + (isReverse ? 0 : me.height);
+        titleY = me.top + (isReverse ? 0 : me.height);
         textAlign = isReverse === isLeft ? 'right' : 'left';
         break;
       case 'end':
-        scaleLabelY = me.top + (isReverse ? me.height : 0);
+        titleY = me.top + (isReverse ? me.height : 0);
         textAlign = isReverse === isLeft ? 'left' : 'right';
         break;
       default:
-        scaleLabelY = me.top + me.height / 2;
+        titleY = me.top + me.height / 2;
         textAlign = 'center';
       }
       rotation = isLeft ? -HALF_PI : HALF_PI;
     }
 
-    renderText(ctx, scaleLabel.labelString, 0, 0, scaleLabelFont, {
-      color: scaleLabel.color,
+    renderText(ctx, title.text, 0, 0, titleFont, {
+      color: title.color,
       rotation,
       textAlign,
       textBaseline: 'middle',
-      translation: [scaleLabelX, scaleLabelY],
+      translation: [titleX, titleY],
     });
   }
 

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -1396,9 +1396,9 @@ describe('Chart', function() {
             },
             y: {
               type: 'linear',
-              scaleLabel: {
+              title: {
                 display: true,
-                labelString: 'Value'
+                text: 'Value'
               }
             }
           }

--- a/test/specs/core.scale.tests.js
+++ b/test/specs/core.scale.tests.js
@@ -6,10 +6,10 @@ describe('Core.scale', function() {
   describe('auto', jasmine.fixture.specs('core.scale'));
 
   it('should provide default scale label options', function() {
-    expect(Chart.defaults.scale.scaleLabel).toEqual({
+    expect(Chart.defaults.scale.title).toEqual({
       color: Chart.defaults.color,
       display: false,
-      labelString: '',
+      text: '',
       padding: {
         top: 4,
         bottom: 4

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -904,8 +904,8 @@ describe('Linear Scale', function() {
     expect(yScale.height).toBeCloseToPixel(450);
 
     // Extra size when scale label showing
-    xScale.options.scaleLabel.display = true;
-    yScale.options.scaleLabel.display = true;
+    xScale.options.title.display = true;
+    yScale.options.title.display = true;
     chart.update();
 
     expect(xScale.paddingTop).toBeCloseToPixel(0);
@@ -957,7 +957,7 @@ describe('Linear Scale', function() {
               drawTicks: false,
               drawBorder: false
             },
-            scaleLabel: {
+            title: {
               display: false,
               lineHeight: 1.2
             },

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -2696,9 +2696,9 @@ export interface CartesianScaleOptions extends CoreScaleOptions {
 
   gridLines: GridLineOptions;
 
-  scaleLabel: {
+  title: {
     display: boolean;
-    labelString: string;
+    text: string;
     color: Color;
     font: FontSpec;
     padding: {


### PR DESCRIPTION
Renames `scaleOpts.scaleLabel` to `scaleOpts.title` and `scaleOpts.scaleLabel.labelString` to `scaleOpts.title.text`. The scale title is now consistent with the legend and chart title options.