### PR TITLE
ensure `getComputedStyle` always has a valid canvas provided

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -36,6 +36,8 @@ rules:
   es/no-regexp-s-flag: "error"
   es/no-regexp-unicode-property-escapes: "error"
   es/no-dynamic-import: "off"
+  es/no-optional-chaining: "off"
+  es/no-nullish-coalescing-operators: "off"
 
 overrides:
   - files: ['**/*.ts']

--- a/src/helpers/helpers.dom.ts
+++ b/src/helpers/helpers.dom.ts
@@ -53,7 +53,12 @@ function parseMaxStyle(styleValue: string | number, node: HTMLElement, parentPro
 const getComputedStyle = (element: HTMLElement): CSSStyleDeclaration =>
   element.ownerDocument.defaultView.getComputedStyle(element, null);
 
-export function getStyle(el: HTMLElement, property: string): string {
+// @ts-ignore
+export function getStyle(el?: HTMLElement, property: string): string {
+  if (!el) {
+    return '';
+  }
+
   return getComputedStyle(el).getPropertyValue(property);
 }
 
@@ -105,20 +110,22 @@ function getCanvasPosition(
 
 /**
  * Gets an event's x, y coordinates, relative to the chart area
- * @param event
- * @param chart
  * @returns x and y coordinates of the event
  */
 
 export function getRelativePosition(
   event: Event | ChartEvent | TouchEvent | MouseEvent,
-  chart: Chart
+  chart?: Chart
 ): { x: number; y: number } {
   if ('native' in event) {
     return event;
   }
 
   const {canvas, currentDevicePixelRatio} = chart;
+  if (!canvas) {
+    return {x: 0, y: 0};
+  }
+
   const style = getComputedStyle(canvas);
   const borderBox = style.boxSizing === 'border-box';
   const paddings = getPositionedStyle(style, 'padding');
@@ -138,19 +145,21 @@ export function getRelativePosition(
   };
 }
 
-function getContainerSize(canvas: HTMLCanvasElement, width: number, height: number): Partial<Scale> {
+// @ts-ignore
+function getContainerSize(canvas?: HTMLCanvasElement, width: number, height: number): Partial<Scale> {
   let maxWidth: number, maxHeight: number;
 
   if (width === undefined || height === undefined) {
     const container = canvas && _getParentNode(canvas);
     if (!container) {
-      width = canvas.clientWidth;
-      height = canvas.clientHeight;
+      width = canvas?.clientWidth ?? 0;
+      height = canvas?.clientHeight ?? 0;
     } else {
       const rect = container.getBoundingClientRect(); // this is the border box of the container
       const containerStyle = getComputedStyle(container);
       const containerBorder = getPositionedStyle(containerStyle, 'border', 'width');
       const containerPadding = getPositionedStyle(containerStyle, 'padding');
+
       width = rect.width - containerPadding.width - containerBorder.width;
       height = rect.height - containerPadding.height - containerBorder.height;
       maxWidth = parseMaxStyle(containerStyle.maxWidth, container, 'clientWidth');
@@ -169,11 +178,15 @@ const round1 = (v: number) => Math.round(v * 10) / 10;
 
 // eslint-disable-next-line complexity
 export function getMaximumSize(
-  canvas: HTMLCanvasElement,
+  canvas?: HTMLCanvasElement,
   bbWidth?: number,
   bbHeight?: number,
   aspectRatio?: number
 ): { width: number; height: number } {
+  if (!canvas) {
+    return {width: 0, height: 0};
+  }
+
   const style = getComputedStyle(canvas);
   const margins = getPositionedStyle(style, 'margin');
   const maxWidth = parseMaxStyle(style.maxWidth, canvas, 'clientWidth') || INFINITY;

--- a/src/helpers/helpers.dom.ts
+++ b/src/helpers/helpers.dom.ts
@@ -53,8 +53,7 @@ function parseMaxStyle(styleValue: string | number, node: HTMLElement, parentPro
 const getComputedStyle = (element: HTMLElement): CSSStyleDeclaration =>
   element.ownerDocument.defaultView.getComputedStyle(element, null);
 
-// @ts-ignore
-export function getStyle(el?: HTMLElement, property: string): string {
+export function getStyle(property: string, el?: HTMLElement): string {
   if (!el) {
     return '';
   }
@@ -145,8 +144,7 @@ export function getRelativePosition(
   };
 }
 
-// @ts-ignore
-function getContainerSize(canvas?: HTMLCanvasElement, width: number, height: number): Partial<Scale> {
+function getContainerSize(width: number, height: number, canvas?: HTMLCanvasElement): Partial<Scale> {
   let maxWidth: number, maxHeight: number;
 
   if (width === undefined || height === undefined) {
@@ -191,7 +189,7 @@ export function getMaximumSize(
   const margins = getPositionedStyle(style, 'margin');
   const maxWidth = parseMaxStyle(style.maxWidth, canvas, 'clientWidth') || INFINITY;
   const maxHeight = parseMaxStyle(style.maxHeight, canvas, 'clientHeight') || INFINITY;
-  const containerSize = getContainerSize(canvas, bbWidth, bbHeight);
+  const containerSize = getContainerSize(bbWidth, bbHeight, canvas);
   let {width, height} = containerSize;
 
   if (style.boxSizing === 'content-box') {
@@ -299,7 +297,7 @@ export function readUsedSize(
   element: HTMLElement,
   property: 'width' | 'height'
 ): number | undefined {
-  const value = getStyle(element, property);
+  const value = getStyle(property, element);
   const matches = value && value.match(/^(\d+)(\.\d+)?px$/);
   return matches ? +matches[1] : undefined;
 }

--- a/src/platform/platform.base.js
+++ b/src/platform/platform.base.js
@@ -51,7 +51,7 @@ export default class BasePlatform {
 
   /**
 	 * Returns the maximum size in pixels of given canvas element.
-	 * @param {?HTMLCanvasElement} element
+	 * @param {HTMLCanvasElement} [element]
 	 * @param {number} [width] - content width of parent element
 	 * @param {number} [height] - content height of parent element
 	 * @param {number} [aspectRatio] - aspect ratio to maintain

--- a/src/platform/platform.base.js
+++ b/src/platform/platform.base.js
@@ -51,14 +51,15 @@ export default class BasePlatform {
 
   /**
 	 * Returns the maximum size in pixels of given canvas element.
-	 * @param {HTMLCanvasElement} element
+	 * @param {?HTMLCanvasElement} element
 	 * @param {number} [width] - content width of parent element
 	 * @param {number} [height] - content height of parent element
 	 * @param {number} [aspectRatio] - aspect ratio to maintain
 	 */
   getMaximumSize(element, width, height, aspectRatio) {
-    width = Math.max(0, width || element.width);
-    height = height || element.height;
+    width = Math.max(0, width || (element?.width ?? 0));
+    height = height || (element?.height ?? 0);
+
     return {
       width,
       height: Math.max(0, aspectRatio ? Math.floor(width / aspectRatio) : height)


### PR DESCRIPTION
### Expected behavior

`getComputedStyle()` from `helpers.dom.js` should be called with valid `canvas` values provided.

### Current behavior

```
TypeError: Cannot read properties of null (reading 'ownerDocument')
  at getComputedStyle(../../node_modules/chart.js/dist/chunks/helpers.segment.js:1841:47)
  at getMaximumSize(../../node_modules/chart.js/dist/chunks/helpers.segment.js:1933:17)
  at DomPlatform.getMaximumSize(../../node_modules/chart.js/dist/chart.js:3435:12)
  at _a._resize(../../node_modules/chart.js/dist/chart.js:5700:35)
  at detached(../../node_modules/chart.js/dist/chart.js:6267:12)
  at _a.bindResponsiveEvents(../../node_modules/chart.js/dist/chart.js:6273:16)
  at _a.bindEvents(../../node_modules/chart.js/dist/chart.js:6215:12)
  at _a._checkEventBindings(../../node_modules/chart.js/dist/chart.js:5911:12)
  at _a.update(../../node_modules/chart.js/dist/chart.js:5860:10)
  at this._doResize(../../node_modules/chart.js/dist/chart.js:5628:46)
  at sentryWrapped(../../node_modules/@sentry/browser/esm/helpers.js:36:17)
```
  
  From sentry:
  
<img width="1121" alt="image" src="https://github.com/chartjs/Chart.js/assets/5031018/bc68878c-e843-42ef-9c55-25d4c3c777e4">

### Reproducible sample
.

### Optional extra steps/info to reproduce

_No response_

### chart.js version

4.4.3

### Browser name and version

Experienced on Chrome >=124.0.0 according to my project's Sentry, but probably impacts others since this is an issue with the provided parameter.

### Link to your project

_No response_
