### PR TITLE
Add attribute to custom legend onclick sample

### DIFF
--- a/docs/configuration/legend.md
+++ b/docs/configuration/legend.md
@@ -176,7 +176,7 @@ var newLegendClickHandler = function (e, legendItem, legend) {
 
     if (index > 1) {
         // Do the original logic
-        defaultLegendClickHandler(e, legendItem);
+        defaultLegendClickHandler(e, legendItem, legend);
     } else {
         let ci = legend.chart;
         [


### PR DESCRIPTION
add legend itself to the default onclick to make sample work so it can get the chart out of it