### PR TITLE
Skip all borders if borderSkipped === true

### DIFF
--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -207,6 +207,11 @@ function setBorderSkipped(properties, options, stack, index) {
     properties.borderSkipped = res;
     return;
   }
+  
+  if (edge === true) {
+    properties.borderSkipped = { top: true, right: true, bottom: true, left: true };
+    return;
+  }
 
   const {start, end, reverse, top, bottom} = borderProps(properties);
 


### PR DESCRIPTION
This will allow you to skip all borders (not just one side) if you set borderSkipped to boolean true and so allow you to have a consistent legend marker even for bars without borders. Reason is that even if same colored borders are set there are artifacts that make the bar look bad and also even with inflateAmount the bars do look good when big but when only a few pixel in size they start to look bad too so this was the only way for me to make it work so legends are looking good and bars too.