### PR TITLE
Allow changing the aspect ratio

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -460,10 +460,6 @@ class Chart {
     config.update();
     me._options = config.createResolver(config.chartOptionScopes(), me.getContext());
 
-    if (me.aspectRatio !== me._aspectRatio) {
-      me.resize();
-    }
-
     each(me.scales, (scale) => {
       layouts.removeBox(me, scale);
     });

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -151,8 +151,19 @@ class Chart {
   }
 
   get aspectRatio() {
-    const {options: {aspectRatio}, width, height} = this;
-    return !isNullOrUndef(aspectRatio) ? aspectRatio : height ? width / height : null;
+    const {options: {aspectRatio, maintainAspectRatio}, width, height, _aspectRatio} = this;
+    if (!isNullOrUndef(aspectRatio)) {
+      // If aspectRatio is defined in options, use that.
+      return aspectRatio;
+    }
+
+    if (maintainAspectRatio && _aspectRatio) {
+      // If maintainAspectRatio is truthly and we had previously determined _aspectRatio, use that
+      return _aspectRatio;
+    }
+
+    // Calculate
+    return height ? width / height : null;
   }
 
   get data() {

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -7,7 +7,7 @@ import PluginService from './core.plugins';
 import registry from './core.registry';
 import Config, {determineAxis, getIndexAxis} from './core.config';
 import {retinaScale} from '../helpers/helpers.dom';
-import {each, callback as callCallback, uid, valueOrDefault, _elementsEqual} from '../helpers/helpers.core';
+import {each, callback as callCallback, uid, valueOrDefault, _elementsEqual, isNullOrUndef} from '../helpers/helpers.core';
 import {clearCanvas, clipArea, unclipArea, _isPointInArea} from '../helpers/helpers.canvas';
 // @ts-ignore
 import {version} from '../../package.json';
@@ -103,8 +103,11 @@ class Chart {
     this.canvas = canvas;
     this.width = width;
     this.height = height;
-    this.aspectRatio = height ? width / height : null;
     this._options = options;
+    // Store the previously used aspect ratio to determine if a resize
+    // is needed during updates. Do this after _options is set since
+    // aspectRatio uses a getter
+    this._aspectRatio = this.aspectRatio;
     this._layers = [];
     this._metasets = [];
     this._stacks = undefined;
@@ -145,6 +148,11 @@ class Chart {
     if (me.attached) {
       me.update();
     }
+  }
+
+  get aspectRatio() {
+    const {options: {aspectRatio}, width, height} = this;
+    return !isNullOrUndef(aspectRatio) ? aspectRatio : height ? width / height : null;
   }
 
   get data() {
@@ -238,6 +246,7 @@ class Chart {
 
     me.width = newSize.width;
     me.height = newSize.height;
+    me._aspectRatio = me.aspectRatio;
     retinaScale(me, newRatio, true);
 
     me.notifyPlugins('resize', {size: newSize});
@@ -450,6 +459,10 @@ class Chart {
 
     config.update();
     me._options = config.createResolver(config.chartOptionScopes(), me.getContext());
+
+    if (me.aspectRatio !== me._aspectRatio) {
+      me.resize();
+    }
 
     each(me.scales, (scale) => {
       layouts.removeBox(me, scale);

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -1213,6 +1213,38 @@ describe('Chart', function() {
     });
   });
 
+  describe('config.options.aspectRatio', function() {
+    it('should resize the canvas when the aspectRatio option changes', function(done) {
+      var chart = acquireChart({
+        options: {
+          responsive: true,
+          aspectRatio: 1,
+        }
+      }, {
+        canvas: {
+          style: '',
+          width: 400,
+        },
+      });
+
+      expect(chart).toBeChartOfSize({
+        dw: 400, dh: 400,
+        rw: 400, rh: 400,
+      });
+
+      waitForResize(chart, function() {
+        expect(chart).toBeChartOfSize({
+          dw: 400, dh: 200,
+          rw: 400, rh: 200,
+        });
+
+        done();
+      });
+      chart.options.aspectRatio = 2;
+      chart.resize();
+    });
+  });
+
   describe('controller.reset', function() {
     it('should reset the chart elements', function() {
       var chart = acquireChart({


### PR DESCRIPTION
Resolves #6271 

I am opening this as a draft since I am worried that it may break other parts of the resize flow. This forces the `options.aspectRatio` setting to take priority over an aspect ratio determined at construct time.