### PR TITLE
Start moving lecacy scale hooks to plugin

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -370,7 +370,7 @@ export default class Scale extends Element {
   // Any function can be extended by the scale type
 
   beforeUpdate() {
-    call(this.options.beforeUpdate, [this]);
+    this._callHooks('beforeUpdate');
   }
 
   /**
@@ -489,13 +489,11 @@ export default class Scale extends Element {
   }
 
   afterUpdate() {
-    call(this.options.afterUpdate, [this]);
+    this._callHooks('afterUpdate');
   }
 
-  //
-
   beforeSetDimensions() {
-    call(this.options.beforeSetDimensions, [this]);
+    this._callHooks('beforeSetDimensions');
   }
   setDimensions() {
     // Set the unconstrained dimension before label rotation
@@ -519,7 +517,7 @@ export default class Scale extends Element {
     this.paddingBottom = 0;
   }
   afterSetDimensions() {
-    call(this.options.afterSetDimensions, [this]);
+    this._callHooks('afterSetDimension');
   }
 
   _callHooks(name) {
@@ -536,10 +534,10 @@ export default class Scale extends Element {
     this._callHooks('afterDataLimits');
   }
 
-  //
   beforeBuildTicks() {
     this._callHooks('beforeBuildTicks');
   }
+
   /**
 	 * @return {object[]} the ticks
 	 */
@@ -551,8 +549,9 @@ export default class Scale extends Element {
   }
 
   beforeTickToLabelConversion() {
-    call(this.options.beforeTickToLabelConversion, [this]);
+    this._callHooks('beforeTickToLabelConversion');
   }
+
   /**
 	 * Convert ticks to label strings
 	 * @param {Tick[]} ticks
@@ -566,14 +565,13 @@ export default class Scale extends Element {
     }
   }
   afterTickToLabelConversion() {
-    call(this.options.afterTickToLabelConversion, [this]);
+    this._callHooks('afterTickToLabelConversion');
   }
-
-  //
 
   beforeCalculateLabelRotation() {
-    call(this.options.beforeCalculateLabelRotation, [this]);
+    this._callHooks('beforeCalculateLabelRotation');
   }
+
   calculateLabelRotation() {
     const options = this.options;
     const tickOpts = options.ticks;
@@ -612,16 +610,17 @@ export default class Scale extends Element {
 
     this.labelRotation = labelRotation;
   }
+
   afterCalculateLabelRotation() {
-    call(this.options.afterCalculateLabelRotation, [this]);
+    this._callHooks('afterCalculateLabelRotation');
   }
+
   afterAutoSkip() {}
 
-  //
-
   beforeFit() {
-    call(this.options.beforeFit, [this]);
+    this._callHooks('beforeFit');
   }
+
   fit() {
     // Reset
     const minSize = {
@@ -741,7 +740,7 @@ export default class Scale extends Element {
   }
 
   afterFit() {
-    call(this.options.afterFit, [this]);
+    this._callHooks('afterFit');
   }
 
   // Shared Methods


### PR DESCRIPTION
Resolves #10155

TODO:
- [ ] Fix Failing test
- [ ] Write migration
- [ ] Update docs https://www.chartjs.org/docs/latest/axes/#callbacks
- [ ] Update typings

@etimberg you added the breaking change to it but in its current form its not breaking right since it still calls the hooks like it used to or do you want to have the `call` (line 527) here also removed?

https://github.com/chartjs/Chart.js/blob/f957aad352a39d4916b6cde3260009dee6ec74a4/src/core/core.scale.js#L525-L528