### PR TITLE
Fix crash with skipNull and uneven datasets

### DIFF
--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -390,29 +390,24 @@ export default class BarController extends DatasetController {
 	 * @private
 	 */
   _getStacks(last, dataIndex) {
-    const meta = this._cachedMeta;
-    const iScale = meta.iScale;
-    const metasets = iScale.getMatchingVisibleMetas(this._type);
+    const {iScale} = this._cachedMeta;
+    const metasets = iScale.getMatchingVisibleMetas(this._type)
+      .filter(meta => meta.controller.options.grouped);
     const stacked = iScale.options.stacked;
-    const ilen = metasets.length;
     const stacks = [];
-    let i, item;
 
-    for (i = 0; i < ilen; ++i) {
-      item = metasets[i];
+    const skipNull = (meta) => {
+      const parsed = meta.controller.getParsed(dataIndex);
+      const val = parsed && parsed[meta.vScale.axis];
 
-      if (!item.controller.options.grouped) {
-        continue;
+      if (isNullOrUndef(val) || isNaN(val)) {
+        return true;
       }
+    };
 
-      if (typeof dataIndex !== 'undefined') {
-        const val = item.controller.getParsed(dataIndex)[
-          item.controller._cachedMeta.vScale.axis
-        ];
-
-        if (isNullOrUndef(val) || isNaN(val)) {
-          continue;
-        }
+    for (const meta of metasets) {
+      if (dataIndex !== undefined && skipNull(meta)) {
+        continue;
       }
 
       // stacked   | meta.stack
@@ -420,11 +415,11 @@ export default class BarController extends DatasetController {
       // false     |   x   |     x     |     x
       // true      |       |     x     |
       // undefined |       |     x     |     x
-      if (stacked === false || stacks.indexOf(item.stack) === -1 ||
-				(stacked === undefined && item.stack === undefined)) {
-        stacks.push(item.stack);
+      if (stacked === false || stacks.indexOf(meta.stack) === -1 ||
+				(stacked === undefined && meta.stack === undefined)) {
+        stacks.push(meta.stack);
       }
-      if (item.index === last) {
+      if (meta.index === last) {
         break;
       }
     }

--- a/test/specs/controller.bar.tests.js
+++ b/test/specs/controller.bar.tests.js
@@ -1655,4 +1655,24 @@ describe('Chart.controllers.bar', function() {
       expect(ctx.getCalls().filter(x => x.name === 'clip').length).toEqual(0);
     });
   });
+
+  it('should not crash with skipNull and uneven datasets', function() {
+    function unevenChart() {
+      window.acquireChart({
+        type: 'bar',
+        data: {
+          labels: [1, 2],
+          datasets: [
+            {data: [1, 2]},
+            {data: [1, 2, 3]},
+          ]
+        },
+        options: {
+          skipNull: true,
+        }
+      });
+    }
+
+    expect(unevenChart).not.toThrow();
+  });
 });


### PR DESCRIPTION
Fix #10411

Includes little bit of chore to reduce complexity of the function.