### PR TITLE
Remove setting of version in package-lock

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,6 @@ jobs:
           pnpm install
           pnpm install -g json
           json -I -f package.json -e "this.version=\"$VERSION\""
-          json -I -f package-lock.json -e "this.version=\"$VERSION\""
           pnpm run build
           ./scripts/docs-config.sh "$VERSION" release
           pnpm run docs


### PR DESCRIPTION
Package-lock.json does not exist anymore after switching to pnpm and pnpm-lock.yml does not use any verison field

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
