### PR TITLE
Remove box padding from legend types

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -2406,11 +2406,6 @@ export interface LegendOptions<TType extends ChartType> {
      */
     boxHeight: number;
     /**
-     * Padding between the color box and the text
-     * @default 1
-     */
-    boxPadding: number;
-    /**
      * Color of label
      * @see Defaults.color
      */


### PR DESCRIPTION
Resolves: https://github.com/chartjs/Chart.js/issues/11803, `boxPadding` does not exist on the legend plugin, it only exists on the tooltip plugin