### PR TITLE
Fix Stack Overflow tag: chart.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ In case you are looking for the docs of version 2, you will have to specify the 
 
 ## Contributing
 
-Instructions on building and testing Chart.js can be found in [the documentation](https://www.chartjs.org/docs/master/developers/contributing.html#building-and-testing). Before submitting an issue or a pull request, please take a moment to look over the [contributing guidelines](https://www.chartjs.org/docs/master/developers/contributing) first. For support, please post questions on [Stack Overflow](https://stackoverflow.com/questions/tagged/chartjs) with the `chartjs` tag.
+Instructions on building and testing Chart.js can be found in [the documentation](https://www.chartjs.org/docs/master/developers/contributing.html#building-and-testing). Before submitting an issue or a pull request, please take a moment to look over the [contributing guidelines](https://www.chartjs.org/docs/master/developers/contributing) first. For support, please post questions on [Stack Overflow](https://stackoverflow.com/questions/tagged/chart.js) with the `chart.js` tag.
 
 ## License
 


### PR DESCRIPTION
The correct Stack Overflow tag name is chart.js and not chartjs

Both links work, but https://stackoverflow.com/questions/tagged/chart.js seems to be the correct one

