### PR TITLE
fix typo on api.md

### DIFF
--- a/docs/developers/api.md
+++ b/docs/developers/api.md
@@ -103,7 +103,7 @@ To get an item that was clicked on, `getElementsAtEventForMode` can be used.
 
 ```javascript
 function clickHandler(evt) {
-    const points = myChart.getElementAtEventForMode(evt, 'nearest', { intersect: true }, true);
+    const points = myChart.getElementsAtEventForMode(evt, 'nearest', { intersect: true }, true);
 
     if (points.length) {
         const firstPoint = points[0];


### PR DESCRIPTION
Hi. 
I found typo on document api.md.

I think collect snippet may this.
`function getElementsAtEventForMode`

But, I found this so I fixed it.
`function getElementAtEventForMode` 

Thank you for your maintenance and great repository.