### PR TITLE
Update helpers types export

### DIFF
--- a/helpers/helpers.esm.d.ts
+++ b/helpers/helpers.esm.d.ts
@@ -1,1 +1,1 @@
-export * from '../types/helpers/index';
+export * from '../types/helpers';


### PR DESCRIPTION
VSCode does not work with the current helpers typing export. This way it works for me.
