### PR TITLE
Update stale documentation for axis titles

### DIFF
--- a/docs/axes/labelling.md
+++ b/docs/axes/labelling.md
@@ -12,8 +12,8 @@ Namespace: `options.scales[scaleId].title`, it defines options for the scale tit
 | `align` | `string` | `'center'` | Alignment of the axis title. Possible options are `'start'`, `'center'` and `'end'`
 | `text` | `string`\|`string[]` | `''` | The text for the title. (i.e. "# of People" or "Response Choices").
 | `color` | [`Color`](../general/colors.md) | `Chart.defaults.color` | Color of label.
-| `font` | `Font` | `Chart.defaults.font` | See [Fonts](../general/fonts.md)
-| `padding` | [`Padding`](../general/padding.md) | `4` | Padding to apply around scale labels. Only `top` and `bottom` are implemented.
+| `font` | [`FontSpec`](../api/interfaces/FontSpec) | `Chart.defaults.font` | Configuration for the axis title font. See [Fonts](../general/fonts.md)
+| `padding` | `number`\|`{ top: number; bottom: number; }` | `4` | Padding to apply around scale labels. See [Padding](../general/padding.md).
 
 ## Creating Custom Tick Formats
 

--- a/docs/axes/labelling.md
+++ b/docs/axes/labelling.md
@@ -12,8 +12,8 @@ Namespace: `options.scales[scaleId].title`, it defines options for the scale tit
 | `align` | `string` | `'center'` | Alignment of the axis title. Possible options are `'start'`, `'center'` and `'end'`
 | `text` | `string`\|`string[]` | `''` | The text for the title. (i.e. "# of People" or "Response Choices").
 | `color` | [`Color`](../general/colors.md) | `Chart.defaults.color` | Color of label.
-| `font` | [`FontSpec`](../api/interfaces/FontSpec) | `Chart.defaults.font` | Configuration for the axis title font. See [Fonts](../general/fonts.md)
-| `padding` | `number`\|`{ top: number; bottom: number; }` | `4` | Padding to apply around scale labels. See [Padding](../general/padding.md).
+| `font` | [`FontSpec`](../api/interfaces/FontSpec) | `Chart.defaults.font` | Configuration for the axis title font. See [Fonts](../general/fonts.md).
+| `padding` | `number`\|`{ top: number; bottom: number; }` | `4` | Padding to apply around scale labels. `left` and `right` properties are not implemented. See [Padding](../general/padding.md).
 
 ## Creating Custom Tick Formats
 

--- a/docs/axes/labelling.md
+++ b/docs/axes/labelling.md
@@ -12,8 +12,8 @@ Namespace: `options.scales[scaleId].title`, it defines options for the scale tit
 | `align` | `string` | `'center'` | Alignment of the axis title. Possible options are `'start'`, `'center'` and `'end'`
 | `text` | `string`\|`string[]` | `''` | The text for the title. (i.e. "# of People" or "Response Choices").
 | `color` | [`Color`](../general/colors.md) | `Chart.defaults.color` | Color of label.
-| `font` | [`FontSpec`](../api/interfaces/FontSpec) | `Chart.defaults.font` | Configuration for the axis title font. See [Fonts](../general/fonts.md).
-| `padding` | `number`\|`{ top: number; bottom: number; }` | `4` | Padding to apply around scale labels. `left` and `right` properties are not implemented. See [Padding](../general/padding.md).
+| `font` | `Font` | `Chart.defaults.font` | See [Fonts](../general/fonts.md)
+| `padding` | [`Padding`](../general/padding.md) | `4` | Padding to apply around scale labels. Only `top`, `bottom` and `y` are implemented.
 
 ## Creating Custom Tick Formats
 

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -2917,7 +2917,9 @@ export interface CartesianScaleOptions extends CoreScaleOptions {
     font: FontSpec;
     /** Padding to apply around scale labels. */
     padding: number | {
+      /** Padding on the (relative) top side of this axis label. */
       top: number;
+      /** Padding on the (relative) bottom side of this axis label. */
       bottom: number;
     };
   };

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -2903,12 +2903,19 @@ export interface CartesianScaleOptions extends CoreScaleOptions {
 
   grid: GridLineOptions;
 
+  /** Options for the scale title. */
   title: {
+    /** If true, displays the axis title. */
     display: boolean;
+    /** Alignment of the axis title. */
     align: 'start' | 'center' | 'end';
+    /** The text for the title, e.g. "# of People" or "Response Choices". */
     text: string | string[];
+    /** Color of the axis label. */
     color: Color;
+    /** Information about the axis title font. */
     font: FontSpec;
+    /** Padding to apply around scale labels. */
     padding: number | {
       top: number;
       bottom: number;

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -2921,6 +2921,8 @@ export interface CartesianScaleOptions extends CoreScaleOptions {
       top: number;
       /** Padding on the (relative) bottom side of this axis label. */
       bottom: number;
+      /** This is a shorthand for defining top/bottom to the same values. */
+      y: number;
     };
   };
 


### PR DESCRIPTION
Updated the documentation for the types on axis labels.

In the corresponding `index.esm.d.ts` file, put JSDoc descriptions for the properties to match the now-updated documentation.

Closes #9682

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
