### PR TITLE
Fixes missing markdown links in docs

### DIFF
--- a/docs/charts/bar.md
+++ b/docs/charts/bar.md
@@ -180,7 +180,7 @@ When the border radius is supplied as a number and the chart is stacked, the rad
 
 #### inflateAmount
 
-This option can be used to inflate the rects that are used to draw the bars. This can be used to hide artifacts between bars when `barPercentage`(#barpercentage) * `categoryPercentage`(#categorypercentage) is 1. The default value `'auto'` should work in most cases.
+This option can be used to inflate the rects that are used to draw the bars. This can be used to hide artifacts between bars when [`barPercentage`](#barpercentage) * [`categoryPercentage`](#categorypercentage) is 1. The default value `'auto'` should work in most cases.
 
 ### Interactions
 


### PR DESCRIPTION
<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->

Seems like markdown links miss square brackets to be rendered correctly.

<img width="1237" alt="image" src="https://user-images.githubusercontent.com/20226733/208660875-07a6281d-d7e7-4761-9436-8773a9131c5d.png">
