### PR TITLE
fix(types): add drawingArea to RadialLinearScale

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -3627,6 +3627,7 @@ export type RadialLinearScaleOptions = CoreScaleOptions & {
 export interface RadialLinearScale<O extends RadialLinearScaleOptions = RadialLinearScaleOptions> extends Scale<O> {
   xCenter: number;
   yCenter: number;
+  readonly drawingArea: number;
   setCenterPoint(leftMovement: number, rightMovement: number, topMovement: number, bottomMovement: number): void;
   getIndexAngle(index: number): number;
   getDistanceFromCenterForValue(value: number): number;


### PR DESCRIPTION
Closes #12026

The `drawingArea` property exists in the `RadialLinearScale` implementation (`scale.radialLinear.js`) and is used for calculating the radius of radar/polar charts.  

However, it was missing from the TypeScript definitions, which caused errors like:

```ts
const scale = chart.scales.r;
console.log(scale.drawingArea); 
//  TS error: Property 'drawingArea' does not exist
```
 **Changes**

- Added readonly drawingArea: number to RadialLinearScale in types/index.d.ts.

```ts
import { Chart, RadialLinearScale } from "chart.js";

const chart = new Chart(document.createElement("canvas"), {
  type: "radar",
  data: { labels: ["A"], datasets: [{ data: [10] }] }
});

const scale = chart.scales.r as RadialLinearScale;
console.log(scale.drawingArea); //  typed as number
```
