### PR TITLE
Include `grace` in LinearScaleOptions type definition

### DIFF
--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -2821,6 +2821,10 @@ export type LinearScaleOptions = CartesianScaleOptions & {
    * Adjustment used when calculating the minimum data value.
    */
   suggestedMax?: number;
+  /**
+  * Percentage (string ending with %) or amount (number) for added room in the scale range above and below data.
+  */
+  grace?: string | number;
 
   ticks: {
     /**


### PR DESCRIPTION
This PR adds the `grace` option, to the LinearScaleOptions type definition as documented here, https://www.chartjs.org/docs/latest/axes/cartesian/linear.html#grace. Without this commit the TS compiler does not allow the option. I'm not sure if this is the right way to go about it, but you know, the classic "fixed it for me." 

I'm not very familiar with type generation / testing types, so if there's more to do here I'm happy to do it.