### PR TITLE
Fix: keep line visible when zooming between data points

### DIFF
--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -83,22 +83,123 @@ export default class LineController extends DatasetController {
       return {start, count};
     }
 
+    const length = _parsed.length;
+
+    // Find the largest value < min (beforeIndex) using binary search.
     let beforeIndex = -1;
     let beforeValue = -Infinity;
+    {
+      let low = 0;
+      let high = length - 1;
+      while (low <= high) {
+        let mid = (low + high) >> 1;
+        let value = _parsed[mid][iAxis];
+
+        // If value is not numeric, search outward from mid to find a nearby numeric value.
+        if (!isNumber(value)) {
+          let left = mid - 1;
+          let right = mid + 1;
+          let found = false;
+          while (left >= low || right <= high) {
+            if (left >= low) {
+              const lv = _parsed[left][iAxis];
+              if (isNumber(lv)) {
+                value = lv;
+                mid = left;
+                found = true;
+                break;
+              }
+              left--;
+            }
+            if (right <= high) {
+              const rv = _parsed[right][iAxis];
+              if (isNumber(rv)) {
+                value = rv;
+                mid = right;
+                found = true;
+                break;
+              }
+              right++;
+            }
+          }
+          if (!found) {
+            // No numeric values in current search window.
+            break;
+          }
+        }
+
+        if (!isNumber(value)) {
+          break;
+        }
+
+        if (value < min) {
+          if (value > beforeValue) {
+            beforeValue = value;
+            beforeIndex = mid;
+          }
+          low = mid + 1;
+        } else {
+          high = mid - 1;
+        }
+      }
+    }
+
+    // Find the smallest value > max (afterIndex) using binary search.
     let afterIndex = -1;
     let afterValue = Infinity;
+    {
+      let low = 0;
+      let high = length - 1;
+      while (low <= high) {
+        let mid = (low + high) >> 1;
+        let value = _parsed[mid][iAxis];
 
-    for (let i = 0; i < _parsed.length; ++i) {
-      const value = _parsed[i][iAxis];
-      if (!isNumber(value)) {
-        continue;
-      }
-      if (value < min && value > beforeValue) {
-        beforeValue = value;
-        beforeIndex = i;
-      } else if (value > max && value < afterValue) {
-        afterValue = value;
-        afterIndex = i;
+        // If value is not numeric, search outward from mid to find a nearby numeric value.
+        if (!isNumber(value)) {
+          let left = mid - 1;
+          let right = mid + 1;
+          let found = false;
+          while (left >= low || right <= high) {
+            if (left >= low) {
+              const lv = _parsed[left][iAxis];
+              if (isNumber(lv)) {
+                value = lv;
+                mid = left;
+                found = true;
+                break;
+              }
+              left--;
+            }
+            if (right <= high) {
+              const rv = _parsed[right][iAxis];
+              if (isNumber(rv)) {
+                value = rv;
+                mid = right;
+                found = true;
+                break;
+              }
+              right++;
+            }
+          }
+          if (!found) {
+            // No numeric values in current search window.
+            break;
+          }
+        }
+
+        if (!isNumber(value)) {
+          break;
+        }
+
+        if (value > max) {
+          if (value < afterValue) {
+            afterValue = value;
+            afterIndex = mid;
+          }
+          high = mid - 1;
+        } else {
+          low = mid + 1;
+        }
       }
     }
 

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -45,13 +45,15 @@ export default class LineController extends DatasetController {
     const animationsDisabled = this.chart._animationsDisabled;
     let {start, count} = _getStartAndCountOfVisiblePoints(meta, points, animationsDisabled);
 
-    this._drawStart = start;
-    this._drawCount = count;
-
     if (_scaleRangesChanged(meta)) {
       start = 0;
       count = points.length;
     }
+
+    ({start, count} = this._includeBoundaryPoints(meta, start, count));
+
+    this._drawStart = start;
+    this._drawCount = count;
 
     // Update Line
     line._chart = this.chart;
@@ -71,6 +73,53 @@ export default class LineController extends DatasetController {
 
     // Update Points
     this.updateElements(points, start, count, mode);
+  }
+
+  _includeBoundaryPoints(meta, start, count) {
+    const {iScale, _parsed} = meta;
+    const {min, max, axis: iAxis} = iScale;
+
+    if (!_parsed?.length || !isNumber(min) || !isNumber(max)) {
+      return {start, count};
+    }
+
+    let beforeIndex = -1;
+    let beforeValue = -Infinity;
+    let afterIndex = -1;
+    let afterValue = Infinity;
+
+    for (let i = 0; i < _parsed.length; ++i) {
+      const value = _parsed[i][iAxis];
+      if (!isNumber(value)) {
+        continue;
+      }
+      if (value < min && value > beforeValue) {
+        beforeValue = value;
+        beforeIndex = i;
+      } else if (value > max && value < afterValue) {
+        afterValue = value;
+        afterIndex = i;
+      }
+    }
+
+    let drawStart = start;
+    let drawEnd = count > 0 ? start + count - 1 : -1;
+
+    if (beforeIndex !== -1) {
+      drawStart = drawEnd === -1 ? beforeIndex : Math.min(drawStart, beforeIndex);
+      drawEnd = Math.max(drawEnd, beforeIndex);
+    }
+
+    if (afterIndex !== -1) {
+      drawStart = drawEnd === -1 ? afterIndex : Math.min(drawStart, afterIndex);
+      drawEnd = Math.max(drawEnd, afterIndex);
+    }
+
+    if (drawEnd >= drawStart && drawEnd !== -1) {
+      return {start: drawStart, count: drawEnd - drawStart + 1};
+    }
+
+    return {start, count};
   }
 
   updateElements(points, start, count, mode) {

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -50,7 +50,9 @@ export default class LineController extends DatasetController {
       count = points.length;
     }
 
-    ({start, count} = this._includeBoundaryPoints(meta, start, count));
+    if (count !== points.length) {
+      ({start, count} = this._includeBoundaryPoints(meta, start, count));
+    }
 
     this._drawStart = start;
     this._drawCount = count;

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -459,8 +459,26 @@ export default class DatasetController {
 
     if (this._parsing === false) {
       meta._parsed = data;
-      meta._sorted = true;
       parsed = data;
+
+      if (sorted && iScale) {
+        const axis = iAxis;
+
+        for (i = start; i < start + count; ++i) {
+          cur = parsed[i];
+          const curValue = cur && cur[axis];
+          const prevValue = prev && prev[axis];
+
+          if (curValue === null || curValue === undefined || (prevValue !== undefined && curValue < prevValue)) {
+            sorted = false;
+            break;
+          }
+
+          prev = cur;
+        }
+      }
+
+      meta._sorted = sorted;
     } else {
       if (isArray(data[start])) {
         parsed = this.parseArrayData(meta, data, start, count);


### PR DESCRIPTION
Fixes #12174

### Problem
When zooming into a range that contains no data points
(between widely spaced points), the line chart disappears
even though the connecting line segment should be visible.

### Cause
The line controller only rendered points strictly inside
the visible scale range. When zero points were visible,
no line segments were drawn.

### Solution
Include the nearest boundary points (before and after the
visible range) when computing the draw window so line
segments crossing the viewport are rendered correctly.

### Verification
- Reproduced using the original CodePen
- Verified line disappears with the CDN build
- Rebuilt Chart.js with this patch
- Confirmed the line remains visible when zooming into
  sparse regions with zero visible points