### PR TITLE
Update OffscreenCanvas documentation, as it is widely available now

### DIFF
--- a/docs/general/performance.md
+++ b/docs/general/performance.md
@@ -72,16 +72,16 @@ new Chart(ctx, {
 });
 ```
 
-## Parallel rendering with web workers (Chromium only)
+## Parallel rendering with web workers
 
-Chromium (Chrome: version 69, Edge: 79, Opera: 56) added the ability to [transfer rendering control of a canvas](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/transferControlToOffscreen) to a web worker. Web workers can use the [OffscreenCanvas API](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas) to render from a web worker onto canvases in the DOM. Chart.js is a canvas-based library and supports rendering in a web worker - just pass an OffscreenCanvas into the Chart constructor instead of a Canvas element. Note that as of today, this API is only supported in Chromium based browsers.
+As of 2023, modern browser have the ability to [transfer rendering control of a canvas](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/transferControlToOffscreen) to a web worker. Web workers can use the [OffscreenCanvas API](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas) to render from a web worker onto canvases in the DOM. Chart.js is a canvas-based library and supports rendering in a web worker - just pass an OffscreenCanvas into the Chart constructor instead of a Canvas element.
 
 By moving all Chart.js calculations onto a separate thread, the main thread can be freed up for other uses. Some tips and tricks when using Chart.js in a web worker:
 
 * Transferring data between threads can be expensive, so ensure that your config and data objects are as small as possible. Try generating them on the worker side if you can (workers can make HTTP requests!) or passing them to your worker as ArrayBuffers, which can be transferred quickly from one thread to another.
 * You can't transfer functions between threads, so if your config object includes functions you'll have to strip them out before transferring and then add them back later.
 * You can't access the DOM from worker threads, so Chart.js plugins that use the DOM (including any mouse interactions) will likely not work.
-* Ensure that you have a fallback if you support browsers other than the most modern Chromium browsers.
+* Ensure that you have a fallback if you support older browsers.
 * Resizing the chart must be done manually. See an example in the worker code below.
 
 Example main thread code:


### PR DESCRIPTION
As [documented by MDN](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas), `OffscreenCanvas` is widely available as of 2023, so this pull request updates the documentation accordingly.

I tested rendering with `OffScreenCanvas` on my own app, and it works with Chrome and Firefox.

However, in Safari 17.5 and 18.0-preview on macOS, it doesn't render anything for me when I switch from `canvas` to `canvas.transferControlToOffscreen()`. There's unfortunately no error message in the console. I wasn't able to reproduce my problem with a [simple test case](https://codepen.io/joliss/pen/zYQQyjV) -- the CodePen works fine in Safari -- so don't really have a good bug report to submit. I think it's also quite possible that there's something else going on in my code that Safari is tripping over.

So perhaps for the moment, it might be worth merging this documentation patch. If people run into issues with Safari (or I can reproduce my issue with a smaller example) down the line, we can always open a new issue for it then.