### PR TITLE
fix: label arrays to be delimited by comma and add spaces for line charts

### DIFF
--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -32,6 +32,24 @@ export default class LineController extends DatasetController {
     }
   };
 
+
+  /**
+   * @protected
+   */
+  getLabelAndValue(index) {
+    const meta = this._cachedMeta;
+    const iScale = meta.iScale;
+    const vScale = meta.vScale;
+    const parsed = this.getParsed(index);
+    const value = vScale ? '' + vScale.getLabelForValue(parsed[vScale.axis]) : '';
+    const label = iScale.getLabelForValue(parsed[iScale.axis]);
+
+    return {
+      label: Array.isArray(label) ? label.join(', ') : '' + label,
+      value
+    };
+  }
+
   initialize() {
     this.enableOptionSharing = true;
     this.supportsDecimation = true;


### PR DESCRIPTION
Closes https://github.com/chartjs/Chart.js/issues/12049

Line controllers apparently didn't have an overridden implementation for DatasetController.
Kept it within the line controller to not affect anything else. 