### PR TITLE
platform.isAttached should return false if canvas is false-y

### DIFF
--- a/src/helpers/helpers.dom.ts
+++ b/src/helpers/helpers.dom.ts
@@ -142,7 +142,7 @@ function getContainerSize(canvas: HTMLCanvasElement, width: number, height: numb
   let maxWidth: number, maxHeight: number;
 
   if (width === undefined || height === undefined) {
-    const container = _getParentNode(canvas);
+    const container = canvas && _getParentNode(canvas);
     if (!container) {
       width = canvas.clientWidth;
       height = canvas.clientHeight;

--- a/src/platform/platform.dom.js
+++ b/src/platform/platform.dom.js
@@ -383,6 +383,10 @@ export default class DomPlatform extends BasePlatform {
 	 * @param {HTMLCanvasElement} canvas
 	 */
   isAttached(canvas) {
+    if (!canvas) {
+      return false;
+    }
+
     const container = _getParentNode(canvas);
     return !!(container && container.isConnected);
   }

--- a/src/platform/platform.dom.js
+++ b/src/platform/platform.dom.js
@@ -383,11 +383,7 @@ export default class DomPlatform extends BasePlatform {
 	 * @param {HTMLCanvasElement} canvas
 	 */
   isAttached(canvas) {
-    if (!canvas) {
-      return false;
-    }
-
-    const container = _getParentNode(canvas);
+    const container = canvas && _getParentNode(canvas);
     return !!(container && container.isConnected);
   }
 }


### PR DESCRIPTION
### Expected behavior

`isAttached()` from `platform.dom.js` should only call `_getParentNode()` on valid a truth-y `canvas` value.

### Current behavior

```
TypeError: Cannot read properties of null (reading 'parentNode')
  at _getParentNode(../../node_modules/chart.js/dist/chunks/helpers.segment.js:1820:24)
  at DomPlatform.isAttached(../../node_modules/chart.js/dist/chart.js:3434:23)
  at _a.bindResponsiveEvents(../../node_modules/chart.js/dist/chart.js:6266:18)
  at _a.bindEvents(../../node_modules/chart.js/dist/chart.js:6211:12)
  at _a._checkEventBindings(../../node_modules/chart.js/dist/chart.js:5907:12)
  at _a.update(../../node_modules/chart.js/dist/chart.js:5856:10)
  at this._doResize(../../node_modules/chart.js/dist/chart.js:5624:46)
  at sentryWrapped(../../node_modules/@sentry/browser/esm/helpers.js:37:17)
  ```
  
  From sentry:
  
<img width="1127" alt="image" src="https://github.com/chartjs/Chart.js/assets/5031018/54c3a073-6ccb-43c3-951d-5a0c6b17cf1e">


### Reproducible sample

.

### Optional extra steps/info to reproduce

_No response_

### Context

* While encountering the prior contribution (#11677) seemed to be frequent, this particular issue appears to be an even more unique edge case. Nonetheless, I've implemented a fix to enhance the stability of chart.js and the applications using it.
* Alternatively, we could check for the canvas within `_getParentNode` itself. I will defer that decision to the @chartjs maintainers if they want this changed.

### chart.js version

4.4.2

### Browser name and version

Experienced on Chrome 122.0.0 according to my project's Sentry, but probably impacts others since this is missing a null check.

### Link to your project

_No response_
