### PR TITLE
Fix typo in auto package

### DIFF
--- a/auto/auto.esm.js
+++ b/auto/auto.esm.js
@@ -1,5 +1,5 @@
-import {Chart, registrables} from '../dist/chart.esm';
+import {Chart, registerables} from '../dist/chart.esm';
 
-Chart.register(...registrables);
+Chart.register(...registerables);
 
 export default Chart;


### PR DESCRIPTION
> ERROR in ./node_modules/chart.js/auto/auto.esm.js 3:18-30
"export 'registrables' was not found in '../dist/chart.esm'