### PR TITLE
Fix docs global fonts property matching current API

### DIFF
--- a/docs/general/fonts.md
+++ b/docs/general/fonts.md
@@ -5,7 +5,7 @@ There are special global settings that can change all of the fonts on the chart.
 For example, in this chart the text will all be red except for the labels in the legend.
 
 ```javascript
-Chart.defaults.font.size = 16;
+Chart.defaults.global.defaultFontSize = 16;
 let chart = new Chart(ctx, {
     type: 'line',
     data: data,
@@ -26,11 +26,10 @@ let chart = new Chart(ctx, {
 
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
-| `family` | `string` | `"'Helvetica Neue', 'Helvetica', 'Arial', sans-serif"` | Default font family for all text, follows CSS font-family options.
-| `size` | `number` | `12` | Default font size (in px) for text. Does not apply to radialLinear scale point labels.
-| `style` | `string` | `'normal'` | Default font style. Does not apply to tooltip title or footer. Does not apply to chart title. Follows CSS font-style options (i.e. normal, italic, oblique, initial, inherit).
-| `weight` | `string` | `undefined` | Default font weight (boldness). (see [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight)).
-| `lineHeight` | `number`\|`string` | `1.2` | Height of an individual line of text (see [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height)).
+| `defaultFontFamily` | `string` | `"'Helvetica Neue', 'Helvetica', 'Arial', sans-serif"` | Default font family for all text, follows CSS font-family options.
+| `defaultFontSize` | `number` | `12` | Default font size (in px) for text. Does not apply to radialLinear scale point labels.
+| `defaultFontStyle` | `string` | `'normal'` | Default font style. Does not apply to tooltip title or footer. Does not apply to chart title. Follows CSS font-style options (i.e. normal, italic, oblique, initial, inherit).
+| `defaultFontColor` | `Color` | `'#666'` | Default font color for all text.
 
 ## Missing Fonts
 


### PR DESCRIPTION
<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->

This PR refactors example code, documentation in [general/fonts](https://www.chartjs.org/docs/master/general/fonts.html).