### PR TITLE
fix(bar): positioning and category isolation for bar charts with stacked axes

### DIFF
--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -497,14 +497,33 @@ export default class BarController extends DatasetController {
   }
 
   _getAxis() {
-    const axis = {};
+    const {chart} = this;
+    const scales = chart.scales;
     const firstScaleAxisId = this.getFirstScaleIdForIndexAxis();
-    for (const dataset of this.chart.data.datasets) {
-      axis[valueOrDefault(
-        this.chart.options.indexAxis === 'x' ? dataset.xAxisID : dataset.yAxisID, firstScaleAxisId
-      )] = true;
+    const processedAxisIds = new Set();
+    const processedStacks = new Set();
+    const axis = [];
+
+    for (const dataset of chart.data.datasets) {
+      const axisId = valueOrDefault(
+        chart.options.indexAxis === 'x' ? dataset.xAxisID : dataset.yAxisID,
+        firstScaleAxisId
+      );
+
+      if (!processedAxisIds.has(axisId)) {
+        processedAxisIds.add(axisId);
+        const scale = scales[axisId];
+        const stack = scale && scale.options.stack;
+
+        if (isNullOrUndef(stack)) {
+          axis.push(axisId);
+        } else if (!processedStacks.has(stack)) {
+          processedStacks.add(stack);
+          axis.push(axisId);
+        }
+      }
     }
-    return Object.keys(axis);
+    return axis;
   }
 
   /**
@@ -639,15 +658,35 @@ export default class BarController extends DatasetController {
     const skipNull = options.skipNull;
     const maxBarThickness = valueOrDefault(options.maxBarThickness, Infinity);
     let center, size;
-    const axisCount = this._getAxisCount();
+
     if (ruler.grouped) {
       const stackCount = skipNull ? this._getStackCount(index) : ruler.stackCount;
+      const axisGroups = this._getAxis();
+      const axisCount = axisGroups.length;
       const range = options.barThickness === 'flex'
         ? computeFlexCategoryTraits(index, ruler, options, stackCount * axisCount)
         : computeFitCategoryTraits(index, ruler, options, stackCount * axisCount);
-      const axisID = this.chart.options.indexAxis === 'x' ? this.getDataset().xAxisID : this.getDataset().yAxisID;
-      const axisNumber = this._getAxis().indexOf(valueOrDefault(axisID, this.getFirstScaleIdForIndexAxis()));
-      const stackIndex = this._getStackIndex(this.index, this._cachedMeta.stack, skipNull ? index : undefined) + axisNumber;
+
+      const dataset = this.getDataset();
+      const axisID = this.chart.options.indexAxis === 'x' ? dataset.xAxisID : dataset.yAxisID;
+      const firstScaleId = this.getFirstScaleIdForIndexAxis();
+      const actualAxisID = valueOrDefault(axisID, firstScaleId);
+      const axisScale = this.chart.scales[actualAxisID];
+      const axisStack = axisScale && axisScale.options.stack;
+
+      let axisNumber = axisGroups.indexOf(actualAxisID);
+      if (axisNumber === -1 && defined(axisStack)) {
+        for (let i = 0; i < axisGroups.length; i++) {
+          const groupScale = this.chart.scales[axisGroups[i]];
+          if (groupScale && groupScale.options.stack === axisStack) {
+            axisNumber = i;
+            break;
+          }
+        }
+      }
+      axisNumber = Math.max(axisNumber, 0);
+
+      const stackIndex = this._getStackIndex(this.index, this._cachedMeta.stack, skipNull ? index : undefined) + axisNumber * stackCount;
       center = range.start + (range.chunk * stackIndex) + (range.chunk / 2);
       size = Math.min(maxBarThickness, range.chunk * range.ratio);
     } else {

--- a/src/scales/scale.category.js
+++ b/src/scales/scale.category.js
@@ -1,5 +1,5 @@
 import Scale from '../core/core.scale.js';
-import {isNullOrUndef, valueOrDefault, _limitValue} from '../helpers/index.js';
+import {isNullOrUndef, valueOrDefault, _limitValue, defined} from '../helpers/index.js';
 
 const addIfString = (labels, raw, index, addedLabels) => {
   if (typeof raw === 'string') {
@@ -54,6 +54,7 @@ export default class CategoryScale extends Scale {
   }
 
   init(scaleOptions) {
+    const data = this.chart.data;
     const added = this._addedLabels;
     if (added.length) {
       const labels = this.getLabels();
@@ -64,7 +65,12 @@ export default class CategoryScale extends Scale {
       }
       this._addedLabels = [];
     }
+
     super.init(scaleOptions);
+
+    if (defined(this.options.stack) && !scaleOptions.labels && !data[this.isHorizontal() ? 'xLabels' : 'yLabels']) {
+      this.options.labels = this.options.labels || [];
+    }
   }
 
   parse(raw, index) {


### PR DESCRIPTION
#### Description
This PR addresses two major issues when using stacked axes (via the `stack` property in scale configurations) in bar charts:
1.  **Incorrect Bar Positioning and Unnecessary Spacing:** Previously, the `BarController` calculated the available space by multiplying the number of stacks by the total number of axes. This led to bars being too thin and incorrectly offset when multiple axes were visually stacked on top of each other.
2.  **Shared Categories across Stacked Category Scales:** When multiple category scales were used in a stack, they would share the global `chart.data.labels` array. This caused categories added by one axis to appear on all other axes in the stack.

Reproduction of the issues:
[https://codepen.io/michael-stubenvoll-heller/pen/vEXWGag](https://codepen.io/michael-stubenvoll-heller/pen/vEXWGag)

#### Changes

##### `src/controllers/controller.bar.js`
-   **Grouped Axis Logic:** Refactored `_getAxis()` to group axes that share the same `stack` ID. This ensures that the calculation of bar width is based only on group of axes. 
-   **Positioning Calculation:** Updated `_calculateBarIndexPixels` to correctly calculate the `axisNumber` and `stackIndex` based on these axis groups. Bars in one axis now correctly use the whole horizontal/vertical space available.

##### `src/scales/scale.category.js`
-   **Label Isolation:** Modified `init()` to provide a local label storage (`this.options.labels`) for category scales that are part of a stack. This isolates the categories of each axis, ensuring that an axis only displays labels relevant to its own datasets. Added a check to only enable this isolation if a `stack` property is defined. This prevents breaking standard charts (like Bubble or simple Bar charts) that rely on the global `chart.data.labels`.