### PR TITLE
Feature/waterfall chart sample

### DIFF
--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -145,6 +145,7 @@ export default defineConfig({
             'bar/border-radius',
             'bar/floating',
             'bar/waterfall',
+            'bar/waterfall-stacked',
             'bar/horizontal',
             'bar/stacked',
             'bar/stacked-groups',

--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -144,6 +144,7 @@ export default defineConfig({
           children: [
             'bar/border-radius',
             'bar/floating',
+            'bar/waterfall',
             'bar/horizontal',
             'bar/stacked',
             'bar/stacked-groups',

--- a/docs/samples/bar/waterfall-stacked.md
+++ b/docs/samples/bar/waterfall-stacked.md
@@ -1,0 +1,74 @@
+# Waterfall Chart Using Stacked Bars
+
+A waterfall chart can be created using stacked bars with a transparent base dataset. The base dataset positions each step, while the change dataset renders the visible positive or negative bars.
+
+```js chart-editor
+// <block:setup:1>
+const labels = ['Start', 'Revenue', 'Cost', 'Tax', 'End'];
+
+const data = {
+  labels: labels,
+  datasets: [
+    {
+      label: 'Base',
+      data: [0, 500, 550, 500, 0],
+      backgroundColor: 'rgba(0, 0, 0, 0)',
+      borderWidth: 0,
+      stack: 'waterfall',
+    },
+    {
+      label: 'Change',
+      data: [500, 200, 150, 50, 500],
+      backgroundColor: [
+        Utils.CHART_COLORS.blue,
+        Utils.CHART_COLORS.green,
+        Utils.CHART_COLORS.red,
+        Utils.CHART_COLORS.red,
+        Utils.CHART_COLORS.blue,
+      ],
+      borderColor: [
+        Utils.CHART_COLORS.blue,
+        Utils.CHART_COLORS.green,
+        Utils.CHART_COLORS.red,
+        Utils.CHART_COLORS.red,
+        Utils.CHART_COLORS.blue,
+      ],
+      borderWidth: 1,
+      stack: 'waterfall',
+    }
+  ]
+};
+// </block:setup>
+
+// <block:config:0>
+const config = {
+  type: 'bar',
+  data: data,
+  options: {
+    responsive: true,
+    plugins: {
+      title: {
+        display: true,
+        text: 'Chart.js Waterfall Chart Using Stacked Bars'
+      },
+    },
+    scales: {
+      x: {
+        stacked: true,
+      },
+      y: {
+        stacked: true
+      }
+    }
+  }
+};
+// </block:config>
+
+module.exports = {
+  config: config,
+};
+```
+
+## Docs
+* [Bar](../../charts/bar.md)
+* [Stacked Bar Chart](../../charts/bar.md#stacked-bar-chart)

--- a/docs/samples/bar/waterfall.md
+++ b/docs/samples/bar/waterfall.md
@@ -1,0 +1,65 @@
+# Waterfall Chart
+
+A waterfall chart can be created using floating bars. Each bar starts from the previous cumulative value and ends at the next cumulative value.
+
+```js chart-editor
+// <block:setup:1>
+const labels = ['Start', 'Revenue', 'Expenses', 'Tax', 'Total'];
+
+const data = {
+  labels: labels,
+  datasets: [{
+    label: 'Waterfall',
+    data: [
+      [0, 100],
+      [100, 170],
+      [170, 120],
+      [120, 90],
+      [0, 90],
+    ],
+    backgroundColor: [
+      Utils.CHART_COLORS.blue,
+      Utils.CHART_COLORS.green,
+      Utils.CHART_COLORS.red,
+      Utils.CHART_COLORS.red,
+      Utils.CHART_COLORS.blue,
+    ],
+    borderColor: [
+      Utils.CHART_COLORS.blue,
+      Utils.CHART_COLORS.green,
+      Utils.CHART_COLORS.red,
+      Utils.CHART_COLORS.red,
+      Utils.CHART_COLORS.blue,
+    ],
+    borderWidth: 1,
+  }]
+};
+// </block:setup>
+
+// <block:config:0>
+const config = {
+  type: 'bar',
+  data: data,
+  options: {
+    responsive: true,
+    plugins: {
+      legend: {
+        display: false,
+      },
+      title: {
+        display: true,
+        text: 'Chart.js Waterfall Chart'
+      }
+    }
+  }
+};
+// </block:config>
+
+module.exports = {
+  config: config,
+};
+```
+
+## Docs
+* [Bar](../../charts/bar.md)
+* [Floating Bars](./floating.md)


### PR DESCRIPTION
## Summary

This PR addresses issue #12152 by adding Waterfall chart examples to the Chart.js documentation samples.

The contribution focuses on documentation/sample enhancement and demonstrates two different ways to create Waterfall charts using existing Chart.js bar chart functionality.

Interactive demo:
https://codepen.io/BrunoDuvane40/pen/pvNEPPB

## Changes Made

* Added `docs/samples/bar/waterfall.md`
* Added `docs/samples/bar/waterfall-stacked.md`
* Updated `docs/.vuepress/config.ts` to register the new samples under the “Bar Charts” section
* Verified both samples render correctly in the local documentation website

## Implementation Notes

Two alternative approaches were implemented and documented:

* Floating bar approach, using `[start, end]` values to directly represent cumulative transitions
* Stacked bar approach, using a transparent base dataset combined with a visible change dataset

Alternative approaches considered:

* Floating bars using cumulative `[start, end]` ranges
* Stacked bars using transparent positioning datasets (recommended by the issue creator)

The floating bar implementation was considered the cleaner and more semantically direct solution because each Waterfall step explicitly represents its visual start and end values without requiring auxiliary transparent datasets.

The stacked bar approach was also included because it aligns closely with the implementation idea discussed in the original issue.

## Testing / Verification

* Ran `pnpm run build`
* Ran `NODE_OPTIONS=--openssl-legacy-provider pnpm run docs:dev`
* Verified both Waterfall chart sample pages render correctly locally
* Confirmed no browser console/runtime errors
* Created an interactive CodePen demonstration for both implementations

## Related Issue

Closes #12152
