### PR TITLE
Changes defaults in documentation for grid.tickLength and ticks.padding

### DIFF
--- a/docs/docs/axes/_common_ticks.md
+++ b/docs/docs/axes/_common_ticks.md
@@ -9,7 +9,7 @@ Namespace: `options.scales[scaleId].ticks`
 | `color` | [`Color`](../general/colors.md) | Yes | `Chart.defaults.color` | Color of ticks.
 | `font` | `Font` | Yes | `Chart.defaults.font` | See [Fonts](../general/fonts.md)
 | `major` | `object` | | `{}` | [Major ticks configuration](./styling.mdx#major-tick-configuration).
-| `padding` | `number` | | `0` | Sets the offset of the tick labels from the axis
+| `padding` | `number` | | `3` | Sets the offset of the tick labels from the axis
 | `textStrokeColor` | [`Color`](../general/colors.md) | Yes | `` | The color of the stroke around the text.
 | `textStrokeWidth` | `number` | Yes | `0` | Stroke width around the text.
 | `z` | `number` | | `0` | z-index of tick layer. Useful when ticks are drawn on chart area. Values &lt;= 0 are drawn under datasets, &gt; 0 on top.

--- a/docs/docs/axes/styling.mdx
+++ b/docs/docs/axes/styling.mdx
@@ -27,7 +27,7 @@ Namespace: `options.scales[scaleId].grid`, it defines options for the grid lines
 | `tickBorderDash` | `number[]` | | | | Length and spacing of the tick mark line. If not set, defaults to the grid line `borderDash` value.
 | `tickBorderDashOffset` | `number` | Yes | Yes |  | Offset for the line dash of the tick mark. If unset, defaults to the grid line `borderDashOffset` value
 | `tickColor` | [`Color`](../general/colors.md) | Yes | Yes | | Color of the tick line. If unset, defaults to the grid line color.
-| `tickLength` | `number` | | | `10` | Length in pixels that the grid lines will draw into the axis area.
+| `tickLength` | `number` | | | `8` | Length in pixels that the grid lines will draw into the axis area.
 | `tickWidth` | `number` | Yes | Yes | | Width of the tick mark in pixels. If unset, defaults to the grid line width.
 | `z` | `number` | | | `0` | z-index of gridline layer. Values &lt;= 0 are drawn under datasets, &gt; 0 on top.
 


### PR DESCRIPTION
PR #8657 changes the defaults of `grid.tickLength` and `ticks.padding`.

This PR applies new values in the documentation.