### PR TITLE
Add random seed reporting to test runs

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,4 @@
+const jasmineSeedReporter = require('./test/seed-reporter');
 const commonjs = require('@rollup/plugin-commonjs');
 const istanbul = require('rollup-plugin-istanbul');
 const json = require('@rollup/plugin-json');
@@ -30,7 +31,8 @@ module.exports = function(karma) {
 
   karma.set({
     frameworks: ['jasmine'],
-    reporters: ['spec', 'kjhtml'],
+    plugins: ['karma-*', jasmineSeedReporter],
+    reporters: ['spec', 'kjhtml', 'jasmine-seed'],
     browsers: (args.browsers || 'chrome,firefox').split(','),
     logLevel: karma.LOG_INFO,
 

--- a/test/seed-reporter.js
+++ b/test/seed-reporter.js
@@ -1,0 +1,13 @@
+const SeedReporter = function(baseReporterDecorator) {
+  baseReporterDecorator(this);
+
+  this.onBrowserComplete = function(browser, result) {
+    if (result.order && result.order.random && result.order.seed) {
+      this.write('%s: Randomized with seed %s\n', browser, result.order.seed);
+    }
+  };
+};
+
+module.exports = {
+  'reporter:jasmine-seed': ['type', SeedReporter]
+};


### PR DESCRIPTION
> Chrome 96.0.4664.93 (Windows 10): Randomized with seed 06604
> Chrome 96.0.4664.93 (Windows 10): Executed 1506 of 1506 SUCCESS (30.024 secs / 24.263 secs)
> 

The seed can be used to re-run specs in same order, as query parameter in browser, or in `client.jasmine.seed` property of the karma config.