### PR TITLE
fix: Property platform missing from chart configuration typings

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -3817,6 +3817,7 @@ export interface ChartConfiguration<
   data: ChartData<TType, TData, TLabel>;
   options?: ChartOptions<TType>;
   plugins?: Plugin<TType>[];
+  platform?: typeof BasePlatform;
 }
 
 export interface ChartConfigurationCustomTypesPerDataset<


### PR DESCRIPTION
Right now, library typings complain about setting property `platform` in configuration.
With this PR, missing property will be added to typings.