### PR TITLE
Updates to scale type definitions

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -56,7 +56,7 @@ function parse(scale, input) {
     value = parser(value);
   }
 
-  // Only parse if its not a timestamp already
+  // Only parse if it's not a timestamp already
   if (!isFinite(value)) {
     value = typeof parser === 'string'
       ? adapter.parse(value, /** @type {Unit} */ (parser))

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1177,6 +1177,22 @@ export interface CoreScaleOptions {
    */
   weight: number;
   /**
+   * User defined minimum value for the scale, overrides minimum value from data.
+   */
+  min: unknown;
+  /**
+   * User defined maximum value for the scale, overrides maximum value from data.
+   */
+  max: unknown;
+  /**
+   * Adjustment used when calculating the maximum data value.
+   */
+  suggestedMin: unknown;
+  /**
+   * Adjustment used when calculating the minimum data value.
+   */
+  suggestedMax: unknown;
+  /**
    * Callback called before the update process starts.
    */
   beforeUpdate(axis: Scale): void;
@@ -1316,7 +1332,7 @@ export interface Scale<O extends CoreScaleOptions = CoreScaleOptions> extends El
   getBasePixel(): number;
 
   init(options: O): void;
-  parse(raw: unknown, index: number): unknown;
+  parse(raw: unknown, index?: number): unknown;
   getUserBounds(): { min: number; max: number; minDefined: boolean; maxDefined: boolean };
   getMinMax(canStack: boolean): { min: number; max: number };
   getTicks(): Tick[];


### PR DESCRIPTION
While adding some type definitions to chartjs-plugin-zoom (see https://github.com/chartjs/chartjs-plugin-zoom/pull/774), I noticed a few limitations in Chart.js's scale types:

* The zoom plugin calls `Scale.parse` with no index parameter.  Scale's JSDoc allows this, but its TypeScript definitions did not.
* The zoom plugin alters scale options' min and max.  The specific types of these depend on which scale is in use, but every scale has them, so `unknown` seems appropriate

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
