### PR TITLE
Adding threshold option to decimation plugin

### DIFF
--- a/docs/configuration/decimation.md
+++ b/docs/configuration/decimation.md
@@ -11,6 +11,7 @@ Namespace: `options.plugins.decimation`, the global options for the plugin are d
 | `enabled` | `boolean` | `false` | Is decimation enabled?
 | `algorithm` | `string` | `'min-max'` | Decimation algorithm to use. See the [more...](#decimation-algorithms)
 | `samples` | `number` | | If the `'lttb'` algorithm is used, this is the number of samples in the output dataset. Defaults to the canvas width to pick 1 sample per pixel.
+| `threshold` | `number` | | If the number of samples in the current axis range is above this value, the decimation will be triggered. Defaults to 4 times the canvas width.<br />The number of point after decimation can be higher than the `threshold` value.
 
 ## Decimation Algorithms
 

--- a/src/plugins/plugin.decimation.js
+++ b/src/plugins/plugin.decimation.js
@@ -234,7 +234,8 @@ export default {
       }
 
       let {start, count} = getStartAndCountOfVisiblePointsSimplified(meta, data);
-      if (count <= 4 * availableWidth) {
+      const threshold = options.threshold || 4 * availableWidth;
+      if (count <= threshold) {
         // No decimation is required until we are above this threshold
         cleanDecimatedDataset(dataset);
         return;

--- a/test/specs/plugin.decimation.tests.js
+++ b/test/specs/plugin.decimation.tests.js
@@ -15,7 +15,7 @@ describe('Plugin.decimation', function() {
       {x: 8, y: 8},
       {x: 9, y: 9}];
 
-    it('should draw all element if sample is greater than data', function() {
+    it('should draw all element if sample is greater than data based on canvas width', function() {
       var chart = window.acquireChart({
         type: 'line',
         data: {
@@ -54,7 +54,7 @@ describe('Plugin.decimation', function() {
       expect(chart.data.datasets[0].data.length).toBe(10);
     });
 
-    it('should draw the specified number of elements', function() {
+    it('should draw the specified number of elements based on canvas width', function() {
       var chart = window.acquireChart({
         type: 'line',
         data: {
@@ -92,6 +92,45 @@ describe('Plugin.decimation', function() {
       });
 
       expect(chart.data.datasets[0].data.length).toBe(7);
+    });
+
+    it('should draw the specified number of elements based on threshold', function() {
+      var chart = window.acquireChart({
+        type: 'line',
+        data: {
+          datasets: [{
+            data: originalData,
+            label: 'dataset1'
+          }]
+        },
+        options: {
+          parsing: false,
+          scales: {
+            x: {
+              type: 'linear'
+            }
+          },
+          plugins: {
+            decimation: {
+              enabled: true,
+              algorithm: 'lttb',
+              samples: 5,
+              threshold: 7
+            }
+          }
+        }
+      }, {
+        canvas: {
+          height: 100,
+          width: 100
+        },
+        wrapper: {
+          height: 100,
+          width: 100
+        }
+      });
+
+      expect(chart.data.datasets[0].data.length).toBe(5);
     });
 
     it('should draw all element only in range', function() {

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -1978,6 +1978,7 @@ export const enum DecimationAlgorithm {
 }
 interface BaseDecimationOptions {
   enabled: boolean;
+  threshold?: number;
 }
 
 interface LttbDecimationOptions extends BaseDecimationOptions {


### PR DESCRIPTION
### Improvement proposition

Adding a new option in the decimation plugin to change the threshold used to detect if the decimation must be applied

### Reason

Currently, to check if the decimation plugin must be called, Chart.js will check the number of point to display and decide to not do anything if the number of points is below 4*canvasWidth.

While in most of cases it is enough, in some cases I find that this threshold is a bit too high
![image](https://user-images.githubusercontent.com/22025789/123764645-43a55e00-d8c5-11eb-9097-eb4d01e899c2.png)

In this case, the number of points is 1183 per dataset and the width is 800px hence the decimation is not called.
There might be other solutions than introducing this variable (such as modifying the scale, editing graph display, etc.) but I think it would be quite useful and is retro-compatible as it will fallback to the old 4*width.

![image](https://user-images.githubusercontent.com/22025789/123765220-d514d000-d8c5-11eb-8dd9-2d024c35fcdb.png)
```javascript
options.plugins.decimation = {
    algorithm: 'lttb',
    enabled: true,
    samples: 200,
    threshold: 100
}
```


