### PR TITLE
feat: add persistOnHover option to keep tooltip visible when hovering over it

### DIFF
--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -1203,7 +1203,27 @@ export class Tooltip extends Element {
       active.reverse();
     }
 
+    // When persistOnHover is enabled, keep the tooltip visible while the cursor
+    // is over the tooltip bounding box (even after leaving the data point).
+    if (options.persistOnHover && !active.length && lastActive.length && this._isMouseOverTooltip(e)) {
+      return lastActive;
+    }
+
     return active;
+  }
+
+  /**
+   * Returns true when the event position is inside the tooltip's rendered bounding box.
+   * @param {ChartEvent} e
+   * @returns {boolean}
+   * @private
+   */
+  _isMouseOverTooltip(e) {
+    const {x, y, width, height, opacity} = this;
+    if (!opacity || isNullOrUndef(x) || isNullOrUndef(y)) {
+      return false;
+    }
+    return e.x >= x && e.x <= x + width && e.y >= y && e.y <= y + height;
   }
 
   /**
@@ -1276,6 +1296,7 @@ export default {
     enabled: true,
     external: null,
     position: 'average',
+    persistOnHover: false,
     backgroundColor: 'rgba(0,0,0,0.8)',
     titleColor: '#fff',
     titleFont: {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -2799,6 +2799,12 @@ export interface TooltipOptions<TType extends ChartType = ChartType> extends Cor
    */
   enabled: Scriptable<boolean, ScriptableTooltipContext<TType>>;
   /**
+   * Keep the tooltip visible when the cursor moves from the data point into
+   * the tooltip bounding box.
+   * @default false
+   */
+  persistOnHover: boolean;
+  /**
    *   See external tooltip section.
    */
   external(this: TooltipModel<TType>, args: { chart: Chart; tooltip: TooltipModel<TType> }): void;


### PR DESCRIPTION
## Summary

This PR addresses issue #12080 by adding a `persistOnHover` option to the tooltip plugin.

The contribution focuses on a behavior improvement: when `tooltip.persistOnHover` is set
to `true`, the tooltip remains visible as the cursor moves from the data point into the
tooltip bounding box, instead of disappearing immediately.

## Changes Made

- Added `_isMouseOverTooltip(e)` method to `src/plugins/plugin.tooltip.js`
- Extended `_getActiveElements()` in `src/plugins/plugin.tooltip.js` to retain active
  elements while the cursor is inside the tooltip bounding box
- Added `persistOnHover: false` to the tooltip defaults in `src/plugins/plugin.tooltip.js`
- Added `persistOnHover: boolean` to `TooltipOptions` in `src/types/index.d.ts`

## Implementation Notes

The solution was implemented by intercepting the result of `_getActiveElements()` after
the normal interaction lookup returns empty. The tooltip's bounding box (`x`, `y`,
`width`, `height`) is already set from the previous render, so we check whether the
cursor is inside it and return the previous active elements if so.

Alternative approaches considered:

- Custom `point+tooltip` interaction mode — rejected because it would require calculating
  tooltip bounds during hit testing (before rendering), creating a circular dependency.

The guard approach was chosen because it requires no changes to interaction modes or
controllers, has zero cost when the option is `false` (the default), and is fully
self-contained inside the tooltip plugin.

## Testing / Verification

- Ran `pnpm run build` — no errors
- Verified manually at `http://localhost:8081/docs/master/samples/tooltip/interactions.html`
- With `persistOnHover: true`: moving cursor from data point into tooltip keeps it visible
- Moving cursor outside tooltip hides it normally
- Confirmed no console/runtime errors
- Existing tooltip behavior unaffected when option is omitted

## Related Issue

Closes #12080
