### PR TITLE
fixing typo in docs on axes labelling

### DIFF
--- a/docs/axes/labelling.md
+++ b/docs/axes/labelling.md
@@ -20,7 +20,7 @@ Namespace: `options.scales[scaleId].title`, it defines options for the scale tit
 It is also common to want to change the tick marks to include information about the data type. For example, adding a dollar sign ('$').
 To do this, you need to override the `ticks.callback` method in the axis configuration.
 
-The method receiver 3 arguments:
+The method receives 3 arguments:
 
 * `value` - the tick value in the **internal data format** of the associated scale.
 * `index` - the tick index in the ticks array.


### PR DESCRIPTION
A tiny PR to fix a typo in the Labelling Axes section of the docs.
<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
