### PR TITLE
Improve error message with id of the canvas

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -111,7 +111,7 @@ class Chart {
     if (existingChart) {
       throw new Error(
         'Canvas is already in use. Chart with ID \'' + existingChart.id + '\'' +
-				' must be destroyed before the canvas can be reused.'
+				' must be destroyed before the canvas with ID \'' + existingChart.canvas.id + '\' can be reused.'
       );
     }
 

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -32,7 +32,7 @@ describe('Chart', function() {
     expect(createChart).toThrow(new Error(
       'Canvas is already in use. ' +
 			'Chart with ID \'' + chart.id + '\'' +
-			' must be destroyed before the canvas can be reused.'
+			' must be destroyed before the canvas with ID \'' + chart.canvas.id + '\' can be reused.'
     ));
 
     chart.destroy();


### PR DESCRIPTION
Noticed on some stack issues people tried to call Chart.getChart('0').destroy() but that does not work since it does not return the chart instance. So added the canvas ID to hopefully make it so people don't get that error anymore.

https://codepen.io/leelenaleee/pen/oNEPGbP