### PR TITLE
Docs: fix broken and inconsistent links

### DIFF
--- a/docs/configuration/tooltip.md
+++ b/docs/configuration/tooltip.md
@@ -350,7 +350,7 @@ var myPieChart = new Chart(ctx, {
 });
 ```
 
-See [samples](/samples/tooltip/html) for examples on how to get started with external tooltips.
+See [samples](/samples/tooltip/html.md) for examples on how to get started with external tooltips.
 
 ## Tooltip Model
 

--- a/docs/general/padding.md
+++ b/docs/general/padding.md
@@ -45,7 +45,7 @@ let chart = new Chart(ctx, {
 
 This is a shorthand for defining left/right and top/bottom to same values.
 
-For example, 10px left / right and 4px top / bottom padding on a Radial Linear Axis [tick backdropPadding](/axes/radial/linear.html#linear-radial-axis-specific-tick-options):
+For example, 10px left / right and 4px top / bottom padding on a Radial Linear Axis [tick backdropPadding](/axes/radial/linear.md#linear-radial-axis-specific-tick-options):
 
 ```javascript
 let chart = new Chart(ctx, {


### PR DESCRIPTION
Noticed a broken link to the tooltip sample and searched for similar links without the `.md` (and not pointing to a folder)
