### PR TITLE
Distribute types as is

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -13,7 +13,7 @@ Chart.js relies on [Travis CI](https://travis-ci.org/) to automate the library [
 Creation of this tag triggers a new build:
 
 * `Chart.js.zip` package is generated, containing dist files and examples
-* `dist/*.js` and `Chart.js.zip` are attached to the GitHub release (downloads)
+* `dist/*.js`, `types/*.ts`, and `Chart.js.zip` are attached to the GitHub release (downloads)
 * A new npm package is published on [npmjs](https://www.npmjs.com/package/chart.js)
 
 Finally, [cdnjs](https://cdnjs.com/libraries/Chart.js) is automatically updated from the npm release.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3581,40 +3581,6 @@
         "rollup-pluginutils": "^2.8.2"
       }
     },
-    "rollup-plugin-dts": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-3.0.1.tgz",
-      "integrity": "sha512-sdTsd0tEIV1b5Bio1k4Ei3N4/7jbwcVRdlYotGYdJOKR59JH7DzqKTSCbfaKPzuAcKTp7k317z2BzYJ3bkhDTw==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.12.13",
-        "magic-string": "^0.25.7"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@babel/highlight": "^7.12.13"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-          "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        }
-      }
-    },
     "rollup-plugin-istanbul": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-istanbul/-/rollup-plugin-istanbul-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "unpkg": "dist/chart.min.js",
   "main": "dist/chart.js",
   "module": "dist/chart.esm.js",
-  "types": "dist/chart.esm.d.ts",
+  "types": "types/chart.esm.d.ts",
   "keywords": [
     "canvas",
     "charts",
@@ -28,9 +28,9 @@
     "auto/**/*.js",
     "auto/**/*.d.ts",
     "dist/*.js",
-    "dist/*.d.ts",
     "dist/chunks/*.js",
-    "dist/chunks/*.d.ts",
+    "types/*.d.ts",
+    "types/helpers/*.d.ts",
     "helpers/**/*.js",
     "helpers/**/*.d.ts"
   ],
@@ -84,7 +84,6 @@
     "rollup": "^2.41.4",
     "rollup-plugin-analyzer": "^4.0.0",
     "rollup-plugin-cleanup": "^3.2.1",
-    "rollup-plugin-dts": "^3.0.1",
     "rollup-plugin-istanbul": "^3.0.0",
     "rollup-plugin-terser": "^7.0.2",
     "typedoc": "^0.20.32",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,5 @@
 const analyze = require('rollup-plugin-analyzer');
 const cleanup = require('rollup-plugin-cleanup');
-const dts = require('rollup-plugin-dts').default;
 const json = require('@rollup/plugin-json');
 const resolve = require('@rollup/plugin-node-resolve').default;
 const terser = require('rollup-plugin-terser').terser;
@@ -10,10 +9,6 @@ const input = 'src/index.js';
 const inputESM = {
   'dist/chart.esm': 'src/index.esm.js',
   'dist/helpers.esm': 'src/helpers/index.js'
-};
-const inputESMTypings = {
-  'dist/chart.esm': 'types/index.esm.d.ts',
-  'dist/helpers.esm': 'types/helpers/index.d.ts'
 };
 
 const banner = `/*!
@@ -84,20 +79,4 @@ module.exports = [
       indent: false,
     },
   },
-  // ES6 Typings builds
-  // dist/chart.esm.d.ts
-  // helpers/*.d.ts
-  {
-    input: inputESMTypings,
-    plugins: [
-      dts()
-    ],
-    output: {
-      dir: './',
-      chunkFileNames: 'dist/chunks/[name].ts',
-      banner,
-      format: 'esm',
-      indent: false,
-    },
-  }
 ];

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -1,17 +1,3 @@
-/**
- * Top-level type definitions. These are processed by Rollup and rollup-plugin-dts
- * to make a combined .d.ts file under dist; that way, all of the type definitions
- * appear directly within the "chart.js" module; that matches the layout of the
- * distributed chart.esm.js bundle and means that users of Chart.js can easily use
- * module augmentation to extend Chart.js's types and plugins within their own
- * code, like so:
- *
- * @example
- * declare module "chart.js" {
- *   // Add types here
- * }
- */
-
 import { DeepPartial, DistributiveArray, UnionToIntersection } from './utils';
 
 import { TimeUnit } from './adapters';


### PR DESCRIPTION
I had initially seen some oddities around type augmentation for type definitions in subdirectories of `types`, and using Rollup seemed to help with that. However, now that all of Chart.js's main types are directly under `types`, there seems to be no need for this.

This simplifies the build process, since it no longer needs to use rollup-plugin-dts.

It also improves some third-party tools. For example, I'm in the habit of using WebStorm's "Go To Declaration or Usages" hotkey with third-party TypeScript definitions as a quick way of getting more information about an API. With the Rollup-generate types, that works poorly; WebStorm goes to the imported-and-re-exported symbol within the barely-readable machine-generated dist/chart.esm.d.ts file, and I have to navigate two more hops to find the actual definitions.

I tested this with my local application, and it seems to work fine. Some of my local type augmentations needed minor tweaks, but that was all.

(Background / further reading: In case it helps, I'd posted a couple of [previous](https://github.com/chartjs/Chart.js/issues/7655#issuecomment-707183221) [comments](https://github.com/chartjs/Chart.js/pull/8190) about this. I intended to submit this PR before now; I apologize for the delay. If it's too close to the 3.0.0 release, I understand.)