### PR TITLE
Remove offscreen canvas types

### DIFF
--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -537,11 +537,9 @@ export const registerables: readonly ChartComponentLike[];
 export declare type ChartItem =
   | string
   | CanvasRenderingContext2D
-  | OffscreenCanvasRenderingContext2D
   | HTMLCanvasElement
-  | OffscreenCanvas
-  | { canvas: HTMLCanvasElement | OffscreenCanvas }
-  | ArrayLike<CanvasRenderingContext2D | HTMLCanvasElement | OffscreenCanvas>;
+  | { canvas: HTMLCanvasElement }
+  | ArrayLike<CanvasRenderingContext2D | HTMLCanvasElement>;
 
 export declare enum UpdateModeEnum {
   resize = 'resize',


### PR DESCRIPTION
Possible fix for #9594 

An alternative is to add `@types/offscreencanvas` as a dependency. I wasn't sure we wanted to do that since we do not have any dependencies right now