### PR TITLE
fix import helpers master branch

### DIFF
--- a/helpers/helpers.mjs
+++ b/helpers/helpers.mjs
@@ -1,1 +1,1 @@
-export * from '../dist/helpers.esm';
+export * from '../dist/helpers.mjs';


### PR DESCRIPTION
Put same fix in master as in 3.9.1 
#10552

Not fully sure if this is necassary since the plan was afaik to remove the mjs file extensions again and use type module so we might not need this