### PR TITLE
Fix typo in animations.mdx

### DIFF
--- a/docs/docs/configuration/animations.mdx
+++ b/docs/docs/configuration/animations.mdx
@@ -175,7 +175,7 @@ These default animations are overridden by most of the dataset controllers.
 ## transitions
 
 The core transitions are `'active'`, `'hide'`, `'reset'`, `'resize'`, `'show'`.
-A custom transtion can be used by passing a custom `mode` to [update](../developers/api.md#updatemode).
+A custom transition can be used by passing a custom `mode` to [update](../developers/api.md#updatemode).
 Transition extends the main [animation configuration](#animation-configuration) and [animations configuration](#animations-configuration).
 
 ### Default transitions


### PR DESCRIPTION
transtion -> transition

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
