### PR TITLE
Docs: Setting maxTicksLimit disabled autoSkip

### DIFF
--- a/docs/axes/cartesian/_common_ticks.md
+++ b/docs/axes/cartesian/_common_ticks.md
@@ -7,7 +7,7 @@ Namespace: `options.scales[scaleId].ticks`
 | `align` | `string` | `'center'` | The tick alignment along the axis. Can be `'start'`, `'center'`, `'end'`, or `'inner'`. `inner` alignment means align `start` for first tick and `end` for the last tick of horizontal axis
 | `crossAlign` | `string` | `'near'` | The tick alignment perpendicular to the axis. Can be `'near'`, `'center'`, or `'far'`. See [Tick Alignment](/axes/cartesian/#tick-alignment)
 | `sampleSize` | `number` | `ticks.length` | The number of ticks to examine when deciding how many labels will fit. Setting a smaller value will be faster, but may be less accurate when there is large variability in label length.
-| `autoSkip` | `boolean` | `true` | If true, automatically calculates how many labels can be shown and hides labels accordingly. Labels will be rotated up to `maxRotation` before skipping any. Turn `autoSkip` off to show all labels no matter what.
+| `autoSkip` | `boolean` | `true` | If true, automatically calculates how many labels can be shown and hides labels accordingly. Labels will be rotated up to `maxRotation` before skipping any. Turn `autoSkip` off to show all labels no matter what. Setting `maxTicksLimit` disables `autoSkip`.
 | `autoSkipPadding` | `number` | `3` | Padding between the ticks on the horizontal axis when `autoSkip` is enabled.
 | `includeBounds` | `boolean` | `true` | Should the defined `min` and `max` values be presented as ticks even if they are not "nice".
 | `labelOffset` | `number` | `0` | Distance in pixels to offset the label from the centre point of the tick (in the x-direction for the x-axis, and the y-direction for the y-axis). *Note: this can cause labels at the edges to be cropped by the edge of the canvas*
@@ -15,4 +15,4 @@ Namespace: `options.scales[scaleId].ticks`
 | `minRotation` | `number` | `0` | Minimum rotation for tick labels. *Note: Only applicable to horizontal scales.*
 | `mirror` | `boolean` | `false` | Flips tick labels around axis, displaying the labels inside the chart instead of outside. *Note: Only applicable to vertical scales.*
 | `padding` | `number` | `0` | Padding between the tick label and the axis. When set on a vertical axis, this applies in the horizontal (X) direction. When set on a horizontal axis, this applies in the vertical (Y) direction.
-| `maxTicksLimit` | `number` | `11` | Maximum number of ticks and gridlines to show.
+| `maxTicksLimit` | `number` | `11` | Maximum number of ticks and gridlines to show. Setting `maxTicksLimit` disables `autoSkip`.


### PR DESCRIPTION
Spent quite a long time debugging why maxTicksLimit wasn't working with autoSkip. I expected autoSkip with maxTicksLimit to use the autoSkip number of ticks if it was smaller or maxTicksLimit number of ticks if it was smaller. There doesn't seem to be a way to do this at the moment. I could do a PR for a new autoSkipMaxTicks if there was interest.

The code that finally gave me my aha moment:
function autoSkip(scale, ticks) {
...
    const ticksLimit = tickOpts.maxTicksLimit || determineMaxTicks(scale);
