### PR TITLE
fix: decimation plugin data not writeable after clean

### DIFF
--- a/src/plugins/plugin.decimation.js
+++ b/src/plugins/plugin.decimation.js
@@ -158,7 +158,12 @@ function cleanDecimatedDataset(dataset) {
     const data = dataset._data;
     delete dataset._decimated;
     delete dataset._data;
-    dataset.data = data;
+    Object.defineProperty(dataset, "data", {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: data,
+    });
   }
 }
 

--- a/src/plugins/plugin.decimation.js
+++ b/src/plugins/plugin.decimation.js
@@ -158,7 +158,7 @@ function cleanDecimatedDataset(dataset) {
     const data = dataset._data;
     delete dataset._decimated;
     delete dataset._data;
-    Object.defineProperty(dataset, 'data', {value: data});
+    dataset.data = data;
   }
 }
 

--- a/src/plugins/plugin.decimation.js
+++ b/src/plugins/plugin.decimation.js
@@ -158,7 +158,7 @@ function cleanDecimatedDataset(dataset) {
     const data = dataset._data;
     delete dataset._decimated;
     delete dataset._data;
-    Object.defineProperty(dataset, "data", {
+    Object.defineProperty(dataset, 'data', {
       configurable: true,
       enumerable: true,
       writable: true,


### PR DESCRIPTION
When using the decimation plugin and changing data it will throw `Uncaught TypeError: Cannot assign to read only property 'data' of object '#<Object>'`, because the `data` property is not writeable anymore after cleanup.

Changing from `defineProperty` (default `writable` false) to normal property assignment, will fix the issue.