### PR TITLE
bugfix #10896 - Changed 'r' to optional for BubbleChart

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -177,7 +177,7 @@ export interface BubbleDataPoint extends Point {
   /**
    * Bubble radius in pixels (not scaled).
    */
-  r: number;
+  r?: number;
 }
 
 export type BubbleController = DatasetController


### PR DESCRIPTION
This is a change to `BubbleDataPoint` to set `r` as an optional parameter. 

As mentioned here #11602  BubbleChart works without this parameter because it takes the default `r` value from the dataset property `radius` and it default value is 3.

TS screams: `Property 'r' is missing in type '{ x: number; y: number; }' but required in type 'BubbleDataPoint'.` but it doesn't affect the chart. 