### PR TITLE
Fix scales option in example

### DIFF
--- a/docs/axes/cartesian/index.md
+++ b/docs/axes/cartesian/index.md
@@ -312,7 +312,7 @@ var myChart = new Chart(ctx, {
             },
             'second-y-axis': {
                 type: 'linear'
-            }]
+            }
         }
     }
 });
@@ -352,7 +352,7 @@ var myChart = new Chart(ctx, {
             'right-y-axis': {
                 type: 'linear',
                 position: 'right'
-            }]
+            }
         }
     }
 });


### PR DESCRIPTION
## Description

There's a typo for the `scales` attribute in the documentation.
The `]` should not be there.

I tested it:

```js
    options: {
        scales: {
            'left-y-axis': {
                type: 'linear',
                position: 'left'
            },
            'right-y-axis': {
                type: 'linear',
                position: 'right'
            } // if you add here `]` it fails
        }
    }
```
