### PR TITLE
Specify node version for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
+          node-version: 16
           cache: pnpm
       - uses: dorny/paths-filter@v2
         id: changes

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
+          node-version: 16
           cache: pnpm
       - name: Package & Deploy Docs
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           registry-url: https://registry.npmjs.org/
+          node-version: 16
           cache: pnpm
       - name: Setup and build
         run: |
@@ -75,6 +76,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           registry-url: https://registry.npmjs.org/
+          node-version: 16
           cache: pnpm
       - name: Setup and build
         run: |

--- a/docs/charts/scatter.md
+++ b/docs/charts/scatter.md
@@ -1,6 +1,6 @@
 # Scatter Chart
 
-Scatter charts are based on basic line charts with the x axis changed to a linear axis. To use a scatter chart, data must be passed as objects containing X and Y properties. The example below creates a scatter chart with 4 points. RUN PACKAGE CI
+Scatter charts are based on basic line charts with the x axis changed to a linear axis. To use a scatter chart, data must be passed as objects containing X and Y properties. The example below creates a scatter chart with 4 points.
 
 ```js chart-editor
 // <block:setup:1>

--- a/docs/charts/scatter.md
+++ b/docs/charts/scatter.md
@@ -1,6 +1,6 @@
 # Scatter Chart
 
-Scatter charts are based on basic line charts with the x axis changed to a linear axis. To use a scatter chart, data must be passed as objects containing X and Y properties. The example below creates a scatter chart with 4 points.
+Scatter charts are based on basic line charts with the x axis changed to a linear axis. To use a scatter chart, data must be passed as objects containing X and Y properties. The example below creates a scatter chart with 4 points. RUN PACKAGE CI
 
 ```js chart-editor
 // <block:setup:1>


### PR DESCRIPTION
Should fix failing CI (ubuntu package step)

From what I read on the internet this is broken on node 17+ because there was a security issue so need to dive deeper into this to see if we can fix this in a good way, but for now the CI runs again so we can merge pr's

![image](https://user-images.githubusercontent.com/39033624/220774330-00d0e3d0-66a0-4efd-a1ed-e61f67bb1927.png)

https://github.com/chartjs/Chart.js/actions/runs/4247487816/jobs/7385590182

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
