### PR TITLE
fix: handle splice with single argument (no deleteCount)

### DIFF
--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -1062,10 +1062,14 @@ export default class DatasetController {
   }
 
   _onDataSplice(start, count) {
+    if (arguments.length <= 1) {
+      // splice(start) with no deleteCount removes everything from start onwards
+      count = this._cachedMeta.data.length - start;
+    }
     if (count) {
       this._sync(['_removeElements', start, count]);
     }
-    const newCount = arguments.length - 2;
+    const newCount = Math.max(arguments.length - 2, 0);
     if (newCount) {
       this._sync(['_insertElements', start, newCount]);
     }

--- a/test/specs/core.datasetController.tests.js
+++ b/test/specs/core.datasetController.tests.js
@@ -538,6 +538,50 @@ describe('Chart.DatasetController', function() {
     expect(controller.getParsed(2)).toBe(data[2]);
   });
 
+  it('should correctly handle splice with a single argument (no deleteCount)', function() {
+    var data = [0, 1, 2, 3, 4, 5];
+    var chart = acquireChart({
+      type: 'line',
+      data: {
+        datasets: [{
+          data: data
+        }]
+      }
+    });
+
+    var meta = chart.getDatasetMeta(0);
+    expect(meta.data.length).toBe(6);
+
+    // splice(0) with no deleteCount should remove all elements (per spec)
+    data.splice(0);
+    chart.update();
+
+    expect(data.length).toBe(0);
+    expect(meta.data.length).toBe(0);
+  });
+
+  it('should correctly handle splice with a single argument from a mid-index', function() {
+    var data = [0, 1, 2, 3, 4, 5];
+    var chart = acquireChart({
+      type: 'line',
+      data: {
+        datasets: [{
+          data: data
+        }]
+      }
+    });
+
+    var meta = chart.getDatasetMeta(0);
+    expect(meta.data.length).toBe(6);
+
+    // splice(2) should remove elements from index 2 onwards
+    data.splice(2);
+    chart.update();
+
+    expect(data.length).toBe(2);
+    expect(meta.data.length).toBe(2);
+  });
+
   it('should re-synchronize metadata when the data object reference changes', function() {
     var data0 = [0, 1, 2, 3, 4, 5];
     var data1 = [6, 7, 8];


### PR DESCRIPTION
When Array.prototype.splice is called with only a start index and no deleteCount argument, JavaScript removes all elements from the start index to the end of the array. The _onDataSplice handler did not account for the omitted deleteCount, causing:

1. No elements being removed from metadata (count was undefined/falsy)
2. newCount becoming -1 (arguments.length - 2), leading to 'RangeError: Invalid array length'

Fix by inferring the delete count from the metadata length when deleteCount is omitted, and clamping newCount to a minimum of 0.

Closes #12191

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=wvezeOq
-->
