### PR TITLE
Add missing mouse events to CoreChartOptions.events type

### DIFF
--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -1492,27 +1492,7 @@ export interface CoreChartOptions<TType extends ChartType> extends ParsingOption
    * The events option defines the browser events that the chart should listen to for tooltips and hovering.
    * @default ['mousemove', 'mouseout', 'click', 'touchstart', 'touchmove']
    */
-  events: (
-    'mousemove' |
-    'mouseout' |
-    'mouseenter' |
-    'mouseleave' |
-    'mousedown' |
-    'mouseup' |
-    'click' |
-    'dblclick' |
-    'mouseover' |
-    'contextmenu' |
-    'touchstart' |
-    'touchmove' |
-    'touchend' |
-    'pointerenter' |
-    'pointerdown' |
-    'pointermove' |
-    'pointerup' |
-    'pointerleave' |
-    'pointerout'
-  )[];
+  events: (keyof HTMLElementEventMap)[]
 
   /**
    * Called when any of the events fire. Passed the event, an array of active elements (bars, points, etc), and the chart.

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -1495,7 +1495,14 @@ export interface CoreChartOptions<TType extends ChartType> extends ParsingOption
   events: (
     'mousemove' |
     'mouseout' |
+    'mouseenter' |
+    'mouseleave' |
+    'mousedown' |
+    'mouseup' |
     'click' |
+    'dblclick' |
+    'mouseover' |
+    'contextmenu' |
     'touchstart' |
     'touchmove' |
     'touchend' |


### PR DESCRIPTION
Following the work done in https://github.com/chartjs/Chart.js/pull/9336, I suggest extending the list of event names that can be specified in `CoreChartOptions.events`. 
