### PR TITLE
Add missing resizeDelay option to types

### DIFF
--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -1412,6 +1412,11 @@ export interface CoreChartOptions<TType extends ChartType> extends ParsingOption
    * @default true
    */
   maintainAspectRatio: boolean;
+  /**
+   * Delay the resize update by give amount of milliseconds. This can ease the resize process by debouncing update of the elements.
+   * @default 0
+   */
+  resizeDelay: number;
 
   /**
    * Canvas aspect ratio (i.e. width / height, a value of 1 representing a square canvas). Note that this option is ignored if the height is explicitly defined either as attribute or via the style.


### PR DESCRIPTION
This option is defined in the documentation (https://www.chartjs.org/docs/master/configuration/responsive.html) and the native js code, but not listed in the types. This allows its use in typescript.

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
