### PR TITLE
Enforce maximum width on chart editor blocks in the docs

### DIFF
--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -4,8 +4,8 @@
   &:not(.custom)
     max-width: unset
   
-  .chart-editor
-    max-width 1200px
+  .chart-view
+    max-width 800px
 
 .sidebar-group.is-sub-group.depth-1
   > .sidebar-group-items

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -3,6 +3,9 @@
 .theme-default-content
   &:not(.custom)
     max-width: unset
+  
+  .chart-editor
+    max-width 1200px
 
 .sidebar-group.is-sub-group.depth-1
   > .sidebar-group-items


### PR DESCRIPTION
Resolves https://github.com/chartjs/Chart.js/issues/10416 (charts get overly large on high-resolution screens).

~I've decided to enforce maximum width on `.chart-editor` (both chart preview and code editor) rather than `.chart-view` because source code in the code editor seems to not be very lengthy anyway—but it looks better when chart preview match code editor width.~

Please see the preview on my 1800px-wide screen.

**Before:**
<img width="1794" alt="Screenshot 2022-06-28 at 23 29 59" src="https://user-images.githubusercontent.com/3852894/176269072-3efb78a1-f041-4f27-9005-71140ee4eed2.png">

**After:**
<img width="1800" alt="Screenshot 2022-06-28 at 23 20 55" src="https://user-images.githubusercontent.com/3852894/176268006-a6f1bd8d-fefc-4157-8ad9-d4fe7b493736.png">

