### PR TITLE
Attempt fixing charts shrinking on certain zoom values in Chrome

### DIFF
--- a/src/helpers/helpers.dom.ts
+++ b/src/helpers/helpers.dom.ts
@@ -211,11 +211,11 @@ export function retinaScale(
   forceStyle?: boolean
 ): boolean | void {
   const pixelRatio = forceRatio || 1;
-  const deviceHeight = Math.floor(chart.height * pixelRatio);
-  const deviceWidth = Math.floor(chart.width * pixelRatio);
+  const deviceHeight = round1(chart.height * pixelRatio);
+  const deviceWidth = round1(chart.width * pixelRatio);
 
-  (chart as PrivateChart).height = Math.floor(chart.height);
-  (chart as PrivateChart).width = Math.floor(chart.width);
+  (chart as PrivateChart).height = round1(chart.height);
+  (chart as PrivateChart).width = round1(chart.width);
 
   const canvas = chart.canvas;
 

--- a/test/specs/helpers.dom.tests.js
+++ b/test/specs/helpers.dom.tests.js
@@ -268,8 +268,8 @@ describe('DOM helpers tests', function() {
     helpers.retinaScale(chart, devicePixelRatio, true);
 
     var canvas = chart.canvas;
-    expect(canvas.width).toBe(Math.floor(chartWidth * devicePixelRatio));
-    expect(canvas.height).toBe(Math.floor(chartHeight * devicePixelRatio));
+    expect(canvas.width).toBe(Math.round(chartWidth * devicePixelRatio));
+    expect(canvas.height).toBe(Math.round(chartHeight * devicePixelRatio));
 
     expect(chart.width).toBe(chartWidth);
     expect(chart.height).toBe(chartHeight);


### PR DESCRIPTION
This is an attempt at fixing #11224 and possibly #12076.
I managed to reproduce the issue with the steps from #11224 on Chromium 138 on Linux, but it is very sensitive to screen width so I'm not sure if I caught all cases. At any rate, with the submitted fix, I'm no longer able to reproduce the issue myself.

Would appreciate if someone with Chrome on Windows could try reproducing the issue with the steps from https://github.com/chartjs/Chart.js/issues/12076#issuecomment-3014797229 and this PR.
