### PR TITLE
Fix tooltip caret position when it is positioned at the corners

### DIFF
--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -306,9 +306,9 @@ function getBackgroundPoint(options, size, alignment, chart) {
       x -= paddingAndSize;
     }
   } else if (xAlign === 'left') {
-    x -= Math.max(topLeft, bottomLeft) + caretPadding;
+    x -= Math.max(topLeft, bottomLeft) + caretSize;
   } else if (xAlign === 'right') {
-    x += Math.max(topRight, bottomRight) + caretPadding;
+    x += Math.max(topRight, bottomRight) + caretSize;
   }
 
   return {


### PR DESCRIPTION
Working example: https://codepen.io/digaus/pen/VwWRVqN

Also works when using different values for `caretPadding` and `caretSize`

Closes https://github.com/chartjs/Chart.js/issues/9701