### PR TITLE
Do not notify plugins after their uninstall function has been called

### DIFF
--- a/src/core/core.plugins.js
+++ b/src/core/core.plugins.js
@@ -19,7 +19,7 @@ import {callback as callCallback, isNullOrUndef, valueOrDefault} from '../helper
 
 export default class PluginService {
   constructor() {
-    this._init = [];
+    this._init = undefined;
   }
 
   /**
@@ -38,12 +38,17 @@ export default class PluginService {
       this._notify(this._init, chart, 'install');
     }
 
+    if (this._init === undefined) { // Do not trigger events before install
+      return;
+    }
+
     const descriptors = filter ? this._descriptors(chart).filter(filter) : this._descriptors(chart);
     const result = this._notify(descriptors, chart, hook, args);
 
     if (hook === 'afterDestroy') {
       this._notify(descriptors, chart, 'stop');
       this._notify(this._init, chart, 'uninstall');
+      this._init = undefined; // Do not trigger events after uninstall
     }
     return result;
   }

--- a/test/specs/core.plugin.tests.js
+++ b/test/specs/core.plugin.tests.js
@@ -480,5 +480,31 @@ describe('Chart.plugins', function() {
       await jasmine.triggerMouseEvent(chart, 'pointerleave', {x: 0, y: 0});
       expect(results).toEqual(['beforetest', 'aftertest', 'beforemouseout', 'aftermouseout']);
     });
+
+    it('should not call plugins after uninstall', async function() {
+      const results = [];
+      const chart = window.acquireChart({
+        options: {
+          events: ['test'],
+          plugins: {
+            testPlugin: {
+              events: ['test']
+            }
+          }
+        },
+        plugins: [{
+          id: 'testPlugin',
+          reset: () => results.push('reset'),
+          afterDestroy: () => results.push('afterDestroy'),
+          uninstall: () => results.push('uninstall'),
+        }]
+      });
+      chart.reset();
+      expect(results).toEqual(['reset']);
+      chart.destroy();
+      expect(results).toEqual(['reset', 'afterDestroy', 'uninstall']);
+      chart.reset();
+      expect(results).toEqual(['reset', 'afterDestroy', 'uninstall']);
+    });
   });
 });


### PR DESCRIPTION
Fixes #12032 - the problem in the issue was that `chart.destroy` was being called in `onClick`, which is probably not the right way to use `chart.destroy` (ideally, it would be wrapped in `requestAnimationFrame` or `setTimeout`), but with this PR, similar issues related to chart.destoy() being called at the wrong time should have less impact on plugins.

