### PR TITLE
Export explicitly the plugin options definition which is augmented by plugins implementation

### DIFF
--- a/docs/developers/plugins.md
+++ b/docs/developers/plugins.md
@@ -194,7 +194,7 @@ For example, to provide typings for the [`canvas backgroundColor plugin`](../con
 import {ChartType, Plugin} from 'chart.js';
 
 declare module 'chart.js' {
-  interface PluginOptionsByType<TType extends ChartType = ChartType> {
+  interface PluginOptionsByType<TType extends ChartType> {
     customCanvasBackgroundColor?: {
       color?: string
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,10 @@ export {
   RadialLinearScale,
   TimeScale,
   TimeSeriesScale,
+  PluginOptionsByType,
+  ElementOptionsByType,
+  ChartDatasetProperties,
+  UpdateModeEnum,
   registerables
 } from './types/index.js';
 export * from './types/index.js';


### PR DESCRIPTION
Fix #11288

The following table is showing the augmented definitions, performed by plugins in **`chartjs`** org (in addition to `PluginOptionsByType`) which are fixed by this PR:
 

| Plugin | Augmented Definitions
|:-|:-
| annotation | ElementOptionsByType
| datalabels | ChartDatasetProperties
| deferred | -
| zoom | UpdateModeEnum

This PR is also reverting PR #11244