### PR TITLE
Bump `markdown-it` in docs

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
         "@simonbrunel/vuepress-plugin-versions": "^0.2.0",
         "@vuepress/plugin-google-analytics": "^1.9.7",
         "@vuepress/plugin-html-redirect": "^0.1.2",
-        "markdown-it": "^8.4.2",
+        "markdown-it": "^12.3.2",
         "markdown-it-include": "^2.0.0",
         "typedoc": "^0.23.10",
         "typedoc-plugin-markdown": "^3.13.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,7 +110,7 @@ importers:
       '@simonbrunel/vuepress-plugin-versions': ^0.2.0
       '@vuepress/plugin-google-analytics': ^1.9.7
       '@vuepress/plugin-html-redirect': ^0.1.2
-      markdown-it: ^8.4.2
+      markdown-it: ^12.3.2
       markdown-it-include: ^2.0.0
       typedoc: ^0.23.10
       typedoc-plugin-markdown: ^3.13.4
@@ -129,8 +129,8 @@ importers:
       '@simonbrunel/vuepress-plugin-versions': 0.2.0
       '@vuepress/plugin-google-analytics': 1.9.7
       '@vuepress/plugin-html-redirect': 0.1.4
-      markdown-it: 8.4.2
-      markdown-it-include: 2.0.0_markdown-it@8.4.2
+      markdown-it: 12.3.2
+      markdown-it-include: 2.0.0_markdown-it@12.3.2
       typedoc: 0.23.10_typescript@4.7.4
       typedoc-plugin-markdown: 3.13.4_typedoc@0.23.10
       typescript: 4.7.4
@@ -3334,7 +3334,7 @@ packages:
       url-loader: 1.1.2_webpack@4.46.0
       vue: 2.7.8
       vue-loader: 15.10.0_pf2nacutanypibfndeigfabsry
-      vue-router: 3.5.4_vue@2.7.8
+      vue-router: 3.5.4
       vue-server-renderer: 2.7.8
       vue-template-compiler: 2.7.8
       vuepress-html-webpack-plugin: 3.2.0_webpack@4.46.0
@@ -6761,6 +6761,10 @@ packages:
 
   /entities/1.1.2:
     resolution: {integrity: sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==}
+    dev: true
+
+  /entities/2.1.0:
+    resolution: {integrity: sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==}
     dev: true
 
   /entities/2.2.0:
@@ -10439,6 +10443,12 @@ packages:
       uc.micro: 1.0.6
     dev: true
 
+  /linkify-it/3.0.3:
+    resolution: {integrity: sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==}
+    dependencies:
+      uc.micro: 1.0.6
+    dev: true
+
   /load-script/1.0.0:
     resolution: {integrity: sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA==}
     dev: true
@@ -10694,18 +10704,29 @@ packages:
     resolution: {integrity: sha512-QCz3Hkd+r5gDYtS2xsFXmBYrgw6KuWcJZLCEkdfAuwzZbShCmCfta+hwAMq4NX/4xPzkSHduMKgMkkPUJxSXNg==}
     dev: true
 
-  /markdown-it-include/2.0.0_markdown-it@8.4.2:
+  /markdown-it-include/2.0.0_markdown-it@12.3.2:
     resolution: {integrity: sha512-wfgIX92ZEYahYWiCk6Jx36XmHvAimeHN420csOWgfyZjpf171Y0xREqZWcm/Rwjzyd0RLYryY+cbNmrkYW2MDw==}
     engines: {node: '>=10'}
     peerDependencies:
       markdown-it: '>=8.4.2'
     dependencies:
-      markdown-it: 8.4.2
+      markdown-it: 12.3.2
     dev: true
 
   /markdown-it-table-of-contents/0.4.4:
     resolution: {integrity: sha512-TAIHTHPwa9+ltKvKPWulm/beozQU41Ab+FIefRaQV1NRnpzwcV9QOe6wXQS5WLivm5Q/nlo0rl6laGkMDZE7Gw==}
     engines: {node: '>6.4.0'}
+    dev: true
+
+  /markdown-it/12.3.2:
+    resolution: {integrity: sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==}
+    hasBin: true
+    dependencies:
+      argparse: 2.0.1
+      entities: 2.1.0
+      linkify-it: 3.0.3
+      mdurl: 1.0.1
+      uc.micro: 1.0.6
     dev: true
 
   /markdown-it/8.4.2:
@@ -13238,12 +13259,6 @@ packages:
   /react-dev-utils/12.0.1_o76vzsp5j2es3tw47tgtdagf3m:
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
-    peerDependencies:
-      typescript: '>=2.7'
-      webpack: '>=4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
     dependencies:
       '@babel/code-frame': 7.18.6
       address: 1.2.0
@@ -13274,7 +13289,9 @@ packages:
     transitivePeerDependencies:
       - eslint
       - supports-color
+      - typescript
       - vue-template-compiler
+      - webpack
     dev: false
 
   /react-dom/18.2.0_react@18.2.0:
@@ -15744,12 +15761,8 @@ packages:
       vue: 2.7.8
     dev: true
 
-  /vue-router/3.5.4_vue@2.7.8:
+  /vue-router/3.5.4:
     resolution: {integrity: sha512-x+/DLAJZv2mcQ7glH2oV9ze8uPwcI+H+GgTgTmb5I55bCgY3+vXWIsqbYUzbBSZnwFHEJku4eoaH/x98veyymQ==}
-    peerDependencies:
-      vue: ^2
-    dependencies:
-      vue: 2.7.8
     dev: true
 
   /vue-server-renderer/2.7.8:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3334,7 +3334,7 @@ packages:
       url-loader: 1.1.2_webpack@4.46.0
       vue: 2.7.8
       vue-loader: 15.10.0_pf2nacutanypibfndeigfabsry
-      vue-router: 3.5.4
+      vue-router: 3.5.4_vue@2.7.8
       vue-server-renderer: 2.7.8
       vue-template-compiler: 2.7.8
       vuepress-html-webpack-plugin: 3.2.0_webpack@4.46.0
@@ -13259,6 +13259,12 @@ packages:
   /react-dev-utils/12.0.1_o76vzsp5j2es3tw47tgtdagf3m:
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=2.7'
+      webpack: '>=4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
       '@babel/code-frame': 7.18.6
       address: 1.2.0
@@ -13289,9 +13295,7 @@ packages:
     transitivePeerDependencies:
       - eslint
       - supports-color
-      - typescript
       - vue-template-compiler
-      - webpack
     dev: false
 
   /react-dom/18.2.0_react@18.2.0:
@@ -15761,8 +15765,12 @@ packages:
       vue: 2.7.8
     dev: true
 
-  /vue-router/3.5.4:
+  /vue-router/3.5.4_vue@2.7.8:
     resolution: {integrity: sha512-x+/DLAJZv2mcQ7glH2oV9ze8uPwcI+H+GgTgTmb5I55bCgY3+vXWIsqbYUzbBSZnwFHEJku4eoaH/x98veyymQ==}
+    peerDependencies:
+      vue: ^2
+    dependencies:
+      vue: 2.7.8
     dev: true
 
   /vue-server-renderer/2.7.8:


### PR DESCRIPTION
Apperently it has a bug that if you have special patterns with lots of characters it slows the parser down big time, don't have the issue now but just to be save bump it

![image](https://user-images.githubusercontent.com/39033624/186784377-a7692c54-277e-4f0c-ae3e-8fb8fcc2bd19.png)
