### PR TITLE
cache also undefined values in option resolver

### DIFF
--- a/src/helpers/helpers.config.js
+++ b/src/helpers/helpers.config.js
@@ -181,17 +181,13 @@ const readKey = (prefix, name) => prefix ? prefix + _capitalize(name) : name;
 const needsSubResolver = (prop, value) => isObject(value) && prop !== 'adapters';
 
 function _cached(target, prop, resolve) {
-  let value = target[prop]; // cached value
-  if (defined(value)) {
-    return value;
+  if (Object.prototype.hasOwnProperty.call(target, prop)) {
+    return target[prop];
   }
 
-  value = resolve();
-
-  if (defined(value)) {
-    // cache the resolved value
-    target[prop] = value;
-  }
+  const value = resolve();
+  // cache the resolved value
+  target[prop] = value;
   return value;
 }
 


### PR DESCRIPTION
Otherwise, repeated lookups of undefined properties always trigger the
comparatively expensive resolution. This can be the case for example in
_calculateBarIndexPixels() in controller.bar.js when looking up
options.skipNull and options.maxBarThickness, which is done for each bar
in a bar chart.

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
