### PR TITLE
Documentation - Added type number[] to radius 

### DIFF
--- a/docs/configuration/elements.md
+++ b/docs/configuration/elements.md
@@ -18,7 +18,7 @@ Namespace: `options.elements.point`, global point options: `Chart.defaults.eleme
 
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
-| `radius` | `number` | `3` | Point radius.
+| `radius` | `number`\|`number[]` | `3` | Point radius.
 | [`pointStyle`](#point-styles) | [`pointStyle`](#types) | `'circle'` | Point style.
 | `rotation` | `number` | `0` | Point rotation (in degrees).
 | `backgroundColor` | [`Color`](../general/colors.md) | `Chart.defaults.backgroundColor` | Point fill color.


### PR DESCRIPTION
I updated the documentation regarding the type of `radius`.
As mentiond #11642 here `radius` can be `number` but also `number[]`. 