### PR TITLE
feat: add persistOnHover option to keep tooltip visible when hovering over it

### DIFF
--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -1203,7 +1203,27 @@ export class Tooltip extends Element {
       active.reverse();
     }
 
+    // When persistOnHover is enabled, keep the tooltip visible while the cursor
+    // is over the tooltip bounding box (even after leaving the data point).
+    if (options.persistOnHover && !active.length && lastActive.length && this._isMouseOverTooltip(e)) {
+      return lastActive;
+    }
+
     return active;
+  }
+
+  /**
+   * Returns true when the event position is inside the tooltip's rendered bounding box.
+   * @param {ChartEvent} e
+   * @returns {boolean}
+   * @private
+   */
+  _isMouseOverTooltip(e) {
+    const {x, y, width, height, opacity} = this;
+    if (!opacity || isNullOrUndef(x) || isNullOrUndef(y)) {
+      return false;
+    }
+    return e.x >= x && e.x <= x + width && e.y >= y && e.y <= y + height;
   }
 
   /**
@@ -1276,6 +1296,7 @@ export default {
     enabled: true,
     external: null,
     position: 'average',
+    persistOnHover: false,
     backgroundColor: 'rgba(0,0,0,0.8)',
     titleColor: '#fff',
     titleFont: {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -2799,6 +2799,12 @@ export interface TooltipOptions<TType extends ChartType = ChartType> extends Cor
    */
   enabled: Scriptable<boolean, ScriptableTooltipContext<TType>>;
   /**
+   * Keep the tooltip visible when the cursor moves from the data point into
+   * the tooltip bounding box.
+   * @default false
+   */
+  persistOnHover: boolean;
+  /**
    *   See external tooltip section.
    */
   external(this: TooltipModel<TType>, args: { chart: Chart; tooltip: TooltipModel<TType> }): void;


### PR DESCRIPTION
## Description

Fixes #12080

Currently, moving the cursor from a data point into the tooltip causes the tooltip to disappear immediately, because the tooltip area is not part of the chart's interaction region. This is especially problematic on scatter plots where the data point is small and the user wants to read the tooltip content.

## Solution

Added a new `tooltip.persistOnHover` option (default: `false`). When enabled, if the cursor leaves a data point but enters the tooltip's bounding box, the tooltip stays visible. It hides normally once the cursor leaves the tooltip area entirely.

## Changes

- `src/plugins/plugin.tooltip.js` — added `_isMouseOverTooltip()` helper and a guard in `_getActiveElements()` that returns the previous active elements when the cursor is over the tooltip bounding box
- `src/types/index.d.ts` — added `persistOnHover: boolean` to `TooltipOptions`

## Usage

```js
options: {
  plugins: {
    tooltip: {
      persistOnHover: true
    }
  }
}
