### PR TITLE
fix: put `types` first in `exports` map

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,16 +14,16 @@
     "main": "./dist/chart.js",
     "exports": {
         ".": {
-            "import": "./dist/chart.js",
-            "types": "./dist/types.d.ts"
+            "types": "./dist/types.d.ts",
+            "import": "./dist/chart.js"
         },
         "./auto": {
-            "import": "./auto/auto.js",
-            "types": "./auto/auto.d.ts"
+            "types": "./auto/auto.d.ts",
+            "import": "./auto/auto.js"
         },
         "./helpers": {
-            "import": "./helpers/helpers.js",
-            "types": "./helpers/helpers.d.ts"
+            "types": "./helpers/helpers.d.ts",
+            "import": "./helpers/helpers.js"
         }
     },
     "types": "./dist/types.d.ts",


### PR DESCRIPTION
the types need to come first: https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing

kind of dumb, but :shrug: 