### PR TITLE
Define with let to avoid "assignment to constant" errors

### DIFF
--- a/docs/configuration/tooltip.md
+++ b/docs/configuration/tooltip.md
@@ -157,7 +157,7 @@ const chart = new Chart(ctx, {
             tooltip: {
                 callbacks: {
                     label: function(context) {
-                        const label = context.dataset.label || '';
+                        let label = context.dataset.label || '';
 
                         if (label) {
                             label += ': ';

--- a/docs/configuration/tooltip.md
+++ b/docs/configuration/tooltip.md
@@ -5,7 +5,7 @@
 Namespace: `options.plugins.tooltip`, the global options for the chart tooltips is defined in `Chart.defaults.plugins.tooltip`.
 
 :::warning
-The bubble, doughnut, pie, polar area, and scatter charts override the tooltip defaults. To change the overrides for those chart types, the options are defined in `Chart.overrides[type].plugins.tooltip`. 
+The bubble, doughnut, pie, polar area, and scatter charts override the tooltip defaults. To change the overrides for those chart types, the options are defined in `Chart.overrides[type].plugins.tooltip`.
 :::
 
 | Name | Type | Default | Description
@@ -282,7 +282,7 @@ const myPieChart = new Chart(ctx, {
 
                 external: function(context) {
                     // Tooltip Element
-                    const tooltipEl = document.getElementById('chartjs-tooltip');
+                    let tooltipEl = document.getElementById('chartjs-tooltip');
 
                     // Create element on first render
                     if (!tooltipEl) {
@@ -316,7 +316,7 @@ const myPieChart = new Chart(ctx, {
                         const titleLines = tooltipModel.title || [];
                         const bodyLines = tooltipModel.body.map(getBody);
 
-                        const innerHtml = '<thead>';
+                        let innerHtml = '<thead>';
 
                         titleLines.forEach(function(title) {
                             innerHtml += '<tr><th>' + title + '</th></tr>';
@@ -325,7 +325,7 @@ const myPieChart = new Chart(ctx, {
 
                         bodyLines.forEach(function(body, i) {
                             const colors = tooltipModel.labelColors[i];
-                            const style = 'background:' + colors.backgroundColor;
+                            let style = 'background:' + colors.backgroundColor;
                             style += '; border-color:' + colors.borderColor;
                             style += '; border-width: 2px';
                             const span = '<span style="' + style + '"></span>';
@@ -333,7 +333,7 @@ const myPieChart = new Chart(ctx, {
                         });
                         innerHtml += '</tbody>';
 
-                        const tableRoot = tooltipEl.querySelector('table');
+                        let tableRoot = tooltipEl.querySelector('table');
                         tableRoot.innerHTML = innerHtml;
                     }
 

--- a/docs/developers/updates.md
+++ b/docs/developers/updates.md
@@ -66,8 +66,8 @@ Variables referencing any one from `chart.scales` would be lost after updating s
 
 ```javascript
 function updateScales(chart) {
-    const xScale = chart.scales.x;
-    const yScale = chart.scales.y;
+    let xScale = chart.scales.x;
+    let yScale = chart.scales.y;
     chart.options.scales = {
         newId: {
             display: true


### PR DESCRIPTION
Thanks for this example. Defining `label` with `const` rather than `let` results in `Uncaught TypeError: Assignment to constant variable.`

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
