### PR TITLE
fix(dom): update canvas style on resize to allow chart to grow

### DIFF
--- a/src/helpers/helpers.dom.ts
+++ b/src/helpers/helpers.dom.ts
@@ -222,9 +222,22 @@ export function retinaScale(
   // If no style has been set on the canvas, the render size is used as display size,
   // making the chart visually bigger, so let's enforce it to the "correct" values.
   // See https://github.com/chartjs/Chart.js/issues/3575
+  // Also update styles when resizing to ensure the canvas grows with its container.
+  // See https://github.com/chartjs/Chart.js/issues/12177
   if (canvas.style && (forceStyle || (!canvas.style.height && !canvas.style.width))) {
     canvas.style.height = `${chart.height}px`;
     canvas.style.width = `${chart.width}px`;
+  } else if (canvas.style) {
+    // Update styles on resize if they were previously set by Chart.js
+    // This ensures the canvas can grow when its container grows
+    const currentStyleHeight = parseFloat(canvas.style.height);
+    const currentStyleWidth = parseFloat(canvas.style.width);
+    if (!isNaN(currentStyleHeight) && currentStyleHeight !== chart.height) {
+      canvas.style.height = `${chart.height}px`;
+    }
+    if (!isNaN(currentStyleWidth) && currentStyleWidth !== chart.width) {
+      canvas.style.width = `${chart.width}px`;
+    }
   }
 
   const canvasHeight = Math.floor(deviceHeight);


### PR DESCRIPTION
## Summary
Fixes #12177

When a chart's container grows (e.g., window resize making the container larger), the canvas would not grow to fill the new space. The canvas style dimensions were only set initially but not updated on subsequent resizes.

## Changes
- Enhanced `retinaScale` function in `helpers.dom.ts` to update the canvas style dimensions during resize if they were previously set by Chart.js
- This ensures the canvas can grow when its container grows, not just shrink

## Technical Details
The fix checks if the current style dimensions differ from the chart dimensions and updates them accordingly. This maintains the behavior where Chart.js-managed styles are kept in sync with the actual chart size.