### PR TITLE
fix: Chart shrinking uncontrollably on browser zoom (#11089)

### DIFF
--- a/src/helpers/helpers.dom.ts
+++ b/src/helpers/helpers.dom.ts
@@ -200,7 +200,7 @@ export function getMaximumSize(
   const maintainHeight = bbWidth !== undefined || bbHeight !== undefined;
 
   if (maintainHeight && aspectRatio && containerSize.height && height > containerSize.height) {
-    height = containerSize.height;
+    height = Math.round(containerSize.height);
     width = round1(Math.floor(height * aspectRatio));
   }
 

--- a/test/specs/helpers.dom.tests.js
+++ b/test/specs/helpers.dom.tests.js
@@ -545,4 +545,21 @@ describe('DOM helpers tests', function() {
 
     document.body.removeChild(container);
   });
+
+  it('should respect aspect ratio and container height and return height as integer', () => {
+    const container = document.createElement('div');
+    container.style.width = '500px';
+    container.style.height = '200px';
+
+    document.body.appendChild(container);
+
+    const target = document.createElement('div');
+    target.style.width = '500px';
+    target.style.height = '500px';
+    container.appendChild(target);
+
+    expect(helpers.getMaximumSize(target, 500, 199.975, 1)).toEqual(jasmine.objectContaining({width: 200, height: 200}));
+
+    document.body.removeChild(container);
+  });
 });


### PR DESCRIPTION
My comment on the original issue contains the full analysis (scenario, root cause, how to reproduce): 
https://github.com/chartjs/Chart.js/issues/11089#issuecomment-1418418088

The functions `retinaScale` and `getMaximumSize` are full of minor details and multiple flows. 
Hence, this area in the code is quite sensitive IMHO. 
I'm making an attempt to fix the issue with minimum side effects. 

Fixes #11089.

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
