### PR TITLE
Add `sideEffects` to pkg.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "Simple HTML5 charts using the canvas element.",
     "version": "3.7.1",
     "license": "MIT",
+    "sideEffects": false,
     "jsdelivr": "dist/chart.min.js",
     "unpkg": "dist/chart.min.js",
     "main": "dist/chart.js",


### PR DESCRIPTION
Some bundlers use this property to decide to tree-shake or not:
https://webpack.js.org/guides/tree-shaking/

It will also allow [bundlephobia](https://bundlephobia.com/package/chart.js@3.7.1) to display accurate information about the tree-shaking possibilities