### PR TITLE
fix: correct grammar in segment comments (an segment -> a segment)

### DIFF
--- a/src/plugins/plugin.filler/filler.target.stack.js
+++ b/src/plugins/plugin.filler/filler.target.stack.js
@@ -65,13 +65,12 @@ function addPointsBelow(points, sourcePoint, linesBelow) {
       continue;
     }
     if (first) {
-      // First point of an segment -> need to add another point before this,
-      // from next line below.
+      // First point of a segment -> need to add another point before this,
       postponed.unshift(point);
     } else {
       points.push(point);
       if (!last) {
-        // In the middle of an segment, no need to add more points.
+        // In the middle of a segment, no need to add more points.
         break;
       }
     }


### PR DESCRIPTION
## Summary
This pull request fixes a minor grammar issue in comments: "an segment" → "a segment" in `plugin.filler/filler.target.stack.js`.

## Checklist
- [x] Only documentation/comments are changed, no code logic is affected.
- [x] Follows the contribution guidelines.

Thank you for maintaining Chart.js!