### PR TITLE
Use custom scale defaults and dataset axis ID options to determine the axis

### DIFF
--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -13,7 +13,7 @@ module.exports = [
   },
   {
     path: 'dist/chart.js',
-    limit: '34 KB',
+    limit: '34.5 KB',
     import: '{ Chart }',
     running: false,
     modifyWebpackConfig

--- a/src/core/core.config.js
+++ b/src/core/core.config.js
@@ -55,6 +55,22 @@ export function determineAxis(id, ...scaleOptions) {
   throw new Error(`Cannot determine type of '${id}' axis. Please provide 'axis' or 'position' option.`);
 }
 
+function getScaleFromDataset(id, axis, dataset) {
+  if (dataset[axis + 'AxisID'] === id) {
+    return {axis};
+  }
+}
+
+function searchScaleIDs(id, config) {
+  if (config.data && config.data.datasets) {
+    const boundDs = config.data.datasets.filter((d) => d.xAxisID === id || d.yAxisID === id);
+    if (boundDs.length) {
+      return getScaleFromDataset(id, 'x', boundDs[0]) || getScaleFromDataset(id, 'y', boundDs[0]);
+    }
+  }
+  return {};
+}
+
 function mergeScaleConfig(config, options) {
   const chartDefaults = overrides[config.type] || {scales: {}};
   const configScales = options.scales || {};
@@ -70,7 +86,7 @@ function mergeScaleConfig(config, options) {
     if (scaleConf._proxy) {
       return console.warn(`Ignoring resolver passed as options for scale: ${id}`);
     }
-    const axis = determineAxis(id, scaleConf, defaults.scales[scaleConf.type]);
+    const axis = determineAxis(id, scaleConf, searchScaleIDs(id, config), defaults.scales[scaleConf.type]);
     const defaultId = getDefaultScaleIDFromAxis(axis, chartIndexAxis);
     const defaultScaleOptions = chartDefaults.scales || {};
     scales[id] = mergeIf(Object.create(null), [{axis}, scaleConf, defaultScaleOptions[axis], defaultScaleOptions[defaultId]]);

--- a/src/core/core.config.js
+++ b/src/core/core.config.js
@@ -38,13 +38,12 @@ function axisFromPosition(position) {
 }
 
 export function determineAxis(id, ...scaleOptions) {
-  let axis = idMatchesAxis(id);
-  if (axis) {
-    return axis;
+  if (idMatchesAxis(id)) {
+    return id;
   }
   for (let i = 0, n = scaleOptions.length; i < n; i++) {
     const opts = scaleOptions[i];
-    axis = opts.axis
+    const axis = opts.axis
       || axisFromPosition(opts.position)
       || id.length > 1 && idMatchesAxis(id[0].toLowerCase());
     if (axis) {

--- a/src/core/core.config.js
+++ b/src/core/core.config.js
@@ -41,8 +41,7 @@ export function determineAxis(id, ...scaleOptions) {
   if (idMatchesAxis(id)) {
     return id;
   }
-  for (let i = 0, n = scaleOptions.length; i < n; i++) {
-    const opts = scaleOptions[i];
+  for (const opts of scaleOptions) {
     const axis = opts.axis
       || axisFromPosition(opts.position)
       || id.length > 1 && idMatchesAxis(id[0].toLowerCase());

--- a/src/core/core.config.js
+++ b/src/core/core.config.js
@@ -22,6 +22,12 @@ function getDefaultScaleIDFromAxis(axis, indexAxis) {
   return axis === indexAxis ? '_index_' : '_value_';
 }
 
+function axisFromId(id) {
+  if (id === 'x' || id === 'y' || id === 'r') {
+    return id;
+  }
+}
+
 function axisFromPosition(position) {
   if (position === 'top' || position === 'bottom') {
     return 'x';
@@ -31,23 +37,15 @@ function axisFromPosition(position) {
   }
 }
 
-function getAxis(id, scaleOptions) {
-  if (id === 'x' || id === 'y' || id === 'r') {
-    return id;
-  }
-
-  id = scaleOptions.axis
-    || axisFromPosition(scaleOptions.position)
-    || id.length > 1 && getAxis(id[0].toLowerCase(), scaleOptions);
-
-  if (id) {
-    return id;
-  }
-}
-
 export function determineAxis(id, ...scaleOptions) {
+  if (axisFromId(id)) {
+    return id;
+  }
   for (let i = 0, n = scaleOptions.length; i < n; i++) {
-    const axis = getAxis(id, scaleOptions[i]);
+    const opts = scaleOptions[i];
+    const axis = opts.axis
+      || axisFromPosition(opts.position)
+      || id.length > 1 && axisFromId(id[0].toLowerCase());
     if (axis) {
       return axis;
     }
@@ -61,7 +59,7 @@ function getAxisFromDataset(id, axis, dataset) {
   }
 }
 
-function retrieveAxisOnDatasets(id, config) {
+function retrieveAxisFromDatasets(id, config) {
   if (config.data && config.data.datasets) {
     const boundDs = config.data.datasets.filter((d) => d.xAxisID === id || d.yAxisID === id);
     if (boundDs.length) {
@@ -86,7 +84,7 @@ function mergeScaleConfig(config, options) {
     if (scaleConf._proxy) {
       return console.warn(`Ignoring resolver passed as options for scale: ${id}`);
     }
-    const axis = determineAxis(id, scaleConf, retrieveAxisOnDatasets(id, config), defaults.scales[scaleConf.type]);
+    const axis = determineAxis(id, scaleConf, retrieveAxisFromDatasets(id, config), defaults.scales[scaleConf.type]);
     const defaultId = getDefaultScaleIDFromAxis(axis, chartIndexAxis);
     const defaultScaleOptions = chartDefaults.scales || {};
     scales[id] = mergeIf(Object.create(null), [{axis}, scaleConf, defaultScaleOptions[axis], defaultScaleOptions[defaultId]]);

--- a/src/core/core.config.js
+++ b/src/core/core.config.js
@@ -22,7 +22,7 @@ function getDefaultScaleIDFromAxis(axis, indexAxis) {
   return axis === indexAxis ? '_index_' : '_value_';
 }
 
-function axisFromId(id) {
+function idMatchesAxis(id) {
   if (id === 'x' || id === 'y' || id === 'r') {
     return id;
   }
@@ -38,14 +38,15 @@ function axisFromPosition(position) {
 }
 
 export function determineAxis(id, ...scaleOptions) {
-  if (axisFromId(id)) {
-    return id;
+  let axis = idMatchesAxis(id);
+  if (axis) {
+    return axis;
   }
   for (let i = 0, n = scaleOptions.length; i < n; i++) {
     const opts = scaleOptions[i];
-    const axis = opts.axis
+    axis = opts.axis
       || axisFromPosition(opts.position)
-      || id.length > 1 && axisFromId(id[0].toLowerCase());
+      || id.length > 1 && idMatchesAxis(id[0].toLowerCase());
     if (axis) {
       return axis;
     }

--- a/src/core/core.config.js
+++ b/src/core/core.config.js
@@ -31,20 +31,28 @@ function axisFromPosition(position) {
   }
 }
 
-export function determineAxis(id, scaleOptions) {
+function getAxis(id, scaleOptions) {
   if (id === 'x' || id === 'y' || id === 'r') {
     return id;
   }
 
   id = scaleOptions.axis
     || axisFromPosition(scaleOptions.position)
-    || id.length > 1 && determineAxis(id[0].toLowerCase(), scaleOptions);
+    || id.length > 1 && getAxis(id[0].toLowerCase(), scaleOptions);
 
   if (id) {
     return id;
   }
+}
 
-  throw new Error(`Cannot determine type of '${name}' axis. Please provide 'axis' or 'position' option.`);
+export function determineAxis(id, ...scaleOptions) {
+  for (let i = 0, n = scaleOptions.length; i < n; i++) {
+    const axis = getAxis(id, scaleOptions[i]);
+    if (axis) {
+      return axis;
+    }
+  }
+  throw new Error(`Cannot determine type of '${id}' axis. Please provide 'axis' or 'position' option.`);
 }
 
 function mergeScaleConfig(config, options) {
@@ -62,7 +70,7 @@ function mergeScaleConfig(config, options) {
     if (scaleConf._proxy) {
       return console.warn(`Ignoring resolver passed as options for scale: ${id}`);
     }
-    const axis = determineAxis(id, scaleConf);
+    const axis = determineAxis(id, scaleConf, defaults.scales[scaleConf.type]);
     const defaultId = getDefaultScaleIDFromAxis(axis, chartIndexAxis);
     const defaultScaleOptions = chartDefaults.scales || {};
     scales[id] = mergeIf(Object.create(null), [{axis}, scaleConf, defaultScaleOptions[axis], defaultScaleOptions[defaultId]]);

--- a/src/core/core.config.js
+++ b/src/core/core.config.js
@@ -55,17 +55,17 @@ export function determineAxis(id, ...scaleOptions) {
   throw new Error(`Cannot determine type of '${id}' axis. Please provide 'axis' or 'position' option.`);
 }
 
-function getScaleFromDataset(id, axis, dataset) {
+function getAxisFromDataset(id, axis, dataset) {
   if (dataset[axis + 'AxisID'] === id) {
     return {axis};
   }
 }
 
-function searchScaleIDs(id, config) {
+function retrieveAxisOnDatasets(id, config) {
   if (config.data && config.data.datasets) {
     const boundDs = config.data.datasets.filter((d) => d.xAxisID === id || d.yAxisID === id);
     if (boundDs.length) {
-      return getScaleFromDataset(id, 'x', boundDs[0]) || getScaleFromDataset(id, 'y', boundDs[0]);
+      return getAxisFromDataset(id, 'x', boundDs[0]) || getAxisFromDataset(id, 'y', boundDs[0]);
     }
   }
   return {};
@@ -86,7 +86,7 @@ function mergeScaleConfig(config, options) {
     if (scaleConf._proxy) {
       return console.warn(`Ignoring resolver passed as options for scale: ${id}`);
     }
-    const axis = determineAxis(id, scaleConf, searchScaleIDs(id, config), defaults.scales[scaleConf.type]);
+    const axis = determineAxis(id, scaleConf, retrieveAxisOnDatasets(id, config), defaults.scales[scaleConf.type]);
     const defaultId = getDefaultScaleIDFromAxis(axis, chartIndexAxis);
     const defaultScaleOptions = chartDefaults.scales || {};
     scales[id] = mergeIf(Object.create(null), [{axis}, scaleConf, defaultScaleOptions[axis], defaultScaleOptions[defaultId]]);

--- a/test/specs/core.scale.tests.js
+++ b/test/specs/core.scale.tests.js
@@ -481,6 +481,35 @@ describe('Core.scale', function() {
       expect(scale._layers().length).toEqual(3);
     });
 
+    it('should create the chart with custom scale ids without axis or position options', function() {
+      function createChart() {
+        return window.acquireChart({
+          type: 'scatter',
+          data: {
+            datasets: [{
+              data: [{x: 0, y: 0}, {x: 1, y: 1}, {x: 2, y: 2}],
+              xAxisID: 'customIDx',
+              yAxisID: 'customIDy'
+            }]
+          },
+          options: {
+            scales: {
+              customIDx: {
+                type: 'linear',
+                display: false
+              },
+              customIDy: {
+                type: 'linear',
+                display: false
+              }
+            }
+          }
+        });
+      }
+
+      expect(createChart).not.toThrow();
+    });
+
     it('should default to one layer for custom scales', function() {
       class CustomScale extends Chart.Scale {
         draw() {}

--- a/test/specs/core.scale.tests.js
+++ b/test/specs/core.scale.tests.js
@@ -514,6 +514,63 @@ describe('Core.scale', function() {
       expect(scale._layers()[0].z).toEqual(20);
     });
 
+    it('should default to one layer for custom scales for axis', function() {
+      class CustomScale1 extends Chart.Scale {
+        draw() {}
+        convertTicksToLabels() {
+          return ['tick'];
+        }
+      }
+      CustomScale1.id = 'customScale1';
+      CustomScale1.defaults = {axis: 'x'};
+      Chart.register(CustomScale1);
+
+      var chart = window.acquireChart({
+        type: 'line',
+        options: {
+          scales: {
+            my: {
+              type: 'customScale1',
+              grid: {
+                z: 10
+              },
+              ticks: {
+                z: 20
+              }
+            }
+          }
+        }
+      });
+
+      var scale = chart.scales.my;
+      expect(scale._layers().length).toEqual(1);
+      expect(scale._layers()[0].z).toEqual(20);
+    });
+
+    it('should fail for custom scales without any axis or position', function() {
+      class CustomScale2 extends Chart.Scale {
+        draw() {}
+      }
+      CustomScale2.id = 'customScale2';
+      CustomScale2.defaults = {};
+      Chart.register(CustomScale2);
+
+      function createChart() {
+        return window.acquireChart({
+          type: 'line',
+          options: {
+            scales: {
+              my: {
+                type: 'customScale2'
+              }
+            }
+          }
+        });
+      }
+
+      expect(createChart).toThrow(new Error('Cannot determine type of \'my\' axis. Please provide \'axis\' or \'position\' option.'));
+    });
+
     it('should return 3 layers when z is not equal between ticks and grid', function() {
       var chart = window.acquireChart({
         type: 'line',


### PR DESCRIPTION
Fix  #10945
This PR is solving the axis option determination if included in the custom scale defaults.
This is also addressing scales configurations (out of the box ones) where the axis is not recognizable by scale ID or axis/position options are missing. It uses datasets x/yAxisID options to determine the axis.
