### PR TITLE
revert node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 16
           cache: pnpm
       - uses: dorny/paths-filter@v2
         id: changes

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 16
           cache: pnpm
       - name: Package & Deploy Docs
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           registry-url: https://registry.npmjs.org/
-          node-version: 20
+          node-version: 16
           cache: pnpm
       - name: Setup and build
         run: |
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           registry-url: https://registry.npmjs.org/
-          node-version: 20
+          node-version: 16
           cache: pnpm
       - name: Setup and build
         run: |


### PR DESCRIPTION
Don't have the time right now to fix this, so revert the node version for now and I will look into this later

https://github.com/chartjs/Chart.js/pull/11498#issuecomment-1719449125

https://github.com/chartjs/Chart.js/actions/runs/6186075685/job/16792908778

```
Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:69:19)
    at Object.createHash (node:crypto:138:10)
    at module.exports (/home/runner/work/Chart.js/Chart.js/node_modules/.pnpm/webpack@4.46.0/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (/home/runner/work/Chart.js/Chart.js/node_modules/.pnpm/webpack@4.46.0/node_modules/webpack/lib/NormalModule.js:417:16)
    at handleParseError (/home/runner/work/Chart.js/Chart.js/node_modules/.pnpm/webpack@4.46.0/node_modules/webpack/lib/NormalModule.js:471:10)
    at /home/runner/work/Chart.js/Chart.js/node_modules/.pnpm/webpack@4.46.0/node_modules/webpack/lib/NormalModule.js:503:5
    at /home/runner/work/Chart.js/Chart.js/node_modules/.pnpm/webpack@4.46.0/node_modules/webpack/lib/NormalModule.js:358:12
    at /home/runner/work/Chart.js/Chart.js/node_modules/.pnpm/loader-runner@2.4.0/node_modules/loader-runner/lib/LoaderRunner.js:373:3
    at iterateNormalLoaders (/home/runner/work/Chart.js/Chart.js/node_modules/.pnpm/loader-runner@2.4.0/node_modules/loader-runner/lib/LoaderRunner.js:[214](https://github.com/chartjs/Chart.js/pull/11498/checks#step:5:215):10)
    at iterateNormalLoaders (/home/runner/work/Chart.js/Chart.js/node_modules/.pnpm/loader-runner@2.4.0/node_modules/loader-runner/lib/LoaderRunner.js:221:10)
    at /home/runner/work/Chart.js/Chart.js/node_modules/.pnpm/loader-runner@2.4.0/node_modules/loader-runner/lib/LoaderRunner.js:236:3
    at context.callback (/home/runner/work/Chart.js/Chart.js/node_modules/.pnpm/loader-runner@2.4.0/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
    at /home/runner/work/Chart.js/Chart.js/node_modules/.pnpm/cache-loader@3.0.1_webpack@4.46.0/node_modules/cache-loader/dist/index.js:134:7
    at /home/runner/work/Chart.js/Chart.js/node_modules/.pnpm/graceful-fs@4.2.11/node_modules/graceful-fs/graceful-fs.js:61:14
    at FSReqCallback.oncomplete (node:fs:189:23) {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'

```