### PR TITLE
Types: Export UpdateModeEnum as const

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -551,7 +551,7 @@ export declare type ChartItem =
   | { canvas: HTMLCanvasElement }
   | ArrayLike<CanvasRenderingContext2D | HTMLCanvasElement>;
 
-export declare enum UpdateModeEnum {
+export const enum UpdateModeEnum {
   resize = 'resize',
   reset = 'reset',
   none = 'none',


### PR DESCRIPTION
Allows a typescript project to consume UpdateModeEnum. 

It is basically the same fix from https://github.com/chartjs/Chart.js/pull/9046 applied to a different enum. 

I'd consider this as an extended fix for https://github.com/chartjs/Chart.js/issues/8993