### PR TITLE
Types: Add `tooltip` to chart instance

### DIFF
--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -480,6 +480,8 @@ export declare class Chart<
   readonly scales: { [key: string]: Scale };
   readonly attached: boolean;
 
+  readonly tooltip?: TooltipModel<TType>; // Only available if tooltip plugin is registered and enabled
+
   data: ChartData<TType, TData, TLabel>;
   options: ChartOptions<TType>;
 

--- a/types/tests/plugins/plugin.tooltip/chart.tooltip.ts
+++ b/types/tests/plugins/plugin.tooltip/chart.tooltip.ts
@@ -1,0 +1,13 @@
+import { Chart } from '../../../index.esm';
+
+const chart = new Chart('id', {
+  type: 'line',
+  data: {
+    labels: [],
+    datasets: [{
+      data: []
+    }]
+  },
+});
+
+const tooltip = chart.tooltip;


### PR DESCRIPTION
Fix: #9480 
