### PR TITLE
Simplify _arrayUnique

### DIFF
--- a/src/helpers/helpers.collection.ts
+++ b/src/helpers/helpers.collection.ts
@@ -182,14 +182,9 @@ export function unlistenArrayEvents(array, listener) {
  * @param items
  */
 export function _arrayUnique<T>(items: T[]) {
-  const set = new Set<T>();
-  let i: number, ilen: number;
+  const set = new Set<T>(items);
 
-  for (i = 0, ilen = items.length; i < ilen; ++i) {
-    set.add(items[i]);
-  }
-
-  if (set.size === ilen) {
+  if (set.size === items.length) {
     return items;
   }
 


### PR DESCRIPTION
I just simplified creating unique array. `Set` supports initial array in constructor. So we don't need use special iteration.
I think this solution was made to support Internet Explorer(which not support initial array).

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
