### PR TITLE
fix: prevent early return in clearStacks when iterating dataset refer…

### DIFF
--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -217,11 +217,15 @@ function clearStacks(meta, items) {
   for (const parsed of items) {
     const stacks = parsed._stacks;
     if (!stacks || stacks[axis] === undefined || stacks[axis][datasetIndex] === undefined) {
-      return;
+      continue;
     }
     delete stacks[axis][datasetIndex];
     if (stacks[axis]._visualValues !== undefined && stacks[axis]._visualValues[datasetIndex] !== undefined) {
       delete stacks[axis]._visualValues[datasetIndex];
+    }
+    // Clean up empty stack objects to prevent memory leaks
+    if (Object.keys(stacks[axis]).length === 1) {
+      delete stacks[axis];
     }
   }
 }


### PR DESCRIPTION
resolves #12154

- Changed `return` to `continue` to iterate through all parsed items
- Added cleanup of empty stack objects to prevent memory leaks
- Handles sparse stacking scenarios where some data points may lack stack references
<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
