### PR TITLE
Pass object from array as value to _fallback

### DIFF
--- a/src/helpers/helpers.config.js
+++ b/src/helpers/helpers.config.js
@@ -275,8 +275,8 @@ function createSubResolver(parentScopes, resolver, prop, value) {
   const rootScopes = resolver._rootScopes;
   const fallback = resolveFallback(resolver._fallback, prop, value);
   const allScopes = [...parentScopes, ...rootScopes];
-  const set = new Set([value]);
-
+  const set = new Set();
+  set.add(value);
   let key = addScopesFromKey(set, allScopes, prop, fallback || prop, value);
   if (key === null) {
     return false;
@@ -291,9 +291,9 @@ function createSubResolver(parentScopes, resolver, prop, value) {
     () => subGetTarget(resolver, prop, value));
 }
 
-function addScopesFromKey(set, allScopes, key, fallbackKey, item) {
+function addScopesFromKey(set, allScopes, key, fallback, item) {
   while (key) {
-    key = addScopes(set, allScopes, key, fallbackKey, item);
+    key = addScopes(set, allScopes, key, fallback, item);
   }
   return key;
 }

--- a/src/helpers/helpers.config.js
+++ b/src/helpers/helpers.config.js
@@ -254,7 +254,7 @@ const getScope = (key, parent) => key === true ? parent
 function addScopes(set, parentScopes, key, parentFallback, value) {
   for (const parent of parentScopes) {
     const scope = getScope(key, parent);
-    if (isObject(scope)) {
+    if (scope) {
       set.add(scope);
       const fallback = resolveFallback(scope._fallback, key, value);
       if (defined(fallback) && fallback !== key && fallback !== parentFallback) {
@@ -277,25 +277,25 @@ function createSubResolver(parentScopes, resolver, prop, value) {
   const allScopes = [...parentScopes, ...rootScopes];
   const set = new Set([value]);
 
-  function addScopesFromKey(key, fallbackKey, item) {
-    while (key) {
-      key = addScopes(set, allScopes, key, fallbackKey, item);
-    }
-    return key;
-  }
-
-  let key = addScopesFromKey(prop, fallback || prop, value);
+  let key = addScopesFromKey(set, allScopes, prop, fallback || prop, value);
   if (key === null) {
     return false;
   }
   if (defined(fallback) && fallback !== prop) {
-    key = addScopesFromKey(fallback, key, value);
+    key = addScopesFromKey(set, allScopes, fallback, key, value);
     if (key === null) {
       return false;
     }
   }
   return _createResolver(Array.from(set), [''], rootScopes, fallback,
     () => subGetTarget(resolver, prop, value));
+}
+
+function addScopesFromKey(set, allScopes, key, fallbackKey, item) {
+  while (key) {
+    key = addScopes(set, allScopes, key, fallbackKey, item);
+  }
+  return key;
 }
 
 function subGetTarget(resolver, prop, value) {

--- a/test/specs/helpers.config.tests.js
+++ b/test/specs/helpers.config.tests.js
@@ -662,8 +662,9 @@ describe('Chart.helpers.config', function() {
       const options = {
         items: [{test: true}]
       };
-      const resolver = _attachContext(_createResolver([options, descriptors]), {dymmy: true});
-      const item0 = resolver.items[0];
+      const resolver = _createResolver([options, descriptors]);
+      const opts = _attachContext(resolver, {dymmy: true});
+      const item0 = opts.items[0];
       expect(item0.test).toEqual(true);
       expect(spy).toHaveBeenCalledWith('items', options.items[0]);
     });
@@ -684,7 +685,6 @@ describe('Chart.helpers.config', function() {
         items: [{test: true}]
       };
       const resolver = _createResolver([options, defaults, descriptors]);
-      // console.warn(resolver.items[0]);
       const opts = _attachContext(resolver, {dymmy: true});
       const item0 = opts.items[0];
       console.warn(opts._proxy._scopes);

--- a/test/specs/helpers.config.tests.js
+++ b/test/specs/helpers.config.tests.js
@@ -652,6 +652,46 @@ describe('Chart.helpers.config', function() {
       });
     });
 
+    it('should call _fallback with proper value from array when descriptor is object', function() {
+      const spy = jasmine.createSpy('fallback');
+      const descriptors = {
+        items: {
+          _fallback: spy
+        }
+      };
+      const options = {
+        items: [{test: true}]
+      };
+      const resolver = _attachContext(_createResolver([options, descriptors]), {dymmy: true});
+      const item0 = resolver.items[0];
+      expect(item0.test).toEqual(true);
+      expect(spy).toHaveBeenCalledWith('items', options.items[0]);
+    });
+
+    it('should call _fallback with proper value from array when descriptor and defaults are objects', function() {
+      const spy = jasmine.createSpy('fallback');
+      const descriptors = {
+        items: {
+          _fallback: spy
+        }
+      };
+      const defaults = {
+        items: {
+          type: 'defaultType'
+        }
+      };
+      const options = {
+        items: [{test: true}]
+      };
+      const resolver = _createResolver([options, defaults, descriptors]);
+      // console.warn(resolver.items[0]);
+      const opts = _attachContext(resolver, {dymmy: true});
+      const item0 = opts.items[0];
+      console.warn(opts._proxy._scopes);
+      expect(item0.test).toEqual(true);
+      expect(spy).toHaveBeenCalledWith('items', options.items[0]);
+    });
+
     it('should support overriding options', function() {
       const options = {
         fn1: ctx => ctx.index,


### PR DESCRIPTION
Encountered this edge case when doing things with `chartjs-plugin-annotation`.

When there was an object with the same name as the array of objects that we are trying to resolve, the `_fallback` functions `value` was actually the last object value with that name, not the array entry as expected.

This is a problem in annotation plugin  where the annotation `type` is read from the `value` passed to `_fallback` to determine what defaults should be used.
