### PR TITLE
Improves chart update performance for a large number of datasets

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -852,8 +852,7 @@ class Chart {
   getDatasetMeta(datasetIndex) {
     const dataset = this.data.datasets[datasetIndex];
     const metasets = this._metasets;
-    let meta = metasets.filter(x => x && x._dataset === dataset).pop();
-
+    let meta = metasets[datasetIndex];
     if (!meta) {
       meta = {
         type: null,
@@ -869,7 +868,7 @@ class Chart {
         _parsed: [],
         _sorted: false
       };
-      metasets.push(meta);
+      metasets[datasetIndex] = meta;
     }
 
     return meta;


### PR DESCRIPTION
Fixes #11814 partly

- This PR improves the chart update performance drastically by replacing a nested loop O(n^2) by an index access O(1) in a method that is called a lot during chart update
- On a reference system (Mac M1 Pro), the fix enables
  - 10.000 datasets instead of 2.500 with acceptable performance
  - including zooming, panning and hovering