### PR TITLE
fix getRelativePosition type definition

### DIFF
--- a/types/helpers/helpers.dom.d.ts
+++ b/types/helpers/helpers.dom.d.ts
@@ -1,6 +1,6 @@
 export function getMaximumSize(node: HTMLElement, width?: number, height?: number, aspectRatio?: number): { width: number, height: number };
 export function getRelativePosition(
-	evt: MouseEvent,
+	evt: MouseEvent | ChartEvent,
 	chart: { readonly canvas: HTMLCanvasElement }
 ): { x: number; y: number };
 export function getStyle(el: HTMLElement, property: string): string;

--- a/types/helpers/helpers.dom.d.ts
+++ b/types/helpers/helpers.dom.d.ts
@@ -1,3 +1,5 @@
+import { ChartEvent } from '../index.esm';
+
 export function getMaximumSize(node: HTMLElement, width?: number, height?: number, aspectRatio?: number): { width: number, height: number };
 export function getRelativePosition(
 	evt: MouseEvent | ChartEvent,


### PR DESCRIPTION
I referred to this official document.
https://www.chartjs.org/docs/latest/configuration/interactions.html#converting-events-to-data-values

The argument of `onClick` function is defined here.
https://github.com/chartjs/Chart.js/blob/3792f9dbf71da9f7eef952eca338b0f339bd3935/types/index.esm.d.ts#L1493

The `getRelativePosition` supports both types in JS code. The following `getCanvasPosition` function is called in `getRelativePosition`.
https://github.com/chartjs/Chart.js/blob/bc7c58d46d8cb4e7019ce4d4227b0fa6ebc71ecd/src/helpers/helpers.dom.js#L63

Then, the first argument of `getRelativePosition` should accept `ChartEvent` too.

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
