### PR TITLE
Fix chart crashing when max is defined but ticks are empty

### DIFF
--- a/src/scales/scale.linearbase.js
+++ b/src/scales/scale.linearbase.js
@@ -128,7 +128,7 @@ function generateTicks(generationOptions, dataRange) {
 
   if (maxDefined && includeBounds && niceMax !== max) {
     // If the previous tick is too close to max, replace it with max, else add max
-    if (almostEquals(ticks[ticks.length - 1].value, max, relativeLabelSize(max, minSpacing, generationOptions))) {
+    if (ticks.length && almostEquals(ticks[ticks.length - 1].value, max, relativeLabelSize(max, minSpacing, generationOptions))) {
       ticks[ticks.length - 1].value = max;
     } else {
       ticks.push({value: max});

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -51,6 +51,29 @@ describe('Linear Scale', function() {
     expect(chart.scales.y.max).toBe(150);
   });
 
+  it('Should handle when only a max value is provided', () => {
+    var chart = window.acquireChart({
+      type: 'line',
+      data: {
+        datasets: [{
+          yAxisID: 'y',
+          data: [200]
+        }],
+      },
+      options: {
+        scales: {
+          y: {
+            type: 'linear',
+            max: 150
+          }
+        }
+      }
+    });
+
+    expect(chart.scales.y).not.toEqual(undefined); // must construct
+    expect(chart.scales.y.max).toBe(150);
+  });
+
   it('Should correctly determine the max & min of string data values', function() {
     var chart = window.acquireChart({
       type: 'bar',


### PR DESCRIPTION
If tick size is 0, and a `max` is defined without `min`, Chart.js would crash with:

```
react_devtools_backend.js:4049 Uncaught TypeError: Cannot read property 'value' of undefined TypeError: Cannot read property 'value' of undefined
    at generateTicks$1 (chart.esm.js:9359)
    at LinearScale.buildTicks (chart.esm.js:9461)
    at LinearScale.update (chart.esm.js:3810)
    at fitBoxes (chart.esm.js:2852)
    at Object.update (chart.esm.js:2988)
    at Chart._updateLayout (chart.esm.js:5657)
    at Chart.update (chart.esm.js:5638)
    at updateChart (index.modern.js:137)
    at index.modern.js:157
```

This adds an extra check to prevent `ticks[ticks.length - 1]` from erroring.