### PR TITLE
Fix: update line options on resize, for gradients

### DIFF
--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -29,17 +29,14 @@ export default class LineController extends DatasetController {
     line._decimated = !!_dataset._decimated;
     line.points = points;
 
-    // In resize mode only point locations change, so no need to set the options.
-    if (mode !== 'resize') {
-      const options = me.resolveDatasetElementOptions(mode);
-      if (!me.options.showLine) {
-        options.borderWidth = 0;
-      }
-      me.updateElement(line, undefined, {
-        animated: !animationsDisabled,
-        options
-      }, mode);
+    const options = me.resolveDatasetElementOptions(mode);
+    if (!me.options.showLine) {
+      options.borderWidth = 0;
     }
+    me.updateElement(line, undefined, {
+      animated: !animationsDisabled,
+      options
+    }, mode);
 
     // Update Points
     me.updateElements(points, start, count, mode);


### PR DESCRIPTION
If there is a gradient border or background, it needs to be updated on resize.
This is especially bad on a chart that is initially hidden, because the size is `0x0`.
