### PR TITLE
addListener and removeListener should be only invoked on truthy values

### DIFF
--- a/src/platform/platform.dom.js
+++ b/src/platform/platform.dom.js
@@ -95,11 +95,15 @@ function initCanvas(canvas, aspectRatio) {
 const eventListenerOptions = supportsEventListenerOptions ? {passive: true} : false;
 
 function addListener(node, type, listener) {
-  node.addEventListener(type, listener, eventListenerOptions);
+  if (node) {
+    node.addEventListener(type, listener, eventListenerOptions);
+  }
 }
 
 function removeListener(chart, type, listener) {
-  chart.canvas.removeEventListener(type, listener, eventListenerOptions);
+  if (chart && chart.canvas) {
+    chart.canvas.removeEventListener(type, listener, eventListenerOptions);
+  }
 }
 
 function fromNativeEvent(event, chart) {


### PR DESCRIPTION
As reported in #11677, this issue is experienced in a few libraries integrating chart.js (such as #11295, samber/chartjs-plugin-datasource-prometheus#40, sgratzl/chartjs-chart-graph#79)

```
TypeError: Cannot read properties of null (reading 'addEventListener')
  at addListener(../../node_modules/chart.js/dist/chart.js:3234:8)
  at createProxyAndListen(../../node_modules/chart.js/dist/chart.js:3360:15)
  at DomPlatform.addEventListener(../../node_modules/chart.js/dist/chart.js:3406:21)
  at _add(../../node_modules/chart.js/dist/chart.js:6216:16)
  at <anonymous>(../../node_modules/chart.js/dist/chart.js:6224:41)
  at each(../../node_modules/chart.js/dist/chunks/helpers.segment.js:56:12)
  at _a.bindUserEvents(../../node_modules/chart.js/dist/chart.js:6224:10)
  at _a.bindEvents(../../node_modules/chart.js/dist/chart.js:6205:10)
  at _a._checkEventBindings(../../node_modules/chart.js/dist/chart.js:5903:12)
  at _a.update(../../node_modules/chart.js/dist/chart.js:5852:10)
  at this._doResize(../../node_modules/chart.js/dist/chart.js:5620:46)
  at sentryWrapped(../../node_modules/@sentry/browser/esm/helpers.js:37:17)
  ```
  
By ensuring that `addEventListener` and `removeEventListener` are called on truth-y values, Chart.js can prevent these TypeErrors from occurring and therefore make implementing applications more stable when integrating chart.js.

Closes #11677