### PR TITLE
docs: Update Slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
     <a href="https://github.com/chartjs/Chart.js/actions?query=workflow%3ACI+branch%3Amaster"><img alt="GitHub Workflow Status" src="https://img.shields.io/github/workflow/status/chartjs/Chart.js/CI"></a>
     <a href="https://coveralls.io/github/chartjs/Chart.js?branch=master"><img src="https://img.shields.io/coveralls/chartjs/Chart.js.svg?style=flat-square&maxAge=600" alt="Coverage"></a>
     <a href="https://github.com/chartjs/awesome"><img src="https://awesome.re/badge-flat2.svg" alt="Awesome"></a>
-    <a href="https://chartjs-slack.herokuapp.com/"><img src="https://img.shields.io/badge/slack-chartjs-blue.svg?style=flat-square&maxAge=3600" alt="Slack"></a>
+    <a href="https://join.slack.com/t/chartjs/shared_invite/zt-1lo81skkk-AZk6ollhOdrjt9GzPeOsLw"><img src="https://img.shields.io/badge/slack-chartjs-blue.svg?style=flat-square&maxAge=3600" alt="Slack"></a>
 </p>
 
 ## Documentation

--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -130,7 +130,7 @@ export default defineConfig({
         ariaLabel: 'Community Menu',
         items: [
           { text: 'Awesome', link: 'https://github.com/chartjs/awesome' },
-          { text: 'Slack', link: 'https://chartjs-slack.herokuapp.com/' },
+          { text: 'Slack', link: 'https://join.slack.com/t/chartjs/shared_invite/zt-1lo81skkk-AZk6ollhOdrjt9GzPeOsLw' },
           { text: 'Stack Overflow', link: 'https://stackoverflow.com/questions/tagged/chart.js' }
         ]
       }

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -2,7 +2,7 @@
 
 New contributions to the library are welcome, but we ask that you please follow these guidelines:
 
-- Before opening a PR for major additions or changes, please discuss the expected API and/or implementation by [filing an issue](https://github.com/chartjs/Chart.js/issues) or asking about it in the [Chart.js Slack](https://chartjs-slack.herokuapp.com/) #dev channel. This will save you development time by getting feedback upfront and make reviews faster by giving the maintainers more context and details.
+- Before opening a PR for major additions or changes, please discuss the expected API and/or implementation by [filing an issue](https://github.com/chartjs/Chart.js/issues) or asking about it in the [Chart.js Slack](https://join.slack.com/t/chartjs/shared_invite/zt-1lo81skkk-AZk6ollhOdrjt9GzPeOsLw) #dev channel. This will save you development time by getting feedback upfront and make reviews faster by giving the maintainers more context and details.
 - Consider whether your changes are useful for all users, or if creating a Chart.js [plugin](plugins.md) would be more appropriate.
 - Check that your code will pass tests and `eslint` code standards. `pnpm test` will run both the linter and tests for you.
 - Add unit tests and document new functionality (in the `test/` and `docs/` directories respectively).
@@ -11,7 +11,7 @@ New contributions to the library are welcome, but we ask that you please follow 
 
 ## Joining the project
 
-Active committers and contributors are invited to introduce themselves and request commit access to this project. We have a very active Slack community that you can join [here](https://chartjs-slack.herokuapp.com/). If you think you can help, we'd love to have you!
+Active committers and contributors are invited to introduce themselves and request commit access to this project. We have a very active Slack community that you can join [here](https://join.slack.com/t/chartjs/shared_invite/zt-1lo81skkk-AZk6ollhOdrjt9GzPeOsLw). If you think you can help, we'd love to have you!
 
 ## Building and Testing
 

--- a/docs/getting-started/usage.md
+++ b/docs/getting-started/usage.md
@@ -586,6 +586,6 @@ By importing and registering only select components, we’ve removed more than 5
 
 Now you’re familiar with all major concepts of Chart.js: chart types and elements, datasets, customization, plugins, components, and tree-shaking.
 
-Feel free to review many [examples of charts](../samples/information.html) in the documentation and check the [awesome list](https://github.com/chartjs/awesome) of Chart.js plugins and additional chart types as well as [framework integrations](https://github.com/chartjs/awesome#integrations) (e.g., React, Vue, Svelte, etc.). Also, don’t hesitate to join [Chart.js Slack](https://chartjs-slack.herokuapp.com) and follow [Chart.js on Twitter](https://twitter.com/chartjs).
+Feel free to review many [examples of charts](../samples/information.html) in the documentation and check the [awesome list](https://github.com/chartjs/awesome) of Chart.js plugins and additional chart types as well as [framework integrations](https://github.com/chartjs/awesome#integrations) (e.g., React, Vue, Svelte, etc.). Also, don’t hesitate to join [Chart.js Slack](https://join.slack.com/t/chartjs/shared_invite/zt-1lo81skkk-AZk6ollhOdrjt9GzPeOsLw) and follow [Chart.js on Twitter](https://twitter.com/chartjs).
 
 Have fun and good luck building with Chart.js!

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ Welcome to Chart.js!
 
 * **[Get started with Chart.js](./getting-started/) — best if you're new to Chart.js**
 * Migrate from [Chart.js v3](./migration/v4-migration.html) or [Chart.js v2](./migration/v3-migration.html)
-* Join the community on [Slack](https://chartjs-slack.herokuapp.com/) and [Twitter](https://twitter.com/chartjs)
+* Join the community on [Slack](https://join.slack.com/t/chartjs/shared_invite/zt-1lo81skkk-AZk6ollhOdrjt9GzPeOsLw) and [Twitter](https://twitter.com/chartjs)
 * Post a question tagged with `chart.js` on [Stack Overflow](https://stackoverflow.com/questions/tagged/chart.js)
 * [Contribute to Chart.js](./developers/contributing.html)
 
@@ -30,7 +30,7 @@ Chart.js comes with built-in TypeScript typings and is compatible with all popul
 
 ### Developer experience
 
-Chart.js has very thorough documentation (yes, you're reading it), [API reference](./api/), and [examples](./samples/information.html). Maintainers and community members eagerly engage in conversations on [Slack](https://chartjs-slack.herokuapp.com), [GitHub Discussions](https://github.com/chartjs/Chart.js/discussions), and [Stack Overflow](https://stackoverflow.com/questions/tagged/chart.js) where more than 11,000 questions are tagged with `chart.js`.
+Chart.js has very thorough documentation (yes, you're reading it), [API reference](./api/), and [examples](./samples/information.html). Maintainers and community members eagerly engage in conversations on [Slack](https://join.slack.com/t/chartjs/shared_invite/zt-1lo81skkk-AZk6ollhOdrjt9GzPeOsLw), [GitHub Discussions](https://github.com/chartjs/Chart.js/discussions), and [Stack Overflow](https://stackoverflow.com/questions/tagged/chart.js) where more than 11,000 questions are tagged with `chart.js`.
 
 ### Canvas rendering
 

--- a/docs/migration/v3-migration.md
+++ b/docs/migration/v3-migration.md
@@ -249,7 +249,7 @@ Animation system was completely rewritten in Chart.js v3. Each property can now 
 
 ## Developer migration
 
-While the end-user migration for Chart.js 3 is fairly straight-forward, the developer migration can be more complicated. Please reach out for help in the #dev [Slack](https://chartjs-slack.herokuapp.com/) channel if tips on migrating would be helpful.
+While the end-user migration for Chart.js 3 is fairly straight-forward, the developer migration can be more complicated. Please reach out for help in the #dev [Slack](https://join.slack.com/t/chartjs/shared_invite/zt-1lo81skkk-AZk6ollhOdrjt9GzPeOsLw) channel if tips on migrating would be helpful.
 
 Some of the biggest things that have changed:
 


### PR DESCRIPTION
Currently, a link to join Chart.js Slack doesn't work because a [slackin](https://github.com/rauchg/slackin) deployment on Heroku [doesn't work as well](https://chartjs-slack.herokuapp.com).

Fortunately, now Slack has an option to [share an invitation link](https://slack.com/help/articles/201330256-Invite-new-members-to-your-workspace#share-an-invitation-link).

I've updated all places I've found with such a link.
<img width="1072" alt="Screen Shot 2022-12-14 at 19 56 57" src="https://user-images.githubusercontent.com/3852894/207644678-bacac578-c255-4fcf-9ed5-ac9d3830412d.png">
