### PR TITLE
Use ticks.steSize instead of time.stepSize on time and timeseries scales

### DIFF
--- a/docs/axes/cartesian/time.md
+++ b/docs/axes/cartesian/time.md
@@ -38,7 +38,6 @@ Namespace: `options.scales[scaleId]`
 | `time.round` | `string` | `false` | If defined, dates will be rounded to the start of this unit. See [Time Units](#time-units) below for the allowed units.
 | `time.tooltipFormat` | `string` | | The format string to use for the tooltip.
 | `time.unit` | `string` | `false` | If defined, will force the unit to be a certain type. See [Time Units](#time-units) section below for details.
-| `time.stepSize` | `number` | `1` | The number of units between grid lines.
 | `time.minUnit` | `string` | `'millisecond'` | The minimum display format to be used for a time unit.
 
 !!!include(axes/cartesian/_common.md)!!!

--- a/docs/migration/v4-migration.md
+++ b/docs/migration/v4-migration.md
@@ -27,6 +27,7 @@ A number of changes were made to the configuration options passed to the `Chart`
 * Linear scales now add and subtracts `5%` of the max value to the range if the min and max are the same instead of `1`.
 * If the tooltip callback returns `undefined`, then the default callback will be used.
 * `maintainAspectRatio` respects container height.
+* Time and timeseries scales use `ticks.stepSize` instead of `time.stepSize`, which has been removed.
 
 #### Type changes
 * The order of the `ChartMeta` parameters have been changed from `<Element, DatasetElement, Type>` to `<Type, Element, DatasetElement>`.

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -456,7 +456,7 @@ export default class TimeScale extends Scale {
     const timeOpts = options.time;
     // @ts-ignore
     const minor = timeOpts.unit || determineUnitForAutoTicks(timeOpts.minUnit, min, max, this._getLabelCapacity(min));
-    const stepSize = valueOrDefault(timeOpts.stepSize, 1);
+    const stepSize = valueOrDefault(options.ticks.stepSize, 1);
     const weekday = minor === 'week' ? timeOpts.isoWeekday : false;
     const hasWeekday = isNumber(weekday) || weekday === true;
     const ticks = {};

--- a/test/fixtures/scale.time/ticks-stepsize.js
+++ b/test/fixtures/scale.time/ticks-stepsize.js
@@ -12,6 +12,8 @@ module.exports = {
           bounds: 'ticks',
           time: {
             unit: 'hour',
+          },
+          ticks: {
             stepSize: 2
           }
         },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3238,12 +3238,6 @@ export type TimeScaleOptions = Omit<CartesianScaleOptions, 'min' | 'max'> & {
      * @default false
      */
     unit: false | TimeUnit;
-
-    /**
-     * The number of units between grid lines.
-     * @default 1
-     */
-    stepSize: number;
     /**
      * The minimum display format to be used for a time unit.
      * @default 'millisecond'


### PR DESCRIPTION
<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
Fix #10651