### PR TITLE
fix: allow require statement in exports.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,15 +15,15 @@
     "exports": {
         ".": {
             "types": "./dist/types.d.ts",
-            "import": "./dist/chart.js"
+            "default": "./dist/chart.js"
         },
         "./auto": {
             "types": "./auto/auto.d.ts",
-            "import": "./auto/auto.js"
+            "default": "./auto/auto.js"
         },
         "./helpers": {
             "types": "./helpers/helpers.d.ts",
-            "import": "./helpers/helpers.js"
+            "default": "./helpers/helpers.js"
         }
     },
     "types": "./dist/types.d.ts",


### PR DESCRIPTION
Hello first contribution on open source project and don't have a clue what's the protocol nor time to read all your docs sorry :/

But here is a really obvious quick fix for a big issue : We cannot require() your library.

As mentioned in this issue that I commented :
https://github.com/chartjs/Chart.js/issues/10911

When specifying exports in package.json it overwrites the main attributes.
So currently there is no rule for "requiring" the module.
I simply added a default rule to package.json instead of the import one and it works like a charm.

Thank you for your work, best regards,

Lucien Perouze
