### PR TITLE
fix: old x axis labels were not destroyed during data update if parsing was set to false or an object with custom axis keys

### DIFF
--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -368,11 +368,11 @@ export default class DatasetController {
     let stackChanged = false;
 
     let labels = meta.iScale ? meta.iScale.getLabels() : null;
-    if (labels && labels.length && (me._parsing === false || isObject(me._parsing))) {
+    if (labels && labels.length && (this._parsing === false || isObject(this._parsing))) {
       labels.splice(0);
     }
 
-    me._dataCheck();
+    this._dataCheck();
 
     // make sure cached _stacked status is current
     const oldStacked = meta._stacked;

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -422,11 +422,12 @@ export default class DatasetController {
       meta._sorted = true;
       parsed = data;
     } else {
-      if (isArray(data[start])) {
+      if (isObject(me._parsing)) {
         iScale.getLabels().splice(0);
+      }
+      if (isArray(data[start])) {
         parsed = me.parseArrayData(meta, data, start, count);
       } else if (isObject(data[start])) {
-        iScale.getLabels().splice(0);
         parsed = me.parseObjectData(meta, data, start, count);
       } else {
         parsed = this.parsePrimitiveData(meta, data, start, count);

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -416,15 +416,18 @@ export default class DatasetController {
     let prev = start > 0 && meta._parsed[start - 1];
     let i, cur, parsed;
 
-    if (this._parsing === false) {
+    if (me._parsing === false) {
+      iScale.getLabels().splice(0);
       meta._parsed = data;
       meta._sorted = true;
       parsed = data;
     } else {
       if (isArray(data[start])) {
-        parsed = this.parseArrayData(meta, data, start, count);
+        iScale.getLabels().splice(0);
+        parsed = me.parseArrayData(meta, data, start, count);
       } else if (isObject(data[start])) {
-        parsed = this.parseObjectData(meta, data, start, count);
+        iScale.getLabels().splice(0);
+        parsed = me.parseObjectData(meta, data, start, count);
       } else {
         parsed = this.parsePrimitiveData(meta, data, start, count);
       }

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -416,19 +416,15 @@ export default class DatasetController {
     let prev = start > 0 && meta._parsed[start - 1];
     let i, cur, parsed;
 
-    if (me._parsing === false) {
-      iScale.getLabels().splice(0);
+    if (this._parsing === false) {
       meta._parsed = data;
       meta._sorted = true;
       parsed = data;
     } else {
-      if (isObject(me._parsing)) {
-        iScale.getLabels().splice(0);
-      }
       if (isArray(data[start])) {
-        parsed = me.parseArrayData(meta, data, start, count);
+        parsed = this.parseArrayData(meta, data, start, count);
       } else if (isObject(data[start])) {
-        parsed = me.parseObjectData(meta, data, start, count);
+        parsed = this.parseObjectData(meta, data, start, count);
       } else {
         parsed = this.parsePrimitiveData(meta, data, start, count);
       }

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -367,7 +367,7 @@ export default class DatasetController {
     const dataset = this.getDataset();
     let stackChanged = false;
 
-    let labels = meta.iScale ? meta.iScale.getLabels() : null;
+    const labels = meta.iScale ? meta.iScale.getLabels() : null;
     if (labels && labels.length && (this._parsing === false || isObject(this._parsing))) {
       labels.splice(0);
     }

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -367,7 +367,12 @@ export default class DatasetController {
     const dataset = this.getDataset();
     let stackChanged = false;
 
-    this._dataCheck();
+    let labels = me.chart.data.labels;
+    if (labels && labels.length && (me._parsing === false || isObject(me._parsing))) {
+      labels.splice(0);
+    }
+
+    me._dataCheck();
 
     // make sure cached _stacked status is current
     const oldStacked = meta._stacked;

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -367,7 +367,7 @@ export default class DatasetController {
     const dataset = this.getDataset();
     let stackChanged = false;
 
-    let labels = me.chart.data.labels;
+    let labels = meta.iScale ? meta.iScale.getLabels() : null;
     if (labels && labels.length && (me._parsing === false || isObject(me._parsing))) {
       labels.splice(0);
     }

--- a/test/specs/core.datasetController.tests.js
+++ b/test/specs/core.datasetController.tests.js
@@ -249,6 +249,69 @@ describe('Chart.DatasetController', function() {
     expect(parsedYValues).toEqual([20, 30]);
   });
 
+  it('should synchronize labels array with X values when chart existing dataset is updated and parsing is off', function() {
+    const chart = acquireChart({
+      type: 'line',
+      data: {
+        datasets: [{
+          data: [
+            {x: 'One', y: 1},
+            {x: 'Two', y: 2}
+          ]
+        }]
+      },
+      options: {
+        parsing: false
+      }
+    });
+
+    const newData = [
+      {x: 'Three', y: 3},
+      {x: 'Four', y: 4},
+      {x: 'Five', y: 5}
+    ];
+
+    chart.data.datasets[0].data = newData;
+    chart.update();
+
+    const meta = chart.getDatasetMeta(0);
+    const labels = meta.iScale.getLabels();
+    expect(labels).toEqual(newData.map(n => n.x));
+  });
+
+  it('should synchronize labels array with X values when chart existing dataset is updated and parsing has provided keys', function() {
+    const chart = acquireChart({
+      type: 'line',
+      data: {
+        datasets: [{
+          data: [
+            {name: 'One', num: 1},
+            {name: 'Two', num: 2}
+          ]
+        }]
+      },
+      options: {
+        parsing: {
+          xAxisKey: 'name',
+          yAxisKey: 'num'
+        }
+      }
+    });
+
+    const newData = [
+      {name: 'Three', num: 3},
+      {name: 'Four', num: 4},
+      {name: 'Five', num: 5}
+    ];
+
+    chart.data.datasets[0].data = newData;
+    chart.update();
+
+    const meta = chart.getDatasetMeta(0);
+    const labels = meta.iScale.getLabels();
+    expect(labels).toEqual(newData.map(n => n.name));
+  });
+
   it('should synchronize metadata when data are inserted or removed and parsing is on', function() {
     const data = [0, 1, 2, 3, 4, 5];
     const chart = acquireChart({


### PR DESCRIPTION
When parsing was set to false or an object with `xAxisKey` or `yAxisKey`, there were issues if chart data was updated more than once.
Apparently, old x labels were not destroyed, resulting in merging old and new x labels.
This PR destroys old x labels every time data is updated, provided that chart has parsing set to `false` or an object with custom keys.

According to docs: https://www.chartjs.org/docs/next/general/data-structures.html, `labels` should only be set manually when importing primitive data so this does not break any kind of labels list set on chart initialization.

Fixes #9599 