### PR TITLE
fix(linear-scale): respect stepSize for non-divisible min/max ranges

### DIFF
--- a/src/scales/scale.linearbase.js
+++ b/src/scales/scale.linearbase.js
@@ -66,7 +66,10 @@ function generateTicks(generationOptions, dataRange) {
     niceMax = rmax;
   }
 
-  if (minDefined && maxDefined && step && almostWhole((max - min) / step, spacing / 1000)) {
+  const stepCount = step ? (max - min) / step : 0;
+  const stepCountEpsilon = Math.max(Math.abs(stepCount) * Number.EPSILON, 1e-14);
+
+  if (minDefined && maxDefined && step && almostWhole(stepCount, stepCountEpsilon)) {
     // Case 1: If min, max and stepSize are set and they make an evenly spaced scale use it.
     // spacing = step;
     // numSpaces = (max - min) / spacing;

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -684,6 +684,48 @@ describe('Linear Scale', function() {
     expect(getLabels(chart.scales.y)).toEqual(['1', '3', '5', '7', '9', '11']);
   });
 
+  it('Should use stepSize increments and keep max as the final shorter interval', function() {
+    var chart = window.acquireChart({
+      type: 'bar',
+      options: {
+        scales: {
+          y: {
+            type: 'linear',
+            min: 0,
+            max: 3333,
+            ticks: {
+              stepSize: 500
+            }
+          }
+        }
+      }
+    });
+
+    expect(chart.scales.y.ticks.map(tick => tick.value)).toEqual([
+      0, 500, 1000, 1500, 2000, 2500, 3000, 3333
+    ]);
+  });
+
+  it('Should use stepSize for floating point ranges that are effectively divisible', function() {
+    var chart = window.acquireChart({
+      type: 'bar',
+      options: {
+        scales: {
+          y: {
+            type: 'linear',
+            min: 0,
+            max: 0.3,
+            ticks: {
+              stepSize: 0.1
+            }
+          }
+        }
+      }
+    });
+
+    expect(chart.scales.y.ticks.map(tick => +tick.value.toFixed(1))).toEqual([0, 0.1, 0.2, 0.3]);
+  });
+
   it('Should not generate any ticks > max if max is specified', function() {
     var chart = window.acquireChart({
       type: 'line',


### PR DESCRIPTION
Fixes #12165

## Summary
When `min`, `max`, and `stepSize` are set, linear tick generation used a spacing-based tolerance (`spacing / 1000`) to detect whole step counts.  
With larger step sizes, that tolerance can be too loose and misclassify non-divisible ranges as divisible, producing evenly distributed ticks instead of `stepSize` increments.

This change switches the whole-step check to a machine-precision-based epsilon derived from `stepCount`.

## Behavior after fix
For non-divisible ranges, ticks follow `stepSize` multiples and keep `max` as the final shorter interval:
- `min: 0`, `max: 3333`, `stepSize: 500`
- ticks: `[0, 500, 1000, 1500, 2000, 2500, 3000, 3333]`

Floating-point divisible ranges still behave correctly:
- `min: 0`, `max: 0.3`, `stepSize: 0.1`

## Tests
Added regression tests in `test/specs/scale.linear.tests.js` for:
1. Large non-divisible range (`0..3333`, `stepSize: 500`)
2. Floating-point divisible range (`0..0.3`, `stepSize: 0.1`)

Validated with:
- `pnpm run lint-js`
- `pnpm run test-ci-karma scale.linear.tests`

## References
- Issue repro: https://github.com/chartjs/Chart.js/issues/12165
- CodePen (reported case): https://codepen.io/Pia-Gerhofer/pen/LENMKOO

