### PR TITLE
docs:  explain how to build cdn js file

### DIFF
--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -33,6 +33,8 @@ The following commands are now available from the repository root:
 > pnpm test                  // perform code linting and run unit tests with coverage
 ```
 
+The `chart.js` file you would get from a CDN will be located at [`./dist/chart.umd.js`](https://github.com/chartjs/Chart.js/blob/b51c52336624a24fe1ec814dc47f9a4cb7dd6a8a/package.json) after `pnpm run build`.
+
 `pnpm run dev` and `pnpm test` can be appended with a string that is used to match the spec filenames. For example: `pnpm run dev plugins` will start karma in watch mode for `test/specs/**/*plugin*.js`.
 
 ### Documentation


### PR DESCRIPTION
I was trying to figure out how to re-build the same file that is served from CDNs, and I got confused and tripped over myself on the way.  through my own mistakes, I had actually convinced myself that the build script in this repo did not produce the file that the CDN was serving.   Nothing in the docs talked about it, so I just assumed it was some "special thing that exists somewhere else."

I am adding this to the docs now so that the next person reading through will be re-assured and hopefully find the right file.
