### PR TITLE
Document requirement of 'this' when calling tick formatters

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1508,7 +1508,7 @@ export declare const Ticks: {
      * @param ticks the list of ticks being converted
      * @return string representation of the tickValue parameter
      */
-    numeric(tickValue: number, index: number, ticks: { value: number }[]): string;
+    numeric(this: Scale, tickValue: number, index: number, ticks: { value: number }[]): string;
     /**
      * Formatter for logarithmic ticks
      * @param tickValue the value to be formatted
@@ -1516,7 +1516,7 @@ export declare const Ticks: {
      * @param ticks the list of ticks being converted
      * @return string representation of the tickValue parameter
      */
-    logarithmic(tickValue: number, index: number, ticks: { value: number }[]): string;
+    logarithmic(this: Scale, tickValue: number, index: number, ticks: { value: number }[]): string;
   };
 };
 

--- a/test/types/ticks/ticks.ts
+++ b/test/types/ticks/ticks.ts
@@ -1,0 +1,15 @@
+import { Chart, Ticks } from '../../../src/types.js';
+
+// @ts-expect-error The 'this' context... is not assignable to method's 'this' of type 'Scale<CoreScaleOptions>'.
+Ticks.formatters.numeric(0, 0, [{ value: 0 }]);
+
+const chart = new Chart('test', {
+  type: 'line',
+  data: {
+    datasets: [{
+      data: [{ x: 1, y: 1 }]
+    }]
+  },
+});
+
+Ticks.formatters.numeric.call(chart.scales.x, 0, 0, [{ value: 0 }]);


### PR DESCRIPTION
The `numeric` and `logarithmic` tick formatters require that `this` be provided. That happens automatically if they're used directly as a tick callback but not if they're invoked manually. Failing to pass `this` results in runtime errors similar to the following:

```
TypeError: Cannot read properties of undefined (reading 'chart')
```

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
