### PR TITLE
Update radar dataset option typings

### DIFF
--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -377,10 +377,8 @@ export const PolarAreaController: ChartComponent & {
 
 export interface RadarControllerDatasetOptions
   extends ControllerDatasetOptions,
-    ScriptableOptions<PointPrefixedOptions, ScriptableContext<'radar'>>,
-    ScriptableOptions<PointPrefixedHoverOptions, ScriptableContext<'radar'>>,
-    ScriptableOptions<LineOptions, ScriptableContext<'radar'>>,
-    ScriptableOptions<LineHoverOptions, ScriptableContext<'radar'>>,
+    ScriptableAndArrayOptions<PointOptions & PointHoverOptions & PointPrefixedOptions & PointPrefixedHoverOptions, ScriptableContext<'radar'>>,
+    ScriptableAndArrayOptions<LineOptions & LineHoverOptions, ScriptableContext<'radar'>>,
     AnimationOptions<'radar'> {
         /**
    * The ID of the x axis to plot this dataset on.

--- a/types/tests/controllers/radar_dataset_indexable_options.ts
+++ b/types/tests/controllers/radar_dataset_indexable_options.ts
@@ -1,0 +1,26 @@
+import { Chart, ChartOptions } from '../../index.esm';
+
+const chart = new Chart('test', {
+  type: 'radar',
+  data: {
+    labels: ['a', 'b', 'c'],
+    datasets: [{
+      data: [1, 2, 3],
+      backgroundColor: ['red', 'green', 'blue'],
+      borderColor: ['red', 'green', 'blue'],
+      hoverRadius: [1, 2, 3],
+      pointBackgroundColor: ['red', 'green', 'blue'],
+      pointBorderColor: ['red', 'green', 'blue'],
+      pointBorderWidth: [1, 2, 3],
+      pointHitRadius: [1, 2, 3],
+      pointHoverBackgroundColor: ['red', 'green', 'blue'],
+      pointHoverBorderColor: ['red', 'green', 'blue'],
+      pointHoverBorderWidth: [1, 2, 3],
+      pointHoverRadius: [1, 2, 3],
+      pointRadius: [1, 2, 3],
+      pointRotation: [1, 2, 3],
+      pointStyle: ['circle', 'cross', 'crossRot'],
+      radius: [1, 2, 3],
+    }]
+  },
+});


### PR DESCRIPTION
Ref: #9461

Typings for radar chart dataset were too limited: not indexable and missing the options without point prefix
