### PR TITLE
Fix: Add missing registerables key to UMD exports

### DIFF
--- a/src/index.umd.js
+++ b/src/index.umd.js
@@ -23,8 +23,8 @@ import Scale from './core/core.scale';
 import * as scales from './scales';
 import Ticks from './core/core.ticks';
 
-  // Register built-ins
-  Chart.register(controllers, scales, elements, plugins);
+// Register built-ins
+Chart.register(controllers, scales, elements, plugins);
 
 Chart.helpers = {...helpers};
 Chart._adapters = _adapters;

--- a/src/index.umd.js
+++ b/src/index.umd.js
@@ -23,8 +23,8 @@ import Scale from './core/core.scale';
 import * as scales from './scales';
 import Ticks from './core/core.ticks';
 
-// Register built-ins
-Chart.register(controllers, scales, elements, plugins);
+  // Register built-ins
+  Chart.register(controllers, scales, elements, plugins);
 
 Chart.helpers = {...helpers};
 Chart._adapters = _adapters;
@@ -40,6 +40,13 @@ Chart.layouts = layouts;
 Chart.platforms = platforms;
 Chart.Scale = Scale;
 Chart.Ticks = Ticks;
+// Add missing registerables to UMD.
+Chart.registerables = [
+  controllers,
+  elements,
+  plugins,
+  scales,
+];
 
 // Compatibility with ESM extensions
 Object.assign(Chart, controllers, scales, elements, plugins, platforms);


### PR DESCRIPTION
During Next.js development, I and @zivnadel found that the `registerables` export was missing from the UMD exports while trying to do Server-Side-Rendering. 
The problem didn't re-appear with using Client-Side-Rendering.

After a thorough investigation, we found that it was not exported from `src/index.umd.js` so we added it.