### PR TITLE
fix: add null checks to prevent crash when a chart is destroyed

### DIFF
--- a/src/helpers/helpers.canvas.ts
+++ b/src/helpers/helpers.canvas.ts
@@ -326,6 +326,7 @@ export function _isPointInArea(
 }
 
 export function clipArea(ctx: CanvasRenderingContext2D, area: TRBL) {
+  if (!ctx) return;
   ctx.save();
   ctx.beginPath();
   ctx.rect(area.left, area.top, area.right - area.left, area.bottom - area.top);
@@ -333,6 +334,7 @@ export function clipArea(ctx: CanvasRenderingContext2D, area: TRBL) {
 }
 
 export function unclipArea(ctx: CanvasRenderingContext2D) {
+  if (!ctx) return;
   ctx.restore();
 }
 

--- a/src/helpers/helpers.dom.ts
+++ b/src/helpers/helpers.dom.ts
@@ -111,6 +111,11 @@ export function getRelativePosition(
   }
 
   const {canvas, currentDevicePixelRatio} = chart;
+  // Guard against null canvas to prevent ownerDocument crash
+  if (!canvas) {
+    return {x: 0, y: 0};
+  }
+
   const style = getComputedStyle(canvas);
   const borderBox = style.boxSizing === 'border-box';
   const paddings = getPositionedStyle(style, 'padding');
@@ -166,6 +171,11 @@ export function getMaximumSize(
   bbHeight?: number,
   aspectRatio?: number
 ): { width: number; height: number } {
+  // Guard against null canvas to prevent ownerDocument crash
+  if (!canvas) {
+    return {width: 0, height: 0};
+  }
+
   const style = getComputedStyle(canvas);
   const margins = getPositionedStyle(style, 'margin');
   const maxWidth = parseMaxStyle(style.maxWidth, canvas, 'clientWidth') || INFINITY;


### PR DESCRIPTION
 ---
  When a chart is destroyed while an animation frame is in-flight, the animation callback can still execute and attempt operations on null/destroyed canvas elements, causing multiple crash scenarios:

  1. Context crash: TypeError: Cannot read properties of null (reading 'save') when clipArea/unclipArea try to call ctx.save() on a null canvas context
  2. ownerDocument crash: TypeError: Cannot read properties of null (reading 'ownerDocument') when getMaximumSize/getRelativePosition call getComputedStyle(canvas) on a null canvas element

  Both issues share the same root cause: Animator._update() executes after chart.destroy(), attempting to render on destroyed canvas resources.

  Crash paths:
  - clipArea: Animator._update() → chart.draw() → _setStyle() → clipArea(ctx) → ctx.save()
  - ownerDocument: Animator._update() → chart.draw() → _resize() → getMaximumSize(canvas) → getComputedStyle(canvas) → canvas.ownerDocument

  This manifests in Vue/React SPAs when users navigate away from pages containing animated charts. The component unmount destroys the chart, but previously-scheduled animation frames may still fire and attempt to access destroyed resources.

  Similar to the issue fixed in #11764 for clearCanvas.