### PR TITLE
Allow 'fill' option for scatter chart dataset

### DIFF
--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -3257,7 +3257,7 @@ export interface ChartTypeRegistry {
   };
   scatter: {
     chartOptions: ScatterControllerChartOptions;
-    datasetOptions: ScatterControllerDatasetOptions;
+    datasetOptions: ScatterControllerDatasetOptions & FillerControllerDatasetOptions;
     defaultDataPoint: ScatterDataPoint | number | null;
     parsedDataType: CartesianParsedData;
     scales: keyof CartesianScaleTypeRegistry;


### PR DESCRIPTION
Fixes #8893