### PR TITLE
scale.category: options.min/max can be index

### DIFF
--- a/src/scales/scale.category.js
+++ b/src/scales/scale.category.js
@@ -1,4 +1,5 @@
 import Scale from '../core/core.scale';
+import {valueOrDefault} from '../helpers';
 
 function findOrAddLabel(labels, raw, index) {
   const first = labels.indexOf(raw);
@@ -22,7 +23,7 @@ export default class CategoryScale extends Scale {
   parse(raw, index) {
     const labels = this.getLabels();
     return isFinite(index) && labels[index] === raw
-      ? index : findOrAddLabel(labels, raw, index);
+      ? index : findOrAddLabel(labels, raw, valueOrDefault(index, raw));
   }
 
   determineDataLimits() {

--- a/test/fixtures/controller.bar/floatBar/float-bar-horizontal.json
+++ b/test/fixtures/controller.bar/floatBar/float-bar-horizontal.json
@@ -18,9 +18,7 @@
             "indexAxis": "y",
             "scales": {
                 "x": {
-                    "display": false,
-                    "min": -8,
-                    "max": 12
+                    "display": false
                 },
                 "y": {
                     "display": false

--- a/test/fixtures/controller.bar/floatBar/float-bar-stacked-horizontal.json
+++ b/test/fixtures/controller.bar/floatBar/float-bar-stacked-horizontal.json
@@ -23,9 +23,7 @@
                 },
                 "y": {
                     "display": false,
-                    "stacked": true,
-                    "min": -8,
-                    "max": 12
+                    "stacked": true
                 }
             }
         }

--- a/test/fixtures/controller.bar/floatBar/float-bar-stacked.json
+++ b/test/fixtures/controller.bar/floatBar/float-bar-stacked.json
@@ -18,9 +18,7 @@
             "scales": {
                 "x": {
                     "display": false,
-                    "stacked": true,
-                    "min": -8,
-                    "max": 12
+                    "stacked": true
                 },
                 "y": {
                     "display": false,

--- a/test/fixtures/controller.bar/floatBar/float-bar.json
+++ b/test/fixtures/controller.bar/floatBar/float-bar.json
@@ -17,9 +17,7 @@
         "options": {
             "scales": {
                 "x": {
-                    "display": false,
-                    "min": -8,
-                    "max": 12
+                    "display": false
                 },
                 "y": {
                     "display": false


### PR DESCRIPTION
Allowing min/max as index values is consistent with other scales like time that allow usage of the internal value (timestamp) as scale limits. This would simplify zooming for example, not having to look up the labels in the indices.

Some misconfigurations were revealed by this in fixtures.