### PR TITLE
Minor type fixes

### DIFF
--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -2367,9 +2367,9 @@ export interface TooltipOptions<TType extends ChartType> extends CoreInteraction
   /**
    * Sort tooltip items.
    */
-  itemSort: (a: TooltipItem<ChartType>, b: TooltipItem<ChartType>) => number;
+  itemSort: (a: TooltipItem<ChartType>, b: TooltipItem<ChartType>, data: ChartData) => number;
 
-  filter: (e: TooltipItem<ChartType>) => boolean;
+  filter: (e: TooltipItem<ChartType>, index: number, array: TooltipItem<ChartType>[], data: ChartData) => boolean;
 
   /**
    * Background color of the tooltip.

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -3038,7 +3038,7 @@ export type RadialLinearScaleOptions = CoreScaleOptions & {
      * Padding of label backdrop.
      * @default 2
      */
-     backdropPadding: Scriptable<number | ChartArea, ScriptableScaleContext>;
+    backdropPadding: Scriptable<number | ChartArea, ScriptableScaleContext>;
 
     /**
      * if true, point labels are shown.
@@ -3057,9 +3057,8 @@ export type RadialLinearScaleOptions = CoreScaleOptions & {
 
     /**
      * Callback function to transform data labels to point labels. The default implementation simply returns the current string.
-     * @default true
      */
-    callback: (label: string) => string;
+    callback: (label: string, index: number) => string;
   };
 
   /**


### PR DESCRIPTION
Add types for additional documented parameters in tooltip callbacks.

Update RadialLinearScaleOptions.pointLabels.callback type. The code passes `index` as the second parameter, and one of the tests uses this.  `@default true` doesn't seem to make sense.