### PR TITLE
fix: Unset _resizeBeforeDraw before _resize() call to avoid possible recursion

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
         "rollup": "^3.3.0",
         "rollup-plugin-cleanup": "^3.2.1",
         "rollup-plugin-istanbul": "^4.0.0",
-        "rollup-plugin-swc3": "^0.11.0",
+        "rollup-plugin-swc3": "^0.7.0",
         "rollup-plugin-terser": "^7.0.2",
         "typescript": "^4.7.4",
         "yargs": "^17.5.1"

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
         "rollup": "^3.3.0",
         "rollup-plugin-cleanup": "^3.2.1",
         "rollup-plugin-istanbul": "^4.0.0",
-        "rollup-plugin-swc3": "^0.7.0",
+        "rollup-plugin-swc3": "^0.11.0",
         "rollup-plugin-terser": "^7.0.2",
         "typescript": "^4.7.4",
         "yargs": "^17.5.1"

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -717,7 +717,7 @@ class Chart {
     let i;
     if (this._resizeBeforeDraw) {
       const {width, height} = this._resizeBeforeDraw;
-      // Unset pending draw now to avoid possible recursion within _resize
+      // Unset pending resize request now to avoid possible recursion within _resize
       this._resizeBeforeDraw = null;
       this._resize(width, height);
     }

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -717,8 +717,9 @@ class Chart {
     let i;
     if (this._resizeBeforeDraw) {
       const {width, height} = this._resizeBeforeDraw;
-      this._resize(width, height);
+      // Unset pending draw now to avoid possible recursion within _resize
       this._resizeBeforeDraw = null;
+      this._resize(width, height);
     }
     this.clear();
 


### PR DESCRIPTION
While using chart.js with NativeScript, we noticed a rare resize bug after few HMR updates.
More specifically, `_resize()` call ended up with a recursion (might be a platform-related issue causing `retinaScale()` to malfunction?).
After some digging, I managed to get rid of the issue by unsetting pending resize request earlier.