### PR TITLE
fix(types): add [number, number] tuple support for line and scatter chart defaultDataPoint

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -3764,7 +3764,7 @@ export interface ChartTypeRegistry {
   line: {
     chartOptions: LineControllerChartOptions;
     datasetOptions: LineControllerDatasetOptions & FillerControllerDatasetOptions;
-    defaultDataPoint: ScatterDataPoint | number | null;
+    defaultDataPoint: ScatterDataPoint | number | [number, number] | null;
     metaExtensions: {};
     parsedDataType: CartesianParsedData;
     scales: keyof CartesianScaleTypeRegistry;
@@ -3772,7 +3772,7 @@ export interface ChartTypeRegistry {
   scatter: {
     chartOptions: ScatterControllerChartOptions;
     datasetOptions: ScatterControllerDatasetOptions;
-    defaultDataPoint: ScatterDataPoint | number | null;
+    defaultDataPoint: ScatterDataPoint | number | [number, number] | null;
     metaExtensions: {};
     parsedDataType: CartesianParsedData;
     scales: keyof CartesianScaleTypeRegistry;

--- a/test/types/data_types.ts
+++ b/test/types/data_types.ts
@@ -8,6 +8,14 @@ const chart = new Chart('chart', {
   }
 });
 
+const lineTupleChart = new Chart('lineTupleChart', {
+  type: 'line',
+  data: {
+    labels: ['1', '2', '3'],
+    datasets: [{ data: [[1, 2], [3, 4], [5, 6]] }],
+  }
+});
+
 const chart2 = new Chart('chart2', {
   type: 'bar',
   data: {

--- a/test/types/dataset_null_data.ts
+++ b/test/types/dataset_null_data.ts
@@ -14,3 +14,11 @@ const radarDataset: ChartDataset<'radar'> = {
   data: [10, null, 20],
 };
 
+// [number, number] tuple data must be accepted for line and scatter, matching bar's floating-range behaviour
+const lineTupleDataset: ChartDataset<'line'> = {
+  data: [[1, 2], [3, 4], [5, 6]],
+};
+const scatterTupleDataset: ChartDataset<'scatter'> = {
+  data: [[1, 2], [3, 4], [5, 6]],
+};
+


### PR DESCRIPTION
## Problem

When using an array of tuples (`[number, number][]`) as dataset data on a `line` 
or `scatter` chart, TypeScript raises:

> Type '[number, number]' is not assignable to type 'ScatterDataPoint | number | null'

This is despite tuples being a [documented data structure](https://chartjs.org/docs/latest/general/data-structures.html#array) 
and already being supported for `bar` charts via `[number, number]` in its `defaultDataPoint`.

Fixes #12232

## Changes

- Added `[number, number]` to `defaultDataPoint` for `line` and `scatter` in `src/types/index.d.ts`, matching the existing `bar` chart behavior
- Added type test cases in `test/types/dataset_null_data.ts` and `test/types/data_types.ts` to cover both `ChartDataset` and full `new Chart(...)` instantiation with tuple data

## Scope

This PR fixes the **TypeScript type error only**. The runtime issue (line not 
rendering when `parsing: false` is set with tuple data) is a separate problem 
in the data parsing pipeline and is not addressed here.