### PR TITLE
Contributing link show 404 error page cause by wrong url 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Currently, there are two versions of the library (2.9.4 and 3.x.x). Version 2 is
 
 ## Contributing
 
-Instructions on building and testing Chart.js can be found in [the documentation](https://www.chartjs.org/docs/master/developers/contributing/#building-and-testing). Before submitting an issue or a pull request, please take a moment to look over the [contributing guidelines](https://www.chartjs.org/docs/master/developers/contributing/) first. For support, please post questions on [Stack Overflow](https://stackoverflow.com/questions/tagged/chartjs) with the `chartjs` tag.
+Instructions on building and testing Chart.js can be found in [the documentation](https://www.chartjs.org/docs/master/developers/contributing.html#building-and-testing). Before submitting an issue or a pull request, please take a moment to look over the [contributing guidelines](https://www.chartjs.org/docs/master/developers/contributing) first. For support, please post questions on [Stack Overflow](https://stackoverflow.com/questions/tagged/chartjs) with the `chartjs` tag.
 
 ## License
 


### PR DESCRIPTION
In README.md

link text : the documentation
from : https://www.chartjs.org/docs/master/developers/contributing/#building-and-testing
to : https://www.chartjs.org/docs/master/developers/contributing.html#building-and-testing

link text : contributing guidelines
from : https://www.chartjs.org/docs/master/developers/contributing/
to : https://www.chartjs.org/docs/master/developers/contributing
