### PR TITLE
Use the element's window in getComputedStyle

### DIFF
--- a/src/helpers/helpers.dom.js
+++ b/src/helpers/helpers.dom.js
@@ -46,7 +46,7 @@ function parseMaxStyle(styleValue, node, parentProperty) {
   return valueInPixels;
 }
 
-const getComputedStyle = (element) => window.getComputedStyle(element, null);
+const getComputedStyle = (element) => element.ownerDocument.defaultView.getComputedStyle(element, null);
 
 export function getStyle(el, property) {
   return getComputedStyle(el).getPropertyValue(property);


### PR DESCRIPTION
In a test environment, when using jsdom, the global window may not be
the window the element belongs to. Use the DOM methods
Node.ownerDocument and Document.defaultView to find the actual window.

For details on these methods, see:

https://developer.mozilla.org/en-US/docs/Web/API/Node/ownerDocument
https://developer.mozilla.org/en-US/docs/Web/API/Document/defaultView
