### PR TITLE
Adds scriptable column to options table in the title documentation

### DIFF
--- a/docs/configuration/title.md
+++ b/docs/configuration/title.md
@@ -7,9 +7,9 @@ The chart title defines text to draw at the top of the chart.
 Namespace: `options.plugins.title`, the global options for the chart title is defined in `Chart.defaults.plugins.title`.
 
 | Name | Type | Default | [Scriptable](../general/options.md#scriptable-options) | Description
-| ---- | ---- | ------- | -----------
+| ---- | ---- | ------- | :----: | -----------
 | `align` | `string` | `'center'` | Yes | Alignment of the title. [more...](#align)
-| `color` | [`Color`](../general/colors.md) | Yes | `Chart.defaults.color` | Color of text.
+| `color` | [`Color`](../general/colors.md) | `Chart.defaults.color` | Yes | Color of text.
 | `display` | `boolean` | `false` | Yes | Is the title shown?
 | `fullSize` | `boolean` | `true` | Yes | Marks that this box should take the full width/height of the canvas. If `false`, the box is sized and placed above/beside the chart area.
 | `position` | `string` | `'top'` | Yes | Position of title. [more...](#position)

--- a/docs/configuration/title.md
+++ b/docs/configuration/title.md
@@ -6,16 +6,16 @@ The chart title defines text to draw at the top of the chart.
 
 Namespace: `options.plugins.title`, the global options for the chart title is defined in `Chart.defaults.plugins.title`.
 
-| Name | Type | Default | Description
+| Name | Type | Default | [Scriptable](../general/options.md#scriptable-options) | Description
 | ---- | ---- | ------- | -----------
-| `align` | `string` | `'center'` | Alignment of the title. [more...](#align)
-| `color` | [`Color`](../general/colors.md) | `Chart.defaults.color` | Color of text.
-| `display` | `boolean` | `false` | Is the title shown?
-| `fullSize` | `boolean` | `true` | Marks that this box should take the full width/height of the canvas. If `false`, the box is sized and placed above/beside the chart area.
-| `position` | `string` | `'top'` | Position of title. [more...](#position)
-| `font` | `Font` | `{style: 'bold'}` | See [Fonts](../general/fonts.md)
-| `padding` | [`Padding`](../general/padding.md) | `10` | Padding to apply around the title. Only `top` and `bottom` are implemented.
-| `text` | `string`\|`string[]` | `''` | Title text to display. If specified as an array, text is rendered on multiple lines.
+| `align` | `string` | `'center'` | Yes | Alignment of the title. [more...](#align)
+| `color` | [`Color`](../general/colors.md) | Yes | `Chart.defaults.color` | Color of text.
+| `display` | `boolean` | `false` | Yes | Is the title shown?
+| `fullSize` | `boolean` | `true` | Yes | Marks that this box should take the full width/height of the canvas. If `false`, the box is sized and placed above/beside the chart area.
+| `position` | `string` | `'top'` | Yes | Position of title. [more...](#position)
+| `font` | `Font` | `{style: 'bold'}` | Yes | See [Fonts](../general/fonts.md)
+| `padding` | [`Padding`](../general/padding.md) | `10` | Yes | Padding to apply around the title. Only `top` and `bottom` are implemented.
+| `text` | `string`\|`string[]` | `''` | Yes | Title text to display. If specified as an array, text is rendered on multiple lines.
 
 ### Position
 

--- a/docs/general/padding.md
+++ b/docs/general/padding.md
@@ -6,7 +6,7 @@ Padding values in Chart options can be supplied in couple of different formats.
 
 If this value is a number, it is applied to all sides (left, top, right, bottom).
 
-For exmaple, defining a 20px padding to all sides of chart:
+For example, defining a 20px padding to all sides of chart:
 
 ```javascript
 let chart = new Chart(ctx, {


### PR DESCRIPTION
PR  #8764 adds the feature to title plugin in order to use scriptable options.
This features wasn't reported in the documentation.
This PR adds the scriptable column to options table.

