### PR TITLE
Fix chartArea undefined when resizeDelay ≠ 0

### DIFF
--- a/docs/configuration/responsive.md
+++ b/docs/configuration/responsive.md
@@ -20,7 +20,7 @@ Namespace: `options`
 | `maintainAspectRatio` | `boolean` | `true` | Maintain the original canvas aspect ratio `(width / height)` when resizing.
 | `aspectRatio` | `number` | `1`\|`2` | Canvas aspect ratio (i.e. `width / height`, a value of 1 representing a square canvas). Note that this option is ignored if the height is explicitly defined either as attribute or via the style. The default value varies by chart type; Radial charts (doughnut, pie, polarArea, radar) default to `1` and others default to `2`.
 | `onResize` | `function` | `null` | Called when a resize occurs. Gets passed two arguments: the chart instance and the new size.
-| `resizeDelay` | `number` | `0` | Delay the resize update by the given amount of milliseconds. This can ease the resize process by debouncing the update of the elements.
+| `resizeDelay` | `number` | `0` | Delay the resize update by the given amount of milliseconds. This can ease the resize process by debouncing the update of the elements.  The initial layout (when the chart is first created or attached) is not delayed, so `chart.chartArea` will be available immediately. |
 
 ## Important Note
 

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -294,9 +294,20 @@ class Chart {
     callCallback(options.onResize, [this, newSize], this);
 
     if (this.attached) {
-      if (this._doResize(mode)) {
-        // The resize update is delayed, only draw without updating.
-        this.render();
+      const delayed = this._doResize(mode);
+      if (delayed) {
+        // When resizeDelay is used the update is debounced and will occur later.
+        // However if the chart has never gone through a layout (chartArea undefined)
+        // we need to perform a synchronous update so that callers can access
+        // `chart.chartArea` immediately after initialization.  Otherwise the
+        // property would remain undefined until the delayed update fires.
+        if (this.chartArea === undefined) {
+          // force immediate layout/update
+          this.update(mode);
+        } else {
+          // The resize update is delayed, only draw without updating.
+          this.render();
+        }
       }
     }
   }

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -977,6 +977,33 @@ describe('Chart', function() {
       chart.resize();
     });
 
+    // When resizeDelay != 0 the initial layout was deferred which left
+    // `chart.chartArea` undefined even though the chart was already attached.
+    // See https://github.com/chartjs/Chart.js/issues/12166
+    it('should initialize chartArea immediately when resizeDelay is non-zero and the canvas is already attached', function() {
+      var wrapper = document.createElement('div');
+      wrapper.style.cssText = 'width: 300px; height: 200px; position: relative';
+      var canvas = document.createElement('canvas');
+      wrapper.appendChild(canvas);
+      document.body.appendChild(wrapper);
+
+      var chart = new Chart(canvas, {
+        type: 'line',
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          resizeDelay: 50
+        }
+      });
+
+      // even though the update may be debounced we expect the chartArea to
+      // be populated synchronously during initialization
+      expect(chart.chartArea).not.toBeUndefined();
+
+      chart.destroy();
+      document.body.removeChild(wrapper);
+    });
+
     // https://github.com/chartjs/Chart.js/issues/3790
     it('should resize the canvas if attached to the DOM after construction', function(done) {
       var canvas = document.createElement('canvas');
@@ -986,7 +1013,10 @@ describe('Chart', function() {
         type: 'line',
         options: {
           responsive: true,
-          maintainAspectRatio: false
+          maintainAspectRatio: false,
+          // ensure that a delay is in effect; the bug manifested only when
+          // resizeDelay was non-zero
+          resizeDelay: 50
         }
       });
 


### PR DESCRIPTION
- force immediate update during initial resize if chartArea is still undefined
- add regression test verifying synchronous chartArea initialization
- update responsive docs to clarify initial layout isn’t delayed

closes #12166

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
