### PR TITLE
Add package.json exports property

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "description": "Simple HTML5 charts using the canvas element.",
   "version": "3.5.1",
   "license": "MIT",
+  "type": "module",
+  "exports": {
+    "import": "./dist/chart.esm.js",
+    "require": "./dist/chart.js"
+  },
   "jsdelivr": "dist/chart.min.js",
   "unpkg": "dist/chart.min.js",
   "main": "dist/chart.js",


### PR DESCRIPTION
This allows modern build systems (vite) to properly use the correct module type (ESM). 

When this is not present, when using Chart.js in Sveltekit, when running a build it will give an error `Named export 'Chart' not found. The requested module 'chart.js' is a CommonJS module, which may not support all module.exports as named exports.`

More info: https://medium.com/swlh/npm-new-package-json-exports-field-1a7d1f489ccf
Also, for background: https://github.com/sveltejs/kit/issues/1498#issuecomment-846340242 and https://github.com/sveltejs/kit/issues/928#issuecomment-907505023