### PR TITLE
feat: Window-independent requestAnimationFrame

### DIFF
--- a/src/core/core.animator.js
+++ b/src/core/core.animator.js
@@ -41,7 +41,7 @@ export class Animator {
     }
     this._running = true;
 
-    this._request = requestAnimFrame.call(window, () => {
+    this._request = requestAnimFrame(() => {
       this._update();
       this._request = null;
 

--- a/src/helpers/helpers.extras.ts
+++ b/src/helpers/helpers.extras.ts
@@ -3,21 +3,23 @@ import type {ChartMeta, PointElement} from '../types/index.js';
 import {_limitValue} from './helpers.math.js';
 import {_lookupByKey} from './helpers.collection.js';
 
+const supportsRequestAnimationFrame = typeof requestAnimationFrame !== 'undefined';
+
 export function fontString(pixelSize: number, fontStyle: string, fontFamily: string) {
   return fontStyle + ' ' + pixelSize + 'px ' + fontFamily;
 }
 
 /**
-* Request animation polyfill
+* Request animation frame polyfill
 */
-export const requestAnimFrame = (function() {
-  if (typeof window === 'undefined') {
-    return function(callback) {
-      return callback();
-    };
-  }
-  return window.requestAnimationFrame;
-}());
+function requestAnimationFrameFallback(callback: FrameRequestCallback): number {
+  callback(-1);
+  return 1;
+}
+
+export const requestAnimFrame = (callback: FrameRequestCallback): number => {
+  return supportsRequestAnimationFrame ? requestAnimationFrame(callback) : requestAnimationFrameFallback(callback);
+};
 
 /**
  * Throttles calling `fn` once per animation frame
@@ -35,7 +37,7 @@ export function throttled<TArgs extends Array<any>>(
     argsToUse = args;
     if (!ticking) {
       ticking = true;
-      requestAnimFrame.call(window, () => {
+      requestAnimFrame(() => {
         ticking = false;
         fn.apply(thisArg, argsToUse);
       });


### PR DESCRIPTION
This PR ensures that library will be able to use `requestAnimationFrame` method regardless of platform.
For example, one can declare a polyfill of this method to Node's `global` object instead of browser's `window` and make use of it.
Methods like `setTimeout` are already used that way so they need no additional handling.

Inspiration came by discussion in #11579 which suggested adding support to chart platforms but this seemed to be a cleaner solution.