### PR TITLE
Filtering data before decimation

### DIFF
--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -140,6 +140,7 @@ function getStartAndCountOfVisiblePoints(meta, points, animationsDisabled) {
     const {iScale, _parsed} = meta;
     const axis = iScale.axis;
     const {min, max, minDefined, maxDefined} = iScale.getUserBounds();
+
     if (minDefined) {
       start = _limitValue(Math.min(
         _lookupByKey(_parsed, iScale.axis, min).lo,

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -1,5 +1,5 @@
 import DatasetController from '../core/core.datasetController';
-import {isNumber, _limitValue} from '../helpers/helpers.math';
+import {_limitValue, isNumber} from '../helpers/helpers.math';
 import {_lookupByKey} from '../helpers/helpers.collection';
 
 export default class LineController extends DatasetController {

--- a/src/plugins/plugin.decimation.js
+++ b/src/plugins/plugin.decimation.js
@@ -32,8 +32,8 @@ function lttbDecimation(data, start, count, availableWidth, options) {
     const avgRangeLength = avgRangeEnd - avgRangeStart;
 
     for (j = avgRangeStart; j < avgRangeEnd; j++) {
-      avgX = data[j].x;
-      avgY = data[j].y;
+      avgX += data[j].x;
+      avgY += data[j].y;
     }
 
     avgX /= avgRangeLength;

--- a/src/plugins/plugin.decimation.js
+++ b/src/plugins/plugin.decimation.js
@@ -22,11 +22,7 @@ function lttbDecimation(data, start, count, availableWidth, options) {
   const endIndex = start + count - 1;
   // Starting from offset
   let a = start;
-  let i,
-    maxAreaPoint,
-    maxArea,
-    area,
-    nextA;
+  let i, maxAreaPoint, maxArea, area, nextA;
 
   decimated[sampledIndex++] = data[a];
 
@@ -63,7 +59,7 @@ function lttbDecimation(data, start, count, availableWidth, options) {
     for (j = rangeOffs; j < rangeTo; j++) {
       area = 0.5 * Math.abs(
         (pointAx - avgX) * (data[j].y - pointAy) -
-        (pointAx - data[j].x) * (avgY - pointAy),
+        (pointAx - data[j].x) * (avgY - pointAy)
       );
 
       if (area > maxArea) {
@@ -86,16 +82,7 @@ function lttbDecimation(data, start, count, availableWidth, options) {
 function minMaxDecimation(data, start, count, availableWidth) {
   let avgX = 0;
   let countX = 0;
-  let i,
-    point,
-    x,
-    y,
-    prevX,
-    minIndex,
-    maxIndex,
-    startIndex,
-    minY,
-    maxY;
+  let i, point, x, y, prevX, minIndex, maxIndex, startIndex, minY, maxY;
   const decimated = [];
   const endIndex = start + count - 1;
 
@@ -142,7 +129,7 @@ function minMaxDecimation(data, start, count, availableWidth) {
         if (intermediateIndex2 !== startIndex && intermediateIndex2 !== lastIndex) {
           decimated.push({
             ...data[intermediateIndex2],
-            x: avgX,
+            x: avgX
           });
         }
       }
@@ -177,25 +164,20 @@ function cleanDecimatedData(chart) {
   });
 }
 
-function getStartAndCountOfVisiblePointsSimplified(meta, points, animationsDisabled) {
+function getStartAndCountOfVisiblePointsSimplified(meta, points) {
   const pointCount = points.length;
 
   let start = 0;
   let count;
 
   const {iScale} = meta;
-  const axis = iScale.axis;
   const {min, max, minDefined, maxDefined} = iScale.getUserBounds();
 
   if (minDefined) {
-    start = _limitValue(Math.min(
-      _lookupByKey(points, iScale.axis, min).lo,
-      animationsDisabled ? pointCount : _lookupByKey(points, axis, iScale.getPixelForValue(min)).lo), 0, pointCount - 1);
+    start = _limitValue(_lookupByKey(points, iScale.axis, min).lo, 0, pointCount - 1);
   }
   if (maxDefined) {
-    count = _limitValue(Math.max(
-      _lookupByKey(points, iScale.axis, max).hi + 1,
-      animationsDisabled ? 0 : _lookupByKey(points, axis, iScale.getPixelForValue(max)).hi + 1), start, pointCount) - start;
+    count = _limitValue(_lookupByKey(points, iScale.axis, max).hi + 1, start, pointCount) - start;
   } else {
     count = pointCount - start;
   }
@@ -247,9 +229,7 @@ export default {
         return;
       }
 
-      // We know that the diagram is a line type
-      const animationsDisabled = chart._animationsDisabled;
-      let {start, count} = getStartAndCountOfVisiblePointsSimplified(meta, data, animationsDisabled);
+      let {start, count} = getStartAndCountOfVisiblePointsSimplified(meta, data);
       if (count <= 4 * availableWidth) {
         // No decimation is required until we are above this threshold
         return;
@@ -269,7 +249,7 @@ export default {
           },
           set: function(d) {
             this._data = d;
-          },
+          }
         });
       }
 
@@ -292,5 +272,5 @@ export default {
 
   destroy(chart) {
     cleanDecimatedData(chart);
-  },
+  }
 };

--- a/test/specs/plugin.decimation.tests.js
+++ b/test/specs/plugin.decimation.tests.js
@@ -1,0 +1,144 @@
+describe('Plugin.decimation', function() {
+
+  describe('auto', jasmine.fixture.specs('plugin.decimation'));
+
+  describe('lttb', function() {
+    const originalData = [
+      {x: 0, y: 0},
+      {x: 1, y: 1},
+      {x: 2, y: 2},
+      {x: 3, y: 3},
+      {x: 4, y: 4},
+      {x: 5, y: 5},
+      {x: 6, y: 6},
+      {x: 7, y: 7},
+      {x: 8, y: 8},
+      {x: 9, y: 9}];
+
+    it('should draw all element if sample is greater than data', function() {
+      var chart = window.acquireChart({
+        type: 'line',
+        data: {
+          datasets: [{
+            data: originalData,
+            label: 'dataset1',
+          }],
+        },
+        scales: {
+          x: {
+            type: 'linear',
+            min: 0,
+            max: 9,
+          },
+        },
+        options: {
+          plugins: {
+            decimation: {
+              enabled: true,
+              algorithm: 'lttb',
+              samples: 100,
+            },
+          },
+        },
+      }, {
+        canvas: {
+          height: 1,
+          width: 1,
+        },
+        wrapper: {
+          height: 1,
+          width: 1,
+        },
+      });
+
+      expect(chart.data.datasets[0].data.length).toBe(10);
+    });
+
+    it('should draw the specified number of elements', function() {
+      var chart = window.acquireChart({
+        type: 'line',
+        data: {
+          datasets: [{
+            data: originalData,
+            label: 'dataset1',
+          }],
+        },
+        options: {
+          parsing: false,
+          scales: {
+            x: {
+              type: 'linear',
+              min: 0,
+              max: 9,
+            },
+          },
+          plugins: {
+            decimation: {
+              enabled: true,
+              algorithm: 'lttb',
+              samples: 7,
+            },
+          },
+        },
+      }, {
+        canvas: {
+          height: 1,
+          width: 1,
+        },
+        wrapper: {
+          height: 1,
+          width: 1,
+        },
+      });
+
+      expect(chart.data.datasets[0].data.length).toBe(7);
+    });
+
+    it('should draw all element only in range', function() {
+      var chart = window.acquireChart({
+        type: 'line',
+        data: {
+          datasets: [{
+            data: originalData,
+            label: 'dataset1',
+          }],
+        },
+        options: {
+          parsing: false,
+          scales: {
+            x: {
+              type: 'linear',
+              min: 3,
+              max: 6,
+            },
+          },
+          plugins: {
+            decimation: {
+              enabled: true,
+              algorithm: 'lttb',
+              samples: 7,
+            },
+          },
+        },
+      }, {
+        canvas: {
+          height: 1,
+          width: 1,
+        },
+        wrapper: {
+          height: 1,
+          width: 1,
+        },
+      });
+
+      // Data range is 4 (3->6) and the first point is added
+      const expectedPoints = 5;
+      expect(chart.data.datasets[0].data.length).toBe(expectedPoints);
+      expect(chart.data.datasets[0].data[0].x).toBe(originalData[2].x);
+      expect(chart.data.datasets[0].data[1].x).toBe(originalData[3].x);
+      expect(chart.data.datasets[0].data[2].x).toBe(originalData[4].x);
+      expect(chart.data.datasets[0].data[3].x).toBe(originalData[5].x);
+      expect(chart.data.datasets[0].data[4].x).toBe(originalData[6].x);
+    });
+  });
+});

--- a/test/specs/plugin.decimation.tests.js
+++ b/test/specs/plugin.decimation.tests.js
@@ -21,34 +21,34 @@ describe('Plugin.decimation', function() {
         data: {
           datasets: [{
             data: originalData,
-            label: 'dataset1',
-          }],
+            label: 'dataset1'
+          }]
         },
         scales: {
           x: {
             type: 'linear',
             min: 0,
-            max: 9,
-          },
+            max: 9
+          }
         },
         options: {
           plugins: {
             decimation: {
               enabled: true,
               algorithm: 'lttb',
-              samples: 100,
-            },
-          },
-        },
+              samples: 100
+            }
+          }
+        }
       }, {
         canvas: {
           height: 1,
-          width: 1,
+          width: 1
         },
         wrapper: {
           height: 1,
-          width: 1,
-        },
+          width: 1
+        }
       });
 
       expect(chart.data.datasets[0].data.length).toBe(10);
@@ -60,8 +60,8 @@ describe('Plugin.decimation', function() {
         data: {
           datasets: [{
             data: originalData,
-            label: 'dataset1',
-          }],
+            label: 'dataset1'
+          }]
         },
         options: {
           parsing: false,
@@ -69,26 +69,26 @@ describe('Plugin.decimation', function() {
             x: {
               type: 'linear',
               min: 0,
-              max: 9,
-            },
+              max: 9
+            }
           },
           plugins: {
             decimation: {
               enabled: true,
               algorithm: 'lttb',
-              samples: 7,
-            },
-          },
-        },
+              samples: 7
+            }
+          }
+        }
       }, {
         canvas: {
           height: 1,
-          width: 1,
+          width: 1
         },
         wrapper: {
           height: 1,
-          width: 1,
-        },
+          width: 1
+        }
       });
 
       expect(chart.data.datasets[0].data.length).toBe(7);
@@ -100,8 +100,8 @@ describe('Plugin.decimation', function() {
         data: {
           datasets: [{
             data: originalData,
-            label: 'dataset1',
-          }],
+            label: 'dataset1'
+          }]
         },
         options: {
           parsing: false,
@@ -109,26 +109,26 @@ describe('Plugin.decimation', function() {
             x: {
               type: 'linear',
               min: 3,
-              max: 6,
-            },
+              max: 6
+            }
           },
           plugins: {
             decimation: {
               enabled: true,
               algorithm: 'lttb',
-              samples: 7,
-            },
-          },
-        },
+              samples: 7
+            }
+          }
+        }
       }, {
         canvas: {
           height: 1,
-          width: 1,
+          width: 1
         },
         wrapper: {
           height: 1,
-          width: 1,
-        },
+          width: 1
+        }
       });
 
       // Data range is 4 (3->6) and the first point is added


### PR DESCRIPTION
fixes #8833 

- Duplication of the getStartAndCountOfVisiblePoints function as the _sorted is not initialized yet but in our case, we know by design that the parsing is disabled
- Adapt min-max and lttb algorithm to start with an offset
- Fix error on LTTB algorithm
- Added simple tests to only count points on LTTB algorithm