### PR TITLE
Fix documentation about how to manage own custom plugin for types

### DIFF
--- a/docs/developers/plugins.md
+++ b/docs/developers/plugins.md
@@ -194,7 +194,7 @@ For example, to provide typings for the [`canvas backgroundColor plugin`](../con
 import {ChartType, Plugin} from 'chart.js';
 
 declare module 'chart.js' {
-  interface PluginOptionsByType<TType extends ChartType> {
+  interface PluginOptionsByType<TType extends ChartType = ChartType> {
     customCanvasBackgroundColor?: {
       color?: string
     }


### PR DESCRIPTION
Fix types from plugins.

`Error: node_modules/chartjs-plugin-annotation/types/index.d.ts:6:13 - error TS2428: All declarations of 'PluginOptionsByType' must have identical type parameters.6   interface PluginOptionsByType<TType extends ChartType> {`