### PR TITLE
Disable warning of unused variables in types/tests

### DIFF
--- a/types/tests/.eslintrc.yml
+++ b/types/tests/.eslintrc.yml
@@ -1,0 +1,2 @@
+rules:
+  '@typescript-eslint/no-unused-vars': 'off'

--- a/types/tests/layout/position.ts
+++ b/types/tests/layout/position.ts
@@ -1,11 +1,11 @@
 import { LayoutPosition } from '../../index.esm';
 
-export const left: LayoutPosition = 'left';
-export const right: LayoutPosition = 'right';
-export const top: LayoutPosition = 'top';
-export const bottom: LayoutPosition = 'bottom';
-export const center: LayoutPosition = 'center';
-export const axis: LayoutPosition = { x: 10 };
+const left: LayoutPosition = 'left';
+const right: LayoutPosition = 'right';
+const top: LayoutPosition = 'top';
+const bottom: LayoutPosition = 'bottom';
+const center: LayoutPosition = 'center';
+const axis: LayoutPosition = { x: 10 };
 
 // @ts-expect-error invalid position
-export const invalid: LayoutPosition = 'none';
+const invalid: LayoutPosition = 'none';

--- a/types/tests/options.ts
+++ b/types/tests/options.ts
@@ -1,6 +1,6 @@
 import { Chart } from '../index.esm';
 
-export const chart = new Chart('test', {
+const chart = new Chart('test', {
   type: 'bar',
   data: {
     labels: ['a'],

--- a/types/tests/parsed.data.type.ts
+++ b/types/tests/parsed.data.type.ts
@@ -8,7 +8,7 @@ interface test {
   testC: ParsedDataType<'pie' | 'line' | 'bar'>
 }
 
-export const testImpl: test = {
+const testImpl: test = {
   pie: 1,
   line: { x: 1, y: 2 },
   testA: 1,

--- a/types/tests/scriptable.ts
+++ b/types/tests/scriptable.ts
@@ -9,7 +9,7 @@ interface test {
   testD?: Scriptable<number, ScriptableContext<ChartType>>
 }
 
-export const testImpl: test = {
+const testImpl: test = {
   pie: (ctx) => ctx.parsed,
   line: (ctx) => ctx.parsed.x + ctx.parsed.y,
   testA: (ctx) => ctx.parsed,

--- a/types/tests/test_instance_assignment.ts
+++ b/types/tests/test_instance_assignment.ts
@@ -15,9 +15,9 @@ interface Context {
   chart: Chart;
 }
 
-export const ctx: Context = {
+const ctx: Context = {
   chart: chart
 };
 
 // @ts-expect-error Type '{ x: number; y: number; }[]' is not assignable to type 'number[]'.
-export const dataArray: number[] = chart.data.datasets[0].data;
+const dataArray: number[] = chart.data.datasets[0].data;


### PR DESCRIPTION
Reduce some non-essential lint warnings