### PR TITLE
helpers.each support modules

### DIFF
--- a/src/helpers/helpers.core.ts
+++ b/src/helpers/helpers.core.ts
@@ -55,6 +55,14 @@ export function isObject(value: unknown): value is AnyObject {
 }
 
 /**
+ * Returns true if `value` is a javascript module, else returns false.
+ * @param value - The value to test.
+ */
+export function isModule(value: unknown): value is AnyObject {
+  return Object.prototype.toString.call(value) === '[object Module]';
+}
+
+/**
  * Returns true if `value` is a finite number, else returns false
  * @param value  - The value to test.
  */
@@ -149,7 +157,7 @@ export function each<T, TA>(
         fn.call(thisArg, loopable[i], i);
       }
     }
-  } else if (isObject(loopable)) {
+  } else if (isObject(loopable) || isModule(loopable)) {
     keys = Object.keys(loopable);
     len = keys.length;
     for (i = 0; i < len; i++) {


### PR DESCRIPTION
## Issue
Impossible to pass a javascript module to  `Chart.register`

## Description
Rollup build with `output.generatedCode.symbols: true` or Vite build by default in some cases causes "not registered" errors.

This code:
```js
// registerables.js
export {
    LineElement,
    PointElement,

    LineController,

    CategoryScale,
    LinearScale,

    Tooltip,
} from 'chart.js';

// index.js
import { Chart } from 'chart.js';
import * as registerables from './registerables';
Chart.register({ ...registerables });
export { Chart };
```

Becomes:
```js
// registerables.js
var rc = Object.freeze({
    __proto__: null,
    [Symbol.toStringTag]: "Module",
    LineElement: se,
    PointElement: Fe,
    LineController: Re,
    CategoryScale: Ae,
    LinearScale: Li,
    Tooltip: Wl
});

Qt.register({ ...rc }) // spreading doesn't help in this case
```

`Error: "category" is not a registered scale.` is thrown when I create a line chart.

Because `registry` uses `each` which doesn't allow to pass modules, only object 
https://github.com/chartjs/Chart.js/blob/2031cdf0512a94d2897a682ca156d150f0a83bb3/src/core/core.registry.js#L124-L146
https://github.com/chartjs/Chart.js/blob/2031cdf0512a94d2897a682ca156d150f0a83bb3/src/helpers/helpers.core.ts#L152-L158

## Workaround

Till PR isn't merged for those who faced this issue too

```js
Chart.register(
    Object.getOwnPropertyNames(registerables).reduce((acc, key) => {
        acc[key] = rc[key];
        return acc
    }, {});
);

```