### PR TITLE
Disable canvas acceleration in Firefox 110 in test cases

### DIFF
--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -86,7 +86,8 @@ module.exports = async function(karma) {
       firefox: {
         base: 'Firefox',
         prefs: {
-          'layers.acceleration.disabled': true
+          'layers.acceleration.disabled': true,
+          'gfx.canvas.accelerated': true
         }
       },
       safari: {

--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -73,6 +73,7 @@ module.exports = async function(karma) {
     // Explicitly disable hardware acceleration to make image
     // diff more stable when ran on Travis and dev machine.
     // https://github.com/chartjs/Chart.js/pull/5629
+    // Since FF 110 https://github.com/chartjs/Chart.js/issues/11164
     customLaunchers: {
       chrome: {
         base: 'Chrome',
@@ -87,7 +88,7 @@ module.exports = async function(karma) {
         base: 'Firefox',
         prefs: {
           'layers.acceleration.disabled': true,
-          'gfx.canvas.accelerated': true
+          'gfx.canvas.accelerated': false
         }
       },
       safari: {

--- a/test/fixtures/controller.bar/aligned-pixels.js
+++ b/test/fixtures/controller.bar/aligned-pixels.js
@@ -11,7 +11,7 @@ module.exports = {
     },
     options: {
       indexAxis: 'y',
-      events: ['none'],
+      events: [],
       backgroundColor: 'navy',
       devicePixelRatio: 1.25,
       scales: {

--- a/test/fixtures/controller.bar/aligned-pixels.js
+++ b/test/fixtures/controller.bar/aligned-pixels.js
@@ -11,7 +11,7 @@ module.exports = {
     },
     options: {
       indexAxis: 'y',
-      events: [],
+      events: ['none'],
       backgroundColor: 'navy',
       devicePixelRatio: 1.25,
       scales: {


### PR DESCRIPTION
Fix #11164

First commit must fail because the acceleration option is set to true