### PR TITLE
fix: use continue instead of return in clearStacks

### DIFF
--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -217,7 +217,7 @@ function clearStacks(meta, items) {
   for (const parsed of items) {
     const stacks = parsed._stacks;
     if (!stacks || stacks[axis] === undefined || stacks[axis][datasetIndex] === undefined) {
-      return;
+      continue;
     }
     delete stacks[axis][datasetIndex];
     if (stacks[axis]._visualValues !== undefined && stacks[axis]._visualValues[datasetIndex] !== undefined) {

--- a/test/specs/core.datasetController.tests.js
+++ b/test/specs/core.datasetController.tests.js
@@ -952,6 +952,39 @@ describe('Chart.DatasetController', function() {
     expect(meta._parsed[0]._stacks).toEqual(jasmine.objectContaining({y: {0: 10, 1: 20, _top: 1, _bottom: null, _visualValues: {0: 10, 1: 20}}}));
   });
 
+  it('should clear stacks for all data points even when some lack stack data', function() {
+    // Regression test for #12154: clearStacks used `return` instead of
+    // `continue`, so if any parsed item lacked _stacks data the remaining
+    // items were skipped, leaving stale stack entries.
+    var chart = acquireChart({
+      type: 'line',
+      data: {
+        datasets: [{
+          data: [{x: 1, y: 10}, {x: 2, y: 20}, {x: 3, y: 30}],
+          label: 'A'
+        }, {
+          data: [{x: 1, y: 11}, {x: 2, y: 21}, {x: 3, y: 31}],
+          label: 'B'
+        }]
+      },
+      options: {
+        parsing: false,
+        scales: {
+          y: {stacked: 'single'}
+        }
+      }
+    });
+
+    // Swap dataset order
+    var datasets = chart.data.datasets;
+    chart.data.datasets = [datasets[1], datasets[0]];
+
+    // This should not throw or leave stale stack data
+    expect(function() {
+      chart.update();
+    }).not.toThrow();
+  });
+
   describe('resolveDataElementOptions', function() {
     it('should cache options when possible', function() {
       const chart = acquireChart({


### PR DESCRIPTION
Fixes #12154

When `clearStacks` was refactored from `forEach` to `for...of` in 1e296cc, the `return` inside the loop was kept as-is. In a `forEach` callback, `return` only skips the current iteration, but in a `for...of` loop it exits the entire function.

This means that if any parsed data point doesn't have `_stacks` data for the current dataset index (which can happen when two points share the same x-coordinate and reference the same `_stacks` object, or when new points are added), the loop exits early and leaves stale stack entries on the remaining data points. This causes lines/bars to be incorrectly stacked when datasets are reordered.

The fix simply changes `return` to `continue` to restore the original skip-this-iteration behavior.

Added a regression test that swaps dataset order and verifies the update doesn't throw.