### PR TITLE
Allow clip to be configurable in options object typescript

### DIFF
--- a/docs/charts/bar.md
+++ b/docs/charts/bar.md
@@ -78,7 +78,7 @@ Only the `data` option needs to be specified in the dataset namespace.
 | [`borderWidth`](#borderwidth) | `number`\|`object` | Yes | Yes | `0`
 | [`borderRadius`](#borderradius) | `number`\|`object` | Yes | Yes | `0`
 | [`categoryPercentage`](#categorypercentage) | `number` | - | - | `0.8` |
-| [`clip`](#general) | `number`\|`object` | - | - |
+| [`clip`](#general) | `number`\|`object`\|`false` | - | - |
 | [`data`](#data-structure) | `object`\|`object[]`\| `number[]`\|`string[]` | - | - | **required**
 | [`grouped`](#general) | `boolean` | - | - | `true` |
 | [`hoverBackgroundColor`](#interactions) | [`Color`](../general/colors.md) | Yes | Yes |

--- a/docs/charts/bubble.md
+++ b/docs/charts/bubble.md
@@ -51,7 +51,7 @@ The bubble chart allows a number of properties to be specified for each dataset.
 | [`backgroundColor`](#styling) | [`Color`](../general/colors.md) | Yes | Yes | `'rgba(0, 0, 0, 0.1)'`
 | [`borderColor`](#styling) | [`Color`](../general/colors.md) | Yes | Yes | `'rgba(0, 0, 0, 0.1)'`
 | [`borderWidth`](#styling) | `number` | Yes | Yes | `3`
-| [`clip`](#general) | `number`\|`object` | - | - | `undefined`
+| [`clip`](#general) | `number`\|`object`\|`false` | - | - | `undefined`
 | [`data`](#data-structure) | `object[]` | - | - | **required**
 | [`drawActiveElementsOnTop`](#general) | `boolean` | Yes | Yes | `true`
 | [`hoverBackgroundColor`](#interactions) | [`Color`](../general/colors.md) | Yes | Yes | `undefined`

--- a/docs/charts/doughnut.md
+++ b/docs/charts/doughnut.md
@@ -109,7 +109,7 @@ The doughnut/pie chart allows a number of properties to be specified for each da
 | [`borderRadius`](#border-radius) | `number`\|`object` | Yes | Yes | `0`
 | [`borderWidth`](#styling) | `number` | Yes | Yes | `2`
 | [`circumference`](#general) | `number` | - | - | `undefined`
-| [`clip`](#general) | `number`\|`object` | - | - | `undefined`
+| [`clip`](#general) | `number`\|`object`\|`false` | - | - | `undefined`
 | [`data`](#data-structure) | `number[]` | - | - | **required**
 | [`hoverBackgroundColor`](#interactions) | [`Color`](../general/colors.md) | Yes | Yes | `undefined`
 | [`hoverBorderColor`](#interactions) | [`Color`](../general/colors.md) | Yes | Yes | `undefined`

--- a/docs/charts/line.md
+++ b/docs/charts/line.md
@@ -51,7 +51,7 @@ The line chart allows a number of properties to be specified for each dataset. T
 | [`borderDashOffset`](#line-styling) | `number` | Yes | - | `0.0`
 | [`borderJoinStyle`](#line-styling) | `'round'`\|`'bevel'`\|`'miter'` | Yes | - | `'miter'`
 | [`borderWidth`](#line-styling) | `number` | Yes | - | `3`
-| [`clip`](#general) | `number`\|`object` | - | - | `undefined`
+| [`clip`](#general) | `number`\|`object`\|`false` | - | - | `undefined`
 | [`cubicInterpolationMode`](#cubicinterpolationmode) | `string` | Yes | - | `'default'`
 | [`data`](#data-structure) | `object`\|`object[]`\| `number[]`\|`string[]` | - | - | **required**
 | [`drawActiveElementsOnTop`](#general) | `boolean` | Yes | Yes | `true`

--- a/docs/charts/polar.md
+++ b/docs/charts/polar.md
@@ -60,7 +60,7 @@ The following options can be included in a polar area chart dataset to configure
 | [`borderColor`](#styling) | [`Color`](../general/colors.md) | Yes | Yes | `'#fff'`
 | [`borderJoinStyle`](#styling) | `'round'`\|`'bevel'`\|`'miter'` | Yes | Yes | `undefined`
 | [`borderWidth`](#styling) | `number` | Yes | Yes | `2`
-| [`clip`](#general) | `number`\|`object` | - | - | `undefined`
+| [`clip`](#general) | `number`\|`object`\|`false` | - | - | `undefined`
 | [`data`](#data-structure) | `number[]` | - | - | **required**
 | [`hoverBackgroundColor`](#interactions) | [`Color`](../general/colors.md) | Yes | Yes | `undefined`
 | [`hoverBorderColor`](#interactions) | [`Color`](../general/colors.md) | Yes | Yes | `undefined`

--- a/docs/charts/radar.md
+++ b/docs/charts/radar.md
@@ -88,7 +88,7 @@ The radar chart allows a number of properties to be specified for each dataset. 
 | [`hoverBorderDashOffset`](#line-styling) | `number` | Yes | - | `undefined`
 | [`hoverBorderJoinStyle`](#line-styling) | `'round'`\|`'bevel'`\|`'miter'` | Yes | - | `undefined`
 | [`hoverBorderWidth`](#line-styling) | `number` | Yes | - | `undefined`
-| [`clip`](#general) | `number`\|`object` | - | - | `undefined`
+| [`clip`](#general) | `number`\|`object`\|`false` | - | - | `undefined`
 | [`data`](#data-structure) | `number[]` | - | - | **required**
 | [`fill`](#line-styling) | `boolean`\|`string` | Yes | - | `false`
 | [`label`](#general) | `string` | - | - | `''`

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -67,7 +67,7 @@ export interface ControllerDatasetOptions extends ParsingOptions {
   /**
    * How to clip relative to chartArea. Positive value allows overflow, negative value clips that many pixels inside chartArea. 0 = clip at chartArea. Clipping can also be configured per side: clip: {left: 5, top: false, right: -2, bottom: 0}
    */
-  clip: number | ChartArea;
+  clip: number | ChartArea | false;
   /**
    * The label for the dataset which appears in the legend and tooltips.
    */
@@ -1456,6 +1456,11 @@ export interface CoreChartOptions<TType extends ChartType> extends ParsingOption
    * @default 'x'
    */
   indexAxis: 'x' | 'y';
+
+  /**
+   * How to clip relative to chartArea. Positive value allows overflow, negative value clips that many pixels inside chartArea. 0 = clip at chartArea. Clipping can also be configured per side: clip: {left: 5, top: false, right: -2, bottom: 0}
+   */
+  clip: number | ChartArea | false;
 
   /**
    * base color


### PR DESCRIPTION
Resolves:

And here's the codepen with `clip: false`, indeed fixing the issue (on line 164 in the JS)

https://codepen.io/bartocc/pen/bGvqvpd

Looks like `clip` is not documented in the Typescript types provided by Chart.js@3 though…

_Originally posted by @bartocc in https://github.com/chartjs/Chart.js/issues/6414#issuecomment-1188985063_