### PR TITLE
fix: handle splice with single argument

### DIFF
--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -1066,7 +1066,7 @@ export default class DatasetController {
       this._sync(['_removeElements', start, count]);
     }
     const newCount = arguments.length - 2;
-    if (newCount) {
+    if (newCount > 0) {
       this._sync(['_insertElements', start, newCount]);
     }
   }

--- a/test/specs/core.datasetController.tests.js
+++ b/test/specs/core.datasetController.tests.js
@@ -40,6 +40,27 @@ describe('Chart.DatasetController', function() {
     });
   });
 
+  it('should handle splice with a single argument', function() {
+    var data = [0, 1, 2, 3, 4, 5];
+    var chart = acquireChart({
+      type: 'line',
+      data: {
+        datasets: [{
+          data: data
+        }]
+      }
+    });
+
+    // splice(0) with no deleteCount should remove all elements from index 0
+    // and not throw a RangeError due to negative newCount
+    expect(function() {
+      data.splice(0);
+      chart.update();
+    }).not.toThrow();
+
+    expect(data.length).toBe(0);
+  });
+
   it('should not try to delete non existent stacks', function() {
     function createAndUpdateChart() {
       var chart = acquireChart({


### PR DESCRIPTION
Fixes #12191

When `Array.prototype.splice` is called with only the `start` argument (e.g. `.splice(0)` to clear an array), the second argument (`deleteCount`) is omitted. In `_onDataSplice`, this caused `arguments.length - 2` to evaluate to `-1`, which is truthy and led to `_insertElements` being called with a negative count, throwing:

> RangeError: Invalid array length

The fix changes the condition from `if (newCount)` to `if (newCount > 0)` so that negative values from omitted arguments are properly ignored.

Added a test that verifies `data.splice(0)` works without throwing.