### PR TITLE
fix: Guard access to window in helpers.dom.ts for browserless rendering

### DIFF
--- a/src/helpers/helpers.dom.ts
+++ b/src/helpers/helpers.dom.ts
@@ -262,8 +262,10 @@ export const supportsEventListenerOptions = (function() {
       }
     } as EventListenerOptions;
 
-    window.addEventListener('test', null, options);
-    window.removeEventListener('test', null, options);
+    if (_isDomSupported()) {
+      window.addEventListener('test', null, options);
+      window.removeEventListener('test', null, options);
+    }
   } catch (e) {
     // continue regardless of error
   }


### PR DESCRIPTION
I'm rendering chart.js on node via chartjs-node-canvas. I found an issue where the window superglobal was accessed even if the DOM wasn't available and have fixed it with a simple guard.

The access is in a try-catch-block which seems to check if event listeners can be added and removed. Since access to window outside of the browser doesn't raise a catcheable error this would fail fatally outside of the browser.

I can provide a test project with chartjs-node-canvas but for this simple fix I was hoping that the bugfix is acceptable without it :)
