### PR TITLE
Improvements to tooltip positioners

### DIFF
--- a/docs/configuration/tooltip.md
+++ b/docs/configuration/tooltip.md
@@ -405,7 +405,7 @@ import { Tooltip } from 'chart.js';
  * @param eventPosition {Point} the position of the event in canvas coordinates
  * @returns {TooltipPosition} the tooltip position
  */
-Tooltip.positioners.myCustomPositioner = function(elements, eventPosition, chart) {
+Tooltip.positioners.myCustomPositioner = function(elements, eventPosition) {
     // A reference to the tooltip model
     const tooltip = this;
 

--- a/docs/configuration/tooltip.md
+++ b/docs/configuration/tooltip.md
@@ -403,7 +403,6 @@ import { Tooltip } from 'chart.js';
  * @function Tooltip.positioners.myCustomPositioner
  * @param elements {Chart.Element[]} the tooltip elements
  * @param eventPosition {Point} the position of the event in canvas coordinates
- * @param chart {Chart} the chart
  * @returns {TooltipPosition} the tooltip position
  */
 Tooltip.positioners.myCustomPositioner = function(elements, eventPosition, chart) {

--- a/docs/configuration/tooltip.md
+++ b/docs/configuration/tooltip.md
@@ -59,33 +59,7 @@ Possible modes are:
 
 `'average'` mode will place the tooltip at the average position of the items displayed in the tooltip. `'nearest'` will place the tooltip at the position of the element closest to the event position.
 
-New modes can be defined by adding functions to the `Chart.Tooltip.positioners` map.
-
-Example:
-
-```javascript
-/**
- * Custom positioner
- * @function Tooltip.positioners.myCustomPositioner
- * @param elements {Chart.Element[]} the tooltip elements
- * @param eventPosition {Point} the position of the event in canvas coordinates
- * @param chart {Chart} the chart
- * @returns {Point} the tooltip position
- */
-const tooltipPlugin = Chart.registry.getPlugin('tooltip');
-tooltipPlugin.positioners.myCustomPositioner = function(elements, eventPosition, chart) {
-    /** @type {Tooltip} */
-    const tooltip = this;
-
-    /* ... */
-
-    return {
-        x: 0,
-        y: 0
-        // You may also include xAlign and yAlign to override those tooltip options.
-    };
-};
-```
+You can also define [custom position modes](#custom-position-modes).
 
 ### Tooltip Alignment
 
@@ -365,6 +339,8 @@ The tooltip model contains parameters that can be used to render the tooltip.
 
 ```javascript
 {
+    chart: Chart,
+
     // The items that we are rendering in the tooltip. See Tooltip Item Interface section
     dataPoints: TooltipItem[],
 
@@ -409,6 +385,61 @@ The tooltip model contains parameters that can be used to render the tooltip.
     opacity: number,
 
     // tooltip options
-    options : Object
+    options: Object
+}
+```
+
+## Custom Position Modes
+
+New modes can be defined by adding functions to the `Chart.Tooltip.positioners` map.
+
+Example:
+
+```javascript
+import { Tooltip } from 'chart.js';
+
+/**
+ * Custom positioner
+ * @function Tooltip.positioners.myCustomPositioner
+ * @param elements {Chart.Element[]} the tooltip elements
+ * @param eventPosition {Point} the position of the event in canvas coordinates
+ * @param chart {Chart} the chart
+ * @returns {TooltipPosition} the tooltip position
+ */
+Tooltip.positioners.myCustomPositioner = function(elements, eventPosition, chart) {
+    // A reference to the tooltip model
+    const tooltip = this;
+
+    /* ... */
+
+    return {
+        x: 0,
+        y: 0
+        // You may also include xAlign and yAlign to override those tooltip options.
+    };
+};
+
+// Then, to use it...
+new Chart.js(ctx, {
+    data,
+    options: {
+        plugins: {
+            tooltip: {
+                position: 'myCustomPositioner'
+            }
+        }
+    }
+})
+```
+
+See [samples](/samples/tooltip/position.md) for a more detailed example.
+
+If you're using TypeScript, you'll also need to register the new mode:
+
+```typescript
+declare module 'chart.js' {
+  interface TooltipPositionerMap {
+    myCustomPositioner: TooltipPositionerFunction<ChartType>;
+  }
 }
 ```

--- a/docs/configuration/tooltip.md
+++ b/docs/configuration/tooltip.md
@@ -69,10 +69,11 @@ Example:
  * @function Tooltip.positioners.myCustomPositioner
  * @param elements {Chart.Element[]} the tooltip elements
  * @param eventPosition {Point} the position of the event in canvas coordinates
+ * @param chart {Chart} the chart
  * @returns {Point} the tooltip position
  */
 const tooltipPlugin = Chart.registry.getPlugin('tooltip');
-tooltipPlugin.positioners.myCustomPositioner = function(elements, eventPosition) {
+tooltipPlugin.positioners.myCustomPositioner = function(elements, eventPosition, chart) {
     /** @type {Tooltip} */
     const tooltip = this;
 

--- a/docs/configuration/tooltip.md
+++ b/docs/configuration/tooltip.md
@@ -81,6 +81,7 @@ tooltipPlugin.positioners.myCustomPositioner = function(elements, eventPosition)
     return {
         x: 0,
         y: 0
+        // You may also include xAlign and yAlign to override those tooltip options.
     };
 };
 ```

--- a/docs/samples/tooltip/position.md
+++ b/docs/samples/tooltip/position.md
@@ -63,11 +63,13 @@ components.Tooltip.positioners.bottom = function(items) {
     return false;
   }
 
-  const chart = this._chart;
+  const chart = this.chart;
 
   return {
     x: pos.x,
     y: chart.chartArea.bottom,
+    xAlign: 'center',
+    yAlign: 'bottom',
   };
 };
 

--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -10,6 +10,7 @@ import {createContext, drawPoint} from '../helpers';
 /**
  * @typedef { import("../platform/platform.base").Chart } Chart
  * @typedef { import("../platform/platform.base").ChartEvent } ChartEvent
+ * @typedef { import("../../types/index.esm").ActiveElement } ActiveElement
  */
 
 const positioners = {
@@ -112,7 +113,7 @@ function splitNewlines(str) {
 /**
  * Private helper to create a tooltip item model
  * @param {Chart} chart
- * @param item - {element, index, datasetIndex} to create the tooltip item for
+ * @param {ActiveElement} item - {element, index, datasetIndex} to create the tooltip item for
  * @return new tooltip item
  */
 function createTooltipItem(chart, item) {
@@ -361,7 +362,9 @@ export class Tooltip extends Element {
     this._tooltipItems = [];
     this.$animations = undefined;
     this.$context = undefined;
-    this.chart = config.chart;
+    // TODO: V4, remove config._chart and this._chart backward compatibility aliases
+    this.chart = config.chart || config._chart;
+    this._chart = this.chart;
     this.options = config.options;
     this.dataPoints = undefined;
     this.title = undefined;
@@ -382,8 +385,6 @@ export class Tooltip extends Element {
     this.labelColors = undefined;
     this.labelPointStyles = undefined;
     this.labelTextColors = undefined;
-    // TODO: V4, remove this backward compatibility alias
-    this._chart = this.chart;
   }
 
   initialize(options) {

--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -531,7 +531,7 @@ export class Tooltip extends Element {
         };
       }
     } else {
-      const position = positioners[options.position].call(this, active, this._eventPosition);
+      const position = positioners[options.position].call(this, active, this._eventPosition, this._chart);
       tooltipItems = this._createItems(options);
 
       this.title = this.getTitle(tooltipItems, options);
@@ -892,7 +892,7 @@ export class Tooltip extends Element {
     const animX = anims && anims.x;
     const animY = anims && anims.y;
     if (animX || animY) {
-      const position = positioners[options.position].call(this, this._active, this._eventPosition);
+      const position = positioners[options.position].call(this, this._active, this._eventPosition, chart);
       if (!position) {
         return;
       }
@@ -1057,7 +1057,7 @@ export class Tooltip extends Element {
 	 */
   _positionChanged(active, e) {
     const {caretX, caretY, options} = this;
-    const position = positioners[options.position].call(this, active, e);
+    const position = positioners[options.position].call(this, active, e, this._chart);
     return position !== false && (caretX !== position.x || caretY !== position.y);
   }
 }

--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -256,10 +256,10 @@ function determineXAlign(chart, options, size, yAlign) {
  * Helper to get the alignment of a tooltip given the size
  */
 function determineAlignment(chart, options, size) {
-  const yAlign = options.yAlign || determineYAlign(chart, size);
+  const yAlign = size.yAlign || options.yAlign || determineYAlign(chart, size);
 
   return {
-    xAlign: options.xAlign || determineXAlign(chart, options, size, yAlign),
+    xAlign: size.xAlign || options.xAlign || determineXAlign(chart, options, size, yAlign),
     yAlign
   };
 }

--- a/test/specs/plugin.tooltip.tests.js
+++ b/test/specs/plugin.tooltip.tests.js
@@ -1419,7 +1419,7 @@ describe('Plugin.Tooltip', function() {
 
     var mockContext = window.createMockContext();
     var tooltip = new Tooltip({
-      _chart: {
+      chart: {
         getContext: () => ({}),
         options: {
           plugins: {

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -2451,7 +2451,7 @@ export interface TooltipModel<TType extends ChartType> {
   options: TooltipOptions<TType>;
 
   getActiveElements(): ActiveElement[];
-  setActiveElements(active: ActiveDataPoint[], eventPosition: { x: number, y: number }): void;
+  setActiveElements(active: ActiveDataPoint[], eventPosition: Point): void;
 }
 
 export interface TooltipPosition {
@@ -2461,19 +2461,21 @@ export interface TooltipPosition {
   yAlign?: TooltipYAlignment;
 }
 
-export type TooltipPositionFunction = (items: readonly ActiveElement[], eventPosition: { x: number; y: number }) => TooltipPosition | false;
+export type TooltipPositionerFunction = (
+  items: readonly ActiveElement[],
+  eventPosition: Point,
+  chart: Chart
+) => TooltipPosition | false;
 
 export interface TooltipPositionerMap {
-  average: TooltipPositionFunction;
-  nearest: TooltipPositionFunction;
+  average: TooltipPositionerFunction;
+  nearest: TooltipPositionerFunction;
 }
 
 export type TooltipPositioner = keyof TooltipPositionerMap;
 
 export const Tooltip: Plugin & {
-  readonly positioners: {
-    [key: string]: (items: readonly ActiveElement[], eventPosition: { x: number; y: number }) => TooltipPosition | false;
-  };
+  readonly positioners: TooltipPositionerMap;
 };
 
 export interface TooltipCallbacks<

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -2402,7 +2402,9 @@ export interface TooltipLabelStyle {
    */
   borderRadius?: number | BorderRadius;
 }
-export interface TooltipModel<TType extends ChartType> {
+export interface TooltipModel<TType extends ChartType> extends Element<AnyObject, TooltipOptions<TType>> {
+  readonly chart: Chart<TType>;
+
   // The items that we are rendering in the tooltip. See Tooltip Item Interface section
   dataPoints: TooltipItem<TType>[];
 
@@ -2461,22 +2463,24 @@ export interface TooltipPosition {
   yAlign?: TooltipYAlignment;
 }
 
-export type TooltipPositionerFunction = (
+export type TooltipPositionerFunction<TType extends ChartType> = (
+  this: TooltipModel<TType>,
   items: readonly ActiveElement[],
-  eventPosition: Point,
-  chart: Chart
+  eventPosition: Point
 ) => TooltipPosition | false;
 
 export interface TooltipPositionerMap {
-  average: TooltipPositionerFunction;
-  nearest: TooltipPositionerFunction;
+  average: TooltipPositionerFunction<ChartType>;
+  nearest: TooltipPositionerFunction<ChartType>;
 }
 
 export type TooltipPositioner = keyof TooltipPositionerMap;
 
-export const Tooltip: Plugin & {
+export interface Tooltip extends Plugin {
   readonly positioners: TooltipPositionerMap;
-};
+}
+
+export const Tooltip: Tooltip;
 
 export interface TooltipCallbacks<
   TType extends ChartType,

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -2454,9 +2454,25 @@ export interface TooltipModel<TType extends ChartType> {
   setActiveElements(active: ActiveDataPoint[], eventPosition: { x: number, y: number }): void;
 }
 
+export interface TooltipPosition {
+  x: number;
+  y: number;
+  xAlign?: TooltipXAlignment;
+  yAlign?: TooltipYAlignment;
+}
+
+export type TooltipPositionFunction = (items: readonly ActiveElement[], eventPosition: { x: number; y: number }) => TooltipPosition | false;
+
+export interface TooltipPositionerMap {
+  average: TooltipPositionFunction;
+  nearest: TooltipPositionFunction;
+}
+
+export type TooltipPositioner = keyof TooltipPositionerMap;
+
 export const Tooltip: Plugin & {
   readonly positioners: {
-    [key: string]: (items: readonly ActiveElement[], eventPosition: { x: number; y: number }) => { x: number; y: number } | false;
+    [key: string]: (items: readonly ActiveElement[], eventPosition: { x: number; y: number }) => TooltipPosition | false;
   };
 };
 
@@ -2529,7 +2545,7 @@ export interface TooltipOptions<TType extends ChartType = ChartType> extends Cor
   /**
    * The mode for positioning the tooltip
    */
-  position: Scriptable<'average' | 'nearest', ScriptableTooltipContext<TType>>
+  position: Scriptable<TooltipPositioner, ScriptableTooltipContext<TType>>
 
   /**
    * Override the tooltip alignment calculations
@@ -2590,7 +2606,7 @@ export interface TooltipOptions<TType extends ChartType = ChartType> extends Cor
    */
   bodyColor: Scriptable<Color, ScriptableTooltipContext<TType>>;
   /**
-   *   See Fonts.
+   * See Fonts.
    * @default {}
    */
   bodyFont: Scriptable<FontSpec, ScriptableTooltipContext<TType>>;
@@ -2630,7 +2646,7 @@ export interface TooltipOptions<TType extends ChartType = ChartType> extends Cor
    */
   padding: Scriptable<number | ChartArea, ScriptableTooltipContext<TType>>;
   /**
-   *   Extra distance to move the end of the tooltip arrow away from the tooltip point.
+   * Extra distance to move the end of the tooltip arrow away from the tooltip point.
    * @default 2
    */
   caretPadding: Scriptable<number, ScriptableTooltipContext<TType>>;


### PR DESCRIPTION
See #9930 for background. Specific changes:

* Allow the positioner's return object to optionally include xAlign and yAlign, overriding any other values for those options.
* Make the `Chart` instance available to positioners. I initially thought I would pass it in as a third parameter; however, I realized it was already available as `this._chart`, and the [position sample](https://www.chartjs.org/docs/latest/samples/tooltip/position.html) uses that. `this._chart` feels like a private or protected member, and the `Scale` and `LegendElement` elements both have a `chart` member, so I renamed the Tooltip element's `_chart` to `chart` to make it consistent and obviously public. I left a `_chart` reference in place, in case any end-user code followed the sample code, to preserve backward compatibility.
* Better TypeScript definitions:
  * Add a `...Map`, similar to `InteractionModeMap`, and add documentation on how to keep type safety.
  * Document the `this` parameter.
* Update documentation:
  * Custom tooltip positioners seems like a more advanced, more code-heavy feature, so I moved put it at the end of the documentation.
  * Accessing `Chart.registry.getPlugin('tooltip')` seemed harder than necessary, and it's not what the sample did, and it's not as TypeScript-friendly, so I replaced it with importing `Tooltip`.
  * Since I was already updating tooltip-related types, I fixed #9782.

Feedback welcome.

**A question**: I noticed some inconsistencies in type names:

* The Legend plugin is called `Legend` by the TypeScript type definitions. It creates instances of a JavaScript class called `Legend`, extending `Element`, whose type is defined in TypeScript as `LegendElement`, extending `Element`.
* Several other types in TypeScript are named `...Element` and extend `Element`.
* The Tooltip plugin is called `Tooltip` by the TypeScript type definitions. It creates instances of a JavaScript class called `Tooltip`, extending `Element`, whose type is defined in TypeScript as `TooltipModel`, extending nothing.

The naming differences between JavaScript and TypeScript aren't ideal, but they're consistent. The differences between `LegendElement` and `TooltipModel` seem inconsistent, so I wondered about addressing them. I updated `TooltipModel` to extend `Element`, but I wondered if it should also be renamed to `TooltipElement`. That would break backward compatibility for type definitions; it's not too unusual for me to have to tweak my types after minor-version updates, so this may be tolerable for a SemVer-minor release. If you'd like for me to rename `TooltipModel` to `TooltipElement` (and optionally make `TooltipModel` a deprecated alias), either in this PR or another, please let me know.

Fixes #9930.