### PR TITLE
fix: disable autoSkip when stepSize is explicitly set

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -453,8 +453,8 @@ export default class Scale extends Element {
     this.calculateLabelRotation(); // Preconditions: number of ticks and sizes of largest labels must be calculated beforehand
     this.afterCalculateLabelRotation();
 
-    // Auto-skip
-    if (tickOpts.display && (tickOpts.autoSkip || tickOpts.source === 'auto')) {
+    // Auto-skip — disabled when stepSize is explicitly set
+    if (tickOpts.display && !tickOpts.stepSize && (tickOpts.autoSkip || tickOpts.source === 'auto')) {
       this.ticks = autoSkip(this, this.ticks);
       this._labelSizes = null;
       this.afterAutoSkip();

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -684,6 +684,37 @@ describe('Linear Scale', function() {
     expect(getLabels(chart.scales.y)).toEqual(['1', '3', '5', '7', '9', '11']);
   });
 
+  it('Should not autoSkip ticks when stepSize is set', function() {
+    var chart = window.acquireChart({
+      type: 'bar',
+      data: {
+        datasets: [{
+          yAxisID: 'y',
+          data: [10, 3, 6, 8, 3, 1]
+        }],
+        labels: ['a', 'b', 'c', 'd', 'e', 'f']
+      },
+      options: {
+        scales: {
+          y: {
+            type: 'linear',
+            min: 0,
+            max: 10,
+            ticks: {
+              stepSize: 1
+            }
+          }
+        }
+      }
+    });
+
+    var ticks = chart.scales.y.ticks;
+    var visibleTicks = ticks.filter(t => !t.skip);
+
+    expect(visibleTicks.length).toBe(ticks.length);
+    expect(getLabels(chart.scales.y)).toEqual(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10']);
+  });
+
   it('Should not generate any ticks > max if max is specified', function() {
     var chart = window.acquireChart({
       type: 'line',


### PR DESCRIPTION
## Summary

When `ticks.stepSize` is set, `autoSkip` (enabled by default) can still hide ticks — contradicting the user's explicit step size configuration. Users currently have to manually set `autoSkip: false` alongside `stepSize`, which is unintuitive.

This fix adds a `!tickOpts.stepSize` check to the autoSkip condition in `core.scale.js`, so that autoSkip is automatically disabled when stepSize is explicitly set.

## Reproduction

```js
options: {
  scales: {
    y: {
      ticks: {
        stepSize: 1  // expects every tick, but autoSkip hides some
      }
    }
  }
}
```

**Before fix:** Some ticks are hidden by autoSkip despite `stepSize: 1`
**After fix:** All ticks are shown at the specified interval

## Changes

- `src/core/core.scale.js` — added `!tickOpts.stepSize` guard to autoSkip condition
- `test/specs/scale.linear.tests.js` — added test verifying all ticks are visible when stepSize is set

## Backward compatibility

- No breaking changes — explicitly setting `autoSkip: false` still works as before
- Only affects behavior when `stepSize` is set (autoSkip is skipped automatically)

Fixes #4048