### PR TITLE
fix RTL tooltip colorBox placement

### DIFF
--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -818,8 +818,8 @@ export class Tooltip extends Element {
       ctx.lineDashOffset = labelColors.borderDashOffset || 0;
 
       // Fill a white rect so that colours merge nicely if the opacity is < 1
-      const outerX = rtlHelper.leftForLtr(rtlColorX, boxWidth - boxPadding);
-      const innerX = rtlHelper.leftForLtr(rtlHelper.xPlus(rtlColorX, 1), boxWidth - boxPadding - 2);
+      const outerX = rtlHelper.leftForLtr(rtlColorX, boxWidth);
+      const innerX = rtlHelper.leftForLtr(rtlHelper.xPlus(rtlColorX, 1), boxWidth - 2);
       const borderRadius = toTRBLCorners(labelColors.borderRadius);
 
       if (Object.values(borderRadius).some(v => v !== 0)) {

--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -782,7 +782,7 @@ export class Tooltip extends Element {
   _drawColorBox(ctx, pt, i, rtlHelper, options) {
     const labelColors = this.labelColors[i];
     const labelPointStyle = this.labelPointStyles[i];
-    const {boxHeight, boxWidth, boxPadding} = options;
+    const {boxHeight, boxWidth} = options;
     const bodyFont = toFont(options.bodyFont);
     const colorX = getAlignedX(this, 'left', options);
     const rtlColorX = rtlHelper.x(colorX);


### PR DESCRIPTION
#10771
[here](https://jsbin.com/hepujok/1/edit?html,css,js,console,output) is the current behavior of the tooltip. and [here](https://github.com/shahabhm/chartjs-changes-preeview/blob/main/test.html) is the results after applying the changes. (sorry but I couldn't upload the js into any of the recommended websites.)

here is a screenshot of the results, for single line and multi line tooltips, rtl on and off, and boxPadding set to 150 and disabled.

![preview](https://github.com/shahabhm/chartjs-changes-preeview/raw/main/preview.png)