### PR TITLE
fix legend line point style not showing the dataset dash

### DIFF
--- a/src/plugins/plugin.legend.js
+++ b/src/plugins/plugin.legend.js
@@ -679,6 +679,12 @@ export default {
         return chart._getSortedDatasetMetas().map((meta) => {
           const style = meta.controller.getStyle(usePointStyle ? 0 : undefined);
           const borderWidth = toPadding(style.borderWidth);
+          const itemPointStyle = pointStyle || style.pointStyle;
+          // a line symbol stands for the dataset line but the point scope has no dash
+          // on it so read that off the dataset element instead, markers stay solid
+          const dashStyle = usePointStyle && itemPointStyle === 'line'
+            ? meta.controller.getStyle(undefined)
+            : style;
 
           return {
             text: datasets[meta.index].label,
@@ -686,12 +692,12 @@ export default {
             fontColor: color,
             hidden: !meta.visible,
             lineCap: style.borderCapStyle,
-            lineDash: style.borderDash,
-            lineDashOffset: style.borderDashOffset,
+            lineDash: dashStyle.borderDash,
+            lineDashOffset: dashStyle.borderDashOffset,
             lineJoin: style.borderJoinStyle,
             lineWidth: (borderWidth.width + borderWidth.height) / 4,
             strokeStyle: style.borderColor,
-            pointStyle: pointStyle || style.pointStyle,
+            pointStyle: itemPointStyle,
             rotation: style.rotation,
             textAlign: textAlign || style.textAlign,
             borderRadius: useBorderRadius && (borderRadius || style.borderRadius),

--- a/test/specs/plugin.legend.tests.js
+++ b/test/specs/plugin.legend.tests.js
@@ -189,6 +189,67 @@ describe('Legend block tests', function() {
     }]);
   });
 
+  it('should take the dataset dash for a line point style', function() {
+    var chart = window.acquireChart({
+      type: 'line',
+      data: {
+        labels: [],
+        datasets: [{
+          label: 'solid',
+          data: []
+        }, {
+          label: 'dashed',
+          borderDash: [6, 3],
+          borderDashOffset: 4,
+          data: []
+        }]
+      },
+      options: {
+        plugins: {
+          legend: {
+            labels: {
+              usePointStyle: true,
+              pointStyle: 'line'
+            }
+          }
+        }
+      }
+    });
+
+    expect(chart.legend.legendItems.map(function(item) {
+      return item.lineDash;
+    })).toEqual([[], [6, 3]]);
+    expect(chart.legend.legendItems.map(function(item) {
+      return item.lineDashOffset;
+    })).toEqual([0, 4]);
+  });
+
+  it('should leave other point styles solid', function() {
+    var chart = window.acquireChart({
+      type: 'line',
+      data: {
+        labels: [],
+        datasets: [{
+          label: 'dashed',
+          borderDash: [6, 3],
+          data: []
+        }]
+      },
+      options: {
+        plugins: {
+          legend: {
+            labels: {
+              usePointStyle: true,
+              pointStyle: 'circle'
+            }
+          }
+        }
+      }
+    });
+
+    expect(chart.legend.legendItems[0].lineDash).toBeUndefined();
+  });
+
   it('should reverse correctly', function() {
     var chart = window.acquireChart({
       type: 'line',


### PR DESCRIPTION
fixes #12291

### what happens

with `usePointStyle: true` and `pointStyle: 'line'` the legend key draws solid even when the dataset has `borderDash` on it. the plotted line is dashed but the key beside it is not so the two do not match.

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/HuzaifaChaudary/Chart.js/proof-12291/before.png) | ![after](https://raw.githubusercontent.com/HuzaifaChaudary/Chart.js/proof-12291/after.png) |

### why it happens

the drawing side is already right. `drawLegendBox` does

```js
ctx.setLineDash(valueOrDefault(legendItem.lineDash, []));
```

so the dash would be honoured if it were there. it is not there. the miss is one step earlier in `generateLabels`

```js
const style = meta.controller.getStyle(usePointStyle ? 0 : undefined);
```

when `usePointStyle` is on this asks for index 0 which resolves the point scope and the point element has no `borderDash` on it. so `style.borderDash` comes back undefined and the legend item gets an empty dash. when `usePointStyle` is off it asks for the dataset element which does carry the dash and that is why the plain box legend has always drawn it fine.

i printed both scopes on master to be sure rather than going off the defaults list

```
getStyle(0).borderDash         = [null, null]
getStyle(undefined).borderDash = [[], [6,3]]
```

### the change

read the dash off the dataset element but only when the point style is `line`. that style stands for the dataset line itself so it should look like it. every other point style is a marker and keeps resolving exactly as before so a dashed dataset does not suddenly get a chopped up circle or rect outline. on chart types with no dataset element such as bar `getStyle(undefined)` falls back to the same point options so nothing moves there either.

### checked

- `test/specs/plugin.legend.tests.js` 79 of 79 pass and that includes all 52 legend image fixtures so the existing legend rendering is untouched
- the new test fails without the source change

```
Expected $[0] = undefined to equal [  ].
Expected $[1] = undefined to equal [ 6, 3 ].
```

- eslint clean on both files
- the two shots above are the same config rendered before and after the change. only the dashed key differs and the solid key is unchanged

i went narrow on purpose here. if you would rather every point style inherit the dataset dash when `usePointStyle` is on i am happy to widen it. also glad to add an image fixture if you want one though the legend needs text so i left it out to avoid a chrome against firefox mismatch.
