### PR TITLE
Explicitly include package.json files for subpackages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,6 @@ on:
       contents: write  # for actions/upload-release-asset to upload release asset
     types: [published]
 
-permissions:
-  contents: read
-
 jobs:
   setup:
     permissions:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "chart.js",
-    "version": "3.8.1",
+    "version": "3.8.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "chart.js",
-            "version": "3.8.1",
+            "version": "3.8.2",
             "license": "MIT",
             "devDependencies": {
                 "@kurkle/color": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "chart.js",
     "homepage": "https://www.chartjs.org",
     "description": "Simple HTML5 charts using the canvas element.",
-    "version": "3.8.1",
+    "version": "3.8.2",
     "license": "MIT",
     "jsdelivr": "dist/chart.min.js",
     "unpkg": "dist/chart.min.js",
@@ -25,12 +25,14 @@
         "url": "https://github.com/chartjs/Chart.js/issues"
     },
     "files": [
+        "auto/package.json",
         "auto/**/*.js",
         "auto/**/*.d.ts",
         "dist/*.js",
         "dist/chunks/*.js",
         "types/*.d.ts",
         "types/helpers/*.d.ts",
+        "helpers/package.json",
         "helpers/**/*.js",
         "helpers/**/*.d.ts"
     ],


### PR DESCRIPTION
Remove redundant permissions on release CI to prevent a failure
Bump version to v3.8.2

Resolves #10512