### PR TITLE
Add version specific urls to release template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -44,10 +44,10 @@ template: |
   # Essential Links
 
   * [npm](https://www.npmjs.com/package/chart.js)
-  * [Migration guide](https://www.chartjs.org/docs/latest/migration/v4-migration.html)
-  * [Docs](https://www.chartjs.org/docs/latest/)
-  * [API](https://www.chartjs.org/docs/latest/api/)
-  * [Samples](https://www.chartjs.org/docs/latest/samples/)
+  * [Migration guide](https://www.chartjs.org/docs/$RESOLVED_VERSION/migration/v4-migration.html)
+  * [Docs](https://www.chartjs.org/docs/$RESOLVED_VERSION/)
+  * [API](https://www.chartjs.org/docs/$RESOLVED_VERSION/api/)
+  * [Samples](https://www.chartjs.org/docs/$RESOLVED_VERSION/samples/)
 
   $CHANGES
 


### PR DESCRIPTION
Did not know of a way of testing this, but according to the docs this should work 🤞🏻 

https://github.com/release-drafter/release-drafter#example

https://github.com/chartjs/Chart.js/issues/11035#issuecomment-1374368697