### PR TITLE
docs: Fix typo for documentation of plugins.tooltip.textDirection

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -2477,7 +2477,7 @@ export interface LegendOptions<TType extends ChartType> {
   rtl: boolean;
   /**
    * This will force the text direction 'rtl' or 'ltr' on the canvas for rendering the legend, regardless of the css specified on the canvas
-   * @default canvas' default
+   * @default canvas's default
    */
   textDirection: string;
 


### PR DESCRIPTION
This is small typo in `src/types/index.d.ts`.
I Just add "s" after `canvas'` at L2480 which explains about plugins.tooltip.textDirection.

Related Issue is https://github.com/chartjs/Chart.js/issues/11453

Thanks