### PR TITLE
Correct broken link in animations.md

### DIFF
--- a/docs/configuration/animations.md
+++ b/docs/configuration/animations.md
@@ -127,7 +127,7 @@ These paths are valid under `defaults` for global configuration and `options` fo
 
 ## animation
 
-The default configuration is defined here: <a href="https://github.com/chartjs/Chart.js/blob/master/src/core/core.animations.js" target="_blank">core.animations.js</a>
+The default configuration is defined here: <a href="https://github.com/chartjs/Chart.js/blob/master/src/core/core.animations.defaults.js" target="_blank">core.animations.defaults.js</a>
 
 Namespace: `options.animation`
 


### PR DESCRIPTION
The link works, but it points to the wrong file.

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
