### PR TITLE
Fix type of tickBorderDash in GridLineOptions

### DIFF
--- a/docs/axes/styling.md
+++ b/docs/axes/styling.md
@@ -15,7 +15,7 @@ Namespace: `options.scales[scaleId].grid`, it defines options for the grid lines
 | `drawTicks` | `boolean` | | | `true` | If true, draw lines beside the ticks in the axis area beside the chart.
 | `lineWidth` | `number` | Yes | Yes | `1` | Stroke width of grid lines.
 | `offset` | `boolean` | | | `false` | If true, grid lines will be shifted to be between labels. This is set to `true` for a bar chart by default.
-| `tickBorderDash` | `number[]` | | | | Length and spacing of the tick mark line. If not set, defaults to the grid line `borderDash` value.
+| `tickBorderDash` | `number[]` | Yes | Yes | `[]` | Length and spacing of the tick mark line. If not set, defaults to the grid line `borderDash` value.
 | `tickBorderDashOffset` | `number` | Yes | Yes |  | Offset for the line dash of the tick mark. If unset, defaults to the grid line `borderDashOffset` value
 | `tickColor` | [`Color`](../general/colors.md) | Yes | Yes | | Color of the tick line. If unset, defaults to the grid line color.
 | `tickLength` | `number` | | | `8` | Length in pixels that the grid lines will draw into the axis area.

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -2971,7 +2971,7 @@ export interface GridLineOptions {
   /**
    * @default []
    */
-  tickBorderDash: number[];
+  tickBorderDash: Scriptable<number[], ScriptableScaleContext>;
   /**
    * @default 0
    */


### PR DESCRIPTION
<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
Closes #11394 