### PR TITLE
fix(types): allow null for line chart point values (#12027)

### DIFF
--- a/src/types/geometric.d.ts
+++ b/src/types/geometric.d.ts
@@ -33,7 +33,7 @@ export type RoundedRect = {
   y: number;
   w: number;
   h: number;
-  radius?: CornerRadius;
+  radius?: CornerRadius
 }
 
 export type Padding = Partial<TRBL> | number | Point;


### PR DESCRIPTION
This PR updates the TypeScript definition for Point to allow null values for x and y.

According to the Chart.js [documentation](https://www.chartjs.org/docs/latest/charts/line.html#missing-data), null is valid for skipped values in line charts. However, the current typings only accept number, which causes TypeScript errors when using null in datasets.

Before

```ts
export interface Point {
  x: number;
  y: number;
 }
```


After

```ts
export interface Point {
  x: number | null;
  y: number | null;
}
```


Example

```ts
new Chart<'line'>(ctx, {
  type: 'line',
  data: {
    datasets: [
      {
        data: [
          { x: 10, y: 20 },
          { x: 15, y: null }, //  now type checks correctly
          { x: 20, y: 10 }
        ]
      }
    ]
  }
});
```
Why this change is needed

- Runtime behavior already supports null (point is skipped).
- Docs confirm null is valid.
- TypeScript definitions should align with runtime and docs.
- Fixes TypeScript error: Type 'null' is not assignable to type 'number'

