### PR TITLE
Fix type definitions and docs for `getPixelForValue`

### DIFF
--- a/docs/developers/axes.md
+++ b/docs/developers/axes.md
@@ -90,9 +90,8 @@ To work with Chart.js, custom scale types must implement the following interface
 
     // Get the pixel (x coordinate for horizontal axis, y coordinate for vertical axis) for a given value
     // @param value : the value to get the pixel for
-    // @param index : index into the data array of the value
-    // @param datasetIndex : index of the dataset the value comes from
-    getPixelForValue: function(value, index, datasetIndex) {},
+    // @param [index] : index into the data array of the value
+    getPixelForValue: function(value, index) {},
 
     // Get the value for a given pixel (x coordinate for horizontal axis, y coordinate for vertical axis)
     // @param pixel : pixel value

--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -467,7 +467,7 @@ The APIs listed in this section have changed in signature or behaviour from vers
 #### Changed in Scales
 
 * `Scale.getLabelForIndex` was replaced by `scale.getLabelForValue`
-* `Scale.getPixelForValue` now has only one parameter. For the `TimeScale` that parameter must be millis since the epoch
+* `Scale.getPixelForValue` now only requires one parameter. For the `TimeScale` that parameter must be millis since the epoch. As a performance optimization, it may take an optional second parameter, giving the index of the data point.
 
 ##### Changed in Ticks
 

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -1219,7 +1219,7 @@ export interface Scale<O extends CoreScaleOptions = CoreScaleOptions> extends El
    * @param {number} [index]
    * @return {number}
    */
-  getPixelForValue(value: number, index: number): number;
+  getPixelForValue(value: number, index?: number): number;
 
   /**
    * Used to get the data value from a given pixel. This is the inverse of getPixelForValue


### PR DESCRIPTION
Update docs: From what I can tell, the `index` parameter was re-introduced as part of the new `normalized` option.

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
