### PR TITLE
test: turn on types linting

### DIFF
--- a/src/helpers/helpers.options.ts
+++ b/src/helpers/helpers.options.ts
@@ -203,6 +203,8 @@ export function _addGrace(minmax: { min: number; max: number; }, grace: number |
  * @param context
  * @returns
  */
-export function createContext<P extends T, T extends object>(parentContext: P, context: T): P extends null ? T : P & T {
+export function createContext<T extends object>(parentContext: null, context: T): T;
+export function createContext<T extends object, P extends T>(parentContext: P, context: T): P & T;
+export function createContext(parentContext: object, context: object) {
   return Object.assign(Object.create(parentContext), context);
 }

--- a/types/tests/autogen.js
+++ b/types/tests/autogen.js
@@ -10,7 +10,7 @@ let fd;
 try {
   const fn = path.resolve(__dirname, 'autogen_helpers.ts');
   fd = fs.openSync(fn, 'w+');
-  fs.writeSync(fd, 'import * as helpers from \'../../dist/helpers\';\n\n');
+  fs.writeSync(fd, 'import * as helpers from \'../../dist/helpers/index.js\';\n\n');
 
   fs.writeSync(fd, 'const testKeys: unknown[] = [];\n');
   for (const key of Object.keys(helpers)) {

--- a/types/tests/dataset_null_data.ts
+++ b/types/tests/dataset_null_data.ts
@@ -1,4 +1,4 @@
-import { ChartDataset } from '../../src/types.js';
+import type { ChartDataset } from '../../src/types.js';
 
 const dataset: ChartDataset = {
   data: [10, null, 20],

--- a/types/tests/extensions/scale.ts
+++ b/types/tests/extensions/scale.ts
@@ -17,7 +17,7 @@ export class TestScale<O extends TestScaleOptions = TestScaleOptions> extends Sc
   }
 }
 
-declare module '../..' {
+declare module '../../index.js' {
   interface CartesianScaleTypeRegistry {
     test: {
       options: TestScaleOptions

--- a/types/tests/interaction.ts
+++ b/types/tests/interaction.ts
@@ -1,6 +1,6 @@
 import {
   Chart, ChartData, ChartConfiguration, Element
-} from '../../src/types';
+} from '../../src/types.js';
 
 const data: ChartData<'line'> = { datasets: [] };
 const chartItem = 'item';

--- a/types/tests/layout/position.ts
+++ b/types/tests/layout/position.ts
@@ -1,4 +1,4 @@
-import { LayoutPosition } from '../../../src/types.js';
+import type { LayoutPosition } from '../../../src/types.js';
 
 const left: LayoutPosition = 'left';
 const right: LayoutPosition = 'right';

--- a/types/tests/parsed.data.type.ts
+++ b/types/tests/parsed.data.type.ts
@@ -1,4 +1,4 @@
-import { ParsedDataType } from '../../src/types.js';
+import type { ParsedDataType } from '../../src/types.js';
 
 interface test {
   pie: ParsedDataType<'pie'>,

--- a/types/tests/plugins/plugin.filler/fill_target_true.ts
+++ b/types/tests/plugins/plugin.filler/fill_target_true.ts
@@ -1,4 +1,4 @@
-import { ChartDataset } from '../../../../src/types.js';
+import type { ChartDataset } from '../../../../src/types.js';
 
 const dataset: ChartDataset = {
   data: [],

--- a/types/tests/register.ts
+++ b/types/tests/register.ts
@@ -24,7 +24,7 @@ import {
   Title,
   SubTitle,
   Tooltip
-} from '../../src/types';
+} from '../../src/types.js';
 
 Chart.register(
   ArcElement,

--- a/types/tests/scales/chart_options.ts
+++ b/types/tests/scales/chart_options.ts
@@ -1,4 +1,4 @@
-import { ChartOptions } from '../../../src/types.js';
+import type { ChartOptions } from '../../../src/types.js';
 
 const chartOptions: ChartOptions<'line'> = {
   scales: {

--- a/types/tests/scales/options.ts
+++ b/types/tests/scales/options.ts
@@ -19,14 +19,13 @@ const chart = new Chart('test', {
           unit: 'year'
         },
         ticks: {
-          stepSzie: 1
+          stepSize: 1
         }
       },
       x1: {
-        // @ts-expect-error Type '"linear"' is not assignable to type '"timeseries" | undefined'.
         type: 'linear',
+        // @ts-expect-error 'time' does not exist in 'linear' options
         time: {
-          // @ts-expect-error Type 'string' is not assignable to type 'false | "millisecond" | "second" | "minute" | "hour" | "day" | "week" | "month" | "quarter" | "year" | undefined'.
           unit: 'year'
         }
       },

--- a/types/tests/scriptable.ts
+++ b/types/tests/scriptable.ts
@@ -1,4 +1,4 @@
-import { ChartType, Scriptable, ScriptableContext } from '../../src/types.js';
+import type { ChartType, Scriptable, ScriptableContext } from '../../src/types.js';
 
 interface test {
   pie?: Scriptable<number, ScriptableContext<'pie'>>,

--- a/types/tests/scriptable_core_chart_options.ts
+++ b/types/tests/scriptable_core_chart_options.ts
@@ -1,4 +1,4 @@
-import { ChartConfiguration } from '../../src/types.js';
+import type { ChartConfiguration } from '../../src/types.js';
 
 const getConfig = (): ChartConfiguration<'bar'> => {
   return {

--- a/types/tests/tsconfig.json
+++ b/types/tests/tsconfig.json
@@ -1,11 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "rootDir": "../../"
   },
   "include": [
     "../",
     "../../src/",
     "../../dist/**/*.d.ts"
+  ],
+  "exclude": [
+    "./**/*.js"
   ]
 }


### PR DESCRIPTION
Types linting didn't work. Test's tsconfig inherited the "exclude" field from root tsconfig, where types were ignored.