### PR TITLE
types: Allow passing undefined for chart options

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -3815,7 +3815,7 @@ export interface ChartConfiguration<
 > {
   type: TType;
   data: ChartData<TType, TData, TLabel>;
-  options?: ChartOptions<TType>;
+  options?: ChartOptions<TType> | undefined;
   plugins?: Plugin<TType>[];
   platform?: typeof BasePlatform;
 }
@@ -3826,6 +3826,6 @@ export interface ChartConfigurationCustomTypesPerDataset<
   TLabel = unknown
 > {
   data: ChartDataCustomTypesPerDataset<TType, TData, TLabel>;
-  options?: ChartOptions<TType>;
+  options?: ChartOptions<TType> | undefined;
   plugins?: Plugin<TType>[];
 }


### PR DESCRIPTION
When exactOptionalPropertyTypes, TypeScript distinguishes between the value undefined and the property not existing. See:

https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes

For Chart.js options, this difference is not important and either passing undefined or not including it have the same effect.

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
