### PR TITLE
Fix: don't generate ticks > max if max is specified

### DIFF
--- a/src/scales/scale.linearbase.js
+++ b/src/scales/scale.linearbase.js
@@ -123,7 +123,11 @@ function generateTicks(generationOptions, dataRange) {
   }
 
   for (; j < numSpaces; ++j) {
-    ticks.push({value: Math.round((niceMin + j * spacing) * factor) / factor});
+    const tickValue = Math.round((niceMin + j * spacing) * factor) / factor;
+    if (maxDefined && tickValue > max) {
+      break;
+    }
+    ticks.push({value: tickValue});
   }
 
   if (maxDefined && includeBounds && niceMax !== max) {

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -684,6 +684,28 @@ describe('Linear Scale', function() {
     expect(getLabels(chart.scales.y)).toEqual(['1', '3', '5', '7', '9', '11']);
   });
 
+  it('Should not generate any ticks > max if max is specified', function() {
+    var chart = window.acquireChart({
+      type: 'line',
+      options: {
+        scales: {
+          x: {
+            type: 'linear',
+            min: 2.404e-8,
+            max: 2.4143e-8,
+            ticks: {
+              includeBounds: false,
+            },
+          },
+        },
+      },
+    });
+
+    expect(chart.scales.x.min).toBe(2.404e-8);
+    expect(chart.scales.x.max).toBe(2.4143e-8);
+    expect(chart.scales.x.ticks[chart.scales.x.ticks.length - 1].value).toBeLessThanOrEqual(2.4143e-8);
+  });
+
   it('Should not generate insane amounts of ticks with small stepSize and large range', function() {
     var chart = window.acquireChart({
       type: 'bar',


### PR DESCRIPTION
Fixes #11083.

I have also added a test which fails without the fix but succedes with it.