### PR TITLE
Logarithmic Scale with zero values

### DIFF
--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -86,7 +86,7 @@ export default class LogarithmicScale extends Scale {
       if (!maxDefined) {
         max = Math.max(max, range.max);
       } 
-      if (metas[i].hidden !== true && min === 0) {
+      if (metas[i].hidden !== true && (min === 0 || this.options.beginAtZero)) {
         this._zero = true;
         this._minNotZero = max;
         for (let j = 0, jlen = metas[i]._dataset.data.length; j < jlen; ++j) {
@@ -109,10 +109,6 @@ export default class LogarithmicScale extends Scale {
 
     this.min = isFinite(min) ? Math.max(0, min) : null;
     this.max = isFinite(max) ? Math.max(0, max) : null;
-
-    if (this.options.beginAtZero) {
-      this._zero = true;
-    }
 
     this.handleTickRangeOptions();
   }

--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -74,6 +74,7 @@ export default class LogarithmicScale extends Scale {
     let {min, max, minDefined, maxDefined} = this.getUserBounds();
     let range;
     this._zero = false;
+    this._minNotZero = min;
     if (minDefined && maxDefined) {
       return {min, max};
     }
@@ -86,18 +87,15 @@ export default class LogarithmicScale extends Scale {
       if (!maxDefined) {
         max = Math.max(max, range.max);
       } 
-      if (metas[i].hidden !== true && (min === 0 || this.options.beginAtZero)) {
-        this._zero = true;
-        this._minNotZero = max;
-        for (let j = 0, jlen = metas[i]._dataset.data.length; j < jlen; ++j) {
-          if (metas[i]._dataset.data[j] > 0) {
-            this._minNotZero = Math.min(this._minNotZero, metas[i]._dataset.data[j]);
-          }
+      for (let j = 0, jlen = metas[i]._dataset.data.length; j < jlen; ++j) {
+        if (metas[i]._dataset.data[j] > 0) {
+          this._minNotZero = Math.min(this._minNotZero, metas[i]._dataset.data[j]);
         }
       }
     }
     min = maxDefined && min > max ? max : min;
     max = minDefined && min > max ? min : max;
+
     return {
       min: finiteOrDefault(min, finiteOrDefault(max, min)),
       max: finiteOrDefault(max, finiteOrDefault(min, max))
@@ -109,6 +107,10 @@ export default class LogarithmicScale extends Scale {
 
     this.min = isFinite(min) ? Math.max(0, min) : null;
     this.max = isFinite(max) ? Math.max(0, max) : null;
+    
+    if (this.min === 0 || this.options.beginAtZero) {
+      this._zero = true;
+    }
 
     this.handleTickRangeOptions();
   }


### PR DESCRIPTION
Issue #9629 : Display multiline chart with zero values. 
_zero is update if dataset is hidden.
get minNotZero value to update chart if zero value is display.

Solved on 3.9 branch

Thanks.