### PR TITLE
fix: hotfix chart.js/auto for commonjs

### DIFF
--- a/auto/auto.cjs
+++ b/auto/auto.cjs
@@ -1,6 +1,6 @@
-const exports = require('../dist/chart.cjs');
-const {Chart, registerables} = exports;
+const chartjs = require('../dist/chart.cjs');
+const {Chart, registerables} = chartjs;
 
 Chart.register(...registerables);
 
-module.exports = Object.assign(Chart, exports);
+module.exports = Object.assign(Chart, chartjs);

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "type": "module",
     "sideEffects": [
         "./auto/auto.js",
+        "./auto/auto.cjs",
         "./dist/chart.umd.js"
     ],
     "jsdelivr": "./dist/chart.umd.js",

--- a/test/integration/node-commonjs/package.json
+++ b/test/integration/node-commonjs/package.json
@@ -2,7 +2,9 @@
   "private": true,
   "description": "chart.js should work in Node",
   "scripts": {
-    "test": "node test.js"
+    "test": "npm run test-index && npm run test-auto",
+    "test-index": "node test.js",
+    "test-auto": "node test-auto.js"
   },
   "dependencies": {
     "chart.js": "workspace:*"

--- a/test/integration/node-commonjs/test-auto.js
+++ b/test/integration/node-commonjs/test-auto.js
@@ -1,0 +1,7 @@
+const Chart = require('chart.js/auto');
+const {valueOrDefault} = require('chart.js/helpers');
+
+Chart.register({
+  id: 'TEST_PLUGIN',
+  dummyValue: valueOrDefault(0, 1)
+});


### PR DESCRIPTION
Sorry for my fault

fixes that:
```
const exports = require('../dist/chart.cjs');
      ^

Uncaught SyntaxError: Identifier 'exports' has already been declared
```