### PR TITLE
Don't require --grep to be given on the command line

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -10,7 +10,7 @@ module.exports = function(karma) {
     .option('verbose', {default: false})
     .argv;
 
-  const grep = args.grep === true ? '' : args.grep;
+  const grep = (args.grep === true || args.grep === undefined) ? '' : args.grep;
   const specPattern = 'test/specs/**/*' + grep + '*.js';
 
   // Use the same rollup config as our dist files: when debugging (npm run dev),


### PR DESCRIPTION
This makes it easier to use the `karma` CLI directly, if desired, and makes it easier to use WebStorm's integrated debugger (which makes up `karma` command-line invocations itself).  Prior to this change, if `--grep` isn't given, Karma looks for `*undefined*.js` and finds no tests to run.

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
