### PR TITLE
Use abs() when comparing for spanGaps

### DIFF
--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -68,7 +68,7 @@ export default class LineController extends DatasetController {
       const vPixel = properties[vAxis] = reset || nullData ? vScale.getBasePixel() : vScale.getPixelForValue(_stacked ? this.applyStack(vScale, parsed, _stacked) : parsed[vAxis], i);
 
       properties.skip = isNaN(iPixel) || isNaN(vPixel) || nullData;
-      properties.stop = i > 0 && (parsed[iAxis] - prevParsed[iAxis]) > maxGapLength;
+      properties.stop = i > 0 && (Math.abs(parsed[iAxis] - prevParsed[iAxis])) > maxGapLength;
       if (segment) {
         properties.parsed = parsed;
         properties.raw = _dataset.data[i];

--- a/test/specs/controller.line.tests.js
+++ b/test/specs/controller.line.tests.js
@@ -964,4 +964,60 @@ describe('Chart.controllers.line', function() {
     expect(isNaN(x)).toBe(false);
     expect(isNaN(y)).toBe(false);
   });
+
+  it('should honor spangap interval forwards', function() {
+    var chart = window.acquireChart({
+      type: 'line',
+      data: {
+        datasets: [{
+          xAxisKey: 'x',
+          yAxisKey: 'y',
+          spanGaps: 10,
+          data: [{x: 10, y: 123}, {x: 15, y: 124}, {x: 26, y: 125}, {x: 30, y: 126}, {x: 35, y: 127}],
+          label: 'dataset1',
+        }],
+      },
+      options: {
+        scales: {
+          x: {
+            type: 'linear',
+          }
+        }
+      }
+    });
+
+    var meta = chart.getDatasetMeta(0);
+    for (var i = 0; i < meta.data.length; ++i) {
+      var point = meta.data[i];
+      expect(point.stop).toBe(i === 2);
+    }
+  });
+
+  it('should honor spangap interval backwards', function() {
+    var chart = window.acquireChart({
+      type: 'line',
+      data: {
+        datasets: [{
+          xAxisKey: 'x',
+          yAxisKey: 'y',
+          spanGaps: 10,
+          data: [{x: 35, y: 123}, {x: 30, y: 124}, {x: 26, y: 125}, {x: 15, y: 126}, {x: 10, y: 127}],
+          label: 'dataset1',
+        }],
+      },
+      options: {
+        scales: {
+          x: {
+            type: 'linear',
+          }
+        }
+      }
+    });
+
+    var meta = chart.getDatasetMeta(0);
+    for (var i = 0; i < meta.data.length; ++i) {
+      var point = meta.data[i];
+      expect(point.stop).toBe(i === 3);
+    }
+  });
 });

--- a/test/specs/controller.line.tests.js
+++ b/test/specs/controller.line.tests.js
@@ -970,8 +970,6 @@ describe('Chart.controllers.line', function() {
       type: 'line',
       data: {
         datasets: [{
-          xAxisKey: 'x',
-          yAxisKey: 'y',
           spanGaps: 10,
           data: [{x: 10, y: 123}, {x: 15, y: 124}, {x: 26, y: 125}, {x: 30, y: 126}, {x: 35, y: 127}],
           label: 'dataset1',
@@ -998,8 +996,6 @@ describe('Chart.controllers.line', function() {
       type: 'line',
       data: {
         datasets: [{
-          xAxisKey: 'x',
-          yAxisKey: 'y',
           spanGaps: 10,
           data: [{x: 35, y: 123}, {x: 30, y: 124}, {x: 26, y: 125}, {x: 15, y: 126}, {x: 10, y: 127}],
           label: 'dataset1',


### PR DESCRIPTION
Not sure if this is intended but I've been using data in descending order by X axis value, to share underlying data structures with components that need it that way. It seems to work fine, except that spanGaps breaks because the "gap" is negative and always compares less-than the threshold.

This fixes that issue, but of course isn't appropriate if ascending order is required -- I may have missed something but I didn't see a specification about that in the docs.