### PR TITLE
Setting correct decimated values when below threshold

### DIFF
--- a/src/plugins/plugin.decimation.js
+++ b/src/plugins/plugin.decimation.js
@@ -229,12 +229,6 @@ export default {
         return;
       }
 
-      let {start, count} = getStartAndCountOfVisiblePointsSimplified(meta, data);
-      if (count <= 4 * availableWidth) {
-        // No decimation is required until we are above this threshold
-        return;
-      }
-
       if (isNullOrUndef(_data)) {
         // First time we are seeing this dataset
         // We override the 'data' property with a setter that stores the
@@ -251,6 +245,13 @@ export default {
             this._data = d;
           }
         });
+      }
+
+      let {start, count} = getStartAndCountOfVisiblePointsSimplified(meta, data);
+      if (count <= 4 * availableWidth) {
+        // No decimation is required until we are above this threshold
+        dataset._decimated = data.slice(start, start + count);
+        return;
       }
 
       // Point the chart to the decimated data

--- a/src/plugins/plugin.decimation.js
+++ b/src/plugins/plugin.decimation.js
@@ -233,6 +233,13 @@ export default {
         return;
       }
 
+      let {start, count} = getStartAndCountOfVisiblePointsSimplified(meta, data);
+      if (count <= 4 * availableWidth) {
+        // No decimation is required until we are above this threshold
+        cleanDecimatedDataset(dataset);
+        return;
+      }
+
       if (isNullOrUndef(_data)) {
         // First time we are seeing this dataset
         // We override the 'data' property with a setter that stores the
@@ -249,13 +256,6 @@ export default {
             this._data = d;
           }
         });
-      }
-
-      let {start, count} = getStartAndCountOfVisiblePointsSimplified(meta, data);
-      if (count <= 4 * availableWidth) {
-        // No decimation is required until we are above this threshold
-        cleanDecimatedDataset(dataset);
-        return;
       }
 
       // Point the chart to the decimated data

--- a/src/plugins/plugin.decimation.js
+++ b/src/plugins/plugin.decimation.js
@@ -153,14 +153,18 @@ function minMaxDecimation(data, start, count, availableWidth) {
   return decimated;
 }
 
+function cleanDecimatedDataset(dataset) {
+  if (dataset._decimated) {
+    const data = dataset._data;
+    delete dataset._decimated;
+    delete dataset._data;
+    Object.defineProperty(dataset, 'data', {value: data});
+  }
+}
+
 function cleanDecimatedData(chart) {
   chart.data.datasets.forEach((dataset) => {
-    if (dataset._decimated) {
-      const data = dataset._data;
-      delete dataset._decimated;
-      delete dataset._data;
-      Object.defineProperty(dataset, 'data', {value: data});
-    }
+    cleanDecimatedDataset(dataset);
   });
 }
 
@@ -250,7 +254,7 @@ export default {
       let {start, count} = getStartAndCountOfVisiblePointsSimplified(meta, data);
       if (count <= 4 * availableWidth) {
         // No decimation is required until we are above this threshold
-        cleanDecimatedData(chart);
+        cleanDecimatedDataset(dataset);
         return;
       }
 

--- a/src/plugins/plugin.decimation.js
+++ b/src/plugins/plugin.decimation.js
@@ -250,7 +250,7 @@ export default {
       let {start, count} = getStartAndCountOfVisiblePointsSimplified(meta, data);
       if (count <= 4 * availableWidth) {
         // No decimation is required until we are above this threshold
-        dataset._decimated = data.slice(start, start + count);
+        cleanDecimatedData(chart);
         return;
       }
 


### PR DESCRIPTION
Not a critical bug, but as one of the primary objectives of #8843 was to have real points when the graph allows it (especially when zooming), the correct data must be set when below the resolution threshold.

Currently, (when using zoom), if the scale contains fewer data than threshold, the algorithm will exit (not doing any decimation), and will then use the last _decimated data instead of data in the current range/the raw data if the dataset was small enough.

This commit aims to fix that.
