### PR TITLE
Ensure scriptable context reflects updated data

### DIFF
--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -151,11 +151,11 @@ function getFirstScaleId(chart, axis) {
   return Object.keys(scales).filter(key => scales[key].axis === axis).shift();
 }
 
-function createDatasetContext(parent, index, dataset) {
+function createDatasetContext(parent, index) {
   return Object.assign(Object.create(parent),
     {
       active: false,
-      dataset,
+      dataset: undefined,
       datasetIndex: index,
       index,
       mode: 'default',
@@ -164,12 +164,12 @@ function createDatasetContext(parent, index, dataset) {
   );
 }
 
-function createDataContext(parent, index, point, raw, element) {
+function createDataContext(parent, index, element) {
   return Object.assign(Object.create(parent), {
     active: false,
     dataIndex: index,
-    parsed: point,
-    raw,
+    parsed: undefined,
+    raw: undefined,
     element,
     index,
     mode: 'default',
@@ -704,9 +704,13 @@ export default class DatasetController {
     if (index >= 0 && index < me._cachedMeta.data.length) {
       const element = me._cachedMeta.data[index];
       context = element.$context ||
-				(element.$context = createDataContext(me.getContext(), index, me.getParsed(index), dataset.data[index], element));
+        (element.$context = createDataContext(me.getContext(), index, element));
+      context.parsed = me.getParsed(index);
+      context.raw = dataset.data[index];
     } else {
-      context = me.$context || (me.$context = createDatasetContext(me.chart.getContext(), me.index, dataset));
+      context = me.$context ||
+        (me.$context = createDatasetContext(me.chart.getContext(), me.index));
+      context.dataset = dataset;
     }
 
     context.active = !!active;

--- a/test/specs/core.datasetController.tests.js
+++ b/test/specs/core.datasetController.tests.js
@@ -881,4 +881,78 @@ describe('Chart.DatasetController', function() {
       });
     });
   });
+
+  describe('getContext', function() {
+    it('should reflect updated data', function() {
+      var chart = acquireChart({
+        type: 'scatter',
+        data: {
+          datasets: [{
+            data: [{x: 1, y: 0}, {x: 2, y: '1'}]
+          }]
+        },
+      });
+      let meta = chart.getDatasetMeta(0);
+
+      expect(meta.controller.getContext(undefined, true, 'test')).toEqual(jasmine.objectContaining({
+        active: true,
+        datasetIndex: 0,
+        dataset: chart.data.datasets[0],
+        index: 0,
+        mode: 'test'
+      }));
+      expect(meta.controller.getContext(1, false, 'datatest')).toEqual(jasmine.objectContaining({
+        active: false,
+        datasetIndex: 0,
+        dataset: chart.data.datasets[0],
+        dataIndex: 1,
+        element: meta.data[1],
+        index: 1,
+        parsed: {x: 2, y: 1},
+        raw: {x: 2, y: '1'},
+        mode: 'datatest'
+      }));
+
+      chart.data.datasets[0].data[1].y = 5;
+      chart.update();
+
+      expect(meta.controller.getContext(1, false, 'datatest')).toEqual(jasmine.objectContaining({
+        active: false,
+        datasetIndex: 0,
+        dataset: chart.data.datasets[0],
+        dataIndex: 1,
+        element: meta.data[1],
+        index: 1,
+        parsed: {x: 2, y: 5},
+        raw: {x: 2, y: 5},
+        mode: 'datatest'
+      }));
+
+      chart.data.datasets = [{
+        data: [{x: 0, y: 0}, {x: 1, y: 1}]
+      }];
+      chart.update();
+      // meta is re-created when dataset is replaced
+      meta = chart.getDatasetMeta(0);
+
+      expect(meta.controller.getContext(undefined, false, 'test2')).toEqual(jasmine.objectContaining({
+        active: false,
+        datasetIndex: 0,
+        dataset: chart.data.datasets[0],
+        index: 0,
+        mode: 'test2'
+      }));
+      expect(meta.controller.getContext(1, true, 'datatest2')).toEqual(jasmine.objectContaining({
+        active: true,
+        datasetIndex: 0,
+        dataset: chart.data.datasets[0],
+        dataIndex: 1,
+        element: meta.data[1],
+        index: 1,
+        parsed: {x: 1, y: 1},
+        raw: {x: 1, y: 1},
+        mode: 'datatest2'
+      }));
+    });
+  });
 });


### PR DESCRIPTION
Scriptable context was not updated when data or dataset is changed.

For example, clicking `randomize` in the following example does not update the bar colors:
https://www.chartjs.org/samples/master/scriptable/bar.html (should go red when <0)
