### PR TITLE
Tick backdrop padding is not scriptable

### DIFF
--- a/docs/axes/_common_ticks.md
+++ b/docs/axes/_common_ticks.md
@@ -5,7 +5,7 @@ Namespace: `options.scales[scaleId].ticks`
 | Name | Type | Scriptable | Default | Description
 | ---- | ---- | :-------------------------------: | ------- | -----------
 | `backdropColor` | [`Color`](../../general/colors.md) | Yes | `'rgba(255, 255, 255, 0.75)'` | Color of label backdrops.
-| `backdropPadding` | [`Padding`](../../general/padding.md) | Yes | `2` | Padding of label backdrop.
+| `backdropPadding` | [`Padding`](../../general/padding.md) | | `2` | Padding of label backdrop.
 | `callback` | `function` | | | Returns the string representation of the tick value as it should be displayed on the chart. See [callback](/axes/labelling.md#creating-custom-tick-formats).
 | `display` | `boolean` | | `true` | If true, show tick labels.
 | `color` | [`Color`](/general/colors.md) | Yes | `Chart.defaults.color` | Color of ticks.

--- a/src/core/core.scale.defaults.js
+++ b/src/core/core.scale.defaults.js
@@ -92,3 +92,8 @@ defaults.describe('scale', {
 defaults.describe('scales', {
   _fallback: 'scale',
 });
+
+defaults.describe('scale.ticks', {
+  _scriptable: (name) => name !== 'backdropPadding',
+  _indexable: (name) => name !== 'backdropPadding',
+});

--- a/src/core/core.scale.defaults.js
+++ b/src/core/core.scale.defaults.js
@@ -94,6 +94,6 @@ defaults.describe('scales', {
 });
 
 defaults.describe('scale.ticks', {
-  _scriptable: (name) => name !== 'backdropPadding',
+  _scriptable: (name) => name !== 'backdropPadding' && name !== 'callback',
   _indexable: (name) => name !== 'backdropPadding',
 });

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -635,5 +635,5 @@ RadialLinearScale.defaultRoutes = {
 RadialLinearScale.descriptors = {
   angleLines: {
     _fallback: 'grid'
-  }
+  },
 };

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -635,5 +635,5 @@ RadialLinearScale.defaultRoutes = {
 RadialLinearScale.descriptors = {
   angleLines: {
     _fallback: 'grid'
-  },
+  }
 };


### PR DESCRIPTION
This was already correct in the types, so correctly updated the docs and code.

Resolves #8842 