### PR TITLE
Bugfix: TypeError in Interaction due to out-of-bounds index

### DIFF
--- a/src/core/core.interaction.js
+++ b/src/core/core.interaction.js
@@ -40,7 +40,7 @@ function binarySearch(metaset, axis, value, intersect) {
         result.lo -= Math.max(0, distanceToDefinedLo);
 
         const distanceToDefinedHi = (_parsed
-          .slice(result.hi - 1)
+          .slice(result.hi)
           .findIndex(
             point => !isNullOrUndef(point[vScale.axis])));
         result.hi += Math.max(0, distanceToDefinedHi);

--- a/test/specs/core.interaction.tests.js
+++ b/test/specs/core.interaction.tests.js
@@ -972,6 +972,26 @@ describe('Core.Interaction', function() {
       data: [12, -1, null, null, null, null, -1, 2],
       clickPointIndex: 4,
       expectedNearestPointIndex: 6
+    },
+    {
+      data: [null, 2],
+      clickPointIndex: 0,
+      expectedNearestPointIndex: 1
+    },
+    {
+      data: [2, null],
+      clickPointIndex: 1,
+      expectedNearestPointIndex: 0
+    },
+    {
+      data: [null, null, 2],
+      clickPointIndex: 0,
+      expectedNearestPointIndex: 2
+    },
+    {
+      data: [2, null, null],
+      clickPointIndex: 2,
+      expectedNearestPointIndex: 0
     }
   ];
   testCases.forEach(({data, clickPointIndex, expectedNearestPointIndex}, i) => {


### PR DESCRIPTION
I have introduced a bug in my previous pull request https://github.com/chartjs/Chart.js/pull/11986. This PR fixes it and adds 4 test cases to make sure it doesn't happen again.

If there is a line chart with the following dataset
```js
data: [1, null, 2],
spanGaps: true,
```

and user hovers close to `2`, then `binarySearch` wrapper returns `hi: 4` for nearest interaction, which is an index not existing in the dataset (it only has 3 elements). An `Uncaught TypeError` is thrown at [core.interaction.js:82](https://github.com/marisst/Chart.js/blob/1e7f6e7072045c87ac0c2b2d25aa77430cf9a5d6/src/core/core.interaction.js#L82).

![image](https://github.com/user-attachments/assets/d83f1141-f328-4850-b1a3-d97c7254a4b6)



I apologize for not being diligent enough and introducing this error. The `end - 1` was  needed in `helpers.extras.ts`, because `+ 1` is added to it in [line 119](https://github.com/marisst/Chart.js/blob/1e7f6e7072045c87ac0c2b2d25aa77430cf9a5d6/src/helpers/helpers.extras.ts#L119) (to the left in screenshot below), but in `core.interaction.js` it was not needed, because `+ 1` is not added to the `result` (to the right in screenshot below).
![image](https://github.com/user-attachments/assets/26466b9a-8769-44ac-9b42-38444ae24313)
