### PR TITLE
Specify UTC time zone for the test suite

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -82,6 +82,7 @@ module.exports = function(karma) {
       {pattern: 'test/fixtures/**/*.json', included: false},
       {pattern: 'test/fixtures/**/*.png', included: false},
       'node_modules/moment/min/moment.min.js',
+      'node_modules/moment-timezone/builds/moment-timezone-with-data.min.js',
       {pattern: 'test/index.js', watched: false},
       {pattern: 'test/BasicChartWebWorker.js', included: false},
       {pattern: 'src/index.js', watched: false},

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
                 "luxon": "^1.26.0",
                 "markdown-it-include": "^2.0.0",
                 "moment": "^2.29.1",
+                "moment-timezone": "^0.5.34",
                 "pixelmatch": "^5.2.1",
                 "rollup": "^2.44.0",
                 "rollup-plugin-analyzer": "^4.0.0",
@@ -11739,6 +11740,18 @@
             "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
             "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
             "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/moment-timezone": {
+            "version": "0.5.34",
+            "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.34.tgz",
+            "integrity": "sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==",
+            "dev": true,
+            "dependencies": {
+                "moment": ">= 2.9.0"
+            },
             "engines": {
                 "node": "*"
             }
@@ -28425,6 +28438,15 @@
             "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
             "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
             "dev": true
+        },
+        "moment-timezone": {
+            "version": "0.5.34",
+            "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.34.tgz",
+            "integrity": "sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==",
+            "dev": true,
+            "requires": {
+                "moment": ">= 2.9.0"
+            }
         },
         "move-concurrently": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
         "luxon": "^1.26.0",
         "markdown-it-include": "^2.0.0",
         "moment": "^2.29.1",
+        "moment-timezone": "^0.5.34",
         "pixelmatch": "^5.2.1",
         "rollup": "^2.44.0",
         "rollup-plugin-analyzer": "^4.0.0",

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,10 @@ jasmine.fixture = {
 
 jasmine.triggerMouseEvent = triggerMouseEvent;
 
+// Set a fixed time zone (and, in particular, disable Daylight Saving Time) for
+// more stable test results.
+window.moment.tz.setDefault('Etc/UTC');
+
 beforeEach(function() {
   addMatchers();
 });

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -450,8 +450,11 @@ describe('Time scale tests', function() {
         datasets: [{
           xAxisID: 'x',
           data: [
-            {t: +new Date('2018-01-08 05:14:23.234'), y: 10},
-            {t: +new Date('2018-01-09 06:17:43.426'), y: 3}
+            // Normally (at least with the moment.js adapter), times would be in
+            // the user's local time zone.  To allow for more stable tests, our
+            // tests/index.js sets moment.js to use UTC; use `Z` here to match.
+            {t: +new Date('2018-01-08 05:14:23.234Z'), y: 10},
+            {t: +new Date('2018-01-09 06:17:43.426Z'), y: 3}
           ]
         }],
       },
@@ -1175,7 +1178,7 @@ describe('Time scale tests', function() {
           }
         });
 
-        // NOTE: built-in adapter uses moment
+        // NOTE: the test suite is configured to use moment
         var expected = {
           datetime: 'MMM D, YYYY, h:mm:ss a',
           millisecond: 'h:mm:ss.SSS a',
@@ -1213,7 +1216,7 @@ describe('Time scale tests', function() {
           }
         });
 
-        // NOTE: built-in adapter uses moment
+        // NOTE: the test suite is configured to use moment
         var expected = {
           datetime: 'MMM D, YYYY, h:mm:ss a',
           millisecond: 'foo',


### PR DESCRIPTION
The controller.bar/not-grouped/on-time test was failing on my computer because the date ranges happen to cross the end of Daylight Saving Time in the U.S., so chart's X axis was generated with one more hour of time than the test fixture expected.

Using moment-timezone to specify a fixed time zone with no DST seemed like the most robust fix. (Alternatively, I could pick a date range that doesn't change DST; that ought to work.)

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
