### PR TITLE
docs: fix typos in markdown documentation

### DIFF
--- a/docs/samples/animations/progressive-line-easing.md
+++ b/docs/samples/animations/progressive-line-easing.md
@@ -21,7 +21,7 @@ let restart = false;
 const totalDuration = 5000;
 const duration = (ctx) => easing(ctx.index / data.length) * totalDuration / data.length;
 const delay = (ctx) => easing(ctx.index / data.length) * totalDuration;
-const previousY = (ctx) => ctx.index === 0 ? ctx.chart.scales.y.getPixelForValue(100) : ctx.chart.getDatasetMeta(ctx.datasetIndex).data[ctx.index - 1].getProps(['y'], true).y;
+const previously = (ctx) => ctx.index === 0 ? ctx.chart.scales.y.getPixelForValue(100) : ctx.chart.getDatasetMeta(ctx.datasetIndex).data[ctx.index - 1].getProps(['y'], true).y;
 const animation = {
   x: {
     type: 'number',
@@ -40,7 +40,7 @@ const animation = {
     type: 'number',
     easing: 'linear',
     duration: duration,
-    from: previousY,
+    from: previously,
     delay(ctx) {
       if (ctx.type !== 'data' || ctx.yStarted) {
         return 0;

--- a/docs/samples/animations/progressive-line.md
+++ b/docs/samples/animations/progressive-line.md
@@ -18,7 +18,7 @@ for (let i = 0; i < 1000; i++) {
 // <block:animation:1>
 const totalDuration = 10000;
 const delayBetweenPoints = totalDuration / data.length;
-const previousY = (ctx) => ctx.index === 0 ? ctx.chart.scales.y.getPixelForValue(100) : ctx.chart.getDatasetMeta(ctx.datasetIndex).data[ctx.index - 1].getProps(['y'], true).y;
+const previously = (ctx) => ctx.index === 0 ? ctx.chart.scales.y.getPixelForValue(100) : ctx.chart.getDatasetMeta(ctx.datasetIndex).data[ctx.index - 1].getProps(['y'], true).y;
 const animation = {
   x: {
     type: 'number',
@@ -37,7 +37,7 @@ const animation = {
     type: 'number',
     easing: 'linear',
     duration: delayBetweenPoints,
-    from: previousY,
+    from: previously,
     delay(ctx) {
       if (ctx.type !== 'data' || ctx.yStarted) {
         return 0;


### PR DESCRIPTION
This PR fixes a few minor typographical errors in the markdown documentation (README, etc.) to improve readability. Found via codespell.