### PR TITLE
Fix #12191: splice with single argument throws RangeError

### DIFF
--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -1065,7 +1065,7 @@ export default class DatasetController {
     if (count) {
       this._sync(['_removeElements', start, count]);
     }
-    const newCount = arguments.length - 2;
+    const newCount = Math.max(0, arguments.length - 2);
     if (newCount) {
       this._sync(['_insertElements', start, newCount]);
     }

--- a/test/specs/core.datasetController.tests.js
+++ b/test/specs/core.datasetController.tests.js
@@ -538,6 +538,28 @@ describe('Chart.DatasetController', function() {
     expect(controller.getParsed(2)).toBe(data[2]);
   });
 
+  it('should handle splice with a single argument without throwing (issue #12191)', function() {
+    var data = [0, 1, 2, 3, 4, 5];
+    var chart = acquireChart({
+      type: 'line',
+      data: {
+        datasets: [{
+          data: data,
+        }],
+      },
+    });
+
+    var meta = chart.getDatasetMeta(0);
+
+    expect(function() {
+      data.splice(0);
+      chart.update();
+    }).not.toThrow();
+
+    expect(meta.data.length).toBe(0);
+    expect(data.length).toBe(0);
+  });
+
   it('should re-synchronize metadata when the data object reference changes', function() {
     var data0 = [0, 1, 2, 3, 4, 5];
     var data1 = [6, 7, 8];


### PR DESCRIPTION
When calling `data.splice(0)` with only one argument (which should clear the array), `_onDataSplice` computed `newCount` as `arguments.length - 2 = -1`, causing a `RangeError: Invalid array length`.

## Fix

Changed `arguments.length - 2` to `Math.max(0, arguments.length - 2)` in `core.datasetController.js` to clamp `newCount` to zero when fewer than 2 arguments are passed.

## Test

Added test case `should handle splice with a single argument without throwing (issue #12191)` in `core.datasetController.tests.js` that:
1. Creates a chart with 6 data points
2. Calls `data.splice(0)` (single argument)
3. Verifies no error is thrown
4. Verifies `meta.data.length` and `data.length` are both 0

Test fails without the fix (RangeError), passes with it. Full test suite passes on macOS ARM (Apple Silicon, ChromeHeadless).