### PR TITLE
Update documentation around radar chart data notation

### DIFF
--- a/docs/charts/radar.md
+++ b/docs/charts/radar.md
@@ -206,4 +206,4 @@ data: {
 
 ## Internal data format
 
-`{x, y}`
+`{x, r}`

--- a/docs/general/data-structures.md
+++ b/docs/general/data-structures.md
@@ -56,6 +56,17 @@ const cfg = {
 }
 ```
 
+```javascript
+const cfg = {
+  type: 'radar',
+  data: {
+    datasets: [{
+      data: [{x: 'Sales', r: 20}, {x: 'Revenue', r: 10}, {x: 'Expenses', r: 10}]
+    }]
+  }
+}
+```
+
 This is also the internal format used for parsed data. In this mode, parsing can be disabled by specifying `parsing: false` at chart options or dataset. If parsing is disabled, data must be sorted and in the formats the associated chart type and scales use internally.
 
 The values provided must be parsable by the associated scales or in the internal format of the associated scales. A common mistake would be to provide integers for the `category` scale, which uses integers as an internal format, where each integer represents an index in the labels array. `null` can be used for skipped values.


### PR DESCRIPTION
This change to the radar chart doc simply updates the internal data format notation at the end of the document.

Instead of y, this chart anticipates the data as an x,r coordinate pair when using object notation.

The change helps the documentation better reflect the expected input for this chart type.

I have also updated the data structures doc with an example of how to correctly provide data to a radar chart in object notation.

If the use of Y is a standard that should be maintained, I think it is pertinent to inform developers that radar will not accept a y coordinate in object notation.