### PR TITLE
Types: Export DecinmationAlgorithm as const

### DIFF
--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -1953,7 +1953,7 @@ export class BasePlatform {
 export class BasicPlatform extends BasePlatform {}
 export class DomPlatform extends BasePlatform {}
 
-export declare enum DecimationAlgorithm {
+export const enum DecimationAlgorithm {
   lttb = 'lttb',
   minmax = 'min-max',
 }


### PR DESCRIPTION
Fix #8993 

This only affects the typescript compiler output of a typescript project consuming these types.
With `declare`, the `DecimationAlgorithm` object is assumed to be found in `chart.esm.js`, and its not, because we only have that in the '.d.ts'.

As said in https://stackoverflow.com/a/50568865/10359775 the `const enum` is however replaced with the string values at compile time, so the end result does not try to use `DecimationAlgorithm` from the `chart.esm.js`, but uses the literal strings instead.

More information: https://www.typescriptlang.org/docs/handbook/enums.html#enums-at-runtime