### PR TITLE
fix(legend): respect horizontal padding for legend title

### DIFF
--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -474,8 +474,8 @@ export class Legend extends Element {
     }
 
     // Now that we know the left edge of the inner legend box, compute the correct
-    // X coordinate from the title alignment
-    const x = _alignStartEnd(position, left, left + maxWidth);
+    // X coordinate from the title alignment, accounting for horizontal padding
+    const x = _alignStartEnd(position, left + titlePadding.left, left + maxWidth - titlePadding.right);
 
     // Canvas setup
     ctx.textAlign = rtlHelper.textAlign(_toLeftRightCenter(position));


### PR DESCRIPTION
## Summary
Fixes #12066

The legend title was not respecting the horizontal padding (`left` and `right`) specified in `titlePadding`. The title would be positioned without accounting for these padding values, causing visual misalignment.

## Changes
- Updated the x-coordinate calculation in `plugin.legend.js` to account for `titlePadding.left` and `titlePadding.right` when computing the title alignment position

## Before
```js
const x = _alignStartEnd(position, left, left + maxWidth);
```

## After
```js
const x = _alignStartEnd(position, left + titlePadding.left, left + maxWidth - titlePadding.right);
```