### PR TITLE
fix(types): make sure ScriptableAndArray covers fns that return arrays

### DIFF
--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -36,7 +36,7 @@ export interface ScriptableLineSegmentContext {
 
 export type Scriptable<T, TContext> = T | ((ctx: TContext, options: AnyObject) => T | undefined);
 export type ScriptableOptions<T, TContext> = { [P in keyof T]: Scriptable<T[P], TContext> };
-export type ScriptableAndArray<T, TContext> = readonly T[] | Scriptable<T, TContext>;
+export type ScriptableAndArray<T, TContext> = Scriptable<T[], TContext> | Scriptable<T, TContext>;
 export type ScriptableAndArrayOptions<T, TContext> = { [P in keyof T]: ScriptableAndArray<T[P], TContext> };
 
 export interface ParsingOptions {


### PR DESCRIPTION
@kurkle the original implementation of ScriptableAndArray allowed these:

- `string`
- `string[]`
- fn that returns `string`

but we also need to allow "fn that returns `string[]`"

This PR makes it possible now to have a function that returns a `string[]` in TS.