### PR TITLE
Remove circumference property retrieving from arc element for center calculation because not used

### DIFF
--- a/src/elements/element.arc.ts
+++ b/src/elements/element.arc.ts
@@ -327,8 +327,7 @@ export default class ArcElement extends Element<ArcProps, ArcOptions> {
       'startAngle',
       'endAngle',
       'innerRadius',
-      'outerRadius',
-      'circumference',
+      'outerRadius'
     ], useFinalPosition);
     const {offset, spacing} = this.options;
     const halfAngle = (startAngle + endAngle) / 2;


### PR DESCRIPTION
Working with arc element, I have seen that circumference property was requested to the element but not used for center calculation.
