### PR TITLE
Types: Change `context.chart` to plain `Chart`

### DIFF
--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -1,4 +1,4 @@
-import { DeepPartial, DistributiveArray, IntersectItems, UnionToIntersection } from './utils';
+import { DeepPartial, DistributiveArray, UnionToIntersection } from './utils';
 
 import { TimeUnit } from './adapters';
 import { AnimationEvent } from './animation';
@@ -17,7 +17,7 @@ export { LayoutItem, LayoutPosition } from './layout';
 
 export interface ScriptableContext<TType extends ChartType> {
   active: boolean;
-  chart: IntersectItems<Chart<TType>>;
+  chart: Chart;
   dataIndex: number;
   dataset: UnionToIntersection<ChartDataset<TType>>;
   datasetIndex: number;

--- a/types/tests/scriptable.ts
+++ b/types/tests/scriptable.ts
@@ -10,9 +10,9 @@ interface test {
 }
 
 const testImpl: test = {
-  pie: (ctx) => ctx.parsed,
+  pie: (ctx) => ctx.parsed + ctx.chart.width,
   line: (ctx) => ctx.parsed.x + ctx.parsed.y,
-  testA: (ctx) => ctx.parsed,
+  testA: (ctx) => ctx.parsed + ctx.dataset.data[0],
   testB: (ctx) => ctx.parsed.x + ctx.parsed.y,
   // @ts-expect-error combined type should not be any
   testC: (ctx) => ctx.fail,

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -19,12 +19,3 @@ export type DistributiveArray<T> = [T] extends [unknown] ? Array<T> : never
 // https://stackoverflow.com/a/50375286
 export type UnionToIntersection<U> = (U extends unknown ? (k: U) => void : never) extends (k: infer I) => void ? I : never;
 
-// https://stackoverflow.com/a/59463385
-type TupleKeys<T extends unknown> = Exclude<keyof T, keyof []>
-type Foo<T extends unknown> = {
-    [K in TupleKeys<T>]: {foo: T[K]}
-}
-type Values<T> = T[keyof T]
-type Unfoo<T> = T extends { foo: unknown } ? T['foo'] : never;
-
-export type IntersectItems<T extends unknown> = Unfoo<UnionToIntersection<Values<Foo<T>>>>;


### PR DESCRIPTION
Fix #9474

This is not perfect, but I guess it would satisfy most use cases. The data is available strongly typed through `dataset` and `parsed`, the `raw` can be casted to desired type when custom properties in data are used.

