### PR TITLE
Run compressed-size on pull_request_target

### DIFF
--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -1,6 +1,6 @@
 name: Compressed Size
 
-on: [pull_request]
+on: [pull_request_target]
 
 permissions:
   contents: read


### PR DESCRIPTION
This should enable it to comment, because the version already in master will be executed.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
