### PR TITLE
feat: grid borderRadius

### DIFF
--- a/docs/axes/radial/linear.md
+++ b/docs/axes/radial/linear.md
@@ -65,6 +65,7 @@ Namespace: `options.scales[scaleId].grid`, it defines options for the grid lines
 | `borderDash` | `number[]` | | | `[]` | Length and spacing of dashes on grid lines. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash).
 | `borderDashOffset` | `number` | Yes | | `0.0` | Offset for line dashes. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineDashOffset).
 | `circular` | `boolean` | | | `false` | If true, gridlines are circular (on radar and polar area charts only).
+| `borderRadius` | `number` | | | `0` | If greater than 0, grid lines will be curved.
 | `color` | [`Color`](../general/colors.md)  | Yes | Yes | `Chart.defaults.borderColor` | The color of the grid lines. If specified as an array, the first color applies to the first grid line, the second to the second grid line, and so on.
 | `display` | `boolean` | | | `true` | If false, do not display grid lines for this axis.
 | `lineWidth` | `number` | Yes | Yes | `1` | Stroke width of grid lines.

--- a/docs/axes/styling.md
+++ b/docs/axes/styling.md
@@ -9,6 +9,7 @@ Namespace: `options.scales[scaleId].grid`, it defines options for the grid lines
 | Name | Type | Scriptable | Indexable | Default | Description
 | ---- | ---- | :-------------------------------: | :-----------------------------: | ------- | -----------
 | `circular` | `boolean` | | | `false` | If true, gridlines are circular (on radar and polar area charts only).
+| `borderRadius` | `number` | | | `0` | If greater than 0, grid lines will be curved.
 | `color` | [`Color`](../general/colors.md)  | Yes | Yes | `Chart.defaults.borderColor` | The color of the grid lines. If specified as an array, the first color applies to the first grid line, the second to the second grid line, and so on.
 | `display` | `boolean` | | | `true` | If false, do not display grid lines for this axis.
 | `drawOnChartArea` | `boolean` | | | `true` | If true, draw lines on the chart area inside the axis lines. This is useful when there are multiple axes and you need to control which grid lines are drawn.

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -2978,6 +2978,10 @@ export interface GridLineOptions {
    */
   circular: boolean;
   /**
+   * @default 0
+   */
+  borderRadius: number;
+  /**
    * @default 'rgba(0, 0, 0, 0.1)'
    */
   color: ScriptableAndArray<Color, ScriptableScaleContext>;


### PR DESCRIPTION
Just adding a new option for the radar graph to let us set a custom border radius to the grid, instead of be straight or circular.

<img width="348" alt="image" src="https://github.com/chartjs/Chart.js/assets/13947260/40f5ca06-f374-4186-94b1-faf28688d36d">
