### PR TITLE
Fix permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,10 @@ name: Release
 
 on:
   release:
-    permissions:
-      contents: write  # for actions/upload-release-asset to upload release asset
     types: [published]
+
+permissions:
+  contents: read
 
 jobs:
   setup:
@@ -20,6 +21,8 @@ jobs:
           TAG: ${{ github.event.release.tag_name }}
 
   release:
+    permissions:
+      contents: write  # for actions/upload-release-asset to upload release asset
     needs: setup
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
`permissions:` is not a valid element of `release` trigger. This is why `contents: read` was mistakenly removed as redundant in #10513. Instead of defining `read` only for all job, but `write` to the `release` job. It was just `read` only for all jobs and it was failing. After removal of the default permission it is using the default [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token).

The PR fixes the default permission and correctly assigns write permission only to the release job.
