### PR TITLE
Remove tooltip constructor fallbacks, `this.chart` and `this._chart`

### DIFF
--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -41,7 +41,7 @@ module.exports = [
   },
   {
     path: 'dist/chart.js',
-    limit: '22 KB',
+    limit: '22.2 KB',
     import: '{ CategoryScale, LinearScale, LogarithmicScale, RadialLinearScale, TimeScale, TimeSeriesScale }',
     running: false,
     modifyWebpackConfig

--- a/docs/migration/v4-migration.md
+++ b/docs/migration/v4-migration.md
@@ -31,3 +31,5 @@ A number of changes were made to the configuration options passed to the `Chart`
 
 ### General
 * Removed fallback to `fontColor` for the legend text and strikethrough color.
+* Removed `config._chart` fallback for `this.chart` in the filler plugin.
+* Removed `this._chart` in the filler plugin.

--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -465,9 +465,7 @@ export class Tooltip extends Element {
     this._tooltipItems = [];
     this.$animations = undefined;
     this.$context = undefined;
-    // TODO: V4, remove config._chart and this._chart backward compatibility aliases
-    this.chart = config.chart || config._chart;
-    this._chart = this.chart;
+    this.chart = config.chart;
     this.options = config.options;
     this.dataPoints = undefined;
     this.title = undefined;


### PR DESCRIPTION
<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
