### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,15 @@ on:
       - master
       - "2.9"
   workflow_dispatch:
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      checks: write  # for coverallsapp/github-action to create new checks
+      contents: read  # for dorny/paths-filter to fetch a list of changed files
+      pull-requests: read  # for dorny/paths-filter to read pull requests
     runs-on: ${{ matrix.os }}
 
     outputs:
@@ -94,6 +101,8 @@ jobs:
           parallel: true
 
   finish:
+    permissions:
+      checks: write  # for coverallsapp/github-action to create new checks
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -2,9 +2,17 @@ name: Compressed Size
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 
+    permissions:
+      checks: write  # for preactjs/compressed-size-action to create and update the checks
+      contents: read  # for actions/checkout to fetch code
+      issues: write  # for preactjs/compressed-size-action to create comments
+      pull-requests: write  # for preactjs/compressed-size-action to write a PR review
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,8 +6,13 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   correct_repository:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     steps:
       - name: fail on fork

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,8 +6,13 @@ on:
       - master
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   correct_repository:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     steps:
     - name: fail on fork
@@ -15,6 +20,9 @@ jobs:
       run: exit 1
 
   update_release_draft:
+    permissions:
+      contents: write  # for release-drafter/release-drafter to create a github release
+      pull-requests: write  # for release-drafter/release-drafter to add label to PR
     needs: correct_repository
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,17 @@ name: Release
 
 on:
   release:
+    permissions:
+      contents: write  # for actions/upload-release-asset to upload release asset
     types: [published]
+
+permissions:
+  contents: read
 
 jobs:
   setup:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.trim.outputs.version }}


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
