### PR TITLE
Fix 404 to samples in release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -47,7 +47,7 @@ template: |
   * [Migration guide](https://www.chartjs.org/docs/$RESOLVED_VERSION/migration/v4-migration.html)
   * [Docs](https://www.chartjs.org/docs/$RESOLVED_VERSION/)
   * [API](https://www.chartjs.org/docs/$RESOLVED_VERSION/api/)
-  * [Samples](https://www.chartjs.org/docs/$RESOLVED_VERSION/samples/)
+  * [Samples](https://www.chartjs.org/docs/$RESOLVED_VERSION/samples/information.html)
 
   $CHANGES
 


### PR DESCRIPTION
Noticed this while clicking through the release note (sadly a bit too late). 