### PR TITLE
Bugfix/issue 11804 tooltip show for all invisible

### DIFF
--- a/src/elements/element.arc.ts
+++ b/src/elements/element.arc.ts
@@ -324,7 +324,8 @@ export default class ArcElement extends Element<ArcProps, ArcOptions> {
     ], useFinalPosition);
     const rAdjust = (this.options.spacing + this.options.borderWidth) / 2;
     const _circumference = valueOrDefault(circumference, endAngle - startAngle);
-    const betweenAngles = _circumference >= TAU || (_angleBetween(angle, startAngle, endAngle) && startAngle !== endAngle);;
+    const nonZeroBetween = _angleBetween(angle, startAngle, endAngle) && startAngle !== endAngle;
+    const betweenAngles = _circumference >= TAU || nonZeroBetween;
     const withinRadius = _isBetween(distance, innerRadius + rAdjust, outerRadius + rAdjust);
 
     return (betweenAngles && withinRadius);

--- a/src/elements/element.arc.ts
+++ b/src/elements/element.arc.ts
@@ -324,7 +324,7 @@ export default class ArcElement extends Element<ArcProps, ArcOptions> {
     ], useFinalPosition);
     const rAdjust = (this.options.spacing + this.options.borderWidth) / 2;
     const _circumference = valueOrDefault(circumference, endAngle - startAngle);
-    const betweenAngles = _circumference >= TAU || _angleBetween(angle, startAngle, endAngle);
+    const betweenAngles = _circumference >= TAU || (_angleBetween(angle, startAngle, endAngle) && startAngle !== endAngle);;
     const withinRadius = _isBetween(distance, innerRadius + rAdjust, outerRadius + rAdjust);
 
     return (betweenAngles && withinRadius);

--- a/test/specs/element.arc.tests.js
+++ b/test/specs/element.arc.tests.js
@@ -281,4 +281,26 @@ describe('Arc element tests', function() {
 
     expect(ctx.getCalls().length).toBeGreaterThan(0);
   });
+
+  it ('should determine not in range when angle 0', function() {
+    // Mock out the arc as if the controller put it there
+    var arc = new Chart.elements.ArcElement({
+      startAngle: 0,
+      endAngle: 0,
+      x: 0,
+      y: 0,
+      innerRadius: 0,
+      outerRadius: 10,
+      circumference: 0,
+      options: {
+        spacing: 0,
+        offset: 0,
+        borderWidth: 0
+      }
+    });
+
+    var center = arc.getCenterPoint();
+
+    expect(arc.inRange(center.x, 1)).toBe(false);
+  });
 });


### PR DESCRIPTION
fixing https://github.com/chartjs/Chart.js/issues/11804
The original codes treat zero angle as inRange, so when hidden all data, then all the datasets are zero angle. And this makes tooltips for all data showed up when mouse goes to zero angle.

![image](https://github.com/user-attachments/assets/330757fd-3f7d-4826-b249-a70cc9ff7490)
