### PR TITLE
Fix setting options in array of objects

### DIFF
--- a/src/helpers/helpers.config.js
+++ b/src/helpers/helpers.config.js
@@ -295,7 +295,12 @@ function createSubResolver(parentScopes, resolver, prop, value) {
     if (!(prop in parent)) {
       parent[prop] = {};
     }
-    return parent[prop];
+    const target = parent[prop];
+    if (isArray(target) && isObject(value)) {
+      // For array of objects, the object is used to store updated values
+      return value;
+    }
+    return target;
   });
 }
 

--- a/src/helpers/helpers.config.js
+++ b/src/helpers/helpers.config.js
@@ -290,18 +290,8 @@ function createSubResolver(parentScopes, resolver, prop, value) {
       return false;
     }
   }
-  return _createResolver([...set], [''], rootScopes, fallback, () => {
-    const parent = resolver._getTarget();
-    if (!(prop in parent)) {
-      parent[prop] = {};
-    }
-    const target = parent[prop];
-    if (isArray(target) && isObject(value)) {
-      // For array of objects, the object is used to store updated values
-      return value;
-    }
-    return target;
-  });
+  return _createResolver([...set], [''], rootScopes, fallback,
+    () => subGetTarget(resolver, prop, value));
 }
 
 function addScopesFromKey(set, allScopes, key, fallback) {
@@ -309,6 +299,19 @@ function addScopesFromKey(set, allScopes, key, fallback) {
     key = addScopes(set, allScopes, key, fallback);
   }
   return key;
+}
+
+function subGetTarget(resolver, prop, value) {
+  const parent = resolver._getTarget();
+  if (!(prop in parent)) {
+    parent[prop] = {};
+  }
+  const target = parent[prop];
+  if (isArray(target) && isObject(value)) {
+    // For array of objects, the object is used to store updated values
+    return value;
+  }
+  return target;
 }
 
 function _resolveWithPrefixes(prop, prefixes, scopes, proxy) {

--- a/test/specs/helpers.config.tests.js
+++ b/test/specs/helpers.config.tests.js
@@ -752,6 +752,23 @@ describe('Chart.helpers.config', function() {
       expect(fn()).toEqual('ok');
     });
 
+    it('should properly set value to object in array of objects', function() {
+      const defaults = {};
+      const options = {
+        annotations: [{
+          value: 10
+        }, {
+          value: 20
+        }]
+      };
+      const resolver = _attachContext(_createResolver([options, defaults]), {test: true});
+      expect(resolver.annotations[0].value).toEqual(10);
+
+      resolver.annotations[0].value = 15;
+      expect(options.annotations[0].value).toEqual(15);
+      expect(options.annotations[1].value).toEqual(20);
+    });
+
     describe('_indexable and _scriptable', function() {
       it('should default to true', function() {
         const options = {


### PR DESCRIPTION
Fix https://github.com/chartjs/chartjs-plugin-annotation/issues/423

In annotation plugin, when the `annotations` option is an array of objects, updating the objects did not work properly.
This is because the array that is returned when accessing options, is an array of resolvers, and those resolvers did not properly determine where the changed value should be stored (it was stored in the array).
