### PR TITLE
Add type tests for float bar / object data arrays

### DIFF
--- a/types/tests/data_types.ts
+++ b/types/tests/data_types.ts
@@ -1,0 +1,20 @@
+import { Chart } from '../index.esm';
+
+const chart = new Chart('chart', {
+  type: 'bar',
+  data: {
+    labels: ['1', '2', '3'],
+    datasets: [{ data: [[1, 2], [1, 2], [1, 2]] }],
+  }
+});
+
+const chart2 = new Chart('chart2', {
+  type: 'bar',
+  data: {
+    datasets: [{
+      data: [{ id: 'Sales', nested: { value: 1500 } }, { id: 'Purchases', nested: { value: 500 } }],
+    }],
+  },
+  options: { parsing: { xAxisKey: 'id', yAxisKey: 'nested.value' },
+  },
+});


### PR DESCRIPTION
Ref #9328

Add tests for the things that were reported as failing. These work with typescript 4.1.x. Something changed in typescript 4.2 that breaks something. Tried with 4.3.5 also, and it still fails.