### PR TITLE
do not attempt to clear canvas if one does not exist

### DIFF
--- a/src/helpers/helpers.canvas.ts
+++ b/src/helpers/helpers.canvas.ts
@@ -131,7 +131,11 @@ export function _alignPixel(chart: Chart, pixel: number, width: number) {
 /**
  * Clears the entire canvas.
  */
-export function clearCanvas(canvas: HTMLCanvasElement, ctx?: CanvasRenderingContext2D) {
+export function clearCanvas(canvas?: HTMLCanvasElement, ctx?: CanvasRenderingContext2D) {
+  if (!ctx && !canvas) {
+    return;
+  }
+
   ctx = ctx || canvas.getContext('2d');
 
   ctx.save();

--- a/test/specs/helpers.canvas.tests.js
+++ b/test/specs/helpers.canvas.tests.js
@@ -27,6 +27,9 @@ describe('Chart.helpers.canvas', function() {
         var chart = acquireChart({}, {
           canvas: null
         });
+        // explicitly set canvas and ctx to null since setting it in acquireChart doesn't do anything
+        chart.canvas = null
+        chart.ctx = null
 
         helpers.clearCanvas(chart.canvas, chart.ctx);
       }

--- a/test/specs/helpers.canvas.tests.js
+++ b/test/specs/helpers.canvas.tests.js
@@ -21,6 +21,16 @@ describe('Chart.helpers.canvas', function() {
       expect(chart.ctx.clearRect.calls.first().object).toBe(chart.ctx);
       expect(chart.ctx.clearRect.calls.first().args).toEqual([0, 0, 150, 245]);
     });
+
+    it('should not throw error when chart is null', function() {
+      function createChart() {
+        return acquireChart({}, {
+          canvas: null
+        });
+      }
+
+      expect(createChart).not.toThrow();
+    });
   });
 
   describe('isPointInArea', function() {

--- a/test/specs/helpers.canvas.tests.js
+++ b/test/specs/helpers.canvas.tests.js
@@ -28,8 +28,8 @@ describe('Chart.helpers.canvas', function() {
           canvas: null
         });
         // explicitly set canvas and ctx to null since setting it in acquireChart doesn't do anything
-        chart.canvas = null
-        chart.ctx = null
+        chart.canvas = null;
+        chart.ctx = null;
 
         helpers.clearCanvas(chart.canvas, chart.ctx);
       }

--- a/test/specs/helpers.canvas.tests.js
+++ b/test/specs/helpers.canvas.tests.js
@@ -23,13 +23,15 @@ describe('Chart.helpers.canvas', function() {
     });
 
     it('should not throw error when chart is null', function() {
-      function createChart() {
-        return acquireChart({}, {
+      function createAndClearChart() {
+        var chart = acquireChart({}, {
           canvas: null
         });
+
+        helpers.clearCanvas(chart.canvas, chart.ctx);
       }
 
-      expect(createChart).not.toThrow();
+      expect(createAndClearChart).not.toThrow();
     });
   });
 


### PR DESCRIPTION
### Expected behavior

`clearCanvas()` from `helpers.canvas.ts` should only call `getContext()` on valid truth-y `ctx` values.

### Current behavior

```
helpers.canvas.js:119 Uncaught TypeError: Cannot read properties of null (reading 'getContext')
    at clearCanvas (helpers.canvas.js:119:23)
    at Chart.clear (core.controller.js:268:5)
    at Chart.draw (core.controller.js:718:10)
    at core.animator.js:89:15
    at Map.forEach (<anonymous>)
    at Animator._update (core.animator.js:60:18)
    at core.animator.js:45:12
  ```

Closes #11743
  
### Reproducible sample

https://github.com/chartjs/Chart.js/issues/11743

### Optional extra steps/info to reproduce

_No response_

### Context

.

### chart.js version

4.4.2

### Browser name and version

experienced on multiple browsers

### Link to your project

_No response_
