### PR TITLE
Fix resolver caching issue when setting values

### DIFF
--- a/src/helpers/helpers.config.js
+++ b/src/helpers/helpers.config.js
@@ -76,8 +76,7 @@ export function _createResolver(scopes, prefixes = [''], rootScopes = scopes, fa
      */
     set(target, prop, value) {
       const storage = target._storage || (target._storage = getTarget());
-      storage[prop] = value; // set to top level scope
-      delete target[prop]; // remove from cache
+      target[prop] = storage[prop] = value; // set to top level scope + cache
       delete target._keys; // remove cached keys
       return true;
     }

--- a/test/specs/helpers.config.tests.js
+++ b/test/specs/helpers.config.tests.js
@@ -492,6 +492,7 @@ describe('Chart.helpers.config', function() {
         resolver.value = false;
         expect(options.value).toBeFalse();
         expect(defaults.value).toBeTrue();
+        expect(resolver.value).toBeFalse();
       });
 
       it('should set values of sub-objects to first scope', function() {
@@ -505,6 +506,7 @@ describe('Chart.helpers.config', function() {
         resolver.sub.value = false;
         expect(options.sub.value).toBeFalse();
         expect(defaults.sub.value).toBeTrue();
+        expect(resolver.sub.value).toBeFalse();
       });
 
       it('should throw when setting a value and options is frozen', function() {


### PR DESCRIPTION
Ref: #9935

Setting an undefined property to a value in a resolver did not update the cached value, but only tried to delete it.
The value was correctly updated to the underlying object, but the resolver still returned undefined.

I think this issue originates from #9661
