### PR TITLE
Add type definition for beforeEvent changed

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1070,9 +1070,10 @@ export interface Plugin<TType extends ChartType = ChartType, O = AnyObject> exte
    * @param {ChartEvent} args.event - The event object.
    * @param {boolean} args.replay - True if this event is replayed from `Chart.update`
    * @param {boolean} args.inChartArea - The event position is inside chartArea
+   * @param {boolean} [args.changed] - Set to true if the plugin needs a render. Should only be changed to true, because this args object is passed through all plugins.
    * @param {object} options - The plugin options.
    */
-  beforeEvent?(chart: Chart<TType>, args: { event: ChartEvent, replay: boolean, cancelable: true, inChartArea: boolean }, options: O): boolean | void;
+  beforeEvent?(chart: Chart<TType>, args: { event: ChartEvent, replay: boolean, changed?: boolean; cancelable: true, inChartArea: boolean }, options: O): boolean | void;
   /**
    * @desc Called after the `event` has been consumed. Note that this hook
    * will not be called if the `event` has been previously discarded.


### PR DESCRIPTION
I'm not certain whether supporting `args.changed` from `beforeEvent` is intended or not:

* It works.
* It wasn't in the type definitions.
* [The migration guide only references it for `afterEvent`.](https://www.chartjs.org/docs/latest/migration/v3-migration.html#:~:text=afterEvent%20should%20notify%20about%20changes%20that%20need%20a%20render%20by%20setting%20args.changed%20to%20true.%20Because%20the%20args%20are%20shared%20with%20all%20plugins%2C%20it%20should%20only%20be%20set%20to%20true%20and%20not%20false.)
* [The plugin documentation](https://www.chartjs.org/docs/latest/developers/plugins.html#event-handling) does NOT limit it to `afterEvent`...
* ...although the plugin documentation's flowchart puts the notice next to `afterEvent`.
* [chartjs-plugin-annotation's draggable sample](https://www.chartjs.org/chartjs-plugin-annotation/latest/samples/interaction/dragging.html) depends on using it from `beforeEvent`.

In the case that it should be supported, this PR adds it to the type definitions.