### PR TITLE
Fixes: Cannot read properties of undefined (reading '_custom') by checking 'parsed' before using it

### DIFF
--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -365,15 +365,18 @@ export default class BarController extends DatasetController {
     const meta = this._cachedMeta;
     const {iScale, vScale} = meta;
     const parsed = this.getParsed(index);
-    const custom = parsed._custom;
-    const value = isFloatBar(custom)
-      ? '[' + custom.start + ', ' + custom.end + ']'
-      : '' + vScale.getLabelForValue(parsed[vScale.axis]);
-
-    return {
-      label: '' + iScale.getLabelForValue(parsed[iScale.axis]),
-      value
-    };
+    if (parsed) {
+      const custom = parsed._custom;
+      const value = isFloatBar(custom)
+        ? '[' + custom.start + ', ' + custom.end + ']'
+        : '' + vScale.getLabelForValue(parsed[vScale.axis]);
+  
+      return {
+        label: '' + iScale.getLabelForValue(parsed[iScale.axis]),
+        value
+      };
+    }
+    return {label: '', value: 0};
   }
 
   initialize() {

--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -376,7 +376,7 @@ export default class BarController extends DatasetController {
         value
       };
     }
-    return {label: '', value: 0};
+    return {label: '', value: ''};
   }
 
   initialize() {


### PR DESCRIPTION
In `getLabelAndValue controller.bar.js`.

There's already a similar issue filed here: https://github.com/chartjs/Chart.js/issues/11365
Though mine happens in bar charts and this one seems to be in the doughnut, but the issue is the same.

This illusive error happens very rarely and it turned out to be impossible to reproduce, but I keep getting this error from our users in our bug tracking system.

Please advise if you think there's a better way to fix the issue than to return a dummy label/value.    
This `parsed` thing is basically dataset meta that was previously cached.
