### PR TITLE
Types: Change grid option of CartesianScaleOptions and RadialLinearScaleOptions to Partial of GridLineOptions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3075,7 +3075,7 @@ export interface CartesianScaleOptions extends CoreScaleOptions {
    */
   offset: boolean;
 
-  grid: GridLineOptions;
+  grid: Partial<GridLineOptions>;
 
   border: BorderOptions;
 
@@ -3359,7 +3359,7 @@ export type RadialLinearScaleOptions = CoreScaleOptions & {
    */
   beginAtZero: boolean;
 
-  grid: GridLineOptions;
+  grid: Partial<GridLineOptions>;
 
   /**
    * User defined minimum number for the scale, overrides minimum value from data.


### PR DESCRIPTION
Since all properties of `GridLineOptions` have default values the usages of this interface should be wrapped in a `Partial`.

Resolves #10740