### PR TITLE
feat: allow escaping dot in parsing axis keys

### DIFF
--- a/docs/general/data-structures.md
+++ b/docs/general/data-structures.md
@@ -85,6 +85,20 @@ options: {
 }
 ```
 
+When using keys of the form `foo.bar`, you can allow for escaping dot symbol and add a double slash before the dot.
+
+```javascript
+type: 'doughnut',
+data: {
+    datasets: [{
+        data: [{ "data.key": "one", "data.value": 20 }, { "data.key": "two", "data.value": 30 }],
+    }]
+},
+options: {
+    parsing: { xAxisKey: "data\\.key", yAxisKey: "data\\.value"},
+}
+```
+
 :::warning
 When using object notation in a radar chart you still need a labels array with labels for the chart to show correctly.
 :::

--- a/src/helpers/helpers.core.js
+++ b/src/helpers/helpers.core.js
@@ -304,6 +304,9 @@ export function resolveObjectKey(obj, key) {
   if (key === emptyString) {
     return obj;
   }
+  if (key.match(/[\\]/g)) {
+    return obj[key.replace(/[\\]/g, '')];
+  }
   let pos = 0;
   let idx = indexOfDotOrLength(key, pos);
   while (obj && idx > pos) {


### PR DESCRIPTION
<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->

Allow escaping '.' in parsing *AxisKey #10348

You can check the build with changes [here](https://codesandbox.io/s/muddy-haze-h9697m?file=/src/components/LineChart.ts:344-352)
