### PR TITLE
Correct tooltip dates displaying incorrectly reported in #11229

### DIFF
--- a/docs/samples/scales/time-combo.md
+++ b/docs/samples/scales/time-combo.md
@@ -66,9 +66,12 @@ const config = {
         type: 'time',
         display: true,
         offset: true,
+        ticks: {
+          source: 'data'
+        },
         time: {
           unit: 'day'
-        }
+        },
       },
     },
   },


### PR DESCRIPTION
Fixes issue #11229 by introducing a tick source to the chart configuration. This resolves the problem of incorrect tooltip date display and ensures that bar graphs are accurately positioned within their respective ticks. Images of before/after the change:

![image](https://github.com/chartjs/Chart.js/assets/55890311/48094917-5f55-4869-b31e-c093a463a213)
![image](https://github.com/chartjs/Chart.js/assets/55890311/b5e5f6ad-08b0-477f-a775-cf76d3c9278b)
