### PR TITLE
Use legendItem.usePointStyle value

### DIFF
--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -312,7 +312,7 @@ export class Legend extends Element {
 
       ctx.setLineDash(valueOrDefault(legendItem.lineDash, []));
 
-      if (labelOpts.usePointStyle) {
+      if (legendItem.usePointStyle) {
         // Recalculate x and y for drawPoint() because its expecting
         // x and y to be center of figure (instead of top left)
         const drawOptions = {


### PR DESCRIPTION
On legend drawing use legentItem.usePointStyle value instead of value in options. 
This allows to overide value with custom generateLabels function.

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
