### PR TITLE
parsing: support dot(s) in object keys

### DIFF
--- a/docs/general/data-structures.md
+++ b/docs/general/data-structures.md
@@ -85,10 +85,26 @@ options: {
 }
 ```
 
+If the key contains a dot, it needs to be escaped with a double slash:
+
+```javascript
+type: 'line',
+data: {
+    datasets: [{
+        data: [{ 'data.key': 'one', 'data.value': 20 }, { 'data.key': 'two', 'data.value': 30 }]
+    }]
+},
+options: {
+    parsing: {
+      xAxisKey: 'data\\.key',
+      yAxisKey: 'data\\.value'
+    }
+}
+```
+
 :::warning
 When using object notation in a radar chart you still need a labels array with labels for the chart to show correctly.
 :::
-
 
 ## Object
 

--- a/test/specs/helpers.core.tests.js
+++ b/test/specs/helpers.core.tests.js
@@ -456,6 +456,44 @@ describe('Chart.helpers.core', function() {
       expect(() => helpers.resolveObjectKey({}, true)).toThrow();
       expect(() => helpers.resolveObjectKey({}, 1)).toThrow();
     });
+    it('should allow escaping dot symbol', function() {
+      expect(helpers.resolveObjectKey({'test.dot': 10}, 'test\\.dot')).toEqual(10);
+      expect(helpers.resolveObjectKey({test: {dot: 10}}, 'test\\.dot')).toEqual(undefined);
+    });
+    it('should allow nested keys with a dot', function() {
+      expect(helpers.resolveObjectKey({
+        a: {
+          'bb.ccc': 'works',
+          bb: {
+            ccc: 'fails'
+          }
+        }
+      }, 'a.bb\\.ccc')).toEqual('works');
+    });
+
+  });
+
+  describe('_splitKey', function() {
+    it('should return array with one entry for string without a dot', function() {
+      expect(helpers._splitKey('')).toEqual(['']);
+      expect(helpers._splitKey('test')).toEqual(['test']);
+      const asciiWithoutDot = ' !"#$%&\'()*+,-/0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
+      expect(helpers._splitKey(asciiWithoutDot)).toEqual([asciiWithoutDot]);
+    });
+
+    it('should split on dot', function() {
+      expect(helpers._splitKey('test1.test2')).toEqual(['test1', 'test2']);
+      expect(helpers._splitKey('a.b.c')).toEqual(['a', 'b', 'c']);
+      expect(helpers._splitKey('a.b.')).toEqual(['a', 'b', '']);
+      expect(helpers._splitKey('a..c')).toEqual(['a', '', 'c']);
+    });
+
+    it('should preserve escaped dot', function() {
+      expect(helpers._splitKey('test1\\.test2')).toEqual(['test1.test2']);
+      expect(helpers._splitKey('a\\.b.c')).toEqual(['a.b', 'c']);
+      expect(helpers._splitKey('a.b\\.c')).toEqual(['a', 'b.c']);
+      expect(helpers._splitKey('a.\\.c')).toEqual(['a', '.c']);
+    });
   });
 
   describe('setsEqual', function() {


### PR DESCRIPTION
Closes #10348
Closes #10501 

@thabarbados sorry for stepping on your pr, but as I already put some time to it, I figured its less time spend for everyone if I post this.

This performs consistently a little bit better than master on the default parsing case (uPlot dataset):

pr:
> 50 runs done in 3389ms. Average: 67ms, min: 57ms, max: 127ms, variation: 70ms.

master:
> 50 runs done in 3602ms. Average: 72ms, min: 62ms, max: 135ms, variation: 73ms.