### PR TITLE
Bump to 3.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "chart.js",
-    "version": "3.9.0",
+    "version": "3.9.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "chart.js",
-            "version": "3.9.0",
+            "version": "3.9.1",
             "license": "MIT",
             "devDependencies": {
                 "@kurkle/color": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "chart.js",
     "homepage": "https://www.chartjs.org",
     "description": "Simple HTML5 charts using the canvas element.",
-    "version": "3.9.0",
+    "version": "3.9.1",
     "license": "MIT",
     "jsdelivr": "dist/chart.min.js",
     "unpkg": "dist/chart.min.js",


### PR DESCRIPTION
Bump to 3.9.1, forgot you can manualy create release, if that is possible we can release that way otherwise someone with access to npm need to manually release it