### PR TITLE
docs(legend): update default onClick example for v4 (fixes #12144)

### DIFF
--- a/docs/configuration/legend.md
+++ b/docs/configuration/legend.md
@@ -162,19 +162,16 @@ const chart = new Chart(ctx, {
 
 It can be common to want to trigger different behaviour when clicking an item in the legend. This can be easily achieved using a callback in the config object.
 
+:::tip Updated
+Starting from Chart.js v4, use `toggleDataVisibility()` and `update()` instead of the old `show()` / `hide()` methods.
+:::
+
 The default legend click handler is:
 
 ```javascript
 function(e, legendItem, legend) {
-    const index = legendItem.datasetIndex;
-    const ci = legend.chart;
-    if (ci.isDatasetVisible(index)) {
-        ci.hide(index);
-        legendItem.hidden = true;
-    } else {
-        ci.show(index);
-        legendItem.hidden = false;
-    }
+    legend.chart.toggleDataVisibility(legendItem.index);
+    legend.chart.update();
 }
 ```
 


### PR DESCRIPTION
<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
The default legend onClick example used outdated methods (`show` / `hide`)
which caused a TypeError in Chart.js v4.
Updated to use `toggleDataVisibility()` and `update()` instead.
Fixes #12144.
