### PR TITLE
Add data.datasets[].tooltip.callbacks to Typescript types

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -2678,10 +2678,23 @@ export interface Tooltip extends Plugin {
 
 export declare const Tooltip: Tooltip;
 
-export interface TooltipCallbacks<
+export interface TooltipDatasetCallbacks<
   TType extends ChartType,
   Model = TooltipModel<TType>,
   Item = TooltipItem<TType>> {
+  beforeLabel(this: Model, tooltipItem: Item): string | string[] | void;
+  label(this: Model, tooltipItem: Item): string | string[] | void;
+  afterLabel(this: Model, tooltipItem: Item): string | string[] | void;
+
+  labelColor(this: Model, tooltipItem: Item): TooltipLabelStyle | void;
+  labelTextColor(this: Model, tooltipItem: Item): Color | void;
+  labelPointStyle(this: Model, tooltipItem: Item): { pointStyle: PointStyle; rotation: number } | void;
+}
+
+export interface TooltipCallbacks<
+  TType extends ChartType,
+  Model = TooltipModel<TType>,
+  Item = TooltipItem<TType>> extends TooltipDatasetCallbacks<TType, Model, Item> {
 
   beforeTitle(this: Model, tooltipItems: Item[]): string | string[] | void;
   title(this: Model, tooltipItems: Item[]): string | string[] | void;
@@ -2913,6 +2926,10 @@ export interface TooltipOptions<TType extends ChartType = ChartType> extends Cor
   callbacks: TooltipCallbacks<TType>;
 }
 
+export interface TooltipDatasetOptions<TType extends ChartType = ChartType> {
+  callbacks: TooltipDatasetCallbacks<TType>;
+}
+
 export interface TooltipItem<TType extends ChartType> {
   /**
    * The chart the tooltip is being shown on
@@ -2958,6 +2975,10 @@ export interface TooltipItem<TType extends ChartType> {
    * The chart element (point, arc, bar, etc.) for this tooltip item
    */
   element: Element;
+}
+
+export interface PluginDatasetOptionsByType<TType extends ChartType> {
+  tooltip: TooltipDatasetOptions<TType>;
 }
 
 export interface PluginOptionsByType<TType extends ChartType> {
@@ -3800,6 +3821,8 @@ export type ChartDataset<
   TData = DefaultDataPoint<TType>
 > = DeepPartial<
 { [key in ChartType]: { type: key } & ChartTypeRegistry[key]['datasetOptions'] }[TType]
+> & DeepPartial<
+PluginDatasetOptionsByType<TType>
 > & ChartDatasetProperties<TType, TData>;
 
 export type ChartDatasetCustomTypesPerDataset<
@@ -3807,6 +3830,8 @@ export type ChartDatasetCustomTypesPerDataset<
   TData = DefaultDataPoint<TType>
 > = DeepPartial<
 { [key in ChartType]: { type: key } & ChartTypeRegistry[key]['datasetOptions'] }[TType]
+> & DeepPartial<
+PluginDatasetOptionsByType<TType>
 > & ChartDatasetPropertiesCustomTypesPerDataset<TType, TData>;
 
 /**


### PR DESCRIPTION
Should fix #12046.

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
