### PR TITLE
Name artifact chart.umd.js, fixes #11455

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -45,7 +45,7 @@ body:
         For typescript issues you can make use of [this TS Playground](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAbzgYQBYENZwL5wGZQQhwDkAxhrAHQBWAziQNwCwAUGwG6ZxkwAecALxwAJhDIBXEAFMAdjCoBzaTACiAG2kz5AIQCeASREAKAEQg9aTDFMBKOOjpwAEgBUAsgBlk6WVzoaWnIwLKxcUHAWVljCstIA7iiUMMa8fAA0iGxwOXAwemDSAFyk6sBxJOnZuSLoMOglCNW5ueroAEbS6nQlANqmAErSIqaZpjrqEtKjcKYAml3qEPEzpgDiUNJyqwAKElBgmqsA8lC+yqYAulWsLS219XQqPXC9Tbd3n22d6iUkAMRwCB4OAANQgMGkDBun0+DwarwAjAAmTKIgCcmQAzJkAKyZVFwLHXZp3bCXUnYGG5CBgGDACCyF7vT50MjoTTM0ktPiNbl3fk5KmCuB6PkfWFwEXYfkyiU4NjYWyMIA) to make a reproducible sample.
 
         If filing a bug against `master`, you may reference the latest code via
-        https://www.chartjs.org/dist/master/chart.umd.js (changing the filename to
+        https://www.chartjs.org/dist/master/chart.umd.min.js (changing the filename to
         point at the file you need as appropriate). Do not rely on these files for
         production purposes as they may be removed at any time.
     validations:

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -74,6 +74,6 @@ Guidelines for reporting bugs:
 
 - Check the issue search to see if it has already been reported
 - Isolate the problem to a simple test case
-- Please include a demonstration of the bug on a website such as [JS Bin](https://jsbin.com/), [JS Fiddle](https://jsfiddle.net/), or [Codepen](https://codepen.io/pen/). ([Template](https://codepen.io/pen?template=wvezeOq)). If filing a bug against `master`, you may reference the latest code via <https://www.chartjs.org/dist/master/chart.umd.js> (changing the filename to point at the file you need as appropriate). Do not rely on these files for production purposes as they may be removed at any time.
+- Please include a demonstration of the bug on a website such as [JS Bin](https://jsbin.com/), [JS Fiddle](https://jsfiddle.net/), or [Codepen](https://codepen.io/pen/). ([Template](https://codepen.io/pen?template=wvezeOq)). If filing a bug against `master`, you may reference the latest code via <https://www.chartjs.org/dist/master/chart.umd.min.js> (changing the filename to point at the file you need as appropriate). Do not rely on these files for production purposes as they may be removed at any time.
 
 Please provide any additional details associated with the bug, if it's browser or screen density specific, or only happens with a certain configuration or data.

--- a/docs/getting-started/integration.md
+++ b/docs/getting-started/integration.md
@@ -7,7 +7,7 @@ If you're using a front-end framework (e.g., React, Angular, or Vue), please see
 ## Script Tag
 
 ```html
-<script src="path/to/chartjs/dist/chart.umd.js"></script>
+<script src="path/to/chartjs/dist/chart.umd.min.js"></script>
 <script>
     const myChart = new Chart(ctx, {...});
 </script>
@@ -122,10 +122,10 @@ const { Chart } = await import('chart.js');
 
 ## RequireJS
 
-**Important:** RequireJS can load only [AMD modules](https://requirejs.org/docs/whyamd.html), so be sure to require one of the UMD builds instead (i.e. `dist/chart.umd.js`).
+**Important:** RequireJS can load only [AMD modules](https://requirejs.org/docs/whyamd.html), so be sure to require one of the UMD builds instead (i.e. `dist/chart.umd.min.js`).
 
 ```javascript
-require(['path/to/chartjs/dist/chart.umd.js'], function(Chart){
+require(['path/to/chartjs/dist/chart.umd.min.js'], function(Chart){
     const myChart = new Chart(ctx, {...});
 });
 ```

--- a/docs/migration/v4-migration.md
+++ b/docs/migration/v4-migration.md
@@ -30,7 +30,7 @@ A number of changes were made to the configuration options passed to the `Chart`
 * Time and timeseries scales use `ticks.stepSize` instead of `time.stepSize`, which has been removed.
 * `maxTickslimit` wont be used for the ticks in `autoSkip` if the determined max ticks is less then the `maxTicksLimit`.
 * `dist/chart.js` has been removed.
-* `dist/chart.min.js` has been renamed to `dist/chart.umd.js`.
+* `dist/chart.min.js` has been renamed to `dist/chart.umd.min.js`.
 * `dist/chart.esm.js` has been renamed to `dist/chart.js`.
 
 #### Type changes

--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
     "sideEffects": [
         "./auto/auto.js",
         "./auto/auto.cjs",
+        "./dist/chart.umd.min.js",
         "./dist/chart.umd.js"
     ],
-    "jsdelivr": "./dist/chart.umd.js",
-    "unpkg": "./dist/chart.umd.js",
+    "jsdelivr": "./dist/chart.umd.min.js",
+    "unpkg": "./dist/chart.umd.min.js",
     "main": "./dist/chart.cjs",
     "module": "./dist/chart.js",
     "exports": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -45,7 +45,21 @@ const plugins = (minify) =>
 
 export default [
   // UMD build
-  // dist/chart.umd.js
+  // dist/chart.umd.min.js
+  {
+    input: 'src/index.umd.ts',
+    plugins: plugins(true),
+    output: {
+      name: 'Chart',
+      file: 'dist/chart.umd.min.js',
+      format: 'umd',
+      indent: false,
+      sourcemap: true,
+    },
+  },
+
+  // UMD build
+  // dist/chart.umd.js (old filename)
   {
     input: 'src/index.umd.ts',
     plugins: plugins(true),

--- a/test/BasicChartWebWorker.js
+++ b/test/BasicChartWebWorker.js
@@ -6,7 +6,7 @@
 // Sends messages with data of types: { type: 'success' } | { type: 'error', errorMessage: string }
 
 // eslint-disable-next-line no-undef
-importScripts('../src/chart.umd.js');
+importScripts('../src/chart.umd.min.js');
 
 onmessage = function(event) {
   try {


### PR DESCRIPTION
This names our already minified UMD dist file to the format that jsDelivr specifies for this type of file.