### PR TITLE
Add align to interface of scale title config

### DIFF
--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -2905,6 +2905,7 @@ export interface CartesianScaleOptions extends CoreScaleOptions {
 
   title: {
     display: boolean;
+    align: 'start' | 'center' | 'end';
     text: string | string[];
     color: Color;
     font: FontSpec;


### PR DESCRIPTION
As described in the [documentation](https://www.chartjs.org/docs/next/axes/labelling.html), a scale title can have an `align` property.

However, it appears to be missing in the type definition.

This adds the missing type definition