### PR TITLE
BorderRadius of Bar Chart issue on Firefox 116

### DIFF
--- a/src/helpers/helpers.canvas.ts
+++ b/src/helpers/helpers.canvas.ts
@@ -498,7 +498,7 @@ export function addRoundedRectPath(
   const {x, y, w, h, radius} = rect;
 
   // top left arc
-  ctx.arc(x + radius.topLeft, y + radius.topLeft, radius.topLeft, -HALF_PI, PI, true);
+  ctx.arc(x + radius.topLeft, y + radius.topLeft, radius.topLeft, 1.5 * PI, PI, true);
 
   // line from top left to bottom left
   ctx.lineTo(x, y + h - radius.bottomLeft);


### PR DESCRIPTION
This is a fix to solve issue [11430](https://github.com/chartjs/Chart.js/issues/11430)
![image](https://github.com/chartjs/Chart.js/assets/49434029/dfc8815f-eff3-43af-abd1-f3cf1a8c7ca9)
![image](https://github.com/chartjs/Chart.js/assets/49434029/3a9ebf34-86df-42f6-aae5-2332c5544d02)
