### PR TITLE
Fix crossAlign 'far' ticks overlapping Y axis title

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -1350,7 +1350,7 @@ export default class Scale extends Element {
   }
 
   _getYAxisLabelAlignment(tl) {
-    const {position, ticks: {crossAlign, mirror, padding}} = this.options;
+    const {position, ticks: {crossAlign, mirror, padding}, title: titleOpts} = this.options;
     const labelSizes = this._getLabelSizes();
     const tickAndPadding = tl + padding;
     const widest = labelSizes.widest.width;
@@ -1379,6 +1379,9 @@ export default class Scale extends Element {
         } else if (crossAlign === 'center') {
           textAlign = 'center';
           x -= (widest / 2);
+        } else if (crossAlign === 'far') {
+          textAlign = 'left';
+          x = this.left + getTitleHeight(titleOpts, this.chart.options.font);
         } else {
           textAlign = 'left';
           x = this.left;
@@ -1405,6 +1408,9 @@ export default class Scale extends Element {
         } else if (crossAlign === 'center') {
           textAlign = 'center';
           x += widest / 2;
+        } else if (crossAlign === 'far') {
+          textAlign = 'right';
+          x = this.right - getTitleHeight(titleOpts, this.chart.options.font);
         } else {
           textAlign = 'right';
           x = this.right;


### PR DESCRIPTION
Fixes #12095

When `crossAlign` is set to `'far'` on a Y axis, tick labels were positioned at the very edge of the chart area, overlapping with the axis title.

The fix adds an offset equal to the title height when positioning tick labels with `crossAlign: 'far'`, so they don't overlap the title text. This applies to both left and right axis positions.

Tested by verifying the `_getYAxisLabelAlignment` method returns correct x positions that account for the title dimensions when `crossAlign` is `'far'`.