### PR TITLE
chore: Add Chart.js meetup announcement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@
     <a href="https://join.slack.com/t/chartjs/shared_invite/zt-1lo81skkk-AZk6ollhOdrjt9GzPeOsLw"><img src="https://img.shields.io/badge/slack-chartjs-blue.svg?style=flat-square&maxAge=3600" alt="Slack"></a>
 </p>
 
+<p align="center">
+  <br/>
+  Join Chart.js maintainers and community at the first Chart.js meetup in January 2023.
+  <br/>
+  <a href="https://cube.dev/events/chart-js-community-meetup" target="_blank">Check agenda and register</a>
+  <br/>
+  <br/>
+</p>
+
 ## Documentation
 
 All the links point to the new version 4 of the lib.


### PR DESCRIPTION
We're getting some registrations through the announcement at https://www.chartjs.org (currently at ~40 regs). Adding a link to README should help make it more visible and boost registrations.