### PR TITLE
Show correct title in multi series pie chart example

### DIFF
--- a/docs/samples/other-charts/multi-series-pie.md
+++ b/docs/samples/other-charts/multi-series-pie.md
@@ -74,9 +74,9 @@ const config = {
       },
       tooltip: {
         callbacks: {
-          label: function(context) {
-            const labelIndex = (context.datasetIndex * 2) + context.dataIndex;
-            return context.chart.data.labels[labelIndex] + ': ' + context.formattedValue;
+          title: function(context) {
+            const labelIndex = (context[0].datasetIndex * 2) + context[0].dataIndex;
+            return context[0].chart.data.labels[labelIndex] + ': ' + context[0].formattedValue;
           }
         }
       }


### PR DESCRIPTION
Resolves: https://github.com/chartjs/Chart.js/issues/11961

Not quite sure if we want to hide the actual label now since it shows both in the title and label the value of the slice.
But without the label the tooltip looks worse in my opinion

![image](https://github.com/user-attachments/assets/a4669d17-2065-4edd-8af1-775cb8b1a2e6)
![image](https://github.com/user-attachments/assets/4d1ebe7b-ba48-483b-9fea-0fe4824767fc)
