### PR TITLE
remove double space, eslint allow dynamic import

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,1 @@
 dist/*
-karma.conf.cjs

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 dist/*
+karma.conf.cjs

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -35,3 +35,4 @@ rules:
   es/no-regexp-named-capture-groups: "error"
   es/no-regexp-s-flag: "error"
   es/no-regexp-unicode-property-escapes: "error"
+  es/no-dynamic-import: "off"

--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -6,7 +6,7 @@ const resolve = require('@rollup/plugin-node-resolve').default;
 const yargs = require('yargs');
 
 module.exports = async function(karma) {
-  const builds  = (await import('./rollup.config.js')).default;
+  const builds = (await import('./rollup.config.js')).default;
 
   const args = yargs
     .option('verbose', {default: false})


### PR DESCRIPTION
Resolves:
@kurkle @LeeLenaleee fyi

```
Chart.js(feat-side-effects-false)$ npx eslint karma.conf.cjs 

/Users/dangreen/github/Chart.js/karma.conf.cjs
  9:15  error  Multiple spaces found before '='       no-multi-spaces
  9:26  error  ES2020 'import()' syntax is forbidden  es/no-dynamic-import

✖ 2 problems (2 errors, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.

```

_Originally posted by @dangreen in https://github.com/chartjs/Chart.js/issues/10549#issuecomment-1206678282_

Did not fail with npm scripts but with direct running is eslint it did for some reason
