### PR TITLE
fix(types): exclude DeepPartial<unknown[]> from ChartOptions interface

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -3741,15 +3741,15 @@ export type ScaleChartOptions<TType extends ChartType = ChartType> = {
 };
 
 export type ChartOptions<TType extends ChartType = ChartType> = Exclude<
-  DeepPartial<
-    CoreChartOptions<TType> &
-    ElementChartOptions<TType> &
-    PluginChartOptions<TType> &
-    DatasetChartOptions<TType> &
-    ScaleChartOptions<TType> &
-    ChartTypeRegistry[TType]['chartOptions']
-  >,
-  DeepPartial<unknown[]>
+DeepPartial<
+CoreChartOptions<TType> &
+ElementChartOptions<TType> &
+PluginChartOptions<TType> &
+DatasetChartOptions<TType> &
+ScaleChartOptions<TType> &
+ChartTypeRegistry[TType]['chartOptions']
+>,
+DeepPartial<unknown[]>
 >;
 
 export type DefaultDataPoint<TType extends ChartType> = DistributiveArray<ChartTypeRegistry[TType]['defaultDataPoint']>;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -3740,13 +3740,16 @@ export type ScaleChartOptions<TType extends ChartType = ChartType> = {
   };
 };
 
-export type ChartOptions<TType extends ChartType = ChartType> = DeepPartial<
-CoreChartOptions<TType> &
-ElementChartOptions<TType> &
-PluginChartOptions<TType> &
-DatasetChartOptions<TType> &
-ScaleChartOptions<TType> &
-ChartTypeRegistry[TType]['chartOptions']
+export type ChartOptions<TType extends ChartType = ChartType> = Exclude<
+  DeepPartial<
+    CoreChartOptions<TType> &
+    ElementChartOptions<TType> &
+    PluginChartOptions<TType> &
+    DatasetChartOptions<TType> &
+    ScaleChartOptions<TType> &
+    ChartTypeRegistry[TType]['chartOptions']
+  >,
+  DeepPartial<unknown[]>
 >;
 
 export type DefaultDataPoint<TType extends ChartType> = DistributiveArray<ChartTypeRegistry[TType]['defaultDataPoint']>;


### PR DESCRIPTION
This PR solves #11866 by excluding `DeepPartial<unknown[]>` from `ChartOptions`.

Closes #11866.

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
