### PR TITLE
Fix grammar typo: 'only draw line' -> 'only draw lines'

### DIFF
--- a/docs/general/performance.md
+++ b/docs/general/performance.md
@@ -161,7 +161,7 @@ new Chart(ctx, {
 
 ### Disable Point Drawing
 
-If you have a lot of data points, it can be more performant to disable rendering of the points for a dataset and only draw line. Doing this means that there is less to draw on the canvas which will improve render performance.
+If you have a lot of data points, it can be more performant to disable rendering of the points for a dataset and only draw lines. Doing this means that there is less to draw on the canvas which will improve render performance.
 
 To disable point drawing:
 


### PR DESCRIPTION
Correct a grammar typo in the General -> Performance section of the docs, Disable Point Drawing subsection.

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
