### PR TITLE
add a regression test for the fractional canvas size

### DIFF
--- a/test/specs/helpers.dom.tests.js
+++ b/test/specs/helpers.dom.tests.js
@@ -278,6 +278,25 @@ describe('DOM helpers tests', function() {
     expect(canvas.style.height).toBe(`${chartHeight}px`);
   });
 
+  it ('should stop reporting a change once a fractional size is applied', function() {
+    var chart = window.acquireChart({}, {
+      canvas: {
+        width: 300,
+        height: 150,
+      }
+    });
+
+    chart.width = 300.4;
+    chart.height = 150.2;
+
+    // the canvas keeps whole pixels only so a fractional size still has to settle
+    expect(helpers.retinaScale(chart, 2, true)).toBe(true);
+    expect(helpers.retinaScale(chart, 2, true)).toBe(false);
+
+    expect(chart.canvas.width).toBe(600);
+    expect(chart.canvas.height).toBe(300);
+  });
+
   describe('getRelativePosition', function() {
     it('should use offsetX/Y when available', function() {
       const event = {offsetX: 50, offsetY: 100};


### PR DESCRIPTION
while looking at #12269 i went to find why 4.5.1 behaves differently from 4.5.0 on a responsive chart and it comes down to `retinaScale`.

in 4.5.1 the canvas dimensions are written straight from `round1`:

```js
const deviceHeight = round1(chart.height * pixelRatio);
const deviceWidth = round1(chart.width * pixelRatio);
...
if (chart.currentDevicePixelRatio !== pixelRatio
    || canvas.height !== deviceHeight
    || canvas.width !== deviceWidth) {
  canvas.height = deviceHeight;
  canvas.width = deviceWidth;
```

`canvas.width` and `canvas.height` are unsigned long so the browser truncates whatever is assigned to them. when the container measures to a fraction the stored value can never equal the value it is compared against. the check is then true on every call and `retinaScale` keeps reporting that the size changed.

i measured it in chrome headless:

```
canvas.width = 600.8            -> 600
4.5.1 logic on 300.4 x 150.2    -> true true true
master on the same size         -> true false false
```

this matters because `_resize` uses the return value as its early exit:

```js
if (!retinaScale(this, newRatio, true)) {
  return;
}
```

so on 4.5.1 a fractional size makes every attach and every resize fall through to `_doResize` instead of stopping there. that is the path in the stack trace on #12269.

#12142 already fixed this by flooring the canvas dimensions but it landed without a test and it is not in a release yet. this adds the missing guard so the behaviour does not slip back. putting the floor back out makes the new test fail with `Expected true to be false` on the second call.

no source change here.
