### PR TITLE
fix issue #11717

### DIFF
--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -438,11 +438,10 @@ export default class BarController extends DatasetController {
     const stacked = iScale.options.stacked;
     const stacks = [];
     const currentParsed = this._cachedMeta.controller.getParsed(dataIndex);
-    const xStackIndex = currentParsed && currentParsed[iScale.axis];
+    const iScaleValue = currentParsed && currentParsed[iScale.axis];
 
     const skipNull = (meta) => {
-      const filtered = meta._parsed.filter(item => item[iScale.axis] === xStackIndex);
-      const parsed = filtered.length > 0 ? filtered[0] : undefined;
+      const parsed = meta._parsed.find(item => item[iScale.axis] === iScaleValue);
       const val = parsed && parsed[meta.vScale.axis];
 
       if (isNullOrUndef(val) || isNaN(val)) {

--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -437,9 +437,12 @@ export default class BarController extends DatasetController {
       .filter(meta => meta.controller.options.grouped);
     const stacked = iScale.options.stacked;
     const stacks = [];
+    const currentParsed = this._cachedMeta.controller.getParsed(dataIndex);
+    const xStackIndex = currentParsed && currentParsed[iScale.axis];
 
     const skipNull = (meta) => {
-      const parsed = meta.controller.getParsed(dataIndex);
+      const filtered = meta._parsed.filter(item => item[iScale.axis] === xStackIndex);
+      const parsed = filtered.length > 0 ? filtered[0] : undefined;
       const val = parsed && parsed[meta.vScale.axis];
 
       if (isNullOrUndef(val) || isNaN(val)) {

--- a/test/specs/controller.bar.tests.js
+++ b/test/specs/controller.bar.tests.js
@@ -1676,6 +1676,92 @@ describe('Chart.controllers.bar', function() {
     expect(unevenChart).not.toThrow();
   });
 
+  it('should correctly count the number of stacks when skipNull and different order datasets', function() {
+
+    const chart = window.acquireChart({
+      type: "bar",
+      data: {
+        datasets: [
+          {
+            id: "1",
+            label: "USA",
+            data: [
+              {
+                xScale: "First",
+                Country: "USA",
+                yScale: 524
+              },
+              {
+                xScale: "Second",
+                Country: "USA",
+                yScale: 325
+              }
+            ],
+
+            yAxisID: "yScale",
+            xAxisID: "xScale",
+
+            parsing: {
+              yAxisKey: "yScale",
+              xAxisKey: "xScale"
+            }
+          },
+          {
+            id: "2",
+            label: "BRA",
+            data: [
+              {
+                xScale: "Second",
+                Country: "BRA",
+                yScale: 183
+              },
+              {
+                xScale: "First",
+                Country: "BRA",
+                yScale: 177
+              }
+            ],
+
+            yAxisID: "yScale",
+            xAxisID: "xScale",
+        
+            parsing: {
+              yAxisKey: "yScale",
+              xAxisKey: "xScale"
+            }
+          },
+          {
+            id: "3",
+            label: "DEU",
+            data: [
+              {
+                xScale: "First",
+                Country: "DEU",
+                yScale: 162
+              }
+            ],
+
+            yAxisID: "yScale",
+            xAxisID: "xScale",
+
+            parsing: {
+              yAxisKey: "yScale",
+              xAxisKey: "xScale"
+            }
+          }
+        ]
+      },
+      options: {
+        skipNull: true
+      }
+    })
+
+    var meta = chart.getDatasetMeta(0);
+    expect(meta.controller._getStackCount(0)).toBe(3);
+    expect(meta.controller._getStackCount(1)).toBe(2);
+
+  });
+
   it('should not override tooltip title and label callbacks', async() => {
     const chart = window.acquireChart({
       type: 'bar',

--- a/test/specs/controller.bar.tests.js
+++ b/test/specs/controller.bar.tests.js
@@ -1679,74 +1679,74 @@ describe('Chart.controllers.bar', function() {
   it('should correctly count the number of stacks when skipNull and different order datasets', function() {
 
     const chart = window.acquireChart({
-      type: "bar",
+      type: 'bar',
       data: {
         datasets: [
           {
-            id: "1",
-            label: "USA",
+            id: '1',
+            label: 'USA',
             data: [
               {
-                xScale: "First",
-                Country: "USA",
+                xScale: 'First',
+                Country: 'USA',
                 yScale: 524
               },
               {
-                xScale: "Second",
-                Country: "USA",
+                xScale: 'Second',
+                Country: 'USA',
                 yScale: 325
               }
             ],
 
-            yAxisID: "yScale",
-            xAxisID: "xScale",
+            yAxisID: 'yScale',
+            xAxisID: 'xScale',
 
             parsing: {
-              yAxisKey: "yScale",
-              xAxisKey: "xScale"
+              yAxisKey: 'yScale',
+              xAxisKey: 'xScale'
             }
           },
           {
-            id: "2",
-            label: "BRA",
+            id: '2',
+            label: 'BRA',
             data: [
               {
-                xScale: "Second",
-                Country: "BRA",
+                xScale: 'Second',
+                Country: 'BRA',
                 yScale: 183
               },
               {
-                xScale: "First",
-                Country: "BRA",
+                xScale: 'First',
+                Country: 'BRA',
                 yScale: 177
               }
             ],
 
-            yAxisID: "yScale",
-            xAxisID: "xScale",
-        
+            yAxisID: 'yScale',
+            xAxisID: 'xScale',
+
             parsing: {
-              yAxisKey: "yScale",
-              xAxisKey: "xScale"
+              yAxisKey: 'yScale',
+              xAxisKey: 'xScale'
             }
           },
           {
-            id: "3",
-            label: "DEU",
+            id: '3',
+            label: 'DEU',
             data: [
               {
-                xScale: "First",
-                Country: "DEU",
+                xScale: 'First',
+                Country: 'DEU',
                 yScale: 162
               }
             ],
 
-            yAxisID: "yScale",
-            xAxisID: "xScale",
+            yAxisID: 'yScale',
+            xAxisID: 'xScale',
 
             parsing: {
-              yAxisKey: "yScale",
-              xAxisKey: "xScale"
+              yAxisKey: 'yScale',
+              xAxisKey: 'xScale'
             }
           }
         ]
@@ -1754,7 +1754,7 @@ describe('Chart.controllers.bar', function() {
       options: {
         skipNull: true
       }
-    })
+    });
 
     var meta = chart.getDatasetMeta(0);
     expect(meta.controller._getStackCount(0)).toBe(3);


### PR DESCRIPTION
Fixing https://github.com/chartjs/Chart.js/issues/11717

The origin code to calculate the stack size used the data absolute index, which cause issue when the data orders are different and the skipNull is true. Change to filter by the current index id value to get count for all datasets.