### PR TITLE
show the utils file in the samples page to clarify what the functions do

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -264,6 +264,7 @@ module.exports = {
             'plugins/quadrants',
           ]
         },
+        'utils'
       ],
       '/': [
         '',

--- a/docs/samples/utils.md
+++ b/docs/samples/utils.md
@@ -1,0 +1,14 @@
+# Utils
+
+## Disclaimer
+The Utils file contains multiple helper functions that the chart.js sample pages use to generate charts.
+These functions are subject to change, including but not limited to breaking changes without prior notice.
+
+Because of this please don't rely on this file in production environments.
+
+## Functions
+
+<<< @/docs/scripts/utils.js
+
+[File on github](https://github.com/chartjs/Chart.js/blob/master/docs/scripts/utils.js)
+


### PR DESCRIPTION
Since the question came by multiple times on where to find the Utils file I think it will clarify things a lot better this way instead of that people need to dig in the repo to find the file