### PR TITLE
Fix cleaning up metasets

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -800,12 +800,11 @@ class Chart {
 	 * @private
 	 */
   _destroyDatasetMeta(datasetIndex) {
-    const meta = this._metasets && this._metasets[datasetIndex];
-
+    const meta = this._metasets[datasetIndex];
     if (meta && meta.controller) {
       meta.controller._destroy();
-      delete this._metasets[datasetIndex];
     }
+    delete this._metasets[datasetIndex];
   }
 
   _stop() {


### PR DESCRIPTION
I believe it's a mistake to only delete the metaset if it has a valid controller; see f191f2f5 for where this behavior was introduced.

As of #7030, `this._metasets` should always be defined, so checking whether it's undefined is no longer necessary.

This is a minimal fix for #9653; as discussed there, it may also be worth updating `updateHoverStyle`.

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
