### PR TITLE
Add fit method to LegendElement interface

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -2344,6 +2344,7 @@ export interface LegendElement<TType extends ChartType> extends Element<AnyObjec
   ctx: CanvasRenderingContext2D;
   legendItems?: LegendItem[];
   options: LegendOptions<TType>;
+  fit(): void;
 }
 
 export interface LegendOptions<TType extends ChartType> {


### PR DESCRIPTION
Purpose
This pull request aims to add the fit method to the LegendElement interface in Chart.js. The primary purpose of this change is to enable the usage of chart.legend.fit within custom plugins, ensuring TypeScript correctly recognizes and supports this method.

Background
While working on a custom plugin that adds a margin below the legend, I encountered a TypeScript error indicating that the fit method was not recognized. The fit method is, however, present on the legend object at runtime. To address this discrepancy and improve TypeScript support, I propose adding the fit method to the LegendElement interface.

Changes
Added the fit method to the LegendElement interface in Chart.js type definitions.
Example Usage
Here's an example of how this change can be utilized in a custom plugin:

`const legendMargin: Plugin = {
  id: 'legendMargin',
  afterInit(chart, args, plugins) {
    const originalFit = chart?.legend?.fit;
    const margin = plugins.margin || 0;
    if (chart.legend) {
      chart.legend.fit = function fit() {
        if (originalFit) {
          originalFit.call(this);
        }
        return (this.height += margin);
      };
    }
  },
};
`