### PR TITLE
docs: document lineTension → tension rename in v3 migration guide

### DIFF
--- a/docs/migration/v3-migration.md
+++ b/docs/migration/v3-migration.md
@@ -98,6 +98,7 @@ A number of changes were made to the configuration options passed to the `Chart`
 * `scales.[x/y]Axes.time.min` was renamed to `scales[id].min`
 * `scales.[x/y]Axes.zeroLine*` options of axes were removed. Use scriptable scale options instead.
 * The dataset option `steppedLine` was removed. Use `stepped`
+* The dataset option `lineTension` was renamed to `tension` and its default changed from `0.4` to `0`. Set `tension` to a value greater than `0` to keep interpolated (curved) lines.
 * The chart option `showLines` was renamed to `showLine` to match the dataset option.
 * The chart option `startAngle` was moved to `radial` scale options.
 * To override the platform class used in a chart instance, pass `platform: PlatformClass` in the config object. Note that the class should be passed, not an instance of the class.


### PR DESCRIPTION
Closes #11928

The v3 migration guide didn't mention that the line dataset's `lineTension` option was renamed to `tension`, nor that its default changed from `0.4` to `0`. As a result, users migrating from v2 saw their curved lines render straight with no explanation in the guide.

This adds a single bullet to the "Specific changes" list (next to the related `steppedLine` change) documenting the rename and the new default, with a hint to set `tension > 0` to keep curved lines.