### PR TITLE
fix: allow colors as array

### DIFF
--- a/types/color.d.ts
+++ b/types/color.d.ts
@@ -1,1 +1,1 @@
-export type Color = string | CanvasGradient | CanvasPattern;
+export type Color = string | string[] | CanvasGradient | CanvasPattern;

--- a/types/color.d.ts
+++ b/types/color.d.ts
@@ -1,1 +1,1 @@
-export type Color = string | string[] | CanvasGradient | CanvasPattern;
+export type Color = string | CanvasGradient | CanvasPattern;

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -2900,7 +2900,7 @@ export interface TickOptions {
    * Color of tick
    * @see Defaults.color
    */
-  color: Scriptable<Color, ScriptableScaleContext> | Color[];
+  color: ScriptableAndArray<Color, ScriptableScaleContext>;
   /**
    * see Fonts
    */

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -2900,7 +2900,7 @@ export interface TickOptions {
    * Color of tick
    * @see Defaults.color
    */
-  color: Scriptable<Color, ScriptableScaleContext>;
+  color: Scriptable<Color, ScriptableScaleContext> | Color[];
   /**
    * see Fonts
    */


### PR DESCRIPTION
There are some charts where I need to use different label colors per label.
Using a `string[]` for the label `color` seems to work, but TS won't allow it.
This PR fixes the types to allow that.