### PR TITLE
Draft: Allow non generic plugin type options

### DIFF
--- a/docs/developers/plugins.md
+++ b/docs/developers/plugins.md
@@ -186,12 +186,22 @@ The `destroy` hook has been deprecated since Chart.js version 3.7.0, use the `af
 
 If you want your plugin to be statically typed, you must provide a `.d.ts` TypeScript declaration file. Chart.js provides a way to augment built-in types with user-defined ones, by using the concept of "declaration merging".
 
-When adding a plugin, `PluginOptionsByType` must contain the declarations for the plugin.
+When adding a plugin, `PluginOptions` must contain the declarations for the plugin, in case you need extra information about the chart type you can use the `PluginOptionsByType` interface.
 
 For example, to provide typings for the [`canvas backgroundColor plugin`](../configuration/canvas-background.md), you would add a `.d.ts` containing:
 
 ```ts
-import {ChartType, Plugin} from 'chart.js';
+declare module 'chart.js' {
+  interface PluginOptions {
+    customCanvasBackgroundColor?: {
+      color?: string
+    }
+  }
+}
+```
+
+```ts
+import {ChartType} from 'chart.js';
 
 declare module 'chart.js' {
   interface PluginOptionsByType<TType extends ChartType> {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -2934,16 +2934,20 @@ export interface TooltipItem<TType extends ChartType> {
 }
 
 export interface PluginOptionsByType<TType extends ChartType> {
+  legend: LegendOptions<TType>;
+  tooltip: TooltipOptions<TType>;
+}
+
+export interface PluginOptions {
   colors: ColorsPluginOptions;
   decimation: DecimationOptions;
   filler: FillerOptions;
-  legend: LegendOptions<TType>;
   subtitle: TitleOptions;
   title: TitleOptions;
-  tooltip: TooltipOptions<TType>;
 }
+
 export interface PluginChartOptions<TType extends ChartType> {
-  plugins: PluginOptionsByType<TType>;
+  plugins: PluginOptionsByType<TType> | PluginOptions;
 }
 
 export interface BorderOptions {


### PR DESCRIPTION
Resolves: https://github.com/chartjs/Chart.js/issues/11877

This is technically breaking I think since the plugins section is not always the same type anymore, so I am not sure if we can do this in V4 or this needs to be targeted to V5.
