### PR TITLE
Types/ type suggestedMin and suggestedMax for time scale

### DIFF
--- a/docs/axes/cartesian/time.md
+++ b/docs/axes/cartesian/time.md
@@ -24,10 +24,10 @@ Namespace: `options.scales[scaleId]`
 
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
-| `min` | `string`\|`number` | | The minimum item to display. [more...](#min-max-configuration)
-| `max` | `string`\|`number` | | The maximum item to display. [more...](#min-max-configuration)
-| `suggestedMin` | `string`\|`number` | | The minimum item to display if there is no datapoint before it. [more...](../index.md#axis-range-settings)
-| `suggestedMax` | `string`\|`number` | | The maximum item to display if there is no datapoint behind it. [more...](../index.md#axis-range-settings)
+| `min` | `number`\|`string` | | The minimum item to display. [more...](#min-max-configuration)
+| `max` | `number`\|`string` | | The maximum item to display. [more...](#min-max-configuration)
+| `suggestedMin` | `number`\|`string` | | The minimum item to display if there is no datapoint before it. [more...](../index.md#axis-range-settings)
+| `suggestedMax` | `number`\|`string` | | The maximum item to display if there is no datapoint behind it. [more...](../index.md#axis-range-settings)
 | `adapters.date` | `object` | `{}` | Options for adapter for external date library if that adapter needs or supports options
 | `bounds` | `string` | `'data'` | Determines the scale bounds. [more...](./index.md#scale-bounds)
 | `ticks.source` | `string` | `'auto'` | How ticks are generated. [more...](#ticks-source)

--- a/docs/axes/cartesian/time.md
+++ b/docs/axes/cartesian/time.md
@@ -26,6 +26,8 @@ Namespace: `options.scales[scaleId]`
 | ---- | ---- | ------- | -----------
 | `min` | `string`\|`number` | | The minimum item to display. [more...](#min-max-configuration)
 | `max` | `string`\|`number` | | The maximum item to display. [more...](#min-max-configuration)
+| `suggestedMin` | `string`\|`number` | | The minimum item to display if there is no datapoint before it. [more...](../index.md#axis-range-settings)
+| `suggestedMax` | `string`\|`number` | | The maximum item to display if there is no datapoint behind it. [more...](../index.md#axis-range-settings)
 | `adapters.date` | `object` | `{}` | Options for adapter for external date library if that adapter needs or supports options
 | `bounds` | `string` | `'data'` | Determines the scale bounds. [more...](./index.md#scale-bounds)
 | `ticks.source` | `string` | `'auto'` | How ticks are generated. [more...](#ticks-source)

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -3176,6 +3176,9 @@ export const LogarithmicScale: ChartComponent & {
 export type TimeScaleOptions = CartesianScaleOptions & {
   min: string | number;
   max: string | number;
+
+  suggestedMin: string | number;
+  suggestedMax: string | number;
   /**
    * Scale boundary strategy (bypassed by min/max time options)
    * - `data`: make sure data are fully visible, ticks outside are removed


### PR DESCRIPTION
Followup on #9985.

Noticed the `suggestedMin` and `suggestedMax` props where also missing for the timescale