### PR TITLE
Time: cache options needed by parse

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -48,8 +48,7 @@ function parse(scale, input) {
   }
 
   const adapter = scale._adapter;
-  const options = scale.options.time;
-  const {parser, round, isoWeekday} = options;
+  const {parser, round, isoWeekday} = scale._parseOpts;
   let value = input;
 
   if (typeof parser === 'function') {
@@ -217,6 +216,7 @@ export default class TimeScale extends Scale {
     this._majorUnit = undefined;
     this._offsets = {};
     this._normalized = false;
+    this._parseOpts = undefined;
   }
 
   init(scaleOpts, opts) {
@@ -228,6 +228,12 @@ export default class TimeScale extends Scale {
     // when loading the scale (adapters are loaded afterward), so let's populate
     // missing formats on update
     mergeIf(time.displayFormats, adapter.formats());
+
+    this._parseOpts = {
+      parser: time.parser,
+      round: time.round,
+      isoWeekday: time.isoWeekday
+    };
 
     super.init(scaleOpts);
 


### PR DESCRIPTION
There is a regression in time scale parsing speed:

![image](https://user-images.githubusercontent.com/27971921/115137843-17ea3a00-a031-11eb-8113-cdecb09b6e3f.png)

By caching the options:

![image](https://user-images.githubusercontent.com/27971921/115137861-2cc6cd80-a031-11eb-988c-2ed14ae7c813.png)
