### PR TITLE
Add missing fields to the ScriptableContext type

### DIFF
--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -21,6 +21,8 @@ export interface ScriptableContext<TType extends ChartType> {
   dataIndex: number;
   dataset: UnionToIntersection<ChartDataset<TType>>;
   datasetIndex: number;
+  type: string;
+  mode: string;
   parsed: UnionToIntersection<ParsedDataType<TType>>;
   raw: unknown;
 }


### PR DESCRIPTION
A follow-up from #10251 - adding two missing fields to the type definition. The documentation should be here, I believe: https://github.com/chartjs/Chart.js/blob/master/docs/general/options.md#scriptable-options