### PR TITLE
Export ...ParsedData interfaces

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -3643,7 +3643,7 @@ export interface CartesianParsedData extends Point {
   }
 }
 
-interface BarParsedData extends CartesianParsedData {
+export interface BarParsedData extends CartesianParsedData {
   // Only specified if floating bars are show
   _custom?: {
     barStart: number;
@@ -3655,12 +3655,12 @@ interface BarParsedData extends CartesianParsedData {
   }
 }
 
-interface BubbleParsedData extends CartesianParsedData {
+export interface BubbleParsedData extends CartesianParsedData {
   // The bubble radius value
   _custom: number;
 }
 
-interface RadialParsedData {
+export interface RadialParsedData {
   r: number;
 }
 


### PR DESCRIPTION
Otherwise, trying to inherit from DatasetController in a TypeScript project may result in TypeScript errors similar to the following:

> error TS9006: Declaration emit for this file requires using private name 'RadialParsedData' from module '"/Users/joshkel/src/app/node_modules/chart.js/dist/types/index"'. An explicit type annotation may unblock declaration emit.

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
