### PR TITLE
Add min extension to umd build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
     "sideEffects": [
         "./auto/auto.js",
         "./auto/auto.cjs",
-        "./dist/chart.umd.js"
+        "./dist/chart.umd.js",
+        "./dist/chart.umd.min.js"
     ],
-    "jsdelivr": "./dist/chart.umd.js",
-    "unpkg": "./dist/chart.umd.js",
+    "jsdelivr": "./dist/chart.umd.min.js",
+    "unpkg": "./dist/chart.umd.min.js",
     "main": "./dist/chart.cjs",
     "module": "./dist/chart.js",
     "exports": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -58,6 +58,20 @@ export default [
     },
   },
 
+  // UMD build with min.js extension for sri with jsdeliver (https://github.com/chartjs/Chart.js/issues/11455)
+  // dist/chart.umd.js
+  {
+    input: 'src/index.umd.ts',
+    plugins: plugins(true),
+    output: {
+      name: 'Chart',
+      file: 'dist/chart.umd.min.js',
+      format: 'umd',
+      indent: false,
+      sourcemap: true,
+    },
+  },
+
   // ES6 builds
   // dist/chart.js
   // helpers/*.js


### PR DESCRIPTION
Resolves: https://github.com/chartjs/Chart.js/issues/11455

I think this is not breaking since we still push the `chart.umd.js` file to both CDN's so current builds should not break on this