### PR TITLE
Expose radial scale point label positions

### DIFF
--- a/docs/docs/getting-started/v3-migration.md
+++ b/docs/docs/getting-started/v3-migration.md
@@ -449,6 +449,7 @@ The private APIs listed below were renamed:
 * `DatasetController.resyncElements` was renamed to `DatasetController._resyncElements`
 * `LayoutItem.isFullWidth` was renamed to `LayoutItem.isFullSize`
 * `RadialLinearScale.setReductions` was renamed to `RadialLinearScale._setReductions`
+* `RadialLinearScale.pointLabels` was renamed to `RadialLinearScale._pointLabels`
 * `Scale.handleMargins` was renamed to `Scale._handleMargins`
 
 ### Changed

--- a/test/specs/scale.radialLinear.tests.js
+++ b/test/specs/scale.radialLinear.tests.js
@@ -324,7 +324,7 @@ describe('Test the radial linear scale', function() {
     });
 
     expect(getLabels(chart.scales.r)).toEqual(['0', '1', '2', '3', '4', '5', '6', '7', '8']);
-    expect(chart.scales.r.pointLabels).toEqual(['label1', 'label2', 'label3', 'label4', 'label5']);
+    expect(chart.scales.r._pointLabels).toEqual(['label1', 'label2', 'label3', 'label4', 'label5']);
   });
 
   it('Should build point labels using the user supplied callback', function() {
@@ -349,7 +349,7 @@ describe('Test the radial linear scale', function() {
       }
     });
 
-    expect(chart.scales.r.pointLabels).toEqual(['0', '1', '2', '3', '4']);
+    expect(chart.scales.r._pointLabels).toEqual(['0', '1', '2', '3', '4']);
   });
 
   it('Should build point labels from falsy values', function() {
@@ -363,7 +363,7 @@ describe('Test the radial linear scale', function() {
       }
     });
 
-    expect(chart.scales.r.pointLabels).toEqual([0, '', '', '', '', '']);
+    expect(chart.scales.r._pointLabels).toEqual([0, '', '', '', '', '']);
   });
 
   it('should correctly set the center point', function() {

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -3089,6 +3089,7 @@ export interface RadialLinearScale<O extends RadialLinearScaleOptions = RadialLi
   getValueForDistanceFromCenter(distance: number): number;
   getPointPosition(index: number, distanceFromCenter: number): { x: number; y: number; angle: number };
   getPointPositionForValue(index: number, value: number): { x: number; y: number; angle: number };
+  getPointLabelPosition(index: number): ChartArea;
   getBasePosition(index: number): { x: number; y: number; angle: number };
 }
 export const RadialLinearScale: ChartComponent & {


### PR DESCRIPTION
Stops computing information on every draw + keeps track of bounding boxes for each radial scale point label. I took the opportunity to make `pointLabels` private in the radial scale so that we can edit the data model later.

Resolves #3049
Resolves #5344
Resolves #6549

Enables solving #5085, #5175