### PR TITLE
Correctly extend ExtendedPlugin interface

### DIFF
--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -742,7 +742,7 @@ export const layouts: {
   update(chart: Chart, width: number, height: number): void;
 };
 
-export interface Plugin<TType extends ChartType = ChartType, O = AnyObject> extends ExtendedPlugin<TType> {
+export interface Plugin<TType extends ChartType = ChartType, O = AnyObject> extends ExtendedPlugin<TType, O> {
   id: string;
 
   /**


### PR DESCRIPTION
Pass the `O` options type from the `Plugin` interface to `ExtendedPlugin`, otherwise the options argument in the tooltip draw callbacks ends up being `AnyObject`, even if the plugin is correctly typed.