### PR TITLE
Fix Stack Overflow tag: chart.js

### DIFF
--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -66,7 +66,7 @@ When a test fails, the expected and actual images are shown. If you'd like to se
 
 ## Bugs and Issues
 
-Please report these on the GitHub page - at <a href="https://github.com/chartjs/Chart.js" target="_blank">github.com/chartjs/Chart.js</a>. Please do not use issues for support requests. For help using Chart.js, please take a look at the [`chartjs`](https://stackoverflow.com/questions/tagged/chartjs) tag on Stack Overflow.
+Please report these on the GitHub page - at <a href="https://github.com/chartjs/Chart.js" target="_blank">github.com/chartjs/Chart.js</a>. Please do not use issues for support requests. For help using Chart.js, please take a look at the [`chart.js`](https://stackoverflow.com/questions/tagged/chart.js) tag on Stack Overflow.
 
 Well structured, detailed bug reports are hugely valuable for the project.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,7 +59,7 @@ const myChart = new Chart(ctx, {
 
 Before submitting an issue or a pull request to the project, please take a moment to look over the [contributing guidelines](./developers/contributing.md) first.
 
-For support using Chart.js, please post questions with the [`chartjs` tag on Stack Overflow](https://stackoverflow.com/questions/tagged/chartjs).
+For support using Chart.js, please post questions with the [`chart.js` tag on Stack Overflow](https://stackoverflow.com/questions/tagged/chart.js).
 
 ## License
 


### PR DESCRIPTION
The same fix as accepted in: https://github.com/chartjs/Chart.js/pull/10520

The correct Stack Overflow tag name is chart.js and not chartjs
