### PR TITLE
Simplify check undefinded

### DIFF
--- a/src/helpers/helpers.core.ts
+++ b/src/helpers/helpers.core.ts
@@ -26,7 +26,7 @@ export const uid = (() => {
  * @since 2.7.0
  */
 export function isNullOrUndef(value: unknown): value is null | undefined {
-  return value === null || typeof value === 'undefined';
+  return value === null || value === undefined;
 }
 
 /**


### PR DESCRIPTION
I've simplified the check for undefined a bit. In this case, there is no need for an additional `typeof` check. Modern browsers do not allow overwriting the global `undefined`. This was only possible in Internet Explorer up to version 9.
<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
