### PR TITLE
Allow `fill: true` and `null` in `ChartDataset.data`

### DIFF
--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -3207,14 +3207,14 @@ export interface ChartTypeRegistry {
   line: {
     chartOptions: LineControllerChartOptions;
     datasetOptions: LineControllerDatasetOptions & FillerControllerDatasetOptions;
-    defaultDataPoint: ScatterDataPoint;
+    defaultDataPoint: ScatterDataPoint | number | null;
     parsedDataType: CartesianParsedData;
     scales: keyof CartesianScaleTypeRegistry;
   };
   scatter: {
     chartOptions: ScatterControllerChartOptions;
     datasetOptions: ScatterControllerDatasetOptions;
-    defaultDataPoint: ScatterDataPoint;
+    defaultDataPoint: ScatterDataPoint | number | null;
     parsedDataType: CartesianParsedData;
     scales: keyof CartesianScaleTypeRegistry;
   };
@@ -3249,7 +3249,7 @@ export interface ChartTypeRegistry {
   radar: {
     chartOptions: RadarControllerChartOptions;
     datasetOptions: RadarControllerDatasetOptions;
-    defaultDataPoint: number;
+    defaultDataPoint: number | null;
     parsedDataType: RadialParsedData;
     scales: keyof RadialScaleTypeRegistry;
   };

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -1966,7 +1966,7 @@ export interface FillerOptions {
   propagate: boolean;
 }
 
-export type FillTarget = number | string | { value: number } | 'start' | 'end' | 'origin' | 'stack' | false;
+export type FillTarget = number | string | { value: number } | 'start' | 'end' | 'origin' | 'stack' | boolean;
 
 export interface ComplexFillTarget {
   /**

--- a/types/tests/dataset_null_data.ts
+++ b/types/tests/dataset_null_data.ts
@@ -1,0 +1,16 @@
+import { ChartDataset } from '../index.esm';
+
+const dataset: ChartDataset = {
+  data: [10, null, 20],
+};
+
+const lineDataset: ChartDataset<'line'> = {
+  data: [10, null, 20],
+};
+const scatterDataset: ChartDataset<'scatter'> = {
+  data: [10, null, 20],
+};
+const radarDataset: ChartDataset<'radar'> = {
+  data: [10, null, 20],
+};
+

--- a/types/tests/plugins/plugin.filler/fill_target_true.ts
+++ b/types/tests/plugins/plugin.filler/fill_target_true.ts
@@ -1,0 +1,6 @@
+import { ChartDataset } from '../../../index.esm';
+
+const dataset: ChartDataset = {
+  data: [],
+  fill: true,
+};


### PR DESCRIPTION
Resolves #8698 
