### PR TITLE
add derived axis default values 

### DIFF
--- a/docs/scripts/log2.js
+++ b/docs/scripts/log2.js
@@ -21,8 +21,8 @@ export default class Log2Axis extends Scale {
   buildTicks() {
     const ticks = [];
 
-    let power = Math.floor(Math.log2(this.min));
-    let maxPower = Math.ceil(Math.log2(this.max));
+    let power = Math.floor(Math.log2(this.min || 1));
+    let maxPower = Math.ceil(Math.log2(this.max || 2));
     while (power <= maxPower) {
       ticks.push({value: Math.pow(2, power)});
       power += 1;


### PR DESCRIPTION
add default values so it wont crash on out of memory calculation 

fixes #9057 

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
