### PR TITLE
fix(bar): floating bars incorrectly offset by stacked base value

### DIFF
--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -270,6 +270,8 @@ export default class BarController extends DatasetController {
     barPercentage: 0.9,
     grouped: true,
 
+    floatingBarMode: 'relative',  // 'absolute' | 'relative'
+    
     animations: {
       numbers: {
         type: 'number',
@@ -583,7 +585,12 @@ export default class BarController extends DatasetController {
       if (value !== 0 && sign(value) !== sign(custom.barEnd)) {
         start = 0;
       }
-      start += value;
+      const relative = this.options.floatingBarMode === 'relative';
+      if (relative) {
+        start += value;
+      } else {
+        start = value;
+      }
     }
 
     const startValue = !isNullOrUndef(baseValue) && !floating ? baseValue : start;


### PR DESCRIPTION
<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
Fixes:  #12197 
When using floating bars `(y: [start, end])` with `stacked: true` on a linear axis, bars sharing the same x value across multiple datasets are rendered at incorrect positions. The stacked base offset calculated by `applyStack` is incorrectly added to the absolute coordinates of the floating bar, causing bars to be shifted away from their intended y range.

Add a `floatingBarMode` option at the dataset level to distinguish between absolute and relative positioning of floating bars.
`'absolute'`: the floating bar is rendered at its exact [start, end] coordinates, ignoring any stacked offset.
`'relative'`: the floating bar is offset by the cumulative stack value of preceding datasets, preserving the current behavior.
To avoid a breaking change, `floatingBarMode` could default to `'relative'` to preserve existing behavior.