### PR TITLE
Adjust text to code example

### DIFF
--- a/docs/general/fonts.md
+++ b/docs/general/fonts.md
@@ -2,7 +2,7 @@
 
 There are special global settings that can change all of the fonts on the chart. These options are in `Chart.defaults.font`. The global font settings only apply when more specific options are not included in the config.
 
-For example, in this chart the text will all be red except for the labels in the legend.
+For example, in this chart the text will have a font size of 16px except for the labels in the legend.
 
 ```javascript
 Chart.defaults.font.size = 16;


### PR DESCRIPTION
The previous text explains that, in the example, the font color is set and overridden but the code sets and overrides the _font size_.

It's a very minor thing but could be confusing to some people.