### PR TITLE
Use integer canvas dimensions

### DIFF
--- a/src/helpers/helpers.dom.ts
+++ b/src/helpers/helpers.dom.ts
@@ -227,12 +227,14 @@ export function retinaScale(
     canvas.style.width = `${chart.width}px`;
   }
 
+  const canvasHeight = Math.floor(deviceHeight);
+  const canvasWidth = Math.floor(deviceWidth);
   if (chart.currentDevicePixelRatio !== pixelRatio
-      || canvas.height !== deviceHeight
-      || canvas.width !== deviceWidth) {
+      || canvas.height !== canvasHeight
+      || canvas.width !== canvasWidth) {
     (chart as PrivateChart).currentDevicePixelRatio = pixelRatio;
-    canvas.height = deviceHeight;
-    canvas.width = deviceWidth;
+    canvas.height = canvasHeight;
+    canvas.width = canvasWidth;
     chart.ctx.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
     return true;
   }


### PR DESCRIPTION
As a result of #12097, the HTMLCanvasElement's `width` and `height` (which are always integers - see [MDN][1]) may be compared to fractional `deviceWidth` and `deviceHeight`, resulting in extra resize and update events being fired.

This PR rounds the dimensions for purposes of comparing to the canvas element's, which should put the behavior closer to Chart.js 4.5.0 and earlier.

I've tested this against #11224, my own code (which was generating errors due to an interaction between these extra events and some internal plugins), and https://codepen.io/joshkel/pen/azdjLGZ, and it seems to work.

[1]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement#instance_properties

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->

Fixes #12143

