### PR TITLE
Add warning about chart types overriding plugin defaults

### DIFF
--- a/docs/configuration/legend.md
+++ b/docs/configuration/legend.md
@@ -6,6 +6,10 @@ The chart legend displays data about the datasets that are appearing on the char
 
 Namespace: `options.plugins.legend`, the global options for the chart legend is defined in `Chart.defaults.plugins.legend`.
 
+:::warning
+The bubble, doughnut, pie, and polar area charts override the tooltip defaults. To change the overrides for those chart types, the options are defined in `Chart.overrides[type].plugins.tooltip`. 
+:::
+
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
 | `display` | `boolean` | `true` | Is the legend shown?

--- a/docs/configuration/tooltip.md
+++ b/docs/configuration/tooltip.md
@@ -4,6 +4,10 @@
 
 Namespace: `options.plugins.tooltip`, the global options for the chart tooltips is defined in `Chart.defaults.plugins.tooltip`.
 
+:::warning
+The bubble, doughnut, pie, polar area, and scatter charts override the tooltip defaults. To change the overrides for those chart types, the options are defined in `Chart.overrides[type].plugins.tooltip`. 
+:::
+
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
 | `enabled` | `boolean` | `true` | Are on-canvas tooltips enabled?


### PR DESCRIPTION
Resolves #9781

![tooltip warning](https://user-images.githubusercontent.com/6757853/138600084-122a8a96-655c-4032-9167-d9c2b492363a.png)
