### PR TITLE
[docs] HTML Legend sample: add flex-shrink: 0 to color box

### DIFF
--- a/docs/samples/legend/html.md
+++ b/docs/samples/legend/html.md
@@ -61,6 +61,7 @@ const htmlLegendPlugin = {
       boxSpan.style.borderColor = item.strokeStyle;
       boxSpan.style.borderWidth = item.lineWidth + 'px';
       boxSpan.style.display = 'inline-block';
+      boxSpan.style.flexShrink = 0;
       boxSpan.style.height = '20px';
       boxSpan.style.marginRight = '10px';
       boxSpan.style.width = '20px';


### PR DESCRIPTION
This way the color box is prevented from shrinking in case of larger legends.

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
