### PR TITLE
remove hardcoded licenseYear in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -65,4 +65,4 @@ For support using Chart.js, please post questions with the [`chartjs` tag on Sta
 
 Chart.js is available under the [MIT license](https://github.com/chartjs/Chart.js/blob/master/LICENSE.md).
 
-Documentation is copyright © 2014-2022 Chart.js contributors.
+Documentation is copyright © 2014-{{new Date().getFullYear()}} Chart.js contributors.


### PR DESCRIPTION
Make licenseYear in docs generated by VUE so when it gets bumped only place it has to be done is in LICENSE.md since afaik you cant add js in md files