### PR TITLE
fix: allow nulls in barchart data type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3539,7 +3539,7 @@ export interface ChartTypeRegistry {
   bar: {
     chartOptions: BarControllerChartOptions;
     datasetOptions: BarControllerDatasetOptions;
-    defaultDataPoint: number;
+    defaultDataPoint: number | null;
     metaExtensions: {};
     parsedDataType: BarParsedData,
     scales: keyof CartesianScaleTypeRegistry;


### PR DESCRIPTION
Allow nulls to be passed to barChart data to allow datasets to spanGaps.
Currently the only way to do this using the existing types is to convert nulls into NaN

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
