### PR TITLE
Detect detach/attach in same observation (alt)

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -806,6 +806,9 @@ class Chart {
     delete this._metasets[datasetIndex];
   }
 
+  /**
+	 * @private
+	 */
   _stop() {
     let i, ilen;
     this.stop();
@@ -893,33 +896,27 @@ class Chart {
       }
     };
 
-    const listener = (width, height) => {
+    const resizeListener = (width, height) => {
       if (this.canvas) {
         this.resize(width, height);
       }
     };
 
-    let detached; // eslint-disable-line prefer-const
     const attached = () => {
-      _remove('attach', attached);
-
       this.attached = true;
       this.resize();
 
-      _add('resize', listener);
-      _add('detach', detached);
+      _add('resize', resizeListener);
     };
 
-    detached = () => {
+    const detached = () => {
       this.attached = false;
 
-      _remove('resize', listener);
+      _remove('resize', resizeListener);
 
       // Stop animating and remove metasets, so when re-attached, the animations start from beginning.
       this._stop();
       this._resize(0, 0);
-
-      _add('attach', attached);
     };
 
     if (platform.isAttached(this.canvas)) {
@@ -927,6 +924,7 @@ class Chart {
     } else {
       detached();
     }
+    _add('mutate', {attached, detached});
   }
 
   /**

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -1078,6 +1078,95 @@ describe('Chart', function() {
       }, 0);
     });
 
+    // https://github.com/chartjs/Chart.js/issues/9875
+    it('should detect detach/attach in series', function(done) {
+      var chart = acquireChart({
+        options: {
+          responsive: true,
+          maintainAspectRatio: false
+        }
+      }, {
+        canvas: {
+          style: ''
+        },
+        wrapper: {
+          style: 'width: 320px; height: 350px'
+        }
+      });
+
+      var wrapper = chart.canvas.parentNode;
+      var parent = wrapper.parentNode;
+
+      parent.removeChild(wrapper);
+      parent.appendChild(wrapper);
+
+      setTimeout(function() {
+        expect(chart.attached).toBeTrue();
+        done();
+      }, 0);
+    });
+
+    it('should detect detach/attach/detach in series', function(done) {
+      var chart = acquireChart({
+        options: {
+          responsive: true,
+          maintainAspectRatio: false
+        }
+      }, {
+        canvas: {
+          style: ''
+        },
+        wrapper: {
+          style: 'width: 320px; height: 350px'
+        }
+      });
+
+      var wrapper = chart.canvas.parentNode;
+      var parent = wrapper.parentNode;
+
+      parent.removeChild(wrapper);
+      parent.appendChild(wrapper);
+      parent.removeChild(wrapper);
+
+      setTimeout(function() {
+        expect(chart.attached).toBeFalse();
+        done();
+      }, 0);
+    });
+
+    it('should detect attach/detach in series', function(done) {
+      var chart = acquireChart({
+        options: {
+          responsive: true,
+          maintainAspectRatio: false
+        }
+      }, {
+        canvas: {
+          style: ''
+        },
+        wrapper: {
+          style: 'width: 320px; height: 350px'
+        }
+      });
+
+      var wrapper = chart.canvas.parentNode;
+      var parent = wrapper.parentNode;
+
+      parent.removeChild(wrapper);
+
+      setTimeout(function() {
+        expect(chart.attached).toBeFalse();
+
+        parent.appendChild(wrapper);
+        parent.removeChild(wrapper);
+
+        setTimeout(function() {
+          expect(chart.attached).toBeFalse();
+          done();
+        }, 0);
+      }, 0);
+    });
+
     // https://github.com/chartjs/Chart.js/issues/4737
     it('should resize the canvas when re-creating the chart', function(done) {
       var chart = acquireChart({


### PR DESCRIPTION
Alternative to #9876

This approach keeps one observer the whole time and fires attach/detach every time encountered.

pros
- less duplication
- every attach / detach is detected
- should ensure chart is resized if detached and immediately attached to different sized container

cons
- every attach / detach is detected