### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/general/colors.md
+++ b/docs/general/colors.md
@@ -26,7 +26,7 @@ Chart.defaults.color = '#000';
 
 ### Per-dataset color settings
 
-If your chart has multiple datasets, using default colors would make individual datasets indistiguishable. In that case, you can set `backgroundColor` and `borderColor` for each dataset:
+If your chart has multiple datasets, using default colors would make individual datasets indistinguishable. In that case, you can set `backgroundColor` and `borderColor` for each dataset:
 
 ```javascript
 const data = {

--- a/src/controllers/controller.doughnut.js
+++ b/src/controllers/controller.doughnut.js
@@ -65,7 +65,7 @@ export default class DoughnutController extends DatasetController {
     // The total circumference of the chart.
     circumference: 360,
 
-    // The outr radius of the chart
+    // The outer radius of the chart
     radius: '100%',
 
     // Spacing between arcs

--- a/src/controllers/controller.pie.js
+++ b/src/controllers/controller.pie.js
@@ -18,7 +18,7 @@ export default class PieController extends DoughnutController {
     // The total circumference of the chart.
     circumference: 360,
 
-    // The outr radius of the chart
+    // The outer radius of the chart
     radius: '100%'
   };
 }

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -611,7 +611,7 @@ export default class TimeScale extends Scale {
     const timeOpts = this.options.time;
     const displayFormats = timeOpts.displayFormats;
 
-    // pick the longest format (milliseconds) for guestimation
+    // pick the longest format (milliseconds) for guesstimation
     const format = displayFormats[timeOpts.unit] || displayFormats.millisecond;
     const exampleLabel = this._tickFormatFunction(exampleTime, 0, ticksFromTimestamps(this, [exampleTime], this._majorUnit), format);
     const size = this._getLabelSize(exampleLabel);


### PR DESCRIPTION
There are small typos in:
- docs/general/colors.md
- src/controllers/controller.doughnut.js
- src/controllers/controller.pie.js
- src/scales/scale.time.js

Fixes:
- Should read `outer` rather than `outr`.
- Should read `indistinguishable` rather than `indistiguishable`.
- Should read `guesstimation` rather than `guestimation`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md