### PR TITLE
fix: correct typing for doughnut, pie, and polarArea charts

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -281,7 +281,7 @@ export interface DoughnutControllerDatasetOptions
   spacing: number;
 }
 
-export interface DoughnutAnimationOptions {
+export interface DoughnutAnimationOptions extends AnimationSpec<'doughnut'> {
   /**
    *   If true, the chart will animate in with a rotation animation. This property is in the options.animation object.
    * @default true

--- a/test/types/options.ts
+++ b/test/types/options.ts
@@ -1,43 +1,35 @@
-import {
-  Chart,
-  ChartOptions,
-  ChartType,
-  DoughnutControllerChartOptions,
-} from '../../src/types.js';
+import { Chart, ChartOptions, ChartType, DoughnutControllerChartOptions } from '../../src/types.js';
 
 const chart = new Chart('test', {
   type: 'bar',
   data: {
     labels: ['a'],
-    datasets: [
-      {
-        data: [1],
-      },
-      {
-        type: 'line',
-        data: [{ x: 1, y: 1 }],
-      },
-    ],
+    datasets: [{
+      data: [1],
+    }, {
+      type: 'line',
+      data: [{ x: 1, y: 1 }]
+    }]
   },
   options: {
     animation: {
-      duration: 500,
+      duration: 500
     },
     backgroundColor: 'red',
     datasets: {
       line: {
         animation: {
-          duration: 600,
+          duration: 600
         },
         backgroundColor: 'blue',
-      },
+      }
     },
     elements: {
       point: {
-        backgroundColor: 'red',
-      },
-    },
-  },
+        backgroundColor: 'red'
+      }
+    }
+  }
 });
 
 const doughnutOptions: DoughnutControllerChartOptions = {

--- a/test/types/options.ts
+++ b/test/types/options.ts
@@ -1,33 +1,53 @@
-import { Chart } from '../../src/types.js';
+import {
+  Chart,
+  ChartOptions,
+  ChartType,
+  DoughnutControllerChartOptions,
+} from '../../src/types.js';
 
 const chart = new Chart('test', {
   type: 'bar',
   data: {
     labels: ['a'],
-    datasets: [{
-      data: [1],
-    }, {
-      type: 'line',
-      data: [{ x: 1, y: 1 }]
-    }]
+    datasets: [
+      {
+        data: [1],
+      },
+      {
+        type: 'line',
+        data: [{ x: 1, y: 1 }],
+      },
+    ],
   },
   options: {
     animation: {
-      duration: 500
+      duration: 500,
     },
     backgroundColor: 'red',
     datasets: {
       line: {
         animation: {
-          duration: 600
+          duration: 600,
         },
         backgroundColor: 'blue',
-      }
+      },
     },
     elements: {
       point: {
-        backgroundColor: 'red'
-      }
-    }
-  }
+        backgroundColor: 'red',
+      },
+    },
+  },
 });
+
+const doughnutOptions: DoughnutControllerChartOptions = {
+  circumference: 360,
+  cutout: '50%',
+  offset: 0,
+  radius: 100,
+  rotation: 0,
+  spacing: 0,
+  animation: false,
+};
+
+const chartOptions: ChartOptions<ChartType> = doughnutOptions;


### PR DESCRIPTION
fixes: #10896

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->

This is a change to `DoughnutAnimationOptions` to base the interface off of `AnimationSpec<"doughnut">`.

This appears to be the correct choice as a few of the existing tests include animation options in various doughnut based charts and include properties such as `delay` and `easing` which are missing from `DoughnutAnimationOptions` but are present in the `AnimationSpec` interface.

Also includes a basic test that ensures that `DoughnutAnimationOptions` is fully assignable to `ChartOptions<"doughnut">`
