### PR TITLE
fix: Unwanted white gap between bar border and bar fill (chartjs#12094)

### DIFF
--- a/src/elements/element.bar.js
+++ b/src/elements/element.bar.js
@@ -161,7 +161,8 @@ export default class BarElement extends Element {
     borderWidth: 0,
     borderRadius: 0,
     inflateAmount: 'auto',
-    pointStyle: undefined
+    pointStyle: undefined,
+    snap: false,
   };
 
   /**
@@ -188,7 +189,7 @@ export default class BarElement extends Element {
   }
 
   draw(ctx) {
-    const {inflateAmount, options: {borderColor, backgroundColor}} = this;
+    const {inflateAmount, options: {borderColor, backgroundColor, snap}} = this;
     const {inner, outer} = boundingRects(this);
     const addRectPath = hasRadius(outer.radius) ? addRoundedRectPath : addNormalRectPath;
 
@@ -196,15 +197,15 @@ export default class BarElement extends Element {
 
     if (outer.w !== inner.w || outer.h !== inner.h) {
       ctx.beginPath();
-      addRectPath(ctx, inflateRect(outer, inflateAmount, inner, true));
+      addRectPath(ctx, inflateRect(outer, inflateAmount, inner, snap));
       ctx.clip();
-      addRectPath(ctx, inflateRect(inner, -inflateAmount, outer, true));
+      addRectPath(ctx, inflateRect(inner, -inflateAmount, outer, snap));
       ctx.fillStyle = borderColor;
       ctx.fill('evenodd');
     }
 
     ctx.beginPath();
-    addRectPath(ctx, inflateRect(inner, inflateAmount, undefined, true));
+    addRectPath(ctx, inflateRect(inner, inflateAmount, undefined, snap));
     ctx.fillStyle = backgroundColor;
     ctx.fill();
 

--- a/test/specs/element.bar.tests.js
+++ b/test/specs/element.bar.tests.js
@@ -83,6 +83,7 @@ describe('Bar element tests', function() {
           elements: {
             bar: {
               inflateAmount: 0,
+              snap: false,
             }
           },
         }
@@ -115,6 +116,7 @@ describe('Bar element tests', function() {
           elements: {
             bar: {
               inflateAmount: 0,
+              snap: false,
             }
           },
         }


### PR DESCRIPTION
Changes
- Applied pixel snapping in `inflateRect` function in element.bar.js
- Fixed white pixel gaps that occur when bar borders are thick

Related issue
- #12094 