### PR TITLE
Support nested scriptable defaults for datasets

### DIFF
--- a/src/core/core.config.js
+++ b/src/core/core.config.js
@@ -372,7 +372,7 @@ function getResolver(resolverCache, scopes, prefixes) {
 }
 
 const hasFunction = value => isObject(value)
-  && Object.keys(value).reduce((acc, key) => acc || isFunction(value[key]), false);
+  && Object.getOwnPropertyNames(value).reduce((acc, key) => acc || isFunction(value[key]), false);
 
 function needContext(proxy, names) {
   const {isScriptable, isIndexable} = _descriptors(proxy);

--- a/test/specs/core.datasetController.tests.js
+++ b/test/specs/core.datasetController.tests.js
@@ -919,6 +919,30 @@ describe('Chart.DatasetController', function() {
         }
       });
     });
+
+    it('should support nested scriptable defaults', function() {
+      Chart.defaults.datasets.line.fill = {
+        value: (ctx) => ctx.type === 'dataset' ? 75 : 0
+      };
+      const chart = acquireChart({
+        type: 'line',
+        data: {
+          datasets: [{
+            data: [100, 120, 130],
+          }]
+        },
+      });
+
+      const controller = chart.getDatasetMeta(0).controller;
+      const opts = controller.resolveDatasetElementOptions();
+      expect(opts).toEqualOptions({
+        fill: {
+          value: 75
+        }
+      });
+      delete Chart.defaults.datasets.line.fill;
+    });
+
   });
 
   describe('_resolveAnimations', function() {


### PR DESCRIPTION
In #9758 I failed to verify defaults work.

`Object.keys` on resolver returns only keys from current scope, while `Object.getOwnPropertyNames` returns combination of keys from all scopes.