### PR TITLE
Allow animations to be set to false for the tooltip typings 

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2771,8 +2771,8 @@ export interface TooltipOptions<TType extends ChartType = ChartType> extends Cor
    */
   textDirection: Scriptable<string, ScriptableTooltipContext<TType>>;
 
-  animation: AnimationSpec<TType>;
-  animations: AnimationsSpec<TType>;
+  animation: AnimationSpec<TType> | false;
+  animations: AnimationsSpec<TType> | false;
   callbacks: TooltipCallbacks<TType>;
 }
 


### PR DESCRIPTION
Comming from #9419

Added to 4.0, since I don't think its a major issue that needs to be patched. 
If we do want it in a 3.9.2 release I can open a second PR against the 3.9 branch