### PR TITLE
Fix broken guidelines url in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 Please consider the following before submitting a pull request:
 
-Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/docs/developers/contributing.md
+Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md
 
 Example of changes on an interactive website such as the following:
 - https://jsbin.com/


### PR DESCRIPTION
<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->

This PR fixes broken contributing.md url in PR template.