### PR TITLE
Specify `module` for Webpack 4

### DIFF
--- a/auto/package.json
+++ b/auto/package.json
@@ -4,6 +4,7 @@
     "description": "Auto registering package. Exists to support bundlers without exports support such as webpack 4.",
     "type": "module",
     "main": "./auto.cjs",
+    "module": "./auto.js",
     "exports": {
         "types": "./auto.d.ts",
         "import": "./auto.js",

--- a/helpers/package.json
+++ b/helpers/package.json
@@ -4,6 +4,7 @@
     "description": "Helpers package. Exists to support bundlers without exports support such as webpack 4.",
     "type": "module",
     "main": "./helpers.cjs",
+    "module": "./helpers.js",
     "exports": {
         "types": "./helpers.d.ts",
         "import": "./helpers.js",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "jsdelivr": "./dist/chart.umd.js",
     "unpkg": "./dist/chart.umd.js",
     "main": "./dist/chart.cjs",
+    "module": "./dist/chart.js",
     "exports": {
         ".": {
             "types": "./dist/types.d.ts",


### PR DESCRIPTION
Hi, thanks for this project!

Webpack 4 currently loads `./dist/chart.cjs` since it doesn't support `exports`: https://github.com/webpack/webpack/issues/9509