### PR TITLE
Remove index interaction override barChart 

### DIFF
--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -634,10 +634,6 @@ BarController.defaults = {
  * @type {any}
  */
 BarController.overrides = {
-  interaction: {
-    mode: 'index'
-  },
-
   scales: {
     _index_: {
       type: 'category',


### PR DESCRIPTION
Make barchart more inline with v2 behaviour and other charts.
In the migrationguide its also said that the horizontalBar interaction mode has changed from `index` to `nearest` to match normal bar so normal bar should not override to index

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
