### PR TITLE
Avoid error if borderOpts.dash is undefined

### DIFF
--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -317,7 +317,7 @@ function drawRadiusLine(scale, gridLineOpts, radius, labelCount, borderOpts) {
   ctx.save();
   ctx.strokeStyle = color;
   ctx.lineWidth = lineWidth;
-  ctx.setLineDash(borderOpts.dash);
+  ctx.setLineDash(borderOpts.dash || []);
   ctx.lineDashOffset = borderOpts.dashOffset;
 
   ctx.beginPath();


### PR DESCRIPTION
As the title suggests.

In my case,
I was implementing a radar chart and had set `options.scales.r.border.dash` to `[3,3]`,
In certain environments, an error would occur and the chart would not display.

The error message is

> Failed to execute 'setLineDash' on 'CanvasRenderingContext2D': The provided value cannot be converted to a sequence.

Reproduction rate is not 100%.
About 80% are displayed correctly with no errors.

I was never able to pinpoint the cause, but for some reason,
`options.scales.r.border.dash` seemed to become `undefined` internally.
Therefore, an error occurred in `setLineDash` in function `drawRadiusLine` and the process stopped.

At the very least, I tried to modify it so that the process would not stop due to an error.