### PR TITLE
Add missing props to ChartArea type

### DIFF
--- a/types/geometric.d.ts
+++ b/types/geometric.d.ts
@@ -1,11 +1,13 @@
 export interface ChartArea {
-	top: number;
-	left: number;
-	right: number;
-	bottom: number;
+  top: number;
+  left: number;
+  right: number;
+  bottom: number;
+  width: number;
+  height: number;
 }
 
 export interface Point {
-	x: number;
-	y: number;
+  x: number;
+  y: number;
 }


### PR DESCRIPTION
Add missing `width` and `height` properties to the `ChartArea` type. These are present in practice and used by sample code such as the [Chart Area Border plugin](https://www.chartjs.org/docs/latest/samples/plugins/chart-area-border.html).