### PR TITLE
Document sample components file

### DIFF
--- a/docs/samples/utils.md
+++ b/docs/samples/utils.md
@@ -12,3 +12,10 @@ Because of this please don't rely on this file in production environments.
 
 [File on github](https://github.com/chartjs/Chart.js/blob/master/docs/scripts/utils.js)
 
+## Components
+
+Some of the samples make reference to a `components` object. This is an artifact of using a module bundler to build the samples. The creation of that components object is shown below. If chart.js is included as a browser script, these items are accessible via the `Chart` object, i.e `Chart.Tooltip`.
+
+<<< @/docs/scripts/components.js
+
+[File on github](https://github.com/chartjs/Chart.js/blob/master/docs/scripts/components.js)


### PR DESCRIPTION
Resolves #9640 by showing where the `components` object in the samples comes from