### PR TITLE
Ensure that controllers derived from the bar controller work correct in stacked charts

### DIFF
--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -7,11 +7,11 @@ import {
 function getAllScaleValues(meta) {
   let scale = meta.iScale;
   if (!scale._cache.$bar) {
-    const visiblemetas = scale.getMatchingVisibleMetas(meta._type);
+    const visibleMetas = scale.getMatchingVisibleMetas(meta._type);
     let values = [];
 
-    for (let i = 0, ilen = visiblemetas.length; i < ilen; i++) {
-      values = values.concat(visiblemetas[i].controller.getAllParsedValues(scale));
+    for (let i = 0, ilen = visibleMetas.length; i < ilen; i++) {
+      values = values.concat(visibleMetas[i].controller.getAllParsedValues(scale));
     }
     scale._cache.$bar = _arrayUnique(values.sort((a, b) => a - b));
   }

--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -4,13 +4,14 @@ import {
   valueOrDefault, resolveObjectKey, sign, defined
 } from '../helpers';
 
-function getAllScaleValues(scale) {
+function getAllScaleValues(meta) {
+  let scale = meta.iScale;
   if (!scale._cache.$bar) {
-    const metas = scale.getMatchingVisibleMetas('bar');
+    const visiblemetas = scale.getMatchingVisibleMetas(meta._type);
     let values = [];
 
-    for (let i = 0, ilen = metas.length; i < ilen; i++) {
-      values = values.concat(metas[i].controller.getAllParsedValues(scale));
+    for (let i = 0, ilen = visiblemetas.length; i < ilen; i++) {
+      values = values.concat(visiblemetas[i].controller.getAllParsedValues(scale));
     }
     scale._cache.$bar = _arrayUnique(values.sort((a, b) => a - b));
   }
@@ -21,8 +22,9 @@ function getAllScaleValues(scale) {
  * Computes the "optimal" sample size to maintain bars equally sized while preventing overlap.
  * @private
  */
-function computeMinSampleSize(scale) {
-  const values = getAllScaleValues(scale);
+function computeMinSampleSize(meta) {
+  const scale = meta.iScale;
+  const values = getAllScaleValues(meta);
   let min = scale._length;
   let i, ilen, curr, prev;
   const updateMinAndPrev = () => {
@@ -479,7 +481,7 @@ export default class BarController extends DatasetController {
     }
 
     const barThickness = opts.barThickness;
-    const min = barThickness || computeMinSampleSize(iScale);
+    const min = barThickness || computeMinSampleSize(meta);
 
     return {
       min,

--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -4,10 +4,9 @@ import {
   valueOrDefault, resolveObjectKey, sign, defined
 } from '../helpers';
 
-function getAllScaleValues(meta) {
-  let scale = meta.iScale;
+function getAllScaleValues(scale, type) {
   if (!scale._cache.$bar) {
-    const visibleMetas = scale.getMatchingVisibleMetas(meta._type);
+    const visibleMetas = scale.getMatchingVisibleMetas(type);
     let values = [];
 
     for (let i = 0, ilen = visibleMetas.length; i < ilen; i++) {
@@ -24,7 +23,7 @@ function getAllScaleValues(meta) {
  */
 function computeMinSampleSize(meta) {
   const scale = meta.iScale;
-  const values = getAllScaleValues(meta);
+  const values = getAllScaleValues(scale, meta.type);
   let min = scale._length;
   let i, ilen, curr, prev;
   const updateMinAndPrev = () => {

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -128,8 +128,8 @@ function getOrCreateStack(stacks, stackKey, indexValue) {
   return subStack[indexValue] || (subStack[indexValue] = {});
 }
 
-function getLastIndexInStack(stack, vScale, positive) {
-  for (const meta of vScale.getMatchingVisibleMetas('bar').reverse()) {
+function getLastIndexInStack(stack, vScale, positive, type) {
+  for (const meta of vScale.getMatchingVisibleMetas(type).reverse()) {
     const value = stack[meta.index];
     if ((positive && value > 0) || (!positive && value < 0)) {
       return meta.index;
@@ -156,8 +156,8 @@ function updateStacks(controller, parsed) {
     stack = itemStacks[vAxis] = getOrCreateStack(stacks, key, index);
     stack[datasetIndex] = value;
 
-    stack._top = getLastIndexInStack(stack, vScale, true);
-    stack._bottom = getLastIndexInStack(stack, vScale, false);
+    stack._top = getLastIndexInStack(stack, vScale, true, meta.type);
+    stack._bottom = getLastIndexInStack(stack, vScale, false, meta.type);
   }
 }
 

--- a/test/specs/core.datasetController.tests.js
+++ b/test/specs/core.datasetController.tests.js
@@ -829,7 +829,7 @@ describe('Chart.DatasetController', function() {
     });
 
     var meta = chart.getDatasetMeta(0);
-    expect(meta._parsed[0]._stacks).toEqual(jasmine.objectContaining({y: {0: 10, 1: 20, _top: null, _bottom: null}}));
+    expect(meta._parsed[0]._stacks).toEqual(jasmine.objectContaining({y: {0: 10, 1: 20, _top: 1, _bottom: null}}));
   });
 
   describe('resolveDataElementOptions', function() {


### PR DESCRIPTION
# Issue Fixes #9569 and fixes #9595 
### What was the Issue?
when deriving a new chart type by extending `BarController` and using the default functionality of the default `bar` chart type, the bars are overlapping in a small space.

Unexpected behaviour: https://codesandbox.io/s/unexpected-behaviour-yiy8y?file=/src/index.js
![image](https://user-images.githubusercontent.com/67068685/130999517-e0de2f79-551f-4dd7-b050-fb856174a8b9.png)

Expected behaviour: 
![image](https://user-images.githubusercontent.com/67068685/130999785-f8b2b884-ee10-4b62-b3dc-ee79f4503a9d.png)

### Changes Made
changes the argument passed in `getMatchingVisibleMetas`   
https://github.com/chartjs/Chart.js/blob/fca030922360a1a2d1292f6936276ad11a7cf7d9/src/controllers/controller.bar.js#L9
from `'bar'` to `meta._type` .

`getMatchingVisibleMetas` returns the datasets that are visible and have type equals to `meta._type`


**UPDATE** 
Also changed the argument passed in 'getMatchingVisibleMetas' at
https://github.com/chartjs/Chart.js/blob/fca030922360a1a2d1292f6936276ad11a7cf7d9/src/core/core.datasetController.js#L132

