### PR TITLE
Add  missing feature for disabling plugins in TyeScript

### DIFF
--- a/docs/developers/plugins.md
+++ b/docs/developers/plugins.md
@@ -194,13 +194,6 @@ For example, to provide typings for the [`canvas backgroundColor plugin`](../con
 import {ChartType, Plugin} from 'chart.js';
 
 declare module 'chart.js' {
-  // For defaults options
-  interface DefaultsPluginOptionsByType<TType extends ChartType> {
-    customCanvasBackgroundColor?: {
-      color?: string
-    }
-  }
-  // for chart options
   interface PluginOptionsByType<TType extends ChartType> {
     customCanvasBackgroundColor?: {
       color?: string

--- a/docs/developers/plugins.md
+++ b/docs/developers/plugins.md
@@ -194,10 +194,17 @@ For example, to provide typings for the [`canvas backgroundColor plugin`](../con
 import {ChartType, Plugin} from 'chart.js';
 
 declare module 'chart.js' {
-  interface PluginOptionsByType<TType extends ChartType> {
+  // For defaults options
+  interface DefaultsPluginOptionsByType<TType extends ChartType> {
     customCanvasBackgroundColor?: {
       color?: string
     }
+  }
+  // for chart options
+  interface PluginOptionsByType<TType extends ChartType> {
+    customCanvasBackgroundColor?: {
+      color?: string
+    } | false
   }
 }
 ```

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -663,7 +663,7 @@ export interface DatasetControllerChartComponent extends ChartComponent {
   };
 }
 
-export interface Defaults extends CoreChartOptions<ChartType>, ElementChartOptions<ChartType>, DefaultsPluginChartOptions<ChartType> {
+export interface Defaults extends CoreChartOptions<ChartType>, ElementChartOptions<ChartType>, PluginChartOptions<ChartType> {
 
   scale: ScaleOptionsByType;
   scales: {
@@ -701,7 +701,7 @@ export type Overrides = {
   [key in ChartType]:
   CoreChartOptions<key> &
   ElementChartOptions<key> &
-  DefaultsPluginChartOptions<key> &
+  PluginChartOptions<key> &
   DatasetChartOptions<ChartType> &
   ScaleChartOptions<key> &
   ChartTypeRegistry[key]['chartOptions'];
@@ -2912,16 +2912,6 @@ export interface TooltipItem<TType extends ChartType> {
   element: Element;
 }
 
-export interface DefaultsPluginOptionsByType<TType extends ChartType> {
-  colors: ColorsPluginOptions;
-  decimation: DecimationOptions;
-  filler: FillerOptions;
-  legend: LegendOptions<TType>;
-  subtitle: TitleOptions;
-  title: TitleOptions;
-  tooltip: TooltipOptions<TType>;
-}
-
 export interface PluginOptionsByType<TType extends ChartType> {
   colors: ColorsPluginOptions | false;
   decimation: DecimationOptions | false;
@@ -2932,12 +2922,8 @@ export interface PluginOptionsByType<TType extends ChartType> {
   tooltip: TooltipOptions<TType> | false;
 }
 
-export interface DefaultsPluginChartOptions<TType extends ChartType> {
-  plugins: DefaultsPluginOptionsByType<TType>;
-}
-
 export interface PluginChartOptions<TType extends ChartType> {
-  plugins: PluginOptionsByType<TType> | false;
+  plugins: PluginOptionsByType<TType>;
 }
 
 export interface BorderOptions {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -663,7 +663,7 @@ export interface DatasetControllerChartComponent extends ChartComponent {
   };
 }
 
-export interface Defaults extends CoreChartOptions<ChartType>, ElementChartOptions<ChartType>, PluginChartOptions<ChartType> {
+export interface Defaults extends CoreChartOptions<ChartType>, ElementChartOptions<ChartType>, DefaultsPluginChartOptions<ChartType> {
 
   scale: ScaleOptionsByType;
   scales: {
@@ -701,7 +701,7 @@ export type Overrides = {
   [key in ChartType]:
   CoreChartOptions<key> &
   ElementChartOptions<key> &
-  PluginChartOptions<key> &
+  DefaultsPluginChartOptions<key> &
   DatasetChartOptions<ChartType> &
   ScaleChartOptions<key> &
   ChartTypeRegistry[key]['chartOptions'];
@@ -2912,7 +2912,7 @@ export interface TooltipItem<TType extends ChartType> {
   element: Element;
 }
 
-export interface PluginOptionsByType<TType extends ChartType> {
+export interface DefaultsPluginOptionsByType<TType extends ChartType> {
   colors: ColorsPluginOptions;
   decimation: DecimationOptions;
   filler: FillerOptions;
@@ -2921,8 +2921,23 @@ export interface PluginOptionsByType<TType extends ChartType> {
   title: TitleOptions;
   tooltip: TooltipOptions<TType>;
 }
+
+export interface PluginOptionsByType<TType extends ChartType> {
+  colors: ColorsPluginOptions | false;
+  decimation: DecimationOptions | false;
+  filler: FillerOptions | false;
+  legend: LegendOptions<TType> | false;
+  subtitle: TitleOptions | false;
+  title: TitleOptions | false;
+  tooltip: TooltipOptions<TType> | false;
+}
+
+export interface DefaultsPluginChartOptions<TType extends ChartType> {
+  plugins: DefaultsPluginOptionsByType<TType>;
+}
+
 export interface PluginChartOptions<TType extends ChartType> {
-  plugins: PluginOptionsByType<TType>;
+  plugins: PluginOptionsByType<TType> | false;
 }
 
 export interface BorderOptions {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -2921,7 +2921,6 @@ export interface PluginOptionsByType<TType extends ChartType> {
   title: TitleOptions | false;
   tooltip: TooltipOptions<TType> | false;
 }
-
 export interface PluginChartOptions<TType extends ChartType> {
   plugins: PluginOptionsByType<TType>;
 }

--- a/test/types/defaults.ts
+++ b/test/types/defaults.ts
@@ -1,8 +1,8 @@
-import { Chart } from '../../src/types.js';
+import { Chart, TitleOptions, TooltipOptions } from '../../src/types.js';
 
 Chart.defaults.scales.time.time.minUnit = 'day';
 
-Chart.defaults.plugins.title.display = false;
+(Chart.defaults.plugins.title as TitleOptions).display = false;
 
 Chart.defaults.datasets.bar.backgroundColor = 'red';
 
@@ -27,4 +27,4 @@ Chart.defaults.layout = {
   },
 };
 
-Chart.defaults.plugins.tooltip.boxPadding = 3;
+(Chart.defaults.plugins.tooltip as TooltipOptions).boxPadding = 3;

--- a/test/types/overrides.ts
+++ b/test/types/overrides.ts
@@ -1,8 +1,8 @@
-import { Chart } from '../../src/types.js';
+import { Chart, TitleOptions } from '../../src/types.js';
 
 Chart.overrides.bar.scales.x.type = 'time';
 
-Chart.overrides.bar.plugins.title.display = false;
+(Chart.overrides.bar.plugins.title as TitleOptions).display = false;
 
 Chart.overrides.line.datasets.bar.backgroundColor = 'red';
 

--- a/test/types/plugins/defaults.ts
+++ b/test/types/plugins/defaults.ts
@@ -1,8 +1,9 @@
-import { defaults } from '../../../src/types.js';
+import { defaults, LegendOptions } from '../../../src/types.js';
 
 // https://github.com/chartjs/Chart.js/issues/8711
-const original = defaults.plugins.legend.labels.generateLabels;
+const original = (defaults.plugins.legend as LegendOptions<"line">).labels.generateLabels;
 
+// @ts-ignore
 defaults.plugins.legend.labels.generateLabels = function(chart) {
   return [{
     datasetIndex: 0,

--- a/test/types/plugins/disable.ts
+++ b/test/types/plugins/disable.ts
@@ -1,0 +1,29 @@
+import { Chart } from '../../../src/types.js';
+
+const chart = new Chart('id', {
+  type: 'bubble',
+  data: {
+    labels: [],
+    datasets: [{
+      data: []
+    }]
+  },
+  options: {
+    plugins: false
+  }
+});
+
+const chart1 = new Chart('id', {
+  type: 'bubble',
+  data: {
+    labels: [],
+    datasets: [{
+      data: []
+    }]
+  },
+  options: {
+    plugins: {
+      legend: false
+    }
+  }
+});

--- a/test/types/plugins/disable.ts
+++ b/test/types/plugins/disable.ts
@@ -9,19 +9,6 @@ const chart = new Chart('id', {
     }]
   },
   options: {
-    plugins: false
-  }
-});
-
-const chart1 = new Chart('id', {
-  type: 'bubble',
-  data: {
-    labels: [],
-    datasets: [{
-      data: []
-    }]
-  },
-  options: {
     plugins: {
       legend: false
     }

--- a/test/types/plugins/plugin.tooltip/tooltip_parsed_data_chart_defaults.ts
+++ b/test/types/plugins/plugin.tooltip/tooltip_parsed_data_chart_defaults.ts
@@ -1,6 +1,6 @@
-import { Chart } from '../../../../src/types.js';
+import { Chart, TooltipOptions } from '../../../../src/types.js';
 
-Chart.overrides.bubble.plugins.tooltip.callbacks.label = (item) => {
+(Chart.overrides.bubble.plugins.tooltip as TooltipOptions<'bubble'>).callbacks.label = (item) => {
   const { x, y, _custom: r } = item.parsed;
   return `${item.label}: (${x}, ${y}, ${r})`;
 };


### PR DESCRIPTION
Fix #11398

@etimberg @LeeLenaleee @kurkle first of all and as you know, my experience on TS is limited. Therefore not sure if the issue can be solved differently.
Furthermore there are 2 thoughts:

1. It sounds to me this is a breaking change because the casting could be needed to access to chart plugins options (maybe I'm wrong)
2. All plugins, which are using the defaults (for instance zoom, annotation, datalabels), should augment also the `DefaultsPluginOptionsByType`, see changes on the doc.