### PR TITLE
Change TimeScaleTimeOptions from Type to Interface to allow for declaration merging in adapters

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -3381,7 +3381,7 @@ export declare const LogarithmicScale: ChartComponent & {
   new <O extends LogarithmicScaleOptions = LogarithmicScaleOptions>(cfg: AnyObject): LogarithmicScale<O>;
 };
 
-export type TimeScaleTimeOptions = {
+export interface TimeScaleTimeOptions {
   /**
    * Custom parser for dates.
    */
@@ -3416,7 +3416,7 @@ export type TimeScaleTimeOptions = {
    * @default 'millisecond'
    */
   minUnit: TimeUnit;
-};
+}
 
 export type TimeScaleTickOptions = {
   /**


### PR DESCRIPTION
See #12220 

This should be a non-breaking change — interface and type are interchangeable for object shapes. But it would allow adapters to augment displayFormats and tooltipFormat via declaration merging:

```js
  // In an adapter package
  declare module 'chart.js' {
    interface TimeScaleTimeOptions {
      displayFormats: {
        [key: string]: string | Intl.DateTimeFormatOptions | ((timestamp: number, context: FormatContext) => string);
      };
    }
  }
```
