### PR TITLE
Fix a typo in data-structures.md

### DIFF
--- a/docs/general/data-structures.md
+++ b/docs/general/data-structures.md
@@ -3,7 +3,7 @@
 The `data` property of a dataset can be passed in various formats. By default, that `data` is parsed using the associated chart type and scales.
 
 If the `labels` property of the main `data` property is used, it has to contain the same amount of elements as the dataset with the most values. These labels are used to label the index axis (default x axes). The values for the labels have to be provided in an array.
-The provides labels can be of the type string or number to be rendered correctly. In case you want multiline labels you can provide an array with each line as one entry in the array.
+The provided labels can be of the type string or number to be rendered correctly. In case you want multiline labels you can provide an array with each line as one entry in the array.
 
 ## Primitive[]
 


### PR DESCRIPTION
Change `The provides labels can be` to `The provided labels can be`.

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
