### PR TITLE
Ensure getPrototypeOf will not crash on plugin options with no scopes

### DIFF
--- a/src/core/core.config.js
+++ b/src/core/core.config.js
@@ -277,6 +277,9 @@ export default class Config {
     });
 
     const array = Array.from(scopes);
+    if (array.length === 0) {
+      array.push(Object.create(null));
+    }
     if (keysCached.has(keyLists)) {
       cache.set(keyLists, array);
     }

--- a/src/helpers/helpers.config.js
+++ b/src/helpers/helpers.config.js
@@ -54,7 +54,7 @@ export function _createResolver(scopes, prefixes = [''], rootScopes = scopes, fa
      * A trap for Object.getPrototypeOf.
      */
     getPrototypeOf() {
-      return Reflect.getPrototypeOf(scopes[0]);
+      return Reflect.getPrototypeOf(scopes[0] || Object.create(null));
     },
 
     /**

--- a/src/helpers/helpers.config.js
+++ b/src/helpers/helpers.config.js
@@ -54,7 +54,7 @@ export function _createResolver(scopes, prefixes = [''], rootScopes = scopes, fa
      * A trap for Object.getPrototypeOf.
      */
     getPrototypeOf() {
-      return Reflect.getPrototypeOf(scopes[0] || Object.create(null));
+      return Reflect.getPrototypeOf(scopes[0]);
     },
 
     /**

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -1707,6 +1707,23 @@ describe('Chart', function() {
         'before-0', 'after-0'
       ]);
     });
+
+    it('should not crash when accessing options of a blank inline plugin', function() {
+      var chart = window.acquireChart({
+        type: 'line',
+        data: {datasets: [{}]},
+        plugins: [{}],
+      });
+
+      function iterateOptions() {
+        for (const plugin of chart._plugins._init) {
+          // triggering bug https://github.com/chartjs/Chart.js/issues/9368
+          expect(Object.getPrototypeOf(plugin.options)).toBeNull();
+        }
+      }
+
+      expect(iterateOptions).not.toThrow();
+    });
   });
 
   describe('metasets', function() {


### PR DESCRIPTION
Resolves #9368 