### PR TITLE
Fix: Typo 'is less' -> 'are lesser'

### DIFF
--- a/src/plugins/plugin.decimation.js
+++ b/src/plugins/plugin.decimation.js
@@ -10,7 +10,7 @@ function lttbDecimation(data, start, count, availableWidth, options) {
    * The original implementation is MIT licensed.
    */
   const samples = options.samples || availableWidth;
-  // There are lesser points than the threshold, returning the whole array
+  // There are less points than the threshold, returning the whole array
   if (samples >= count) {
     return data.slice(start, start + count);
   }


### PR DESCRIPTION
Fixed a typo that was grammatically incorrect.
<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
