### PR TITLE
fix(types): add xCenter and yCenter properties to RadialLinearScale interface

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -3577,6 +3577,8 @@ export type RadialLinearScaleOptions = CoreScaleOptions & {
 };
 
 export interface RadialLinearScale<O extends RadialLinearScaleOptions = RadialLinearScaleOptions> extends Scale<O> {
+  xCenter: number;
+  yCenter: number;
   setCenterPoint(leftMovement: number, rightMovement: number, topMovement: number, bottomMovement: number): void;
   getIndexAngle(index: number): number;
   getDistanceFromCenterForValue(value: number): number;


### PR DESCRIPTION
This PR introduces changes described in #11861, adding missing typings for properties `xCenter` & `yCenter` to the `RadialLinearScale` interface.

Closes #11861.