### PR TITLE
Fix: applyStack() returned the sum of all values for hidden dataset i…

### DIFF
--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -76,9 +76,11 @@ function applyStack(stack, value, dsIndex, options = {}) {
     return;
   }
 
+  let found = false;
   for (i = 0, ilen = keys.length; i < ilen; ++i) {
     datasetIndex = +keys[i];
     if (datasetIndex === dsIndex) {
+      found = true;
       if (options.all) {
         continue;
       }
@@ -89,6 +91,11 @@ function applyStack(stack, value, dsIndex, options = {}) {
       value += otherValue;
     }
   }
+
+  if (!found && !options.all) {
+    return 0;
+  }
+
   return value;
 }
 

--- a/test/specs/controller.bar.tests.js
+++ b/test/specs/controller.bar.tests.js
@@ -1613,6 +1613,49 @@ describe('Chart.controllers.bar', function() {
     expect(data[0].y).toBeCloseToPixel(512);
   });
 
+  it('should hide bar dataset beneath the chart for correct animations', function() {
+    var chart = window.acquireChart({
+      type: 'bar',
+      data: {
+        datasets: [{
+          data: [1, 2, 3, 4]
+        }, {
+          data: [1, 2, 3, 4]
+        }],
+        labels: ['A', 'B', 'C', 'D']
+      },
+      options: {
+        plugins: {
+          legend: false,
+          title: false
+        },
+        scales: {
+          x: {
+            type: 'category',
+            display: false,
+            stacked: true,
+          },
+          y: {
+            type: 'linear',
+            display: false,
+            stacked: true,
+          }
+        }
+      }
+    });
+
+    var data = chart.getDatasetMeta(0).data;
+    expect(data[0].base).toBeCloseToPixel(512);
+    expect(data[0].y).toBeCloseToPixel(448);
+
+    chart.setDatasetVisibility(0, false);
+    chart.update();
+
+    data = chart.getDatasetMeta(0).data;
+    expect(data[0].base).toBeCloseToPixel(640);
+    expect(data[0].y).toBeCloseToPixel(512);
+  });
+
   describe('Float bar', function() {
     it('Should return correct values from getMinMax', function() {
       var chart = window.acquireChart({


### PR DESCRIPTION
…ndices, which causes incorrect animations when showing/hiding stacked datasets. This fixes https://github.com/chartjs/Chart.js/issues/11198.

This is a clone of [this](https://github.com/chartjs/Chart.js/pull/11834) with added test, as I promised there.
I didn't find an easy way to test applyStack directly, so I decided that it would be better to test the behaviour and not the implementation and added a test for bar chart rendering.

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
