### PR TITLE
fix: Add backgroundColor type on CoreScaleOptions

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -3151,6 +3151,11 @@ export interface CartesianScaleOptions extends CoreScaleOptions {
   bounds: 'ticks' | 'data';
 
   /**
+   * Background color of the scale area.
+   */
+  backgroundColor: Color;
+
+  /**
    * Position of the axis.
    */
   position: 'left' | 'top' | 'right' | 'bottom' | 'center' | { [scale: string]: number };

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1167,6 +1167,10 @@ export interface CoreScaleOptions {
    */
   alignToPixels: boolean;
   /**
+   * Background color of the scale area.
+   */
+  backgroundColor: Color;
+  /**
    * Reverse the scale.
    * @default false
    */
@@ -3149,11 +3153,6 @@ export interface CartesianScaleOptions extends CoreScaleOptions {
    * @default 'ticks'
    */
   bounds: 'ticks' | 'data';
-
-  /**
-   * Background color of the scale area.
-   */
-  backgroundColor: Color;
 
   /**
    * Position of the axis.

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -3447,8 +3447,6 @@ export type RadialTickOptions = TickOptions & {
 }
 
 export type RadialLinearScaleOptions = CoreScaleOptions & {
-  backgroundColor: Color;
-
   animate: boolean;
 
   startAngle: number;


### PR DESCRIPTION
Very similar to issue https://github.com/chartjs/Chart.js/issues/11082 with same fix, ~~but in `CartesianScaleOptions`~~ added to `CoreScaleOptions` so this isn't duplicated in various extensions of the `CoreScaleOptions`

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
