### PR TITLE
Links: Rename .mdx to .md

### DIFF
--- a/docs/axes/_common.md
+++ b/docs/axes/_common.md
@@ -8,12 +8,12 @@ Namespace: `options.scales[scaleId]`
 | `alignToPixels` | `boolean` | `false` | Align pixel values to device pixels.
 | `backgroundColor` | [`Color`](../general/colors.md) | | Background color of the scale area.
 | `display` | `boolean`\|`string` | `true` | Controls the axis global visibility (visible when `true`, hidden when `false`). When `display: 'auto'`, the axis is visible only if at least one associated dataset is visible.
-| `grid` | `object` | | Grid line configuration. [more...](./styling.mdx#grid-line-configuration)
-| `min` | `number` | | User defined minimum number for the scale, overrides minimum value from data. [more...](./index.mdx#axis-range-settings)
-| `max` | `number` | | User defined maximum number for the scale, overrides maximum value from data. [more...](./index.mdx#axis-range-settings)
+| `grid` | `object` | | Grid line configuration. [more...](./styling.md#grid-line-configuration)
+| `min` | `number` | | User defined minimum number for the scale, overrides minimum value from data. [more...](./index.md#axis-range-settings)
+| `max` | `number` | | User defined maximum number for the scale, overrides maximum value from data. [more...](./index.md#axis-range-settings)
 | `reverse` | `boolean` | `false` | Reverse the scale.
-| `stacked` | `boolean`\|`string` | `false` | Should the data be stacked. [more...](./index.mdx#stacking)
-| `suggestedMax` | `number` | | Adjustment used when calculating the maximum data value. [more...](./index.mdx#axis-range-settings)
-| `suggestedMin` | `number` | | Adjustment used when calculating the minimum data value. [more...](./index.mdx#axis-range-settings)
+| `stacked` | `boolean`\|`string` | `false` | Should the data be stacked. [more...](./index.md#stacking)
+| `suggestedMax` | `number` | | Adjustment used when calculating the maximum data value. [more...](./index.md#axis-range-settings)
+| `suggestedMin` | `number` | | Adjustment used when calculating the minimum data value. [more...](./index.md#axis-range-settings)
 | `ticks` | `object` | | Tick configuration. [more...](#tick-configuration)
 | `weight` | `number` | `0` | The weight used to sort the axis. Higher weights are further away from the chart area.

--- a/docs/axes/_common_ticks.md
+++ b/docs/axes/_common_ticks.md
@@ -8,7 +8,7 @@ Namespace: `options.scales[scaleId].ticks`
 | `display` | `boolean` | | `true` | If true, show tick labels.
 | `color` | [`Color`](../general/colors.md) | Yes | `Chart.defaults.color` | Color of ticks.
 | `font` | `Font` | Yes | `Chart.defaults.font` | See [Fonts](../general/fonts.md)
-| `major` | `object` | | `{}` | [Major ticks configuration](./styling.mdx#major-tick-configuration).
+| `major` | `object` | | `{}` | [Major ticks configuration](./styling.md#major-tick-configuration).
 | `padding` | `number` | | `3` | Sets the offset of the tick labels from the axis
 | `textStrokeColor` | [`Color`](../general/colors.md) | Yes | `` | The color of the stroke around the text.
 | `textStrokeWidth` | `number` | Yes | `0` | Stroke width around the text.

--- a/docs/axes/cartesian/_common.md
+++ b/docs/axes/cartesian/_common.md
@@ -4,8 +4,8 @@ Namespace: `options.scales[scaleId]`
 
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
-| `bounds` | `string` | `'ticks'` | Determines the scale bounds. [more...](./index.mdx#scale-bounds)
-| `position` | `string` | | Position of the axis. [more...](./index.mdx#axis-position)
+| `bounds` | `string` | `'ticks'` | Determines the scale bounds. [more...](./index.md#scale-bounds)
+| `position` | `string` | | Position of the axis. [more...](./index.md#axis-position)
 | `axis` | `string` | | Which type of axis this is. Possible values are: `'x'`, `'y'`. If not set, this is inferred from the first character of the ID which should be `'x'` or `'y'`.
 | `offset` | `boolean` | `false` | If true, extra space is added to the both edges and the axis is scaled to fit into the chart area. This is set to `true` for a bar chart by default.
 | `title` | `object` | | Scale title configuration. [more...](../labelling.md#scale-title-configuration)

--- a/docs/axes/cartesian/time.md
+++ b/docs/axes/cartesian/time.md
@@ -25,7 +25,7 @@ Namespace: `options.scales[scaleId]`
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
 | `adapters.date` | `object` | `{}` | Options for adapter for external date library if that adapter needs or supports options
-| `bounds` | `string` | `'data'` | Determines the scale bounds. [more...](./index.mdx#scale-bounds)
+| `bounds` | `string` | `'data'` | Determines the scale bounds. [more...](./index.md#scale-bounds)
 | `ticks.source` | `string` | `'auto'` | How ticks are generated. [more...](#ticks-source)
 | `time.displayFormats` | `object` | | Sets how different time units are displayed. [more...](#display-formats)
 | `time.isoWeekday` | `boolean`\|`number` | `false` | If `boolean` and true and the unit is set to 'week', then the first day of the week will be Monday. Otherwise, it will be Sunday. If `number`, the index of the first day of the week (0 - Sunday, 6 - Saturday)

--- a/docs/axes/cartesian/timeseries.md
+++ b/docs/axes/cartesian/timeseries.md
@@ -20,4 +20,4 @@ var chart = new Chart(ctx, {
 
 ## More details
 
-Please see [the time scale documentation](./time.mdx) for all other details.
+Please see [the time scale documentation](./time.md) for all other details.

--- a/docs/axes/radial/index.md
+++ b/docs/axes/radial/index.md
@@ -2,7 +2,7 @@
 
 Radial axes are used specifically for the radar and polar area chart types. These axes overlay the chart area, rather than being positioned on one of the edges. One radial axis is included by default in Chart.js.
 
-* [radialLinear](./linear.mdx)
+* [radialLinear](./linear.md)
 
 ## Visual Components
 

--- a/docs/charts/area.md
+++ b/docs/charts/area.md
@@ -1,6 +1,6 @@
 # Area Chart
 
-Both [line](./line.mdx) and [radar](./radar.mdx) charts support a `fill` option on the dataset object which can be used to create space between two datasets or a dataset and a boundary, i.e. the scale `origin`, `start,` or `end` (see [filling modes](#filling-modes)).
+Both [line](./line.md) and [radar](./radar.md) charts support a `fill` option on the dataset object which can be used to create space between two datasets or a dataset and a boundary, i.e. the scale `origin`, `start,` or `end` (see [filling modes](#filling-modes)).
 
 :::tip Note
 This feature is implemented by the [`filler` plugin](https://github.com/chartjs/Chart.js/blob/master/src/plugins/plugin.filler.js).

--- a/docs/charts/polar.md
+++ b/docs/charts/polar.md
@@ -115,7 +115,7 @@ These are the customisation options specific to Polar Area charts. These options
 | `animation.animateRotate` | `boolean` | `true` | If true, the chart will animate in with a rotation animation. This property is in the `options.animation` object.
 | `animation.animateScale` | `boolean` | `true` | If true, will animate scaling the chart from the center outwards.
 
-The polar area chart uses the [radialLinear](../axes/radial/linear.mdx) scale. Additional configuration is provided via the scale.
+The polar area chart uses the [radialLinear](../axes/radial/linear.md) scale. Additional configuration is provided via the scale.
 
 ## Default Options
 

--- a/docs/charts/scatter.md
+++ b/docs/charts/scatter.md
@@ -48,7 +48,7 @@ module.exports = {
 
 ## Dataset Properties
 
-The scatter chart supports all of the same properties as the [line chart](./charts/line.mdx#dataset-properties).
+The scatter chart supports all of the same properties as the [line chart](./charts/line.md#dataset-properties).
 By default, the scatter chart will override the showLine property of the line chart to `false`.
 
 The index scale is of the type `linear`. This means if you are using the labels array the values have to be numbers or parsable to numbers, the same applies to the object format for the keys.

--- a/docs/configuration/elements.md
+++ b/docs/configuration/elements.md
@@ -62,7 +62,7 @@ Namespace: `options.elements.line`, global line options: `Chart.defaults.element
 | `borderDashOffset` | `number` | `0.0` | Line dash offset. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineDashOffset).
 | `borderJoinStyle` | `string` | `'miter'` | Line join style. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineJoin).
 | `capBezierPoints` | `boolean` | `true` | `true` to keep Bézier control inside the chart, `false` for no restriction.
-| `cubicInterpolationMode` | `string` | `'default'` |  Interpolation mode to apply. [See more...](./charts/line.mdx/#cubicinterpolationmode)
+| `cubicInterpolationMode` | `string` | `'default'` |  Interpolation mode to apply. [See more...](./charts/line.md/#cubicinterpolationmode)
 | `fill` | `boolean`\|`string` | `false` | How to fill the area under the line. See [area charts](../charts/area.md#filling-modes).
 | `stepped` | `boolean` | `false` | `true` to show the line as a stepped line (`tension` will be ignored).
 

--- a/docs/developers/api.md
+++ b/docs/developers/api.md
@@ -26,7 +26,7 @@ myLineChart.data.datasets[0].data[2] = 50; // Would update the first dataset's v
 myLineChart.update(); // Calling update now animates the position of March from 90 to 50.
 ```
 
-A `mode` string can be provided to indicate transition configuration should be used. Core calls this method using any of `'active'`, `'hide'`, `'reset'`, `'resize'`, `'show'` or `undefined`. `'none'` is also a supported mode for skipping animations for single update. Please see [animations](../configuration/animations.mdx) docs for more details.
+A `mode` string can be provided to indicate transition configuration should be used. Core calls this method using any of `'active'`, `'hide'`, `'reset'`, `'resize'`, `'show'` or `undefined`. `'none'` is also a supported mode for skipping animations for single update. Please see [animations](../configuration/animations.md) docs for more details.
 
 Example:
 
@@ -154,7 +154,7 @@ var visible = chart.getDataVisibility(2);
 
 ## hide(datasetIndex)
 
-Sets the visibility for the given dataset to false. Updates the chart and animates the dataset with `'hide'` mode. This animation can be configured under the `hide` key in animation options. Please see [animations](../configuration/animations.mdx) docs for more details.
+Sets the visibility for the given dataset to false. Updates the chart and animates the dataset with `'hide'` mode. This animation can be configured under the `hide` key in animation options. Please see [animations](../configuration/animations.md) docs for more details.
 
 ```javascript
 chart.hide(1); // hides dataset at index 1 and does 'hide' animation.
@@ -162,7 +162,7 @@ chart.hide(1); // hides dataset at index 1 and does 'hide' animation.
 
 ## show(datasetIndex)
 
-Sets the visibility for the given dataset to true. Updates the chart and animates the dataset with `'show'` mode. This animation can be configured under the `show` key in animation options. Please see [animations](../configuration/animations.mdx) docs for more details.
+Sets the visibility for the given dataset to true. Updates the chart and animates the dataset with `'show'` mode. This animation can be configured under the `show` key in animation options. Please see [animations](../configuration/animations.md) docs for more details.
 
 ```javascript
 chart.show(1); // shows dataset at index 1 and does 'show' animation.

--- a/docs/general/performance.md
+++ b/docs/general/performance.md
@@ -24,11 +24,11 @@ Line charts are able to do [automatic data decimation during draw](#automatic-da
 
 ### Rotation
 
-[Specify a rotation value](./axes/cartesian/index.mdx#tick-configuration) by setting `minRotation` and `maxRotation` to the same value, which avoids the chart from having to automatically determine a value to use.
+[Specify a rotation value](./axes/cartesian/index.md#tick-configuration) by setting `minRotation` and `maxRotation` to the same value, which avoids the chart from having to automatically determine a value to use.
 
 ### Sampling
 
-Set the [`ticks.sampleSize`](./axes/cartesian/index.mdx#tick-configuration) option. This will determine how large your labels are by looking at only a subset of them in order to render axes more quickly. This works best if there is not a large variance in the size of your labels.
+Set the [`ticks.sampleSize`](./axes/cartesian/index.md#tick-configuration) option. This will determine how large your labels are by looking at only a subset of them in order to render axes more quickly. This works best if there is not a large variance in the size of your labels.
 
 ## Disable Animations
 

--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -51,7 +51,7 @@ const chart = new Chart(ctx, {
 
 ### Chart types
 
-* `horizontalBar` chart type was removed. Horizontal bar charts can be configured using the new [`indexAxis`](./charts/bar.mdx#horizontal-bar-chart) option
+* `horizontalBar` chart type was removed. Horizontal bar charts can be configured using the new [`indexAxis`](./charts/bar.md#horizontal-bar-chart) option
 
 ### Options
 
@@ -208,7 +208,7 @@ options: {
 
 #### Animations
 
-Animation system was completely rewritten in Chart.js v3. Each property can now be animated separately. Please see [animations](../configuration/animations.mdx) docs for details.
+Animation system was completely rewritten in Chart.js v3. Each property can now be animated separately. Please see [animations](../configuration/animations.md) docs for details.
 
 #### Customizability
 


### PR DESCRIPTION
There are a number of links to .mdx pages that were renamed to .md.
